### PR TITLE
Fix for `spindle.generate.dryRun` not passing `userId` needed for operator-scope extensions

### DIFF
--- a/developer-docs/docs/backend-api/generation.md
+++ b/developer-docs/docs/backend-api/generation.md
@@ -61,12 +61,12 @@ const results = await spindle.generate.batch({
 
 Run the full prompt assembly pipeline — macros, world info, context filters, memory retrieval, token counting — without actually calling the LLM. Useful for prompt debugging, token budget analysis, and previewing what the model will see.
 
-### `spindle.generate.dryRun(input)`
+### `spindle.generate.dryRun(input, userId?)`
 
 ```ts
 const result = await spindle.generate.dryRun({
   chatId: 'chat-id',
-})
+}, userId) // userId required for operator-scoped extensions
 
 spindle.log.info(`Provider: ${result.provider}, Model: ${result.model}`)
 spindle.log.info(`Assembled ${result.messages.length} messages`)
@@ -95,7 +95,7 @@ const result = await spindle.generate.dryRun({
   presetId: 'specific-preset',           // default: connection's linked preset
   generationType: 'continue',            // default: 'normal'
   parameters: { temperature: 0.8 },      // override sampler params
-})
+}, userId)
 ```
 
 ### DryRunRequestDTO
@@ -108,6 +108,12 @@ const result = await spindle.generate.dryRun({
 | `presetId` | `string` | Optional. Use a specific preset. |
 | `generationType` | `string` | Optional. One of `"normal"`, `"continue"`, `"regenerate"`, `"swipe"`, `"impersonate"`. |
 | `parameters` | `Record<string, unknown>` | Optional. Override sampler parameters. |
+
+`dryRun` also accepts a second argument:
+
+| Argument | Type | Description |
+|---|---|---|
+| `userId` | `string` | **Required for operator-scoped extensions.** The user ID to scope the dry run to. For user-scoped extensions, this is inferred automatically and can be omitted. |
 
 ### DryRunResultDTO
 

--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -161,12 +161,13 @@ const spindleApi: SpindleAPI = {
         input: { ...input, type: "batch" },
       });
     },
-    async dryRun(input) {
+    async dryRun(input, userId?: string) {
       const requestId = crypto.randomUUID();
       const result = await request({
         type: "generate_dry_run",
         requestId,
         input,
+        userId,
       });
       return result as import("lumiverse-spindle-types").DryRunResultDTO;
     },


### PR DESCRIPTION
Added second optional `userId` argument to `spindle.generate.dryRun`, plus documentation