### PR TITLE
Add Memory Cortex diagnostics UI and API types

### DIFF
--- a/frontend/src/api/memory-cortex.ts
+++ b/frontend/src/api/memory-cortex.ts
@@ -80,6 +80,83 @@ export interface CortexUsageStats {
   estimatedEmbeddingCalls: number;
 }
 
+export interface CortexHealthCheck {
+  key: string;
+  label: string;
+  status: "pass" | "warn" | "fail" | "info";
+  message: string;
+}
+
+export interface CortexHealthReport {
+  generatedAt: string;
+  healthy: boolean;
+  summary: {
+    failures: number;
+    warnings: number;
+    passes: number;
+    info: number;
+  };
+  config: {
+    enabled: boolean;
+    presetMode: "simple" | "standard" | "advanced" | null;
+    formatterMode: "shadow" | "attributed" | "clinical" | "minimal";
+    entityExtractionMode: "heuristic" | "sidecar" | "off";
+    salienceScoringMode: "heuristic" | "sidecar";
+    sidecarConnectionProfileId: string | null;
+  };
+  embeddings: {
+    enabled: boolean;
+    hasApiKey: boolean;
+    vectorizeChatMessages: boolean;
+    provider: string;
+    model: string;
+    dimensions: number | null;
+    ready: boolean;
+    connectivity: {
+      attempted: boolean;
+      success: boolean | null;
+      message: string;
+      dimension: number | null;
+    };
+  };
+  sidecar: {
+    required: boolean;
+    configured: boolean;
+    connectionProfileId: string | null;
+    connectionName: string | null;
+    provider: string | null;
+    model: string | null;
+    hasApiKey: boolean;
+    ready: boolean;
+    connectivity: {
+      attempted: boolean;
+      success: boolean | null;
+      message: string;
+    };
+  };
+  chat: {
+    id: string;
+    name: string | null;
+    exists: boolean;
+    messageCount: number;
+    chunkCount: number;
+    vectorizedChunkCount: number;
+    pendingChunkCount: number;
+    entityCount: number;
+    activeEntityCount: number;
+    relationCount: number;
+    consolidationCount: number;
+    rebuildStatus: {
+      status: string;
+      current?: number;
+      total?: number;
+      percent?: number;
+      error?: string;
+    };
+  } | null;
+  checks: CortexHealthCheck[];
+}
+
 // ─── API ───────────────────────────────────────────────────────
 
 const BASE = "/memory-cortex";
@@ -89,6 +166,11 @@ export const memoryCortexApi = {
   getConfig: () => get<CortexConfig>(`${BASE}/config`),
   updateConfig: (data: Partial<CortexConfig>) => put<CortexConfig>(`${BASE}/config`, data),
   applyPreset: (mode: string) => post<CortexConfig>(`${BASE}/config/preset`, { mode }),
+  getHealth: (options?: { chatId?: string; probeConnectivity?: boolean }) =>
+    get<CortexHealthReport>(`${BASE}/health`, {
+      chatId: options?.chatId,
+      probeConnectivity: options?.probeConnectivity ? "1" : undefined,
+    }),
 
   // Entities
   getEntities: (chatId: string, status?: string) =>

--- a/frontend/src/components/modals/MemoryCortexDiagnosticsModal.module.css
+++ b/frontend/src/components/modals/MemoryCortexDiagnosticsModal.module.css
@@ -1,0 +1,403 @@
+.modal {
+  width: min(1100px, calc(100vw - 40px));
+  min-height: 0;
+}
+
+.shell {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-shrink: 0;
+  gap: 16px;
+  padding: 22px 24px 16px;
+  border-bottom: 1px solid var(--lumiverse-border);
+  background: var(--lumiverse-fill-subtle);
+}
+
+.titleWrap {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.eyebrow {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--lumiverse-text-dim);
+}
+
+.title {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--lumiverse-text);
+}
+
+.subtitle {
+  margin: 0;
+  max-width: 760px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--lumiverse-text-muted);
+}
+
+.headerActions {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  gap: 18px;
+  min-height: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+  padding: 18px 24px 24px;
+  background: var(--lumiverse-bg-deep);
+}
+
+.actionBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--lumiverse-border);
+  background: transparent;
+  color: var(--lumiverse-text);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--lumiverse-transition-fast);
+}
+
+.actionBtn:hover:not(:disabled) {
+  background: var(--lumiverse-fill-subtle);
+}
+
+.actionBtn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.actionBtnDone {
+  border-color: rgba(76, 175, 80, 0.35);
+  color: #4caf50;
+}
+
+.actionBtnError {
+  border-color: rgba(255, 107, 107, 0.25);
+  color: #ff6b6b;
+}
+
+.overview {
+  border-radius: 14px;
+  border: 1px solid var(--lumiverse-border);
+  padding: 16px 18px;
+}
+
+.overviewPass {
+  background: rgba(76, 175, 80, 0.08);
+  border-color: rgba(76, 175, 80, 0.28);
+}
+
+.overviewWarn {
+  background: rgba(255, 152, 0, 0.08);
+  border-color: rgba(255, 152, 0, 0.28);
+}
+
+.overviewFail {
+  background: rgba(255, 107, 107, 0.08);
+  border-color: rgba(255, 107, 107, 0.28);
+}
+
+.overviewInfo {
+  background: var(--lumiverse-fill-subtle);
+}
+
+.overviewHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+}
+
+.overviewTitleWrap {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  min-width: 0;
+  color: var(--lumiverse-text);
+}
+
+.overviewTitle {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.overviewMeta {
+  margin-top: 2px;
+  font-size: 12px;
+  color: var(--lumiverse-text-muted);
+}
+
+.summaryGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  min-width: 260px;
+}
+
+.summaryItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.summaryValue {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--lumiverse-text);
+}
+
+.summaryLabel {
+  font-size: 11px;
+  color: var(--lumiverse-text-muted);
+}
+
+.section {
+  border: 1px solid var(--lumiverse-border);
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--lumiverse-bg);
+}
+
+.sectionHeader {
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--lumiverse-border);
+  background: var(--lumiverse-fill-subtle);
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--lumiverse-text);
+}
+
+.checkList {
+  display: flex;
+  flex-direction: column;
+}
+
+.checkListWrap {
+  max-height: 340px;
+  overflow: auto;
+  scrollbar-gutter: stable;
+  overscroll-behavior: contain;
+  box-sizing: border-box;
+}
+
+.checkRow {
+  padding: 12px 14px;
+  border-top: 1px solid var(--lumiverse-border);
+}
+
+.checkRow:first-child {
+  border-top: none;
+}
+
+.checkTop {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+}
+
+.checkLabel {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--lumiverse-text);
+}
+
+.checkMessage {
+  margin-top: 6px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--lumiverse-text-muted);
+}
+
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 54px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--lumiverse-border);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.statusPass {
+  background: rgba(76, 175, 80, 0.12);
+  color: #4caf50;
+  border-color: rgba(76, 175, 80, 0.25);
+}
+
+.statusWarn {
+  background: rgba(255, 152, 0, 0.12);
+  color: #ff9800;
+  border-color: rgba(255, 152, 0, 0.25);
+}
+
+.statusFail {
+  background: rgba(255, 107, 107, 0.12);
+  color: #ff6b6b;
+  border-color: rgba(255, 107, 107, 0.25);
+}
+
+.statusInfo {
+  background: rgba(125, 125, 125, 0.12);
+  color: var(--lumiverse-text-dim);
+  border-color: rgba(125, 125, 125, 0.2);
+}
+
+.detailGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.metaList {
+  display: flex;
+  flex-direction: column;
+}
+
+.selectedChatWrap {
+  max-height: 260px;
+  overflow: auto;
+  scrollbar-gutter: stable;
+  overscroll-behavior: contain;
+  box-sizing: border-box;
+}
+
+.scrollSpacer {
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.metaRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  border-top: 1px solid var(--lumiverse-border);
+  font-size: 12px;
+}
+
+.metaRow:first-child {
+  border-top: none;
+}
+
+.metaRow span {
+  color: var(--lumiverse-text-muted);
+}
+
+.metaRow strong {
+  color: var(--lumiverse-text);
+  text-align: right;
+  font-weight: 600;
+}
+
+.loadingRow,
+.emptyRow {
+  padding: 16px 14px;
+  font-size: 12px;
+  color: var(--lumiverse-text-muted);
+}
+
+.errorState {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 107, 107, 0.25);
+  background: rgba(255, 107, 107, 0.08);
+  color: #ff6b6b;
+}
+
+.spinning {
+  animation: spin 1s linear infinite;
+}
+
+@media (max-width: 920px) {
+  .detailGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .overviewHeader {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+@media (max-width: 720px) {
+  .modal {
+    width: min(100vw - 24px, 1100px);
+  }
+
+  .header {
+    flex-direction: column;
+  }
+
+  .headerActions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .actions {
+    flex-wrap: wrap;
+  }
+
+  .body {
+    padding: 16px;
+  }
+
+  .summaryGrid {
+    min-width: 0;
+  }
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/src/components/modals/MemoryCortexDiagnosticsModal.tsx
+++ b/frontend/src/components/modals/MemoryCortexDiagnosticsModal.tsx
@@ -1,0 +1,353 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Activity, AlertTriangle, CheckCircle2, Copy, RefreshCw } from 'lucide-react'
+import clsx from 'clsx'
+import { memoryCortexApi, type CortexHealthCheck, type CortexHealthReport } from '@/api/memory-cortex'
+import { ModalShell } from '@/components/shared/ModalShell'
+import { CloseButton } from '@/components/shared/CloseButton'
+import styles from './MemoryCortexDiagnosticsModal.module.css'
+
+function formatCheckLabel(status: CortexHealthCheck['status']) {
+  switch (status) {
+    case 'pass':
+      return 'Pass'
+    case 'warn':
+      return 'Warn'
+    case 'fail':
+      return 'Fail'
+    default:
+      return 'Info'
+  }
+}
+
+async function copyTextToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text)
+    return
+  }
+
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.setAttribute('readonly', 'true')
+  textarea.style.position = 'fixed'
+  textarea.style.opacity = '0'
+  textarea.style.pointerEvents = 'none'
+  document.body.appendChild(textarea)
+  textarea.select()
+  textarea.setSelectionRange(0, textarea.value.length)
+
+  try {
+    const successful = document.execCommand('copy')
+    if (!successful) {
+      throw new Error('Copy command failed.')
+    }
+  } finally {
+    document.body.removeChild(textarea)
+  }
+}
+
+function buildReportText(report: CortexHealthReport): string {
+  const lines: string[] = []
+
+  lines.push('Memory Cortex Diagnostics')
+  lines.push(`Generated: ${new Date(report.generatedAt).toLocaleString()}`)
+  lines.push(`Overall: ${report.healthy ? 'Healthy' : 'Needs attention'}`)
+  lines.push('')
+
+  lines.push('Summary')
+  lines.push(`- Failures: ${report.summary.failures}`)
+  lines.push(`- Warnings: ${report.summary.warnings}`)
+  lines.push(`- Passes: ${report.summary.passes}`)
+  lines.push(`- Info: ${report.summary.info}`)
+  lines.push('')
+
+  lines.push('Checks')
+  for (const check of report.checks) {
+    lines.push(`- [${formatCheckLabel(check.status)}] ${check.label}: ${check.message}`)
+  }
+  lines.push('')
+
+  lines.push('Config')
+  lines.push(`- Enabled: ${report.config.enabled ? 'Yes' : 'No'}`)
+  lines.push(`- Preset: ${report.config.presetMode ?? 'manual'}`)
+  lines.push(`- Entity extraction: ${report.config.entityExtractionMode}`)
+  lines.push(`- Salience scoring: ${report.config.salienceScoringMode}`)
+  lines.push(`- Formatter: ${report.config.formatterMode}`)
+  lines.push('')
+
+  lines.push('Embeddings')
+  lines.push(`- Enabled: ${report.embeddings.enabled ? 'Yes' : 'No'}`)
+  lines.push(`- API key: ${report.embeddings.hasApiKey ? 'Present' : 'Missing'}`)
+  lines.push(`- Vectorize chat messages: ${report.embeddings.vectorizeChatMessages ? 'Yes' : 'No'}`)
+  lines.push(`- Provider/model: ${report.embeddings.provider || 'N/A'} / ${report.embeddings.model || 'N/A'}`)
+  lines.push(`- Dimensions: ${report.embeddings.dimensions ?? 'Unknown'}`)
+  lines.push(`- Connectivity: ${report.embeddings.connectivity.message}`)
+  lines.push('')
+
+  lines.push('Sidecar')
+  lines.push(`- Required: ${report.sidecar.required ? 'Yes' : 'No'}`)
+  lines.push(`- Configured: ${report.sidecar.configured ? 'Yes' : 'No'}`)
+  lines.push(`- Connection: ${report.sidecar.connectionName ?? 'None'}`)
+  lines.push(`- Provider/model: ${report.sidecar.provider ?? 'N/A'} / ${report.sidecar.model ?? 'Default'}`)
+  lines.push(`- API key: ${report.sidecar.hasApiKey ? 'Ready' : 'Missing or not required'}`)
+  lines.push(`- Connectivity: ${report.sidecar.connectivity.message}`)
+  lines.push('')
+
+  lines.push('Chat')
+  if (!report.chat) {
+    lines.push('- No chat selected')
+  } else if (!report.chat.exists) {
+    lines.push(`- Requested chat was not found: ${report.chat.id}`)
+  } else {
+    lines.push(`- Chat: ${report.chat.name ?? report.chat.id}`)
+    lines.push(`- Messages: ${report.chat.messageCount}`)
+    lines.push(`- Chunks: ${report.chat.chunkCount}`)
+    lines.push(`- Vectorized chunks: ${report.chat.vectorizedChunkCount}`)
+    lines.push(`- Pending chunks: ${report.chat.pendingChunkCount}`)
+    lines.push(`- Entities: ${report.chat.entityCount} (${report.chat.activeEntityCount} active)`)
+    lines.push(`- Relations: ${report.chat.relationCount}`)
+    lines.push(`- Consolidations: ${report.chat.consolidationCount}`)
+    lines.push(`- Rebuild status: ${report.chat.rebuildStatus.status}`)
+  }
+
+  return lines.join('\n')
+}
+
+function StatusBadge({ status }: { status: CortexHealthCheck['status'] }) {
+  return (
+    <span
+      className={clsx(
+        styles.statusBadge,
+        status === 'pass' && styles.statusPass,
+        status === 'warn' && styles.statusWarn,
+        status === 'fail' && styles.statusFail,
+        status === 'info' && styles.statusInfo,
+      )}
+    >
+      {formatCheckLabel(status)}
+    </span>
+  )
+}
+
+interface Props {
+  chatId?: string | null
+  onClose: () => void
+}
+
+export default function MemoryCortexDiagnosticsModal({ chatId, onClose }: Props) {
+  const [report, setReport] = useState<CortexHealthReport | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'error'>('idle')
+
+  const loadReport = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const nextReport = await memoryCortexApi.getHealth({
+        chatId: chatId || undefined,
+        probeConnectivity: true,
+      })
+      setReport(nextReport)
+    } catch (err: any) {
+      setReport(null)
+      setError(err?.body?.error || err?.message || 'Failed to load Memory Cortex diagnostics.')
+    } finally {
+      setLoading(false)
+    }
+  }, [chatId])
+
+  useEffect(() => {
+    void loadReport()
+  }, [loadReport])
+
+  const handleCopy = useCallback(async () => {
+    if (!report) return
+
+    try {
+      await copyTextToClipboard(buildReportText(report))
+      setCopyState('copied')
+    } catch {
+      setCopyState('error')
+    }
+
+    window.setTimeout(() => setCopyState('idle'), 2000)
+  }, [report])
+
+  const overallTone = useMemo(() => {
+    if (!report) return 'info'
+    if (report.summary.failures > 0) return 'fail'
+    if (report.summary.warnings > 0) return 'warn'
+    return 'pass'
+  }, [report])
+
+  return (
+    <ModalShell
+      isOpen={true}
+      onClose={onClose}
+      maxWidth={1100}
+      maxHeight="88vh"
+      className={styles.modal}
+    >
+      <div className={styles.shell}>
+        <div className={styles.header}>
+          <div className={styles.titleWrap}>
+            <div className={styles.eyebrow}>Popup Diagnostics</div>
+            <h2 className={styles.title}>Memory Cortex Diagnostics</h2>
+            <p className={styles.subtitle}>
+              Focused health checks for cortex setup, embeddings, sidecar readiness, and the selected chat.
+              {chatId ? ` Chat: ${chatId}` : ' Open this from an active chat for chat-specific checks.'}
+            </p>
+          </div>
+
+          <div className={styles.headerActions}>
+            <div className={styles.actions}>
+              <button type="button" className={styles.actionBtn} onClick={() => void loadReport()} disabled={loading}>
+                <RefreshCw size={15} className={loading ? styles.spinning : undefined} />
+                Refresh
+              </button>
+              <button
+                type="button"
+                className={clsx(
+                  styles.actionBtn,
+                  copyState === 'copied' && styles.actionBtnDone,
+                  copyState === 'error' && styles.actionBtnError,
+                )}
+                onClick={() => void handleCopy()}
+                disabled={!report}
+              >
+                <Copy size={15} />
+                {copyState === 'copied' ? 'Copied' : copyState === 'error' ? 'Copy failed' : 'Copy Report'}
+              </button>
+            </div>
+            <CloseButton onClick={onClose} />
+          </div>
+        </div>
+
+        <div className={styles.body}>
+          {error ? (
+            <div className={styles.errorState}>
+              <AlertTriangle size={18} />
+              <span>{error}</span>
+            </div>
+          ) : (
+            <>
+              <div
+                className={clsx(
+                  styles.overview,
+                  overallTone === 'pass' && styles.overviewPass,
+                  overallTone === 'warn' && styles.overviewWarn,
+                  overallTone === 'fail' && styles.overviewFail,
+                  overallTone === 'info' && styles.overviewInfo,
+                )}
+              >
+                <div className={styles.overviewHeader}>
+                  <div className={styles.overviewTitleWrap}>
+                    {overallTone === 'pass' ? <CheckCircle2 size={18} /> : overallTone === 'fail' ? <AlertTriangle size={18} /> : <Activity size={18} />}
+                    <div>
+                      <div className={styles.overviewTitle}>
+                        {!report ? 'Loading health report...' : report.healthy ? 'Memory Cortex looks healthy' : 'Memory Cortex needs attention'}
+                      </div>
+                      <div className={styles.overviewMeta}>
+                        {report ? `Generated ${new Date(report.generatedAt).toLocaleString()}` : 'Running live health checks'}
+                      </div>
+                    </div>
+                  </div>
+                  {report && (
+                    <div className={styles.summaryGrid}>
+                      <div className={styles.summaryItem}>
+                        <span className={styles.summaryValue}>{report.summary.failures}</span>
+                        <span className={styles.summaryLabel}>Failures</span>
+                      </div>
+                      <div className={styles.summaryItem}>
+                        <span className={styles.summaryValue}>{report.summary.warnings}</span>
+                        <span className={styles.summaryLabel}>Warnings</span>
+                      </div>
+                      <div className={styles.summaryItem}>
+                        <span className={styles.summaryValue}>{report.summary.passes}</span>
+                        <span className={styles.summaryLabel}>Passes</span>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div className={styles.section}>
+                <div className={styles.sectionHeader}>Checks</div>
+                {loading && !report ? (
+                  <div className={styles.loadingRow}>Running diagnostics...</div>
+                ) : (
+                  <div className={styles.checkListWrap}>
+                    <div className={styles.checkList}>
+                      {report?.checks.map((check) => (
+                        <div key={check.key} className={styles.checkRow}>
+                          <div className={styles.checkTop}>
+                            <div className={styles.checkLabel}>{check.label}</div>
+                            <StatusBadge status={check.status} />
+                          </div>
+                          <div className={styles.checkMessage}>{check.message}</div>
+                        </div>
+                      ))}
+                      <div className={styles.scrollSpacer} aria-hidden="true" />
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className={styles.detailGrid}>
+                <div className={styles.section}>
+                  <div className={styles.sectionHeader}>Embeddings</div>
+                  <div className={styles.metaList}>
+                    <div className={styles.metaRow}><span>Enabled</span><strong>{report?.embeddings.enabled ? 'Yes' : 'No'}</strong></div>
+                    <div className={styles.metaRow}><span>API key</span><strong>{report?.embeddings.hasApiKey ? 'Present' : 'Missing'}</strong></div>
+                    <div className={styles.metaRow}><span>Vectorize chat messages</span><strong>{report?.embeddings.vectorizeChatMessages ? 'Yes' : 'No'}</strong></div>
+                    <div className={styles.metaRow}><span>Provider</span><strong>{report?.embeddings.provider ?? 'N/A'}</strong></div>
+                    <div className={styles.metaRow}><span>Model</span><strong>{report?.embeddings.model ?? 'N/A'}</strong></div>
+                    <div className={styles.metaRow}><span>Dimensions</span><strong>{report?.embeddings.dimensions ?? 'Unknown'}</strong></div>
+                    <div className={styles.metaRow}><span>Live probe</span><strong>{report?.embeddings.connectivity.message ?? 'N/A'}</strong></div>
+                  </div>
+                </div>
+
+                <div className={styles.section}>
+                  <div className={styles.sectionHeader}>Sidecar</div>
+                  <div className={styles.metaList}>
+                    <div className={styles.metaRow}><span>Required</span><strong>{report?.sidecar.required ? 'Yes' : 'No'}</strong></div>
+                    <div className={styles.metaRow}><span>Configured</span><strong>{report?.sidecar.configured ? 'Yes' : 'No'}</strong></div>
+                    <div className={styles.metaRow}><span>Connection</span><strong>{report?.sidecar.connectionName ?? 'None'}</strong></div>
+                    <div className={styles.metaRow}><span>Provider</span><strong>{report?.sidecar.provider ?? 'N/A'}</strong></div>
+                    <div className={styles.metaRow}><span>Model</span><strong>{report?.sidecar.model ?? 'Default'}</strong></div>
+                    <div className={styles.metaRow}><span>API key</span><strong>{report?.sidecar.hasApiKey ? 'Ready' : 'Missing / not required'}</strong></div>
+                    <div className={styles.metaRow}><span>Live probe</span><strong>{report?.sidecar.connectivity.message ?? 'N/A'}</strong></div>
+                  </div>
+                </div>
+              </div>
+
+              <div className={styles.section}>
+                <div className={styles.sectionHeader}>Selected Chat</div>
+                {!report?.chat ? (
+                  <div className={styles.emptyRow}>No chat was selected when this popup was opened.</div>
+                ) : !report.chat.exists ? (
+                  <div className={styles.emptyRow}>The requested chat could not be found.</div>
+                ) : (
+                  <div className={styles.selectedChatWrap}>
+                    <div className={styles.metaList}>
+                      <div className={styles.metaRow}><span>Name</span><strong>{report.chat.name ?? report.chat.id}</strong></div>
+                      <div className={styles.metaRow}><span>Messages</span><strong>{report.chat.messageCount}</strong></div>
+                      <div className={styles.metaRow}><span>Chunks</span><strong>{report.chat.chunkCount}</strong></div>
+                      <div className={styles.metaRow}><span>Vectorized chunks</span><strong>{report.chat.vectorizedChunkCount}</strong></div>
+                      <div className={styles.metaRow}><span>Pending chunks</span><strong>{report.chat.pendingChunkCount}</strong></div>
+                      <div className={styles.metaRow}><span>Entities</span><strong>{report.chat.entityCount} ({report.chat.activeEntityCount} active)</strong></div>
+                      <div className={styles.metaRow}><span>Relations</span><strong>{report.chat.relationCount}</strong></div>
+                      <div className={styles.metaRow}><span>Consolidations</span><strong>{report.chat.consolidationCount}</strong></div>
+                      <div className={styles.metaRow}><span>Rebuild status</span><strong>{report.chat.rebuildStatus.status}</strong></div>
+                      <div className={styles.scrollSpacer} aria-hidden="true" />
+                    </div>
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </ModalShell>
+  )
+}

--- a/frontend/src/components/modals/ModalContainer.tsx
+++ b/frontend/src/components/modals/ModalContainer.tsx
@@ -13,6 +13,7 @@ import GroupChatCreatorModal from './GroupChatCreatorModal'
 import AddGroupMemberModal from '@/components/chat/AddGroupMemberModal'
 import ManageChatsModal from './ManageChatsModal'
 import ChatPickerModal from './ChatPickerModal'
+import MemoryCortexDiagnosticsModal from './MemoryCortexDiagnosticsModal'
 import PermissionRequestModal from './PermissionRequestModal'
 import CommandPalette from './CommandPalette'
 import RegexEditorModal from './RegexEditorModal'
@@ -98,6 +99,12 @@ export default function ModalContainer() {
       {activeModal === 'regexImport' && <RegexImportModal />}
       {activeModal === 'personaAddons' && <PersonaAddonsModal />}
       {activeModal === 'groupSettings' && <GroupSettingsModal />}
+      {activeModal === 'memoryCortexDiagnostics' && (
+        <MemoryCortexDiagnosticsModal
+          chatId={modalProps.chatId}
+          onClose={closeModal}
+        />
+      )}
 
       {activeModal === 'regenFeedback' && (
         <RegenFeedbackModal

--- a/frontend/src/components/settings/MemoryCortexSettings.module.css
+++ b/frontend/src/components/settings/MemoryCortexSettings.module.css
@@ -409,6 +409,18 @@
 
 /* ── Spinner ────────────────────────────────────────────────────── */
 
+@media (max-width: 680px) {
+  .sectionHeader {
+    flex-wrap: wrap;
+  }
+
+  .sectionHeaderActions {
+    width: 100%;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+  }
+}
+
 @keyframes spin {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }

--- a/frontend/src/components/settings/MemoryCortexSettings.tsx
+++ b/frontend/src/components/settings/MemoryCortexSettings.tsx
@@ -4,6 +4,7 @@ import {
   Sparkles,
   Users,
   Network,
+  Activity,
   BarChart3,
   RefreshCw,
   ChevronDown,
@@ -55,6 +56,7 @@ const FORMATTER_OPTIONS = [
 
 export default function MemoryCortexSettings() {
   const addToast = useStore((s) => s.addToast);
+  const openModal = useStore((s) => s.openModal);
   const [config, setConfig] = useState<CortexConfig | null>(null);
   const [stats, setStats] = useState<CortexUsageStats | null>(null);
   const [loading, setLoading] = useState(true);
@@ -70,6 +72,10 @@ export default function MemoryCortexSettings() {
 
   // Active chat for stats (if available)
   const activeChatId = useStore((s) => s.activeChatId);
+
+  const handleOpenDiagnostics = useCallback(() => {
+    openModal("memoryCortexDiagnostics", { chatId: activeChatId || null });
+  }, [activeChatId, openModal]);
 
   // Fetch models when sidecar connection changes
   const fetchModels = useCallback(async (connectionId: string | null) => {
@@ -229,6 +235,10 @@ export default function MemoryCortexSettings() {
           <Brain size={14} />
           <span>Memory Cortex</span>
           <div className={styles.sectionHeaderActions}>
+            <button type="button" className={styles.actionBtn} onClick={handleOpenDiagnostics}>
+              <Activity size={12} />
+              Diagnostics
+            </button>
             <span className={clsx(styles.statusDot, config.enabled ? styles.statusActive : styles.statusInactive)} />
             <span className={styles.statusLabel}>{config.enabled ? "Active" : "Off"}</span>
           </div>

--- a/src/routes/memory-cortex.routes.ts
+++ b/src/routes/memory-cortex.routes.ts
@@ -10,6 +10,11 @@
  */
 
 import { Hono } from "hono";
+import { getDb } from "../db/connection";
+import { getProvider } from "../llm/registry";
+import * as chatsSvc from "../services/chats.service";
+import * as connectionsSvc from "../services/connections.service";
+import * as embeddingsSvc from "../services/embeddings.service";
 import * as memoryCortex from "../services/memory-cortex";
 import { getCharacter } from "../services/characters.service";
 import { getChat } from "../services/chats.service";
@@ -46,6 +51,402 @@ app.post("/config/preset", async (c) => {
 });
 
 // ─── Entities ──────────────────────────────────────────────────
+
+/** GET /health — Diagnose common Memory Cortex blockers and readiness */
+app.get("/health", async (c) => {
+  const userId = c.get("userId");
+  const chatId = c.req.query("chatId")?.trim() || null;
+  const probeConnectivity = ["1", "true", "yes", "on"].includes(
+    (c.req.query("probeConnectivity") || "").toLowerCase(),
+  );
+
+  const config = memoryCortex.getCortexConfig(userId);
+  const embeddings = await embeddingsSvc.getEmbeddingConfig(userId);
+
+  const checks: Array<{
+    key: string;
+    label: string;
+    status: "pass" | "warn" | "fail" | "info";
+    message: string;
+  }> = [];
+
+  const pushCheck = (
+    key: string,
+    label: string,
+    status: "pass" | "warn" | "fail" | "info",
+    message: string,
+  ) => {
+    checks.push({ key, label, status, message });
+  };
+
+  pushCheck(
+    "cortex_enabled",
+    "Memory Cortex enabled",
+    config.enabled ? "pass" : "warn",
+    config.enabled
+      ? "Memory Cortex is enabled."
+      : "Memory Cortex is turned off. Turn it on before expecting entity tracking or cortex retrieval.",
+  );
+
+  pushCheck(
+    "embeddings_enabled",
+    "Embeddings enabled",
+    embeddings.enabled ? "pass" : "fail",
+    embeddings.enabled
+      ? "Embeddings are enabled."
+      : "Embeddings are off. Chat chunks and long-term memory vectorization will not run until embeddings are enabled.",
+  );
+
+  pushCheck(
+    "chat_vectorization_enabled",
+    "Chat vectorization enabled",
+    embeddings.vectorize_chat_messages ? "pass" : "fail",
+    embeddings.vectorize_chat_messages
+      ? "Chat message vectorization is enabled."
+      : "Vectorize Chat Messages is off. Memory Cortex depends on chat_chunks being created from chat memory.",
+  );
+
+  pushCheck(
+    "embedding_api_key",
+    "Embedding API key",
+    embeddings.has_api_key ? "pass" : "fail",
+    embeddings.has_api_key
+      ? "An embedding API key is configured."
+      : "No embedding API key is configured. Embeddings cannot be generated until a key is saved.",
+  );
+
+  pushCheck(
+    "embedding_dimensions",
+    "Embedding dimensions",
+    embeddings.dimensions ? "pass" : "warn",
+    embeddings.dimensions
+      ? `Embedding dimensions are set to ${embeddings.dimensions}.`
+      : "Embedding dimensions have not been confirmed yet. Running a live probe will verify the embedding connection.",
+  );
+
+  let embeddingConnectivity: {
+    attempted: boolean;
+    success: boolean | null;
+    message: string;
+    dimension: number | null;
+  } = {
+    attempted: false,
+    success: null,
+    message: "Live embedding probe not run.",
+    dimension: embeddings.dimensions,
+  };
+
+  if (probeConnectivity && embeddings.enabled && embeddings.has_api_key) {
+    try {
+      const result = await embeddingsSvc.testEmbeddingConfig(userId, "Memory Cortex health check.");
+      embeddingConnectivity = {
+        attempted: true,
+        success: true,
+        message: `Embedding request succeeded (${result.dimension} dimensions).`,
+        dimension: result.dimension,
+      };
+      pushCheck(
+        "embedding_probe",
+        "Embedding connectivity",
+        "pass",
+        embeddingConnectivity.message,
+      );
+    } catch (err: any) {
+      const message = err?.message || "Embedding probe failed.";
+      embeddingConnectivity = {
+        attempted: true,
+        success: false,
+        message,
+        dimension: embeddings.dimensions,
+      };
+      pushCheck(
+        "embedding_probe",
+        "Embedding connectivity",
+        "fail",
+        message,
+      );
+    }
+  }
+
+  const sidecarConnectionId = config.sidecar?.connectionProfileId || null;
+  const sidecarRequired =
+    config.entityExtractionMode === "sidecar" ||
+    config.salienceScoringMode === "sidecar" ||
+    config.consolidation.useSidecar;
+
+  const sidecarProfile = sidecarConnectionId
+    ? connectionsSvc.getConnection(userId, sidecarConnectionId)
+    : null;
+  const sidecarProvider = sidecarProfile ? getProvider(sidecarProfile.provider) : null;
+  const sidecarApiKeyRequired = sidecarProvider?.capabilities.apiKeyRequired ?? true;
+  const sidecarHasApiKey = sidecarProfile
+    ? (!sidecarApiKeyRequired || !!sidecarProfile.has_api_key)
+    : false;
+  const sidecarReady = !sidecarRequired || !!(sidecarProfile && sidecarProvider && sidecarHasApiKey);
+
+  if (sidecarRequired && !sidecarConnectionId) {
+    pushCheck(
+      "sidecar_required",
+      "Sidecar connection",
+      "fail",
+      "Sidecar-assisted cortex features are enabled, but no sidecar connection is selected.",
+    );
+  } else if (sidecarConnectionId && !sidecarProfile) {
+    pushCheck(
+      "sidecar_exists",
+      "Sidecar connection",
+      sidecarRequired ? "fail" : "warn",
+      "The selected sidecar connection profile no longer exists.",
+    );
+  } else if (sidecarConnectionId && !sidecarProvider) {
+    pushCheck(
+      "sidecar_provider",
+      "Sidecar provider",
+      sidecarRequired ? "fail" : "warn",
+      `The selected provider "${sidecarProfile?.provider}" is not available.`,
+    );
+  } else if (sidecarConnectionId && !sidecarHasApiKey) {
+    pushCheck(
+      "sidecar_api_key",
+      "Sidecar API key",
+      sidecarRequired ? "fail" : "warn",
+      "The selected sidecar connection is missing its API key.",
+    );
+  } else if (sidecarRequired) {
+    pushCheck(
+      "sidecar_ready",
+      "Sidecar readiness",
+      "pass",
+      "A valid sidecar connection is configured for cortex features that require it.",
+    );
+  } else if (sidecarConnectionId) {
+    pushCheck(
+      "sidecar_optional",
+      "Sidecar connection",
+      "info",
+      "A sidecar connection is configured, but current cortex modes can still run in heuristic mode.",
+    );
+  } else {
+    pushCheck(
+      "sidecar_optional",
+      "Sidecar connection",
+      "info",
+      "No sidecar connection is configured. Heuristic cortex mode can still run without it.",
+    );
+  }
+
+  let sidecarConnectivity: {
+    attempted: boolean;
+    success: boolean | null;
+    message: string;
+  } = {
+    attempted: false,
+    success: null,
+    message: "Live sidecar probe not run.",
+  };
+
+  if (probeConnectivity && sidecarConnectionId && sidecarProfile) {
+    const result = await connectionsSvc.testConnection(userId, sidecarConnectionId);
+    sidecarConnectivity = {
+      attempted: true,
+      success: result.success,
+      message: result.message,
+    };
+    pushCheck(
+      "sidecar_probe",
+      "Sidecar connectivity",
+      result.success ? "pass" : "fail",
+      result.message,
+    );
+  }
+
+  let chatReport: {
+    id: string;
+    name: string | null;
+    exists: boolean;
+    messageCount: number;
+    chunkCount: number;
+    vectorizedChunkCount: number;
+    pendingChunkCount: number;
+    entityCount: number;
+    activeEntityCount: number;
+    relationCount: number;
+    consolidationCount: number;
+    rebuildStatus: any;
+  } | null = null;
+
+  if (chatId) {
+    const chat = getChat(userId, chatId);
+    if (!chat) {
+      chatReport = {
+        id: chatId,
+        name: null,
+        exists: false,
+        messageCount: 0,
+        chunkCount: 0,
+        vectorizedChunkCount: 0,
+        pendingChunkCount: 0,
+        entityCount: 0,
+        activeEntityCount: 0,
+        relationCount: 0,
+        consolidationCount: 0,
+        rebuildStatus: { status: "idle" },
+      };
+      pushCheck(
+        "chat_exists",
+        "Selected chat",
+        "fail",
+        "The requested chat could not be found.",
+      );
+    } else {
+      const db = getDb();
+      const messageCount = (db.query("SELECT COUNT(*) as c FROM messages WHERE chat_id = ?").get(chatId) as any)?.c ?? 0;
+      const vectorStatus = chatsSvc.getVectorizationStatus(userId, chatId);
+      const stats = memoryCortex.getCortexUsageStats(chatId);
+      const rebuildStatus = memoryCortex.getRebuildStatus(chatId) ?? { status: "idle" };
+
+      chatReport = {
+        id: chatId,
+        name: chat.name || null,
+        exists: true,
+        messageCount,
+        chunkCount: vectorStatus.totalChunks,
+        vectorizedChunkCount: vectorStatus.vectorizedChunks,
+        pendingChunkCount: vectorStatus.pendingChunks,
+        entityCount: stats.entityCount,
+        activeEntityCount: stats.activeEntityCount,
+        relationCount: stats.relationCount,
+        consolidationCount: stats.consolidationCount,
+        rebuildStatus,
+      };
+
+      pushCheck(
+        "chat_loaded",
+        "Selected chat",
+        "pass",
+        `Chat "${chat.name || chatId}" is available for diagnostics.`,
+      );
+
+      if (messageCount === 0) {
+        pushCheck(
+          "chat_messages",
+          "Chat messages",
+          "warn",
+          "This chat has no messages yet, so there is nothing for Memory Cortex to process.",
+        );
+      } else if (vectorStatus.totalChunks === 0) {
+        pushCheck(
+          "chat_chunks",
+          "Chat chunks",
+          "fail",
+          "No chat_chunks exist for this chat. Recompile chat memory after enabling chat vectorization.",
+        );
+      } else if (vectorStatus.vectorizedChunks === 0) {
+        pushCheck(
+          "chat_chunks_vectorized",
+          "Chunk vectorization",
+          "fail",
+          "Chat chunks exist, but none are vectorized yet. Check your embedding setup, then recompile chat memory.",
+        );
+      } else if (vectorStatus.pendingChunks > 0) {
+        pushCheck(
+          "chat_chunks_vectorized",
+          "Chunk vectorization",
+          "warn",
+          `${vectorStatus.pendingChunks} chat chunk(s) are still waiting on vectorization.`,
+        );
+      } else {
+        pushCheck(
+          "chat_chunks_vectorized",
+          "Chunk vectorization",
+          "pass",
+          "Chat chunks exist and are vectorized.",
+        );
+      }
+
+      if (rebuildStatus.status === "processing") {
+        pushCheck(
+          "cortex_rebuild",
+          "Cortex rebuild",
+          "info",
+          `A rebuild is currently running (${rebuildStatus.percent ?? 0}% complete).`,
+        );
+      } else if (stats.entityCount > 0 || stats.relationCount > 0 || stats.consolidationCount > 0) {
+        pushCheck(
+          "cortex_output",
+          "Cortex output",
+          "pass",
+          `Cortex data exists for this chat (${stats.entityCount} entities, ${stats.relationCount} relations).`,
+        );
+      } else if (messageCount >= 4 && config.enabled) {
+        pushCheck(
+          "cortex_output",
+          "Cortex output",
+          "warn",
+          "No cortex entities or relations were found for this chat yet. Run a rebuild after chat vectorization is healthy.",
+        );
+      } else {
+        pushCheck(
+          "cortex_output",
+          "Cortex output",
+          "info",
+          "This chat may still be too small for meaningful cortex extraction.",
+        );
+      }
+    }
+  } else {
+    pushCheck(
+      "chat_context",
+      "Selected chat",
+      "info",
+      "No chat was selected. Open diagnostics from an active chat to see chunk and cortex stats for that chat.",
+    );
+  }
+
+  const summary = {
+    failures: checks.filter((check) => check.status === "fail").length,
+    warnings: checks.filter((check) => check.status === "warn").length,
+    passes: checks.filter((check) => check.status === "pass").length,
+    info: checks.filter((check) => check.status === "info").length,
+  };
+
+  return c.json({
+    generatedAt: new Date().toISOString(),
+    healthy: summary.failures === 0,
+    summary,
+    config: {
+      enabled: config.enabled,
+      presetMode: config.presetMode,
+      formatterMode: config.formatterMode,
+      entityExtractionMode: config.entityExtractionMode,
+      salienceScoringMode: config.salienceScoringMode,
+      sidecarConnectionProfileId: sidecarConnectionId,
+    },
+    embeddings: {
+      enabled: embeddings.enabled,
+      hasApiKey: embeddings.has_api_key,
+      vectorizeChatMessages: embeddings.vectorize_chat_messages,
+      provider: embeddings.provider,
+      model: embeddings.model,
+      dimensions: embeddingConnectivity.dimension,
+      ready: embeddings.enabled && embeddings.vectorize_chat_messages && embeddings.has_api_key,
+      connectivity: embeddingConnectivity,
+    },
+    sidecar: {
+      required: sidecarRequired,
+      configured: !!sidecarConnectionId,
+      connectionProfileId: sidecarConnectionId,
+      connectionName: sidecarProfile?.name ?? null,
+      provider: sidecarProfile?.provider ?? null,
+      model: config.sidecar?.model || sidecarProfile?.model || null,
+      hasApiKey: sidecarHasApiKey,
+      ready: sidecarReady,
+      connectivity: sidecarConnectivity,
+    },
+    chat: chatReport,
+    checks,
+  });
+});
 
 /** GET /chats/:chatId/entities — List entities for a chat */
 app.get("/chats/:chatId/entities", (c) => {


### PR DESCRIPTION
## What changed

This adds a dedicated Memory Cortex diagnostics flow so setup issues are easier to understand without digging through config manually.

The change includes:
- a new `GET /memory-cortex/health` endpoint that reports cortex readiness, embedding status, sidecar readiness, and chat-specific diagnostics
- frontend API/types for consuming the diagnostics report
- a `Diagnostics` button in Memory Cortex settings
- an in-app popup modal for diagnostics instead of a separate page

## Why

Memory Cortex setup failures were hard to diagnose, especially when the problem was caused by one missing dependency or toggle such as:
- embeddings being disabled
- chat vectorization being disabled
- a missing embedding API key
- sidecar configuration issues
- chat chunks or vectorization not being present for the active chat

This change gives users one place to see the actual blocker.

## User impact

Users can now open Diagnostics directly from Memory Cortex settings and immediately see:
- whether Memory Cortex is enabled
- whether embeddings are configured and reachable
- whether the sidecar connection is valid
- whether the selected chat has chunks, vectors, and cortex output
- a copyable report for debugging/support

## Root cause

The main issue was not one specific backend bug. It was a lack of observability around Memory Cortex prerequisites and chat-level readiness, which made normal setup problems feel opaque.