### PR TITLE
Add entry search to world book panels

### DIFF
--- a/frontend/src/components/modals/WorldBookEditorModal.module.css
+++ b/frontend/src/components/modals/WorldBookEditorModal.module.css
@@ -292,6 +292,40 @@
   color: var(--lumiverse-text);
 }
 
+.entrySearch {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  padding: 7px 10px;
+  border-radius: 8px;
+  background: var(--lumiverse-fill-subtle);
+  border: 1px solid var(--lumiverse-border);
+}
+
+.entrySearch:focus-within {
+  border-color: var(--lumiverse-primary);
+}
+
+.entrySearchIcon {
+  color: var(--lumiverse-text-dim);
+  flex-shrink: 0;
+}
+
+.entrySearchInput {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  color: var(--lumiverse-text);
+  font-size: 12px;
+  outline: none;
+}
+
+.entrySearchInput::placeholder {
+  color: var(--lumiverse-text-dim);
+}
+
 .newEntryBtn {
   display: flex;
   align-items: center;
@@ -517,6 +551,14 @@
 
 .entryDeleteBtn:hover {
   color: var(--lumiverse-error);
+}
+
+.entryEmptyState {
+  padding: 24px 12px;
+  text-align: center;
+  color: var(--lumiverse-text-dim);
+  font-size: 13px;
+  font-style: italic;
 }
 
 @media (max-width: 640px) {

--- a/frontend/src/components/modals/WorldBookEditorModal.tsx
+++ b/frontend/src/components/modals/WorldBookEditorModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { motion } from 'motion/react'
-import { X, Plus, Trash2, BookOpen, Upload, User, FileUp } from 'lucide-react'
+import { X, Plus, Trash2, BookOpen, Upload, User, FileUp, Search } from 'lucide-react'
 import { useStore } from '@/store'
 import { worldBooksApi } from '@/api/world-books'
 import ConfirmationModal from '@/components/shared/ConfirmationModal'
@@ -30,6 +30,7 @@ export default function WorldBookEditorModal() {
   const [entryTotal, setEntryTotal] = useState(0)
   const [entryOffset, setEntryOffset] = useState(0)
   const [loadingMore, setLoadingMore] = useState(false)
+  const [entrySearchFilter, setEntrySearchFilter] = useState('')
 
   // Book editing state
   const [bookName, setBookName] = useState('')
@@ -53,11 +54,27 @@ export default function WorldBookEditorModal() {
   const enabledNonEmptyCount = vectorSummary?.enabled_non_empty ?? 0
   const allNonEmptySemanticEnabled = nonEmptyEntryCount > 0 && enabledNonEmptyCount === nonEmptyEntryCount
   const someNonEmptySemanticEnabled = enabledNonEmptyCount > 0 && enabledNonEmptyCount < nonEmptyEntryCount
+  const normalizedEntrySearch = entrySearchFilter.trim().toLowerCase()
+  const filteredEntries = normalizedEntrySearch
+    ? entries.filter((entry) =>
+        [entry.comment, entry.content, ...entry.key, ...entry.keysecondary]
+          .join('\n')
+          .toLowerCase()
+          .includes(normalizedEntrySearch)
+      )
+    : entries
 
   useEffect(() => {
     if (!bulkSemanticToggleRef.current) return
     bulkSemanticToggleRef.current.indeterminate = someNonEmptySemanticEnabled
   }, [someNonEmptySemanticEnabled])
+
+  useEffect(() => {
+    if (!selectedEntryId) return
+    if (!filteredEntries.some((entry) => entry.id === selectedEntryId)) {
+      setSelectedEntryId(null)
+    }
+  }, [filteredEntries, selectedEntryId])
 
   // Load books
   const loadBooks = useCallback(async () => {
@@ -113,11 +130,13 @@ export default function WorldBookEditorModal() {
         setBookName(book.name)
         setBookDescription(book.description)
       }
+      setEntrySearchFilter('')
       setSelectedEntryId(null)
     } else {
       setEntries([])
       setEntryTotal(0)
       setEntryOffset(0)
+      setEntrySearchFilter('')
       setSelectedEntryId(null)
       setVectorSummary(null)
     }
@@ -287,7 +306,7 @@ export default function WorldBookEditorModal() {
     setPostImportBook(result.world_book)
   }, [])
 
-  const selectedEntry = entries.find((e) => e.id === selectedEntryId) || null
+  const selectedEntry = filteredEntries.find((e) => e.id === selectedEntryId) || null
 
   return createPortal(
     <div className={styles.overlay} onClick={closeModal}>
@@ -465,9 +484,20 @@ export default function WorldBookEditorModal() {
                 </button>
               </div>
 
+              <label className={styles.entrySearch}>
+                <Search size={14} className={styles.entrySearchIcon} />
+                <input
+                  type="text"
+                  className={styles.entrySearchInput}
+                  placeholder="Search entries..."
+                  value={entrySearchFilter}
+                  onChange={(e) => setEntrySearchFilter(e.target.value)}
+                />
+              </label>
+
               {/* Entry list */}
               <div className={styles.entryList}>
-                {entries.map((entry) => (
+                {filteredEntries.map((entry) => (
                   <div
                     key={entry.id}
                     className={clsx(styles.entryRow, selectedEntryId === entry.id && styles.entryRowActive)}
@@ -506,6 +536,12 @@ export default function WorldBookEditorModal() {
                     </span>
                   </div>
                 ))}
+                {entries.length === 0 && (
+                  <div className={styles.entryEmptyState}>No entries yet</div>
+                )}
+                {entries.length > 0 && filteredEntries.length === 0 && (
+                  <div className={styles.entryEmptyState}>No entries match your search</div>
+                )}
                 {entries.length < entryTotal && (
                   <button
                     type="button"

--- a/frontend/src/components/panels/world-book/WorldBookPanel.module.css
+++ b/frontend/src/components/panels/world-book/WorldBookPanel.module.css
@@ -669,6 +669,40 @@
   color: var(--lumiverse-text);
 }
 
+.entrySearch {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  padding: 7px 10px;
+  border-radius: 8px;
+  background: var(--lumiverse-fill-subtle);
+  border: 1px solid var(--lumiverse-border);
+}
+
+.entrySearch:focus-within {
+  border-color: var(--lumiverse-primary);
+}
+
+.entrySearchIcon {
+  color: var(--lumiverse-text-dim);
+  flex-shrink: 0;
+}
+
+.entrySearchInput {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  color: var(--lumiverse-text);
+  font-size: 12px;
+  outline: none;
+}
+
+.entrySearchInput::placeholder {
+  color: var(--lumiverse-text-dim);
+}
+
 .newEntryBtn {
   display: flex;
   align-items: center;

--- a/frontend/src/components/panels/world-book/WorldBookPanel.tsx
+++ b/frontend/src/components/panels/world-book/WorldBookPanel.tsx
@@ -33,6 +33,7 @@ export default function WorldBookPanel() {
   const [entryTotal, setEntryTotal] = useState(0)
   const [entryOffset, setEntryOffset] = useState(0)
   const [loadingMore, setLoadingMore] = useState(false)
+  const [entrySearchFilter, setEntrySearchFilter] = useState('')
 
   // Book editing state
   const [bookFieldsOpen, setBookFieldsOpen] = useState(false)
@@ -59,11 +60,27 @@ export default function WorldBookPanel() {
   const enabledNonEmptyCount = vectorSummary?.enabled_non_empty ?? 0
   const allNonEmptySemanticEnabled = nonEmptyEntryCount > 0 && enabledNonEmptyCount === nonEmptyEntryCount
   const someNonEmptySemanticEnabled = enabledNonEmptyCount > 0 && enabledNonEmptyCount < nonEmptyEntryCount
+  const normalizedEntrySearch = entrySearchFilter.trim().toLowerCase()
+  const filteredEntries = normalizedEntrySearch
+    ? entries.filter((entry) =>
+        [entry.comment, entry.content, ...entry.key, ...entry.keysecondary]
+          .join('\n')
+          .toLowerCase()
+          .includes(normalizedEntrySearch)
+      )
+    : entries
 
   useEffect(() => {
     if (!bulkSemanticToggleRef.current) return
     bulkSemanticToggleRef.current.indeterminate = someNonEmptySemanticEnabled
   }, [someNonEmptySemanticEnabled])
+
+  useEffect(() => {
+    if (!selectedEntryId) return
+    if (!filteredEntries.some((entry) => entry.id === selectedEntryId)) {
+      setSelectedEntryId(null)
+    }
+  }, [filteredEntries, selectedEntryId])
 
   // Load books
   const loadBooks = useCallback(async () => {
@@ -119,12 +136,14 @@ export default function WorldBookPanel() {
         setBookName(book.name)
         setBookDescription(book.description)
       }
+      setEntrySearchFilter('')
       setSelectedEntryId(null)
       setShowDiagnosticsModal(false)
     } else {
       setEntries([])
       setEntryTotal(0)
       setEntryOffset(0)
+      setEntrySearchFilter('')
       setSelectedEntryId(null)
       setVectorSummary(null)
       setShowDiagnosticsModal(false)
@@ -609,9 +628,20 @@ export default function WorldBookPanel() {
             </button>
           </div>
 
+          <label className={styles.entrySearch}>
+            <Search size={14} className={styles.entrySearchIcon} />
+            <input
+              type="text"
+              className={styles.entrySearchInput}
+              placeholder="Search entries..."
+              value={entrySearchFilter}
+              onChange={(e) => setEntrySearchFilter(e.target.value)}
+            />
+          </label>
+
           {/* Entry list */}
           <div className={styles.entryList}>
-            {entries.map((entry) => (
+            {filteredEntries.map((entry) => (
               <div key={entry.id}>
                 <div
                   className={clsx(styles.entryRow, selectedEntryId === entry.id && styles.entryRowActive)}
@@ -661,6 +691,9 @@ export default function WorldBookPanel() {
             ))}
             {entries.length === 0 && (
               <div className={styles.emptyState}>No entries yet</div>
+            )}
+            {entries.length > 0 && filteredEntries.length === 0 && (
+              <div className={styles.emptyState}>No entries match your search</div>
             )}
             {entries.length < entryTotal && (
               <button


### PR DESCRIPTION
## Summary

This PR adds a search bar to the lorebook entry list so users can quickly filter entries while editing a world book. The search input appears directly under the `Entries (...)` header and updates the visible list as you type.

## What changed

### Entry list search

- Added a search input directly under the `Entries (...)` label
- Filters the currently loaded entry list client-side as the user types
- Matches against:
  - entry comment / label
  - primary keys
  - secondary keys
  - entry content
- Keeps `Load More` available so additional entries can still be loaded while searching

### UX improvements

- Added a clear empty state when no entries match the current search
- Clears the selected entry automatically if it becomes hidden by the active filter
- Applied the same behavior to both lorebook editing surfaces so the experience stays consistent:
  - the main world-book panel
  - the full world-book editor modal

## Files changed

- `frontend/src/components/panels/world-book/WorldBookPanel.tsx`
- `frontend/src/components/panels/world-book/WorldBookPanel.module.css`
- `frontend/src/components/modals/WorldBookEditorModal.tsx`
- `frontend/src/components/modals/WorldBookEditorModal.module.css`

## Result

This makes larger lorebooks much easier to navigate by letting users quickly narrow the visible entries without changing the underlying data or activation behavior.