### PR TITLE
Fix `Convert to Vectorized` failures caused by reindex progress stream timeouts

### DIFF
--- a/src/routes/embeddings.routes.ts
+++ b/src/routes/embeddings.routes.ts
@@ -43,9 +43,37 @@ app.post("/world-books/:bookId/reindex", async (c) => {
     const stream = new ReadableStream({
       async start(controller) {
         const encoder = new TextEncoder();
-        const send = (event: string, data: any) => {
-          controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+        let closed = false;
+        const close = () => {
+          if (closed) return;
+          closed = true;
+          clearInterval(heartbeat);
+          try {
+            controller.close();
+          } catch {
+            // Controller may already be closed/cancelled by the client.
+          }
         };
+        const send = (event: string, data: any) => {
+          if (closed) return false;
+          try {
+            controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+            return true;
+          } catch {
+            closed = true;
+            clearInterval(heartbeat);
+            return false;
+          }
+        };
+        const heartbeat = setInterval(() => {
+          if (closed) return;
+          try {
+            controller.enqueue(encoder.encode(`:\n\n`));
+          } catch {
+            closed = true;
+            clearInterval(heartbeat);
+          }
+        }, 5000);
 
         send("progress", {
           total: entries.length,
@@ -61,13 +89,18 @@ app.post("/world-books/:bookId/reindex", async (c) => {
         try {
           const result = await embeddingsSvc.reindexWorldBookEntries(userId, entries, {
             batchSize,
-            onProgress: (progress) => send("progress", progress),
+            onProgress: (progress) => {
+              send("progress", progress);
+            },
           });
           send("done", { success: true, ...result });
         } catch (err: any) {
           send("error", { error: err.message || "Reindex failed" });
         }
-        controller.close();
+        close();
+      },
+      cancel() {
+        // Client disconnected or request timed out.
       },
     });
 

--- a/src/services/embeddings.service.ts
+++ b/src/services/embeddings.service.ts
@@ -979,6 +979,14 @@ export async function reindexWorldBookEntries(
     skipped_disabled_or_empty: 0,
     failed: 0,
   };
+  const emitProgress = () => {
+    if (!options?.onProgress) return;
+    try {
+      options.onProgress({ ...progress });
+    } catch (err) {
+      console.warn("[embeddings] Progress callback failed:", err);
+    }
+  };
   const toIndex: WorldBookEntry[] = [];
   const notEnabled: WorldBookEntry[] = [];
   const disabledOrEmpty: WorldBookEntry[] = [];
@@ -1001,7 +1009,7 @@ export async function reindexWorldBookEntries(
     updateWorldBookEntryVectorState(entry.id, "not_enabled", null, null);
     progress.removed += 1;
     progress.current += 1;
-    options?.onProgress?.({ ...progress });
+    emitProgress();
   }
 
   for (const entry of disabledOrEmpty) {
@@ -1009,7 +1017,7 @@ export async function reindexWorldBookEntries(
     updateWorldBookEntryVectorState(entry.id, "pending", null, null);
     progress.removed += 1;
     progress.current += 1;
-    options?.onProgress?.({ ...progress });
+    emitProgress();
   }
 
   const cfg = await getEmbeddingConfig(userId);
@@ -1019,7 +1027,7 @@ export async function reindexWorldBookEntries(
       updateWorldBookEntryVectorState(entry.id, "pending", null, null);
       progress.removed += 1;
       progress.current += 1;
-      options?.onProgress?.({ ...progress });
+      emitProgress();
     }
     return progress;
   }
@@ -1060,14 +1068,14 @@ export async function reindexWorldBookEntries(
       updateWorldBookEntriesVectorState(batch.map((entry) => entry.id), "indexed", now, null);
       progress.indexed += batch.length;
       progress.current += batch.length;
-      options?.onProgress?.({ ...progress });
+      emitProgress();
     } catch (err) {
       console.warn("[embeddings] Batch embedding failed:", err);
       const message = err instanceof Error ? err.message : "Batch vector indexing failed";
       updateWorldBookEntriesVectorState(batch.map((entry) => entry.id), "error", null, message);
       progress.failed += batch.length;
       progress.current += batch.length;
-      options?.onProgress?.({ ...progress });
+      emitProgress();
     }
   }
 


### PR DESCRIPTION
## Summary

This PR fixes a failure path in world-book vector reindexing that could break the `Convert to Vectorized` flow when large books took too long between progress updates. In practice, this showed up easily on books where many or all entries needed full vectorization, including cases where entries had no keywords.

## What changed

### Reindex progress streaming

- Hardened the SSE progress stream used by world-book reindexing
- Added heartbeat messages so long-running reindex requests are less likely to time out while work is still in progress
- Made stream writes safe after disconnect/timeout so the backend no longer throws when the controller has already closed

### Reindex progress callback handling

- Wrapped `onProgress` emissions in a guarded helper inside the embeddings service
- Progress callback failures are now logged as progress-stream issues instead of being treated as embedding batch failures
- Reindexing can continue even if the client-side progress stream drops mid-run

## Root cause

The actual indexing work was not inherently failing because entries had no keywords. The real issue was:

1. the live progress stream could time out during a long reindex
2. the backend then tried to send another progress update to the closed stream
3. that thrown error was treated like the embedding batch itself had failed

This PR separates those concerns so a dead progress connection no longer poisons the indexing run.

## Files changed

- `src/routes/embeddings.routes.ts`
- `src/services/embeddings.service.ts`

## Result

`Convert to Vectorized` should now be much more reliable for large or slow world-book reindexes, including books where none of the entries have keywords.