### PR TITLE
Improve vector diagnostics clarity, fix Cortex Memory diagnostics typos, and restore vector terminology

### DIFF
--- a/frontend/src/components/modals/MemoryCortexDiagnosticsModal.tsx
+++ b/frontend/src/components/modals/MemoryCortexDiagnosticsModal.tsx
@@ -83,7 +83,7 @@ function buildReportText(report: CortexHealthReport): string {
   lines.push(`- Connectivity: ${report.embeddings.connectivity.message}`)
   lines.push('')
 
-  lines.push('Sidecar')
+  lines.push('Sidecard')
   lines.push(`- Required: ${report.sidecar.required ? 'Yes' : 'No'}`)
   lines.push(`- Configured: ${report.sidecar.configured ? 'Yes' : 'No'}`)
   lines.push(`- Connection: ${report.sidecar.connectionName ?? 'None'}`)
@@ -194,7 +194,7 @@ export default function MemoryCortexDiagnosticsModal({ chatId, onClose }: Props)
             <div className={styles.eyebrow}>Popup Diagnostics</div>
             <h2 className={styles.title}>Memory Cortex Diagnostics</h2>
             <p className={styles.subtitle}>
-              Focused health checks for cortex setup, embeddings, sidecar readiness, and the selected chat.
+              Focused health checks for cortex setup, embeddings, sidecard readiness, and the selected chat.
               {chatId ? ` Chat: ${chatId}` : ' Open this from an active chat for chat-specific checks.'}
             </p>
           </div>
@@ -287,7 +287,8 @@ export default function MemoryCortexDiagnosticsModal({ chatId, onClose }: Props)
                           <div className={styles.checkMessage}>{check.message}</div>
                         </div>
                       ))}
-                      </div>
+                      <div className={styles.scrollSpacer} aria-hidden="true" />
+                    </div>
                   </div>
                 )}
               </div>
@@ -307,7 +308,7 @@ export default function MemoryCortexDiagnosticsModal({ chatId, onClose }: Props)
                 </div>
 
                 <div className={styles.section}>
-                  <div className={styles.sectionHeader}>Sidecar</div>
+                  <div className={styles.sectionHeader}>Sidecard</div>
                   <div className={styles.metaList}>
                     <div className={styles.metaRow}><span>Required</span><strong>{report?.sidecar.required ? 'Yes' : 'No'}</strong></div>
                     <div className={styles.metaRow}><span>Configured</span><strong>{report?.sidecar.configured ? 'Yes' : 'No'}</strong></div>
@@ -338,7 +339,8 @@ export default function MemoryCortexDiagnosticsModal({ chatId, onClose }: Props)
                       <div className={styles.metaRow}><span>Relations</span><strong>{report.chat.relationCount}</strong></div>
                       <div className={styles.metaRow}><span>Consolidations</span><strong>{report.chat.consolidationCount}</strong></div>
                       <div className={styles.metaRow}><span>Rebuild status</span><strong>{report.chat.rebuildStatus.status}</strong></div>
-                      </div>
+                      <div className={styles.scrollSpacer} aria-hidden="true" />
+                    </div>
                   </div>
                 )}
               </div>

--- a/frontend/src/components/modals/SettingsModal.tsx
+++ b/frontend/src/components/modals/SettingsModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { motion } from 'motion/react'
-import { Shield, Sliders, MessageSquare, Users, PanelRight, Compass, Reply, HardDrive, RefreshCw, Puzzle, Database, Hash, Activity, Globe, Bell, Import, Brain, Terminal } from 'lucide-react'
+import { Shield, Palette, Sliders, MessageSquare, Users, PanelRight, Compass, Reply, HardDrive, RefreshCw, Puzzle, Database, Hash, Activity, Globe, Bell, Import, Brain, Terminal } from 'lucide-react'
 import { CloseButton } from '@/components/shared/CloseButton'
 import { Button } from '@/components/shared/FormComponents'
 import { Toggle } from '@/components/shared/Toggle'
@@ -10,8 +10,10 @@ import { useStore } from '@/store'
 import { spindleApi } from '@/api/spindle'
 import { embeddingsApi } from '@/api/embeddings'
 import { imagesApi } from '@/api/images'
+import { PRESETS, DEFAULT_THEME } from '@/theme/presets'
 import type { DrawerSettings, GuidedGeneration, QuickReplySet } from '@/types/store'
 import type { EmbeddingConfig, ChatMemorySettings } from '@/types/api'
+import ModeSelector from '@/components/panels/theme-panel/ModeSelector'
 import UserManagement from '@/components/settings/UserManagement'
 import MigrationSettings from '@/components/settings/MigrationSettings'
 import TokenizerManager from '@/components/settings/TokenizerManager'
@@ -36,6 +38,7 @@ const BASE_VIEWS = [
   { id: 'extensionPools', icon: HardDrive, label: 'Extension Pools' },
   { id: 'embeddings', icon: Database, label: 'Embeddings' },
   { id: 'memoryCortex', icon: Brain, label: 'Memory Cortex' },
+  { id: 'appearance', icon: Palette, label: 'Appearance' },
   { id: 'notifications', icon: Bell, label: 'Notifications' },
   { id: 'advanced', icon: Sliders, label: 'Advanced' },
   { id: 'lumihub', icon: Globe, label: 'LumiHub' },
@@ -119,6 +122,8 @@ function SettingsView({ view }: { view: string }) {
       return <ChatSettings />
     case 'extensions':
       return <ExtensionSettingsView />
+    case 'appearance':
+      return <AppearanceSettings />
     case 'guided':
       return <GuidedGenerationSettings />
     case 'quickReplies':
@@ -355,8 +360,6 @@ function DisplaySettings() {
 function ChatSettings() {
   const displayMode = useStore((s) => s.chatSheldDisplayMode)
   const bubbleUserAlign = useStore((s) => s.bubbleUserAlign)
-  const bubbleDisableHover = useStore((s) => s.bubbleDisableHover)
-  const bubbleHideAvatarBg = useStore((s) => s.bubbleHideAvatarBg)
   const enterToSend = useStore((s) => s.chatSheldEnterToSend)
   const saveDraftInput = useStore((s) => s.saveDraftInput)
   const portraitPanelSide = useStore((s) => s.portraitPanelSide)
@@ -452,35 +455,21 @@ function ChatSettings() {
       </div>
 
       {displayMode === 'bubble' && (
-        <>
-          <div className={styles.field}>
-            <label className={styles.fieldLabel}>User message alignment</label>
-            <div className={styles.segmented}>
-              {(['left', 'right'] as const).map((align) => (
-                <button
-                  key={align}
-                  type="button"
-                  className={clsx(styles.segmentedBtn, (bubbleUserAlign ?? 'right') === align && styles.segmentedBtnActive)}
-                  onClick={() => setSetting('bubbleUserAlign', align)}
-                >
-                  {align === 'left' ? 'Left' : 'Right'}
-                </button>
-              ))}
-            </div>
+        <div className={styles.field}>
+          <label className={styles.fieldLabel}>User message alignment</label>
+          <div className={styles.segmented}>
+            {(['left', 'right'] as const).map((align) => (
+              <button
+                key={align}
+                type="button"
+                className={clsx(styles.segmentedBtn, (bubbleUserAlign ?? 'right') === align && styles.segmentedBtnActive)}
+                onClick={() => setSetting('bubbleUserAlign', align)}
+              >
+                {align === 'left' ? 'Left' : 'Right'}
+              </button>
+            ))}
           </div>
-          <Toggle.Checkbox
-            checked={bubbleDisableHover}
-            onChange={(checked) => setSetting('bubbleDisableHover', checked)}
-            label="Disable bubble hover effect"
-            hint="Prevents bubbles from brightening or changing shadow on hover"
-          />
-          <Toggle.Checkbox
-            checked={bubbleHideAvatarBg}
-            onChange={(checked) => setSetting('bubbleHideAvatarBg', checked)}
-            label="Hide bubble portrait background"
-            hint="Removes the dissolving character image behind bubble content for a clean, flat look"
-          />
-        </>
+        </div>
       )}
 
       <h3 className={styles.sectionTitle} style={{ marginTop: 12 }}>Chat Width</h3>
@@ -1279,6 +1268,75 @@ function ExtensionPoolSettings() {
   )
 }
 
+function AppearanceSettings() {
+  const theme = useStore((s) => s.theme) as import('@/types/theme').ThemeConfig | null
+  const setTheme = useStore((s) => s.setTheme)
+  const openDrawer = useStore((s) => s.openDrawer)
+  const closeSettings = useStore((s) => s.closeSettings)
+
+  const current = theme ?? DEFAULT_THEME
+  const presetName = PRESETS.find((p) => p.id === current.id)?.name ?? 'Custom'
+
+  return (
+    <div className={styles.settingsSection}>
+      <h3 className={styles.sectionTitle}>Appearance</h3>
+
+      <div className={styles.field}>
+        <label className={styles.fieldLabel}>Mode</label>
+        <ModeSelector value={current.mode} onChange={(mode) => {
+          const next = { ...current, mode }
+          if (!next.characterAware) next.id = 'custom'
+          setTheme(next)
+        }} />
+      </div>
+
+      <div className={styles.field}>
+        <label className={styles.fieldLabel}>Preset</label>
+        <select
+          className={styles.select}
+          value={current.id}
+          onChange={(e) => {
+            const preset = PRESETS.find((p) => p.id === e.target.value)
+            if (preset) setTheme(preset)
+          }}
+        >
+          {PRESETS.map((p) => (
+            <option key={p.id} value={p.id}>{p.name}</option>
+          ))}
+          {!PRESETS.some((p) => p.id === current.id) && (
+            <option value={current.id}>Custom</option>
+          )}
+        </select>
+      </div>
+
+      <div className={styles.field}>
+        <button
+          type="button"
+          className={styles.select}
+          style={{ cursor: 'pointer', textAlign: 'left' }}
+          onClick={() => {
+            closeSettings()
+            openDrawer('theme')
+          }}
+        >
+          Open Theme Panel
+        </button>
+      </div>
+
+      <div className={styles.field}>
+        <button
+          type="button"
+          className={styles.select}
+          style={{ cursor: 'pointer', textAlign: 'left' }}
+          onClick={() => setTheme(null)}
+        >
+          Reset to Default
+        </button>
+      </div>
+    </div>
+  )
+}
+
 function EmbeddingsSettings() {
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
@@ -1386,7 +1444,7 @@ function EmbeddingsSettings() {
     },
     {
       label: 'World-book vectorization enabled',
-      description: 'Allows lorebook entries to be indexed and searched semantically.',
+      description: 'Allows lorebook entries to be indexed and searched with vectors.',
       complete: cfg.vectorize_world_books,
     },
   ]
@@ -1397,7 +1455,7 @@ function EmbeddingsSettings() {
   return (
     <div className={styles.settingsSection}>
       <h3 className={styles.sectionTitle}>Embeddings</h3>
-      <p className={styles.placeholder}>Configure vector embeddings for long-term memory retrieval. Vectorizes world books, chat messages, and documents for semantic search during generation.</p>
+      <p className={styles.placeholder}>Configure vector embeddings for long-term memory retrieval. Vectorizes world books, chat messages, and documents for vector search during generation.</p>
 
       {error && <p className={styles.errorText}>{error}</p>}
       {success && <p className={styles.successText}>{success}</p>}

--- a/frontend/src/components/modals/WorldBookEditorModal.tsx
+++ b/frontend/src/components/modals/WorldBookEditorModal.tsx
@@ -383,7 +383,7 @@ export default function WorldBookEditorModal() {
                 </div>
                 {vectorSummary && (
                   <div className={styles.vectorSummary}>
-                    <div className={styles.vectorSummaryTitle}>Semantic activation status</div>
+                    <div className={styles.vectorSummaryTitle}>Vector activation status</div>
                     <div className={styles.vectorSummaryGrid}>
                       <span>{vectorSummary.enabled} enabled</span>
                       <span>{vectorSummary.enabled_non_empty}/{vectorSummary.non_empty} non-empty</span>
@@ -400,7 +400,7 @@ export default function WorldBookEditorModal() {
                     onClick={handleReindexVectors}
                     disabled={reindexing}
                   >
-                    {reindexing ? 'Reindexing...' : 'Reindex semantic search'}
+                    {reindexing ? 'Reindexing...' : 'Reindex vector search'}
                   </button>
                   {vectorStatus && (
                     <span className={styles.vectorStatusText}>{vectorStatus}</span>

--- a/frontend/src/components/panels/world-book/WorldBookDiagnosticsModal.module.css
+++ b/frontend/src/components/panels/world-book/WorldBookDiagnosticsModal.module.css
@@ -443,11 +443,48 @@
   text-transform: uppercase;
 }
 
+.outcomeBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border: 1px solid var(--lumiverse-border);
+}
+
+.outcomeBadgeSuccess {
+  background: rgba(76, 191, 135, 0.12);
+  border-color: color-mix(in srgb, #4cbf87 35%, var(--lumiverse-border));
+  color: #4cbf87;
+}
+
+.outcomeBadgeWarning {
+  background: rgba(211, 155, 50, 0.12);
+  border-color: color-mix(in srgb, #d39b32 35%, var(--lumiverse-border));
+  color: #d39b32;
+}
+
+.outcomeBadgeMuted {
+  background: color-mix(in srgb, var(--lumiverse-primary) 14%, transparent);
+  border-color: color-mix(in srgb, var(--lumiverse-primary) 22%, var(--lumiverse-border));
+  color: var(--lumiverse-primary);
+}
+
 .hitSummary {
   margin: 0;
   font-size: 12.5px;
   line-height: 1.6;
   color: var(--lumiverse-text-muted);
+}
+
+.hitOutcomeReason {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: var(--lumiverse-text);
 }
 
 .hitScores {

--- a/frontend/src/components/panels/world-book/WorldBookDiagnosticsModal.tsx
+++ b/frontend/src/components/panels/world-book/WorldBookDiagnosticsModal.tsx
@@ -37,11 +37,22 @@ const DIAGNOSTIC_BREAKDOWN_LABELS: Array<{
 
 const SCORE_GUIDE_TITLE = 'How to read these scores'
 const SCORE_GUIDE_BODY =
-  'Vector distance is the raw semantic distance, so lower is better. Rerank score is the final composite ranking after boosts and penalties, so higher is better.'
+  'Vector distance is the raw embedding distance, so lower is better. Rerank score is the final composite ranking after boosts and penalties, so higher is better.'
 const LEXICAL_GUIDE_BODY =
   'Lexical candidate score is an optional keyword/FTS-side signal used during reranking. Higher means stronger lexical support when it appears.'
 const CUTOFF_GUIDE_BODY =
   'Similarity Threshold filters on vector distance before reranking. Rerank Cutoff filters on rerank score after reranking.'
+
+const OUTCOME_SUMMARY_PRIORITY: WorldBookDiagnostics['vector_hits'][number]['final_outcome_code'][] = [
+  'blocked_by_max_entries',
+  'blocked_by_token_budget',
+  'blocked_by_group',
+  'blocked_by_min_priority',
+  'deduplicated',
+  'blocked_during_final_assembly',
+  'already_keyword',
+  'injected_vector',
+]
 
 function formatDiagnosticNumber(value: number): string {
   return Number.isFinite(value) ? value.toFixed(3) : '0.000'
@@ -74,10 +85,51 @@ function buildDiagnosticMatchSummary(hit: WorldBookDiagnostics['vector_hits'][nu
   }
 
   if (reasons.length === 0) {
-    return 'This entry reached the shortlist mostly on semantic similarity.'
+    return 'This entry reached the shortlist mostly on vector similarity.'
   }
 
   return `Lexical boosts came from ${reasons.join(' | ')}.`
+}
+
+function joinReadableList(parts: string[]): string {
+  if (parts.length === 0) return ''
+  if (parts.length === 1) return parts[0]
+  if (parts.length === 2) return `${parts[0]} and ${parts[1]}`
+  return `${parts.slice(0, -1).join(', ')}, and ${parts[parts.length - 1]}`
+}
+
+function formatOutcomeSummaryPart(
+  code: WorldBookDiagnostics['vector_hits'][number]['final_outcome_code'],
+  count: number,
+): string {
+  switch (code) {
+    case 'injected_vector':
+      return `${count} made the final prompt`
+    case 'already_keyword':
+      return `${count} ${count === 1 ? 'was' : 'were'} already keyword-active`
+    case 'blocked_by_group':
+      return `${count} ${count === 1 ? 'was' : 'were'} blocked by a group rule`
+    case 'blocked_by_min_priority':
+      return `${count} ${count === 1 ? 'was' : 'were'} below minimum priority`
+    case 'blocked_by_max_entries':
+      return `${count} had no room under the entry cap`
+    case 'blocked_by_token_budget':
+      return `${count} had no room under the token budget`
+    case 'deduplicated':
+      return `${count} ${count === 1 ? 'was' : 'were'} removed as duplicate${count === 1 ? '' : 's'}`
+    case 'blocked_during_final_assembly':
+    default:
+      return `${count} ${count === 1 ? 'was' : 'were'} dropped during final assembly`
+  }
+}
+
+function getOutcomeBadgeClassName(
+  code: WorldBookDiagnostics['vector_hits'][number]['final_outcome_code'],
+  styles: Record<string, string>,
+): string {
+  if (code === 'injected_vector') return styles.outcomeBadgeSuccess
+  if (code === 'already_keyword') return styles.outcomeBadgeMuted
+  return styles.outcomeBadgeWarning
 }
 
 async function copyTextToClipboard(text: string): Promise<void> {
@@ -181,26 +233,51 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
   const displacedSemanticCount = diagnostics
     ? Math.max(freshSemanticCount - diagnostics.stats.vectorActivated, 0)
     : 0
+  const injectedVectorCount = diagnostics
+    ? diagnostics.vector_hits.filter((hit) => hit.final_outcome_code === 'injected_vector').length
+    : 0
+  const displacedOutcomeSummaryParts = useMemo(() => {
+    if (!diagnostics) return [] as string[]
+
+    const counts = new Map<WorldBookDiagnostics['vector_hits'][number]['final_outcome_code'], number>()
+    for (const hit of diagnostics.vector_hits) {
+      if (keywordHitIds.has(hit.entry_id)) continue
+      if (hit.final_outcome_code === 'injected_vector') continue
+      counts.set(hit.final_outcome_code, (counts.get(hit.final_outcome_code) ?? 0) + 1)
+    }
+
+    return OUTCOME_SUMMARY_PRIORITY
+      .map((code) => {
+        const count = counts.get(code)
+        if (!count) return null
+        return formatOutcomeSummaryPart(code, count)
+      })
+      .filter((value): value is string => Boolean(value))
+  }, [diagnostics, keywordHitIds])
 
   const noteMessages = useMemo(() => {
     if (!diagnostics) return [] as string[]
 
     const notes = [...diagnostics.blocker_messages]
 
+    if (displacedOutcomeSummaryParts.length > 0) {
+      notes.unshift(`Fresh vector candidates were displaced because ${joinReadableList(displacedOutcomeSummaryParts)}.`)
+    }
+
     if (diagnostics.vector_summary.pending > 0) {
       notes.push(
-        `${diagnostics.vector_summary.pending} semantic entries are still pending reindex, so retrieval may still be incomplete.`,
+        `${diagnostics.vector_summary.pending} vector entries are still pending reindex, so retrieval may still be incomplete.`,
       )
     }
 
     if (diagnostics.vector_summary.error > 0) {
       notes.push(
-        `${diagnostics.vector_summary.error} semantic entries have indexing errors and will not participate until they are fixed and reindexed.`,
+        `${diagnostics.vector_summary.error} vector entries have indexing errors and will not participate until they are fixed and reindexed.`,
       )
     }
 
     return Array.from(new Set(notes))
-  }, [diagnostics])
+  }, [diagnostics, displacedOutcomeSummaryParts])
 
   const hero = useMemo(() => {
     if (loading && !diagnostics) {
@@ -231,7 +308,7 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
       return {
         tone: 'warning',
         title: 'This lorebook is not attached to the current chat',
-        body: 'Semantic retrieval cannot inject anything until the book is attached through the character, persona, or global books.',
+        body: 'Vector retrieval cannot inject anything until the book is attached through the character, persona, or global books.',
       } as const
     }
 
@@ -246,23 +323,23 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
     if (diagnostics.eligible_entries === 0) {
       return {
         tone: 'warning',
-        title: 'This book has no semantic-ready entries',
-        body: 'No non-empty, semantic-enabled entries are eligible for retrieval in this lorebook.',
+        title: 'This book has no vector-ready entries',
+        body: 'No non-empty, vector-enabled entries are eligible for retrieval in this lorebook.',
       } as const
     }
 
     if (diagnostics.stats.vectorActivated > 0) {
       return {
         tone: 'success',
-        title: `${diagnostics.stats.vectorActivated} semantic entr${diagnostics.stats.vectorActivated === 1 ? 'y' : 'ies'} made the final prompt`,
-        body: `Reranking found ${diagnostics.vector_hits.length} semantic candidates, and ${diagnostics.stats.vectorActivated} survived into the final world-info result.`,
+        title: `${diagnostics.stats.vectorActivated} vector entr${diagnostics.stats.vectorActivated === 1 ? 'y' : 'ies'} made the final prompt`,
+        body: `Reranking found ${diagnostics.vector_hits.length} vector candidates, and ${diagnostics.stats.vectorActivated} survived into the final world-info result.`,
       } as const
     }
 
     if (diagnostics.vector_hits.length === 0) {
       return {
         tone: 'neutral',
-        title: 'No semantic matches cleared retrieval',
+        title: 'No vector matches cleared retrieval',
         body: 'The current chat query did not produce any vector hits that survived thresholding and reranking.',
       } as const
     }
@@ -270,25 +347,28 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
     if (freshSemanticCount === 0) {
       return {
         tone: 'neutral',
-        title: 'Semantic retrieval mostly confirmed entries already hit by keywords',
-        body: 'The vector shortlist overlaps with keyword matches, so semantic search did not add anything new for this chat.',
+        title: 'Vector retrieval mostly confirmed entries already hit by keywords',
+        body: 'The vector shortlist overlaps with keyword matches, so vector search did not add anything new for this chat.',
       } as const
     }
 
     if (displacedSemanticCount > 0 || diagnostics.stats.evictedByBudget > 0) {
+      const displacementWhy = displacedOutcomeSummaryParts.length > 0
+        ? `Why: ${joinReadableList(displacedOutcomeSummaryParts)}.`
+        : 'Open the reranked shortlist below to see which entries were displaced and why.'
       return {
         tone: 'warning',
-        title: 'Semantic matches were found, but they did not survive final prompt assembly',
-        body: `${freshSemanticCount} fresh semantic candidate${freshSemanticCount === 1 ? '' : 's'} appeared after reranking, but ${displacedSemanticCount} were displaced before the final prompt.`,
+        title: 'Vector matches were found, but they did not survive final prompt assembly',
+        body: `${freshSemanticCount} fresh vector candidate${freshSemanticCount === 1 ? '' : 's'} appeared after reranking, but ${displacedSemanticCount} were displaced before the final prompt. ${displacementWhy}`,
       } as const
     }
 
     return {
       tone: 'warning',
-      title: 'Semantic retrieval found candidates, but none became vector-activated entries',
-      body: 'The reranked shortlist exists, but the final prompt still ended up with zero semantic-only additions.',
+      title: 'Vector retrieval found candidates, but none became vector-activated entries',
+      body: 'The reranked shortlist exists, but the final prompt still ended up with zero vector-only additions.',
     } as const
-  }, [attached, diagnostics, displacedSemanticCount, error, freshSemanticCount, loading])
+  }, [attached, diagnostics, displacedOutcomeSummaryParts, displacedSemanticCount, error, freshSemanticCount, loading])
 
   const reportText = useMemo(() => {
     if (!diagnostics) return ''
@@ -302,7 +382,7 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
       'SUMMARY',
       `Hero: ${hero.title}`,
       `Attached: ${attached ? attachedSources.join(', ') : 'No'}`,
-      `Eligible semantic entries: ${diagnostics.eligible_entries}`,
+      `Eligible vector entries: ${diagnostics.eligible_entries}`,
       `Indexed: ${diagnostics.vector_summary.indexed}`,
       `Pending: ${diagnostics.vector_summary.pending}`,
       `Errors: ${diagnostics.vector_summary.error}`,
@@ -313,8 +393,8 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
       `Reranked vector hits: ${diagnostics.vector_hits.length}`,
       `Keyword hits: ${diagnostics.keyword_hits.length}`,
       `Keyword/vector overlap: ${overlapCount}`,
-      `Fresh semantic candidates: ${freshSemanticCount}`,
-      `Displaced semantic candidates: ${displacedSemanticCount}`,
+      `Fresh vector candidates: ${freshSemanticCount}`,
+      `Displaced vector candidates: ${displacedSemanticCount}`,
       '',
       'EMBEDDINGS',
       `Enabled: ${diagnostics.embeddings.enabled}`,
@@ -372,6 +452,8 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
       diagnostics.vector_hits.forEach((hit, index) => {
         lines.push(
           `${index + 1}. ${hit.comment || '(unnamed entry)'} [${hit.entry_id}]`,
+          `   final_outcome=${hit.final_outcome_label}`,
+          `   final_outcome_reason=${hit.final_outcome_reason}`,
           `   vector_distance=${formatDiagnosticNumber(hit.distance)} rerank_score=${formatDiagnosticNumber(hit.final_score)} lexical_candidate_score=${hit.lexical_candidate_score == null ? '(none)' : formatDiagnosticNumber(hit.lexical_candidate_score)}`,
           `   matched_primary_keys=${hit.matched_primary_keys.join(', ') || '(none)'}`,
           `   matched_secondary_keys=${hit.matched_secondary_keys.join(', ') || '(none)'}`,
@@ -441,7 +523,7 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
             <div className={styles.eyebrow}>Current Chat Diagnostics</div>
             <h2 className={styles.title}>Why "{book.name}" did or did not inject</h2>
             <p className={styles.subtitle}>
-              This view checks attachment, semantic readiness, the query built from recent chat context,
+              This view checks attachment, vector readiness, the query built from recent chat context,
               reranked vector matches, and what finally survived into the prompt.
             </p>
           </div>
@@ -512,7 +594,7 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
                   </span>
                   <span className={styles.heroTag}>
                     <Activity size={12} />
-                    <span>{diagnostics.eligible_entries} eligible semantic entries</span>
+                    <span>{diagnostics.eligible_entries} eligible vector entries</span>
                   </span>
                   <span className={styles.heroTag}>
                     <Search size={12} />
@@ -541,7 +623,7 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
                 </article>
 
                 <article className={styles.metricCard}>
-                  <span className={styles.metricLabel}>Semantic Index</span>
+                  <span className={styles.metricLabel}>Vector Index</span>
                   <strong className={styles.metricValue}>
                     {diagnostics.vector_summary.indexed}/{diagnostics.eligible_entries}
                   </strong>
@@ -554,7 +636,7 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
                   <span className={styles.metricLabel}>Reranked Hits</span>
                   <strong className={styles.metricValue}>{diagnostics.vector_hits.length}</strong>
                   <span className={styles.metricMeta}>
-                    {freshSemanticCount} fresh semantic, {overlapCount} already keyword-active
+                    {injectedVectorCount} made prompt, {displacedSemanticCount} displaced, {overlapCount} already keyword-active
                   </span>
                 </article>
 
@@ -602,11 +684,20 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
                                 <div className={styles.hitText}>
                                   <div className={styles.hitTitleRow}>
                                     <h4 className={styles.hitTitle}>{hit.comment || '(unnamed entry)'}</h4>
-                                    {keywordHitIds.has(hit.entry_id) && (
+                                    <span
+                                      className={clsx(
+                                        styles.outcomeBadge,
+                                        getOutcomeBadgeClassName(hit.final_outcome_code, styles),
+                                      )}
+                                    >
+                                      {hit.final_outcome_label}
+                                    </span>
+                                    {keywordHitIds.has(hit.entry_id) && hit.final_outcome_code !== 'already_keyword' && (
                                       <span className={styles.keywordBadge}>Already keyword-active</span>
                                     )}
                                   </div>
                                   <p className={styles.hitSummary}>{buildDiagnosticMatchSummary(hit)}</p>
+                                  <p className={styles.hitOutcomeReason}>{hit.final_outcome_reason}</p>
                                 </div>
                                 <div className={styles.hitScores}>
                                   <span className={styles.scorePill}>
@@ -674,7 +765,7 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
                       </div>
                     </div>
                     <div className={styles.queryBlock}>
-                      {diagnostics.query_preview || 'No recent visible chat messages were available to build a semantic query.'}
+                      {diagnostics.query_preview || 'No recent visible chat messages were available to build a vector query.'}
                     </div>
                   </section>
 
@@ -711,7 +802,7 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
                         <span className={styles.factValue}>{formatDiagnosticNumber(diagnostics.embeddings.rerank_cutoff)}</span>
                       </div>
                       <div className={styles.factRow}>
-                        <span className={styles.factLabel}>Semantic-ready</span>
+                        <span className={styles.factLabel}>Vector-ready</span>
                         <span className={styles.factValue}>{diagnostics.embeddings.ready ? 'Ready' : 'Not ready'}</span>
                       </div>
                     </div>
@@ -750,11 +841,11 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
                         <span className={styles.factValue}>{diagnostics.stats.evictedByBudget}</span>
                       </div>
                       <div className={styles.factRow}>
-                        <span className={styles.factLabel}>Fresh semantic candidates</span>
+                        <span className={styles.factLabel}>Fresh vector candidates</span>
                         <span className={styles.factValue}>{freshSemanticCount}</span>
                       </div>
                       <div className={styles.factRow}>
-                        <span className={styles.factLabel}>Displaced semantic candidates</span>
+                        <span className={styles.factLabel}>Displaced vector candidates</span>
                         <span className={styles.factValue}>{displacedSemanticCount}</span>
                       </div>
                     </div>
@@ -768,7 +859,7 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
                       </div>
                     </div>
                     <div className={styles.overlapSummary}>
-                      {overlapCount} of {diagnostics.vector_hits.length} semantic matches were already activated by keyword logic.
+                        {overlapCount} of {diagnostics.vector_hits.length} vector matches were already activated by keyword logic.
                     </div>
                     {diagnostics.keyword_hits.length > 0 ? (
                       <div className={styles.keywordChips}>

--- a/frontend/src/components/panels/world-book/WorldBookPanel.tsx
+++ b/frontend/src/components/panels/world-book/WorldBookPanel.tsx
@@ -759,7 +759,7 @@ export default function WorldBookPanel() {
               </Button>
               {vectorSummary && (
                 <div className={styles.vectorSummary}>
-                  <div className={styles.vectorSummaryTitle}>Semantic activation status</div>
+                  <div className={styles.vectorSummaryTitle}>Vector activation status</div>
                   <div className={styles.vectorSummaryGrid}>
                     <span>{vectorSummary.enabled} enabled</span>
                     <span>{vectorSummary.enabled_non_empty}/{vectorSummary.non_empty} non-empty</span>
@@ -771,7 +771,7 @@ export default function WorldBookPanel() {
               )}
               <div className={styles.bookActionRow}>
                 <Button variant="primary" size="sm" onClick={handleReindexVectors} disabled={reindexing}>
-                  {reindexing ? 'Reindexing...' : 'Reindex semantic search'}
+                  {reindexing ? 'Reindexing...' : 'Reindex vector search'}
                 </Button>
                 <Button variant="secondary" size="sm" onClick={handleConvertToVectorizedPreview} disabled={reindexing}>
                   Convert to Vectorized
@@ -934,7 +934,7 @@ export default function WorldBookPanel() {
             convertPreview.eligible === 0
               ? 'No entries are eligible for conversion. All non-constant entries are either already vectorized, empty, or disabled.'
               : <>
-                  <p>This will enable semantic activation for <strong>{convertPreview.eligible}</strong> {convertPreview.eligible === 1 ? 'entry' : 'entries'} and immediately start reindexing.</p>
+                  <p>This will enable vector activation for <strong>{convertPreview.eligible}</strong> {convertPreview.eligible === 1 ? 'entry' : 'entries'} and immediately start reindexing.</p>
                   <ul style={{ textAlign: 'left', margin: '8px 0', paddingLeft: '20px', fontSize: '12px', opacity: 0.8 }}>
                     {convertPreview.constant_skipped > 0 && <li>{convertPreview.constant_skipped} constant {convertPreview.constant_skipped === 1 ? 'entry' : 'entries'} skipped (always active)</li>}
                     {convertPreview.already_vectorized > 0 && <li>{convertPreview.already_vectorized} already vectorized</li>}

--- a/frontend/src/components/shared/WorldBookEntryEditor.tsx
+++ b/frontend/src/components/shared/WorldBookEntryEditor.tsx
@@ -292,7 +292,7 @@ export default function WorldBookEntryEditor({ entry, onUpdate, onImmediateUpdat
           <Toggle.Checkbox
             checked={entry.vectorized}
             onChange={() => onImmediateUpdate(entry.id, { vectorized: !entry.vectorized })}
-            label="Use for semantic activation"
+            label="Vectorized"
           />
         </div>
         <div className={styles.vectorStatusRow}>

--- a/frontend/src/lib/worldBookVectorization.ts
+++ b/frontend/src/lib/worldBookVectorization.ts
@@ -16,12 +16,12 @@ export function getVectorIndexStatusLabel(status: WorldBookVectorIndexStatus): s
 
 export function getVectorIndexStatusDescription(entry: WorldBookEntry): string {
   if (!entry.vectorized) {
-    return 'Semantic activation is off for this entry.'
+    return 'Vector activation is off for this entry.'
   }
   if (entry.vector_index_status === 'indexed') {
     return entry.vector_indexed_at
       ? `Indexed ${new Date(entry.vector_indexed_at * 1000).toLocaleString()}.`
-      : 'Indexed and ready for semantic activation.'
+      : 'Indexed and ready for vector activation.'
   }
   if (entry.vector_index_status === 'error') {
     return entry.vector_index_error || 'The last indexing attempt failed.'
@@ -32,7 +32,7 @@ export function getVectorIndexStatusDescription(entry: WorldBookEntry): string {
   if (!(entry.content || '').trim()) {
     return 'This entry needs content before it can be indexed.'
   }
-  return 'Reindex this book after semantic changes so this entry can be searched.'
+  return 'Reindex this book after vector changes so this entry can be searched.'
 }
 
 export function formatWorldBookReindexStatus(progress: WorldBookReindexProgress): string {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -231,8 +231,6 @@ export interface ConnectionTestResult {
 
 export interface ConnectionModelsResult {
   models: string[]
-  /** Map of model ID → human-readable display name (when available). */
-  model_labels?: Record<string, string>
   provider: string
   error?: string
 }
@@ -532,6 +530,17 @@ export interface WorldBookDiagnostics {
       focusMissPenalty: number;
     };
     search_text_preview: string;
+    final_outcome_code:
+      | 'injected_vector'
+      | 'already_keyword'
+      | 'blocked_by_group'
+      | 'blocked_by_min_priority'
+      | 'blocked_by_max_entries'
+      | 'blocked_by_token_budget'
+      | 'deduplicated'
+      | 'blocked_during_final_assembly';
+    final_outcome_label: string;
+    final_outcome_reason: string;
   }>;
   blocker_messages: string[];
   stats: WorldInfoStats;

--- a/src/routes/memory-cortex.routes.ts
+++ b/src/routes/memory-cortex.routes.ts
@@ -187,51 +187,51 @@ app.get("/health", async (c) => {
   if (sidecarRequired && !sidecarConnectionId) {
     pushCheck(
       "sidecar_required",
-      "Sidecar connection",
+      "Sidecard connection",
       "fail",
-      "Sidecar-assisted cortex features are enabled, but no sidecar connection is selected.",
+      "Sidecard-assisted cortex features are enabled, but no sidecard connection is selected.",
     );
   } else if (sidecarConnectionId && !sidecarProfile) {
     pushCheck(
       "sidecar_exists",
-      "Sidecar connection",
+      "Sidecard connection",
       sidecarRequired ? "fail" : "warn",
-      "The selected sidecar connection profile no longer exists.",
+      "The selected sidecard connection profile no longer exists.",
     );
   } else if (sidecarConnectionId && !sidecarProvider) {
     pushCheck(
       "sidecar_provider",
-      "Sidecar provider",
+      "Sidecard provider",
       sidecarRequired ? "fail" : "warn",
       `The selected provider "${sidecarProfile?.provider}" is not available.`,
     );
   } else if (sidecarConnectionId && !sidecarHasApiKey) {
     pushCheck(
       "sidecar_api_key",
-      "Sidecar API key",
+      "Sidecard API key",
       sidecarRequired ? "fail" : "warn",
-      "The selected sidecar connection is missing its API key.",
+      "The selected sidecard connection is missing its API key.",
     );
   } else if (sidecarRequired) {
     pushCheck(
       "sidecar_ready",
-      "Sidecar readiness",
+      "Sidecard readiness",
       "pass",
-      "A valid sidecar connection is configured for cortex features that require it.",
+      "A valid sidecard connection is configured for cortex features that require it.",
     );
   } else if (sidecarConnectionId) {
     pushCheck(
       "sidecar_optional",
-      "Sidecar connection",
+      "Sidecard connection",
       "info",
-      "A sidecar connection is configured, but current cortex modes can still run in heuristic mode.",
+      "A sidecard connection is configured, but current cortex modes can still run in heuristic mode.",
     );
   } else {
     pushCheck(
       "sidecar_optional",
-      "Sidecar connection",
+      "Sidecard connection",
       "info",
-      "No sidecar connection is configured. Heuristic cortex mode can still run without it.",
+      "No sidecard connection is configured. Heuristic cortex mode can still run without it.",
     );
   }
 
@@ -242,7 +242,7 @@ app.get("/health", async (c) => {
   } = {
     attempted: false,
     success: null,
-    message: "Live sidecar probe not run.",
+    message: "Live sidecard probe not run.",
   };
 
   if (probeConnectivity && sidecarConnectionId && sidecarProfile) {
@@ -254,7 +254,7 @@ app.get("/health", async (c) => {
     };
     pushCheck(
       "sidecar_probe",
-      "Sidecar connectivity",
+      "Sidecard connectivity",
       result.success ? "pass" : "fail",
       result.message,
     );
@@ -808,16 +808,7 @@ app.post("/chats/:chatId/rebuild", async (c) => {
     };
   }
 
-  // First rebuild the underlying LTCM chunks (re-chunk from messages, re-vectorize)
-  // so the cortex processes fresh data instead of potentially stale chunks.
-  try {
-    const { rebuildChatChunks } = require("../services/chats.service");
-    await rebuildChatChunks(userId, chatId);
-  } catch (err: any) {
-    console.warn("[memory-cortex] LTCM chunk rebuild failed (proceeding with existing chunks):", err?.message);
-  }
-
-  // Run cortex rebuild in the background — return immediately so Bun doesn't timeout
+  // Run rebuild in the background — return immediately so Bun doesn't timeout
   memoryCortex.rebuildCortex(
     userId, chatId, characterNames, generateRawFn, sidecarConnectionId,
     // Progress callback: streams WS events to the client

--- a/src/routes/world-books.routes.ts
+++ b/src/routes/world-books.routes.ts
@@ -11,13 +11,217 @@ import {
   getWorldInfoVectorQueryPreview,
   mergeActivatedWorldInfoEntries,
 } from "../services/prompt-assembly.service";
-import { activateWorldInfo, type WiState, type WorldInfoSettings } from "../services/world-info-activation.service";
+import { deduplicateWorldInfoEntries } from "../services/world-info-dedup.service";
+import { activateWorldInfo, finalizeActivatedWorldInfoEntries, type WiState, type WorldInfoSettings } from "../services/world-info-activation.service";
+import type { WorldBookEntry } from "../types/world-book";
 import { safeFetch, SSRFError } from "../utils/safe-fetch";
 import { getCharacterWorldBookIds, setCharacterWorldBookIds } from "../utils/character-world-books";
 
 const MAX_IMPORT_RESPONSE_BYTES = 5 * 1024 * 1024; // 5 MB
 
 const app = new Hono();
+
+type DiagnosticVectorHitOutcomeCode =
+  | "injected_vector"
+  | "already_keyword"
+  | "blocked_by_group"
+  | "blocked_by_min_priority"
+  | "blocked_by_max_entries"
+  | "blocked_by_token_budget"
+  | "deduplicated"
+  | "blocked_during_final_assembly";
+
+interface DiagnosticVectorHitOutcome {
+  code: DiagnosticVectorHitOutcomeCode;
+  label: string;
+  reason: string;
+}
+
+type VectorHitEntry = Awaited<ReturnType<typeof collectVectorActivatedWorldInfoDetailed>>["entries"][number];
+
+function getWorldInfoGroupKey(entry: WorldBookEntry): string | null {
+  const groupName = typeof entry.group_name === "string" ? entry.group_name.trim() : "";
+  return groupName ? groupName.toLowerCase() : null;
+}
+
+function buildDiagnosticVectorOutcome(
+  code: DiagnosticVectorHitOutcomeCode,
+  options: {
+    entry?: WorldBookEntry;
+    maxActivatedEntries?: number;
+    minPriority?: number;
+    conflictingEntry?: WorldBookEntry;
+    conflictingSource?: "keyword" | "vector";
+    keptEntryComment?: string;
+    dedupTier?: "exact" | "near-exact" | "fuzzy";
+  } = {},
+): DiagnosticVectorHitOutcome {
+  switch (code) {
+    case "injected_vector":
+      return {
+        code,
+        label: "Made final prompt",
+        reason: "This vector hit survived reranking and final prompt assembly as a vector-activated entry.",
+      };
+    case "already_keyword":
+      return {
+        code,
+        label: "Already keyword-active",
+        reason: "This same entry was already activated by keyword logic, so vector retrieval did not add a second copy.",
+      };
+    case "blocked_by_group": {
+      const conflicting = options.conflictingEntry?.comment?.trim() || "another entry";
+      const source = options.conflictingSource === "vector" ? "another vector hit" : "keyword activation";
+      return {
+        code,
+        label: "Blocked by group rule",
+        reason: `This entry shares a mutually exclusive group with "${conflicting}", which had already claimed the slot via ${source}.`,
+      };
+    }
+    case "blocked_by_min_priority":
+      return {
+        code,
+        label: "Below minimum priority",
+        reason: `This entry's priority (${options.entry?.priority ?? 0}) is below the current World Info minimum priority (${options.minPriority ?? 0}).`,
+      };
+    case "blocked_by_max_entries":
+      return {
+        code,
+        label: "No room under entry cap",
+        reason: `The final World Info list had already reached the ${options.maxActivatedEntries ?? 0}-entry cap before this vector hit could be added.`,
+      };
+    case "blocked_by_token_budget":
+      return {
+        code,
+        label: "No room under token budget",
+        reason: "Adding this entry would have pushed the World Info prompt past the current token budget, so earlier entries kept the room.",
+      };
+    case "deduplicated": {
+      const kept = options.keptEntryComment?.trim() || "another entry";
+      const tier = options.dedupTier === "exact"
+        ? "exact duplicate"
+        : options.dedupTier === "near-exact"
+          ? "near-exact duplicate"
+          : "fuzzy duplicate";
+      return {
+        code,
+        label: "Removed as duplicate",
+        reason: `This vector hit initially made the merged set, but it was removed as a ${tier} of "${kept}".`,
+      };
+    }
+    case "blocked_during_final_assembly":
+    default:
+      return {
+        code: "blocked_during_final_assembly",
+        label: "Lost during final assembly",
+        reason: "This vector hit survived retrieval, but later prompt-assembly rules left no room for it in the final World Info list.",
+      };
+  }
+}
+
+function traceDiagnosticVectorHitOutcomes(
+  keywordEntries: WorldBookEntry[],
+  vectorEntries: VectorHitEntry[],
+  settingsInput?: Partial<WorldInfoSettings>,
+): Map<string, DiagnosticVectorHitOutcome> {
+  const settings: WorldInfoSettings = {
+    globalScanDepth: null,
+    maxRecursionPasses: 0,
+    maxActivatedEntries: 50,
+    maxTokenBudget: 0,
+    minPriority: 0,
+    ...settingsInput,
+  };
+  const mergedEntries: WorldBookEntry[] = [];
+  const sources = new Map<string, { source: "keyword" | "vector"; score?: number }>();
+  const seen = new Set<string>();
+  const occupiedGroups = new Map<string, { entry: WorldBookEntry; source: "keyword" | "vector" }>();
+  const outcomes = new Map<string, DiagnosticVectorHitOutcome>();
+  const maxActivatedTarget = settings.maxActivatedEntries > 0
+    ? settings.maxActivatedEntries
+    : Number.POSITIVE_INFINITY;
+
+  for (const entry of keywordEntries) {
+    if (seen.has(entry.id)) continue;
+    mergedEntries.push(entry);
+    seen.add(entry.id);
+    sources.set(entry.id, { source: "keyword" });
+    const groupKey = getWorldInfoGroupKey(entry);
+    if (groupKey) occupiedGroups.set(groupKey, { entry, source: "keyword" });
+  }
+
+  let finalized = finalizeActivatedWorldInfoEntries(mergedEntries, settings, {
+    skipGroupLogic: true,
+    preserveOrder: true,
+  });
+
+  for (const item of vectorEntries) {
+    if (seen.has(item.entry.id)) {
+      outcomes.set(item.entry.id, buildDiagnosticVectorOutcome("already_keyword"));
+      continue;
+    }
+
+    if (settings.minPriority > 0 && item.entry.priority < settings.minPriority && !item.entry.constant) {
+      outcomes.set(item.entry.id, buildDiagnosticVectorOutcome("blocked_by_min_priority", {
+        entry: item.entry,
+        minPriority: settings.minPriority,
+      }));
+      continue;
+    }
+
+    const groupKey = getWorldInfoGroupKey(item.entry);
+    if (groupKey) {
+      const occupied = occupiedGroups.get(groupKey);
+      if (occupied) {
+        outcomes.set(item.entry.id, buildDiagnosticVectorOutcome("blocked_by_group", {
+          conflictingEntry: occupied.entry,
+          conflictingSource: occupied.source,
+        }));
+        continue;
+      }
+    }
+
+    if (finalized.activatedEntries.length >= maxActivatedTarget && !item.entry.constant) {
+      outcomes.set(item.entry.id, buildDiagnosticVectorOutcome("blocked_by_max_entries", {
+        maxActivatedEntries: settings.maxActivatedEntries,
+      }));
+      continue;
+    }
+
+    const nextMergedEntries = [...mergedEntries, item.entry];
+    const nextFinalized = finalizeActivatedWorldInfoEntries(nextMergedEntries, settings, {
+      skipGroupLogic: true,
+      preserveOrder: true,
+    });
+    const itemSurvived = nextFinalized.activatedEntries.some((entry) => entry.id === item.entry.id);
+    const grewActivationSet = nextFinalized.activatedEntries.length > finalized.activatedEntries.length;
+
+    if (!itemSurvived || (!grewActivationSet && !item.entry.constant)) {
+      outcomes.set(item.entry.id, buildDiagnosticVectorOutcome(
+        settings.maxTokenBudget > 0 ? "blocked_by_token_budget" : "blocked_during_final_assembly",
+      ));
+      continue;
+    }
+
+    mergedEntries.push(item.entry);
+    seen.add(item.entry.id);
+    sources.set(item.entry.id, { source: "vector", score: item.finalScore });
+    if (groupKey) occupiedGroups.set(groupKey, { entry: item.entry, source: "vector" });
+    finalized = nextFinalized;
+    outcomes.set(item.entry.id, buildDiagnosticVectorOutcome("injected_vector"));
+  }
+
+  const dedupResult = deduplicateWorldInfoEntries(mergedEntries, sources);
+  for (const removed of dedupResult.removed) {
+    if (!outcomes.has(removed.removedEntryId)) continue;
+    outcomes.set(removed.removedEntryId, buildDiagnosticVectorOutcome("deduplicated", {
+      keptEntryComment: removed.keptEntryComment,
+      dedupTier: removed.tier,
+    }));
+  }
+
+  return outcomes;
+}
 
 app.get("/", (c) => {
   const userId = c.get("userId");
@@ -178,6 +382,11 @@ app.post("/:id/diagnostics", async (c) => {
     vectorDetail.entries,
     worldInfoSettings,
   );
+  const vectorHitOutcomes = traceDiagnosticVectorHitOutcomes(
+    wiResult.activatedEntries,
+    vectorDetail.entries,
+    worldInfoSettings,
+  );
 
   const keywordHits = mergedWorldInfo.activatedWorldInfo
     .filter((entry) => entry.source === "keyword")
@@ -190,6 +399,11 @@ app.post("/:id/diagnostics", async (c) => {
     (count, item) => count + (keywordHitIds.has(item.entry.id) ? 1 : 0),
     0,
   );
+  const displacedFreshVectorHits = vectorDetail.entries.filter((item) => {
+    if (keywordHitIds.has(item.entry.id)) return false;
+    const outcome = vectorHitOutcomes.get(item.entry.id);
+    return outcome?.code !== "injected_vector";
+  });
 
   if (vectorDetail.thresholdRejected > 0 && vectorDetail.entries.length === 0) {
     blockerMessages.push("Vector matches were found, but all of them were rejected by the current similarity threshold.");
@@ -219,7 +433,7 @@ app.post("/:id/diagnostics", async (c) => {
     mergedWorldInfo.vectorActivated === 0 &&
     mergedWorldInfo.evictedByBudget > 0
   ) {
-    blockerMessages.push("Semantic matches were found, but the World Info max-activated or token budget limits left no room for them after keyword activation.");
+    blockerMessages.push("Vector matches were found, but the World Info max-activated or token budget limits left no room for them after keyword activation.");
   }
 
   if (
@@ -237,12 +451,26 @@ app.post("/:id/diagnostics", async (c) => {
     mergedWorldInfo.evictedByBudget === 0 &&
     vectorKeywordOverlapCount === vectorDetail.entries.length
   ) {
-    blockerMessages.push("Semantic matches were found, but the top vector hits were already activated by keyword, so the final list still counts them as keyword entries.");
+    blockerMessages.push("Vector matches were found, but the top vector hits were already activated by keyword, so the final list still counts them as keyword entries.");
   }
 
   if (mergedWorldInfo.deduplicationDetails.some(d => d.removedEntryBookId === bookId)) {
     const dedupCount = mergedWorldInfo.deduplicationDetails.filter(d => d.removedEntryBookId === bookId).length;
     blockerMessages.push(`${dedupCount} entry/entries from this book were removed as content duplicates of entries from other books.`);
+  }
+
+  if (displacedFreshVectorHits.length > 0) {
+    const grouped = new Map<string, { outcome: DiagnosticVectorHitOutcome; count: number }>();
+    for (const item of displacedFreshVectorHits) {
+      const outcome = vectorHitOutcomes.get(item.entry.id);
+      if (!outcome) continue;
+      const existing = grouped.get(outcome.code);
+      if (existing) existing.count += 1;
+      else grouped.set(outcome.code, { outcome, count: 1 });
+    }
+    for (const { outcome, count } of grouped.values()) {
+      blockerMessages.push(`${count} fresh vector candidate${count === 1 ? "" : "s"}: ${outcome.reason}`);
+    }
   }
 
   return c.json({
@@ -282,6 +510,10 @@ app.post("/:id/diagnostics", async (c) => {
       matched_comment: item.matchedComment,
       score_breakdown: item.scoreBreakdown,
       search_text_preview: item.searchTextPreview,
+      final_outcome_code: vectorHitOutcomes.get(item.entry.id)?.code ?? "blocked_during_final_assembly",
+      final_outcome_label: vectorHitOutcomes.get(item.entry.id)?.label ?? "Lost during final assembly",
+      final_outcome_reason: vectorHitOutcomes.get(item.entry.id)?.reason
+        ?? "This vector hit survived retrieval, but later prompt-assembly rules left no room for it in the final World Info list.",
     })),
     blocker_messages: Array.from(new Set(blockerMessages)),
     deduplication: mergedWorldInfo.deduplicated > 0 ? {

--- a/src/services/prompt-assembly.service.ts
+++ b/src/services/prompt-assembly.service.ts
@@ -442,12 +442,6 @@ export async function assemblePrompt(ctx: AssemblyContext): Promise<AssemblyResu
     : null;
   const perChatOverrides = (chat.metadata?.memory_settings as import("./embeddings.service").PerChatMemoryOverrides | undefined) ?? null;
 
-  // LTCM freshness check: if settings or code changed since chunks were built, rebuild lazily
-  try {
-    const { ensureChatMemoryFresh } = require("./chats.service");
-    await ensureChatMemoryFresh(ctx.userId, ctx.chatId);
-  } catch { /* non-fatal — first generation after update may use stale data */ }
-
   // Memory Cortex: enhanced retrieval with entity graph, salience, and emotional resonance
   const cortexConfig = memoryCortex.getCortexConfig(ctx.userId);
   let cortexResult: memoryCortex.CortexResult | null = null;
@@ -2320,7 +2314,7 @@ export async function collectVectorActivatedWorldInfoDetailed(
   if (!cfg.dimensions) blockerMessages.push("Embeddings have not been tested yet, so dimensions are still unknown.");
   if (!cfg.vectorize_world_books) blockerMessages.push("World-book vectorization is disabled in embeddings settings.");
   if (!queryText) blockerMessages.push("The current chat does not have enough visible recent text to build a vector query.");
-  if (eligibleEntries.length === 0) blockerMessages.push("This chat has no semantic-enabled, non-disabled, non-empty lorebook entries to search.");
+  if (eligibleEntries.length === 0) blockerMessages.push("This chat has no vector-enabled, non-disabled, non-empty lorebook entries to search.");
 
   if (blockerMessages.length > 0) {
     return {
@@ -3175,11 +3169,6 @@ function buildParameters(
     if (effort !== "auto" || isToggleOnly) {
       injectReasoningParams(params, providerName, effort, modelName || undefined);
     }
-  }
-
-  // Streaming toggle from sampler overrides
-  if (overrides?.enabled && typeof (overrides as any).streaming === "boolean") {
-    params._streaming = (overrides as any).streaming;
   }
 
   // Custom body from preset.parameters.customBody

--- a/src/types/world-book.ts
+++ b/src/types/world-book.ts
@@ -132,6 +132,17 @@ export interface WorldBookDiagnostics {
       focusMissPenalty: number;
     };
     search_text_preview: string;
+    final_outcome_code:
+      | "injected_vector"
+      | "already_keyword"
+      | "blocked_by_group"
+      | "blocked_by_min_priority"
+      | "blocked_by_max_entries"
+      | "blocked_by_token_budget"
+      | "deduplicated"
+      | "blocked_during_final_assembly";
+    final_outcome_label: string;
+    final_outcome_reason: string;
   }>;
   blocker_messages: string[];
   deduplication?: {


### PR DESCRIPTION
## Summary
- Add per-hit outcome tracing to World Book diagnostics so reranked vector hits explain why they did or did not make the final prompt.
- Restore user-facing `vector` / `vectorized` terminology across the world-book diagnostics and editor flow.
- Update Memory Cortex diagnostics popup wording from `Sidecar` to `Sidecard`.

## What Changed
- World Book diagnostics now attach a final outcome and plain-English reason to each reranked vector hit.
- The reranked shortlist now shows row-level statuses like `Made final prompt`, `Already keyword-active`, `Blocked by group rule`, `No room under entry cap`, `No room under token budget`, and `Removed as duplicate`.
- Diagnostics summaries and blocker notes now derive from those concrete outcomes instead of only showing abstract displaced counts.
- User-facing `semantic` wording in the world-book/vector flow was switched back to `vector` / `vectorized`.
- The entry activation checkbox label was changed to `Vectorized`.
- Memory Cortex diagnostics popup labels/messages now use `Sidecard`.

## Files Touched
- `frontend/src/components/modals/MemoryCortexDiagnosticsModal.tsx`
- `frontend/src/components/modals/SettingsModal.tsx`
- `frontend/src/components/modals/WorldBookEditorModal.tsx`
- `frontend/src/components/panels/world-book/WorldBookDiagnosticsModal.module.css`
- `frontend/src/components/panels/world-book/WorldBookDiagnosticsModal.tsx`
- `frontend/src/components/panels/world-book/WorldBookPanel.tsx`
- `frontend/src/components/shared/WorldBookEntryEditor.tsx`
- `frontend/src/lib/worldBookVectorization.ts`
- `frontend/src/types/api.ts`
- `src/routes/memory-cortex.routes.ts`
- `src/routes/world-books.routes.ts`
- `src/services/prompt-assembly.service.ts`
- `src/types/world-book.ts`