### PR TITLE
Add full vector retrieval trace to diagnostics, Improve world-book vector diagnostics trace, and shortlist UX

### DIFF
--- a/frontend/src/components/panels/world-book/WorldBookDiagnosticsModal.module.css
+++ b/frontend/src/components/panels/world-book/WorldBookDiagnosticsModal.module.css
@@ -364,6 +364,115 @@
   color: var(--lumiverse-text);
 }
 
+.collapsibleSection {
+  border-radius: 16px;
+  border: 1px solid var(--lumiverse-border);
+  background: var(--lumiverse-fill-subtle);
+  overflow: hidden;
+}
+
+.collapsibleSummary {
+  list-style: none;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 16px;
+  cursor: pointer;
+}
+
+.collapsibleSummary::-webkit-details-marker {
+  display: none;
+}
+
+.collapsibleSummaryCopy {
+  min-width: 0;
+}
+
+.collapsibleSummaryText {
+  margin: 6px 0 0;
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: var(--lumiverse-text-muted);
+}
+
+.collapsibleSummaryMeta {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.collapsibleChevron {
+  color: var(--lumiverse-text-muted);
+  transition: transform var(--lumiverse-transition-fast);
+}
+
+.collapsibleSection[open] .collapsibleChevron {
+  transform: rotate(180deg);
+}
+
+.collapsibleBody {
+  padding: 0 16px 16px;
+}
+
+.searchField {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--lumiverse-border);
+  background: color-mix(in srgb, var(--lumiverse-bg) 78%, transparent);
+}
+
+.searchIcon {
+  color: var(--lumiverse-text-muted);
+  flex-shrink: 0;
+}
+
+.searchInput {
+  width: 100%;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: var(--lumiverse-text);
+  font-size: 12.5px;
+  line-height: 1.4;
+}
+
+.searchInput::placeholder {
+  color: var(--lumiverse-text-dim);
+}
+
+.traceSearchMeta {
+  font-size: 11.5px;
+  line-height: 1.5;
+  color: var(--lumiverse-text-muted);
+}
+
+.scrollPanel {
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.scrollPanel::-webkit-scrollbar {
+  width: 6px;
+}
+
+.scrollPanel::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--lumiverse-text-muted) 28%, transparent);
+}
+
+.shortlistScrollPanel {
+  max-height: 560px;
+}
+
+.traceScrollPanel {
+  max-height: 640px;
+}
+
 .scoreGuide {
   display: flex;
   flex-direction: column;
@@ -437,6 +546,20 @@
   border-radius: 999px;
   background: color-mix(in srgb, var(--lumiverse-primary) 14%, transparent);
   color: var(--lumiverse-primary);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.rankBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--lumiverse-border);
+  background: color-mix(in srgb, var(--lumiverse-bg) 74%, transparent);
+  color: var(--lumiverse-text-muted);
   font-size: 10.5px;
   font-weight: 700;
   letter-spacing: 0.04em;

--- a/frontend/src/components/panels/world-book/WorldBookDiagnosticsModal.tsx
+++ b/frontend/src/components/panels/world-book/WorldBookDiagnosticsModal.tsx
@@ -4,6 +4,7 @@ import { motion } from 'motion/react'
 import {
   Activity,
   AlertTriangle,
+  ChevronDown,
   CheckCircle2,
   Check,
   Copy,
@@ -18,8 +19,12 @@ import { worldBooksApi } from '@/api/world-books'
 import type { WorldBook, WorldBookDiagnostics } from '@/types/api'
 import styles from './WorldBookDiagnosticsModal.module.css'
 
+type DiagnosticVectorEntry = WorldBookDiagnostics['vector_trace'][number]
+type DiagnosticOutcomeCode = DiagnosticVectorEntry['final_outcome_code']
+type DiagnosticBreakdownKey = keyof DiagnosticVectorEntry['score_breakdown']
+
 const DIAGNOSTIC_BREAKDOWN_LABELS: Array<{
-  key: keyof WorldBookDiagnostics['vector_hits'][number]['score_breakdown']
+  key: DiagnosticBreakdownKey
   label: string
 }> = [
   { key: 'vectorSimilarity', label: 'Vector' },
@@ -43,7 +48,7 @@ const LEXICAL_GUIDE_BODY =
 const CUTOFF_GUIDE_BODY =
   'Similarity Threshold filters on vector distance before reranking. Rerank Cutoff filters on rerank score after reranking.'
 
-const OUTCOME_SUMMARY_PRIORITY: WorldBookDiagnostics['vector_hits'][number]['final_outcome_code'][] = [
+const OUTCOME_SUMMARY_PRIORITY: DiagnosticOutcomeCode[] = [
   'blocked_by_max_entries',
   'blocked_by_token_budget',
   'blocked_by_group',
@@ -59,7 +64,7 @@ function formatDiagnosticNumber(value: number): string {
 }
 
 function formatDiagnosticBreakdownValue(
-  key: keyof WorldBookDiagnostics['vector_hits'][number]['score_breakdown'],
+  key: DiagnosticBreakdownKey,
   value: number,
 ): string {
   const formatted = formatDiagnosticNumber(value)
@@ -71,7 +76,7 @@ function truncateDiagnosticPreview(text: string, maxLength = 420): string {
   return `${text.slice(0, maxLength).trimEnd()}...`
 }
 
-function buildDiagnosticMatchSummary(hit: WorldBookDiagnostics['vector_hits'][number]): string {
+function buildDiagnosticMatchSummary(hit: DiagnosticVectorEntry): string {
   const reasons: string[] = []
 
   if (hit.matched_primary_keys.length > 0) {
@@ -99,7 +104,7 @@ function joinReadableList(parts: string[]): string {
 }
 
 function formatOutcomeSummaryPart(
-  code: WorldBookDiagnostics['vector_hits'][number]['final_outcome_code'],
+  code: DiagnosticOutcomeCode,
   count: number,
 ): string {
   switch (code) {
@@ -117,6 +122,12 @@ function formatOutcomeSummaryPart(
       return `${count} had no room under the token budget`
     case 'deduplicated':
       return `${count} ${count === 1 ? 'was' : 'were'} removed as duplicate${count === 1 ? '' : 's'}`
+    case 'trimmed_by_top_k':
+      return `${count} ${count === 1 ? 'was' : 'were'} outside the returned top-k`
+    case 'rejected_by_rerank_cutoff':
+      return `${count} ${count === 1 ? 'was' : 'were'} below the rerank cutoff`
+    case 'rejected_by_similarity_threshold':
+      return `${count} ${count === 1 ? 'was' : 'were'} above the similarity threshold`
     case 'blocked_during_final_assembly':
     default:
       return `${count} ${count === 1 ? 'was' : 'were'} dropped during final assembly`
@@ -124,12 +135,23 @@ function formatOutcomeSummaryPart(
 }
 
 function getOutcomeBadgeClassName(
-  code: WorldBookDiagnostics['vector_hits'][number]['final_outcome_code'],
+  code: DiagnosticOutcomeCode,
   styles: Record<string, string>,
 ): string {
   if (code === 'injected_vector') return styles.outcomeBadgeSuccess
   if (code === 'already_keyword') return styles.outcomeBadgeMuted
   return styles.outcomeBadgeWarning
+}
+
+function formatScoreBreakdownReport(
+  breakdown: DiagnosticVectorEntry['score_breakdown'],
+): string {
+  return DIAGNOSTIC_BREAKDOWN_LABELS
+    .map(({ key }) => {
+      const value = breakdown[key]
+      return `${key}:${key === 'broadPenalty' || key === 'focusMissPenalty' ? `-${formatDiagnosticNumber(value)}` : formatDiagnosticNumber(value)}`
+    })
+    .join(', ')
 }
 
 async function copyTextToClipboard(text: string): Promise<void> {
@@ -164,18 +186,107 @@ interface Props {
   onClose: () => void
 }
 
+interface DiagnosticCandidateCardProps {
+  hit: DiagnosticVectorEntry
+  keywordHitIds: Set<string>
+}
+
+function DiagnosticCandidateCard({ hit, keywordHitIds }: DiagnosticCandidateCardProps) {
+  const breakdownItems = DIAGNOSTIC_BREAKDOWN_LABELS
+    .map(({ key, label }) => ({ key, label, value: hit.score_breakdown[key] }))
+    .filter((item) => item.value > 0.001)
+
+  return (
+    <article className={styles.hitCard}>
+      <div className={styles.hitHeader}>
+        <div className={styles.hitText}>
+          <div className={styles.hitTitleRow}>
+            <h4 className={styles.hitTitle}>{hit.comment || '(unnamed entry)'}</h4>
+            <span
+              className={clsx(
+                styles.outcomeBadge,
+                getOutcomeBadgeClassName(hit.final_outcome_code, styles),
+              )}
+            >
+              {hit.final_outcome_label}
+            </span>
+            {hit.rerank_rank != null && (
+              <span className={styles.rankBadge}>Rerank #{hit.rerank_rank}</span>
+            )}
+            {keywordHitIds.has(hit.entry_id) && hit.final_outcome_code !== 'already_keyword' && (
+              <span className={styles.keywordBadge}>Already keyword-active</span>
+            )}
+          </div>
+          <p className={styles.hitSummary}>{buildDiagnosticMatchSummary(hit)}</p>
+          <p className={styles.hitOutcomeReason}>{hit.final_outcome_reason}</p>
+        </div>
+        <div className={styles.hitScores}>
+          <span className={styles.scorePill}>
+            Rerank score {formatDiagnosticNumber(hit.final_score)}
+          </span>
+          <span className={styles.distancePill}>
+            Vector distance {formatDiagnosticNumber(hit.distance)}
+          </span>
+        </div>
+      </div>
+
+      {(hit.matched_primary_keys.length > 0 || hit.matched_secondary_keys.length > 0 || hit.matched_comment) && (
+        <div className={styles.matchChipRow}>
+          {hit.matched_primary_keys.map((value) => (
+            <span key={`${hit.entry_id}-primary-${value}`} className={styles.matchChip}>
+              Primary: {value}
+            </span>
+          ))}
+          {hit.matched_secondary_keys.map((value) => (
+            <span key={`${hit.entry_id}-secondary-${value}`} className={styles.matchChip}>
+              Alias: {value}
+            </span>
+          ))}
+          {hit.matched_comment && (
+            <span className={styles.matchChip}>Title: {hit.matched_comment}</span>
+          )}
+        </div>
+      )}
+
+      {breakdownItems.length > 0 && (
+        <div className={styles.breakdownGrid}>
+          {breakdownItems.map((item) => (
+            <span key={`${hit.entry_id}-${item.label}`} className={styles.breakdownChip}>
+              <span className={styles.breakdownLabel}>{item.label}</span>
+              <span className={styles.breakdownValue}>
+                {formatDiagnosticBreakdownValue(item.key, item.value)}
+              </span>
+            </span>
+          ))}
+        </div>
+      )}
+
+      {hit.search_text_preview && (
+        <div className={styles.previewBlock}>
+          <div className={styles.previewLabel}>Indexed search text</div>
+          <div className={styles.previewText}>
+            {truncateDiagnosticPreview(hit.search_text_preview)}
+          </div>
+        </div>
+      )}
+    </article>
+  )
+}
+
 export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Props) {
   const [diagnostics, setDiagnostics] = useState<WorldBookDiagnostics | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [copyState, setCopyState] = useState<'idle' | 'copying' | 'copied' | 'error'>('idle')
   const [copyMessage, setCopyMessage] = useState<string | null>(null)
+  const [traceSearch, setTraceSearch] = useState('')
 
   const loadDiagnostics = useCallback(async () => {
     setLoading(true)
     setError(null)
     setCopyState('idle')
     setCopyMessage(null)
+    setTraceSearch('')
     try {
       const result = await worldBooksApi.getDiagnostics(book.id, chatId)
       setDiagnostics(result)
@@ -236,6 +347,50 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
   const injectedVectorCount = diagnostics
     ? diagnostics.vector_hits.filter((hit) => hit.final_outcome_code === 'injected_vector').length
     : 0
+  const pulledTraceCount = diagnostics?.vector_trace.length ?? 0
+  const trimmedByTopKCount = diagnostics
+    ? diagnostics.vector_trace.filter((hit) => hit.final_outcome_code === 'trimmed_by_top_k').length
+    : 0
+  const pulledTraceSummaryParts = useMemo(() => {
+    if (!diagnostics) return [] as string[]
+
+    const parts: string[] = []
+    if (diagnostics.retrieval.threshold_rejected > 0) {
+      parts.push(`${diagnostics.retrieval.threshold_rejected} above threshold`)
+    }
+    if (diagnostics.retrieval.rerank_rejected > 0) {
+      parts.push(`${diagnostics.retrieval.rerank_rejected} below rerank cutoff`)
+    }
+    if (trimmedByTopKCount > 0) {
+      parts.push(`${trimmedByTopKCount} outside the returned top-k`)
+    }
+    if (diagnostics.vector_hits.length > 0) {
+      parts.push(`${diagnostics.vector_hits.length} in the shortlist`)
+    }
+    return parts
+  }, [diagnostics, trimmedByTopKCount])
+  const filteredVectorTrace = useMemo(() => {
+    if (!diagnostics) return [] as WorldBookDiagnostics['vector_trace']
+
+    const search = traceSearch.trim().toLowerCase()
+    if (!search) return diagnostics.vector_trace
+
+    return diagnostics.vector_trace.filter((hit) => {
+      const haystack = [
+        hit.comment,
+        hit.final_outcome_label,
+        hit.final_outcome_reason,
+        hit.matched_comment ?? '',
+        hit.search_text_preview,
+        ...hit.matched_primary_keys,
+        ...hit.matched_secondary_keys,
+      ]
+        .join('\n')
+        .toLowerCase()
+
+      return haystack.includes(search)
+    })
+  }, [diagnostics, traceSearch])
   const displacedOutcomeSummaryParts = useMemo(() => {
     if (!diagnostics) return [] as string[]
 
@@ -332,7 +487,7 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
       return {
         tone: 'success',
         title: `${diagnostics.stats.vectorActivated} vector entr${diagnostics.stats.vectorActivated === 1 ? 'y' : 'ies'} made the final prompt`,
-        body: `Reranking found ${diagnostics.vector_hits.length} vector candidates, and ${diagnostics.stats.vectorActivated} survived into the final world-info result.`,
+        body: `Retrieval pulled ${pulledTraceCount} candidates, ${diagnostics.retrieval.hits_after_rerank_cutoff} cleared the rerank cutoff, and ${diagnostics.stats.vectorActivated} survived into the final world-info result.`,
       } as const
     }
 
@@ -359,7 +514,7 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
       return {
         tone: 'warning',
         title: 'Vector matches were found, but they did not survive final prompt assembly',
-        body: `${freshSemanticCount} fresh vector candidate${freshSemanticCount === 1 ? '' : 's'} appeared after reranking, but ${displacedSemanticCount} were displaced before the final prompt. ${displacementWhy}`,
+        body: `Retrieval pulled ${pulledTraceCount} candidates. ${freshSemanticCount} fresh vector candidate${freshSemanticCount === 1 ? '' : 's'} made the shortlist, but ${displacedSemanticCount} were displaced before the final prompt. ${displacementWhy}`,
       } as const
     }
 
@@ -368,7 +523,7 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
       title: 'Vector retrieval found candidates, but none became vector-activated entries',
       body: 'The reranked shortlist exists, but the final prompt still ended up with zero vector-only additions.',
     } as const
-  }, [attached, diagnostics, displacedOutcomeSummaryParts, displacedSemanticCount, error, freshSemanticCount, loading])
+  }, [attached, diagnostics, displacedOutcomeSummaryParts, displacedSemanticCount, error, freshSemanticCount, loading, pulledTraceCount])
 
   const reportText = useMemo(() => {
     if (!diagnostics) return ''
@@ -387,10 +542,13 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
       `Pending: ${diagnostics.vector_summary.pending}`,
       `Errors: ${diagnostics.vector_summary.error}`,
       `Vector recall size (top-k): ${diagnostics.retrieval.top_k}`,
+      `Pulled vector candidates: ${diagnostics.vector_trace.length}`,
       `Hits before similarity threshold: ${diagnostics.retrieval.hits_before_threshold}`,
       `Rejected by similarity threshold: ${diagnostics.retrieval.threshold_rejected}`,
+      `Cleared similarity threshold: ${diagnostics.retrieval.hits_after_threshold}`,
       `Rejected by rerank cutoff: ${diagnostics.retrieval.rerank_rejected}`,
-      `Reranked vector hits: ${diagnostics.vector_hits.length}`,
+      `Cleared rerank cutoff: ${diagnostics.retrieval.hits_after_rerank_cutoff}`,
+      `Shortlisted vector hits shown: ${diagnostics.vector_hits.length}`,
       `Keyword hits: ${diagnostics.keyword_hits.length}`,
       `Keyword/vector overlap: ${overlapCount}`,
       `Fresh vector candidates: ${freshSemanticCount}`,
@@ -445,7 +603,7 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
       }
     }
 
-    lines.push('', 'VECTOR HITS')
+    lines.push('', 'RERANKED SHORTLIST')
     if (diagnostics.vector_hits.length === 0) {
       lines.push('(none)')
     } else {
@@ -459,9 +617,29 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
           `   matched_secondary_keys=${hit.matched_secondary_keys.join(', ') || '(none)'}`,
           `   matched_comment=${hit.matched_comment || '(none)'}`,
           `   overlaps_keyword=${keywordHitIds.has(hit.entry_id)}`,
-          `   score_breakdown=${Object.entries(hit.score_breakdown)
-            .map(([key, value]) => `${key}:${key === 'broadPenalty' || key === 'focusMissPenalty' ? `-${formatDiagnosticNumber(value)}` : formatDiagnosticNumber(value)}`)
-            .join(', ')}`,
+          `   score_breakdown=${formatScoreBreakdownReport(hit.score_breakdown)}`,
+          '   search_text_preview:',
+          `   ${truncateDiagnosticPreview(hit.search_text_preview || '(empty)', 800).replace(/\n/g, '\n   ')}`,
+        )
+      })
+    }
+
+    lines.push('', 'ALL PULLED VECTOR CANDIDATES')
+    if (diagnostics.vector_trace.length === 0) {
+      lines.push('(none)')
+    } else {
+      diagnostics.vector_trace.forEach((hit, index) => {
+        lines.push(
+          `${index + 1}. ${hit.comment || '(unnamed entry)'} [${hit.entry_id}]`,
+          `   final_outcome=${hit.final_outcome_label}`,
+          `   final_outcome_reason=${hit.final_outcome_reason}`,
+          `   rerank_rank=${hit.rerank_rank == null ? '(n/a)' : hit.rerank_rank}`,
+          `   vector_distance=${formatDiagnosticNumber(hit.distance)} rerank_score=${formatDiagnosticNumber(hit.final_score)} lexical_candidate_score=${hit.lexical_candidate_score == null ? '(none)' : formatDiagnosticNumber(hit.lexical_candidate_score)}`,
+          `   matched_primary_keys=${hit.matched_primary_keys.join(', ') || '(none)'}`,
+          `   matched_secondary_keys=${hit.matched_secondary_keys.join(', ') || '(none)'}`,
+          `   matched_comment=${hit.matched_comment || '(none)'}`,
+          `   overlaps_keyword=${keywordHitIds.has(hit.entry_id)}`,
+          `   score_breakdown=${formatScoreBreakdownReport(hit.score_breakdown)}`,
           '   search_text_preview:',
           `   ${truncateDiagnosticPreview(hit.search_text_preview || '(empty)', 800).replace(/\n/g, '\n   ')}`,
         )
@@ -482,6 +660,7 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
     keywordHitIds,
     noteMessages,
     overlapCount,
+    pulledTraceCount,
   ])
 
   const handleCopyReport = useCallback(async () => {
@@ -598,7 +777,7 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
                   </span>
                   <span className={styles.heroTag}>
                     <Search size={12} />
-                    <span>{diagnostics.vector_hits.length} reranked vector matches</span>
+                    <span>{pulledTraceCount} pulled, {diagnostics.vector_hits.length} shown in shortlist</span>
                   </span>
                 </div>
               )}
@@ -633,10 +812,10 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
                 </article>
 
                 <article className={styles.metricCard}>
-                  <span className={styles.metricLabel}>Reranked Hits</span>
+                  <span className={styles.metricLabel}>Reranked shortlist</span>
                   <strong className={styles.metricValue}>{diagnostics.vector_hits.length}</strong>
                   <span className={styles.metricMeta}>
-                    {injectedVectorCount} made prompt, {displacedSemanticCount} displaced, {overlapCount} already keyword-active
+                    {pulledTraceCount} pulled, {diagnostics.retrieval.hits_after_rerank_cutoff} cleared cutoff, {injectedVectorCount} made prompt
                   </span>
                 </article>
 
@@ -672,88 +851,80 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
                         No vector hits survived the threshold and rerank steps for this chat.
                       </div>
                     ) : (
-                      <div className={styles.hitList}>
-                        {diagnostics.vector_hits.map((hit) => {
-                          const breakdownItems = DIAGNOSTIC_BREAKDOWN_LABELS
-                            .map(({ key, label }) => ({ key, label, value: hit.score_breakdown[key] }))
-                            .filter((item) => item.value > 0.001)
-
-                          return (
-                            <article key={hit.entry_id} className={styles.hitCard}>
-                              <div className={styles.hitHeader}>
-                                <div className={styles.hitText}>
-                                  <div className={styles.hitTitleRow}>
-                                    <h4 className={styles.hitTitle}>{hit.comment || '(unnamed entry)'}</h4>
-                                    <span
-                                      className={clsx(
-                                        styles.outcomeBadge,
-                                        getOutcomeBadgeClassName(hit.final_outcome_code, styles),
-                                      )}
-                                    >
-                                      {hit.final_outcome_label}
-                                    </span>
-                                    {keywordHitIds.has(hit.entry_id) && hit.final_outcome_code !== 'already_keyword' && (
-                                      <span className={styles.keywordBadge}>Already keyword-active</span>
-                                    )}
-                                  </div>
-                                  <p className={styles.hitSummary}>{buildDiagnosticMatchSummary(hit)}</p>
-                                  <p className={styles.hitOutcomeReason}>{hit.final_outcome_reason}</p>
-                                </div>
-                                <div className={styles.hitScores}>
-                                  <span className={styles.scorePill}>
-                                    Rerank score {formatDiagnosticNumber(hit.final_score)}
-                                  </span>
-                                  <span className={styles.distancePill}>
-                                    Vector distance {formatDiagnosticNumber(hit.distance)}
-                                  </span>
-                                </div>
-                              </div>
-
-                              {(hit.matched_primary_keys.length > 0 || hit.matched_secondary_keys.length > 0 || hit.matched_comment) && (
-                                <div className={styles.matchChipRow}>
-                                  {hit.matched_primary_keys.map((value) => (
-                                    <span key={`${hit.entry_id}-primary-${value}`} className={styles.matchChip}>
-                                      Primary: {value}
-                                    </span>
-                                  ))}
-                                  {hit.matched_secondary_keys.map((value) => (
-                                    <span key={`${hit.entry_id}-secondary-${value}`} className={styles.matchChip}>
-                                      Alias: {value}
-                                    </span>
-                                  ))}
-                                  {hit.matched_comment && (
-                                    <span className={styles.matchChip}>Title: {hit.matched_comment}</span>
-                                  )}
-                                </div>
-                              )}
-
-                              {breakdownItems.length > 0 && (
-                                <div className={styles.breakdownGrid}>
-                                  {breakdownItems.map((item) => (
-                                    <span key={`${hit.entry_id}-${item.label}`} className={styles.breakdownChip}>
-                                      <span className={styles.breakdownLabel}>{item.label}</span>
-                                      <span className={styles.breakdownValue}>
-                                        {formatDiagnosticBreakdownValue(item.key, item.value)}
-                                      </span>
-                                    </span>
-                                  ))}
-                                </div>
-                              )}
-
-                              {hit.search_text_preview && (
-                                <div className={styles.previewBlock}>
-                                  <div className={styles.previewLabel}>Indexed search text</div>
-                                  <div className={styles.previewText}>
-                                    {truncateDiagnosticPreview(hit.search_text_preview)}
-                                  </div>
-                                </div>
-                              )}
-                            </article>
-                          )
-                        })}
+                      <div className={clsx(styles.scrollPanel, styles.shortlistScrollPanel)}>
+                        <div className={styles.hitList}>
+                          {diagnostics.vector_hits.map((hit) => (
+                            <DiagnosticCandidateCard
+                              key={hit.entry_id}
+                              hit={hit}
+                              keywordHitIds={keywordHitIds}
+                            />
+                          ))}
+                        </div>
                       </div>
                     )}
                   </section>
+
+                  <details className={styles.collapsibleSection}>
+                    <summary className={styles.collapsibleSummary}>
+                      <div className={styles.collapsibleSummaryCopy}>
+                        <div className={styles.sectionEyebrow}>Full retrieval trace</div>
+                        <h3 className={styles.sectionTitle}>All pulled vector candidates</h3>
+                        <p className={styles.collapsibleSummaryText}>
+                          {pulledTraceCount === 0
+                            ? 'No candidates were pulled from vector search for this chat.'
+                            : `${pulledTraceCount} pulled total. ${pulledTraceSummaryParts.length > 0 ? `${joinReadableList(pulledTraceSummaryParts)}.` : 'Open to inspect every pulled entry and why it stayed or got dropped.'}`}
+                        </p>
+                      </div>
+                      <div className={styles.collapsibleSummaryMeta}>
+                        <span className={styles.sectionCount}>{pulledTraceCount}</span>
+                        <ChevronDown size={16} className={styles.collapsibleChevron} />
+                      </div>
+                    </summary>
+
+                    <div className={styles.collapsibleBody}>
+                      {diagnostics.vector_trace.length === 0 ? (
+                        <div className={styles.emptyStateSmall}>
+                          No vector candidates were pulled for this chat.
+                        </div>
+                      ) : (
+                        <>
+                          <label className={styles.searchField}>
+                            <Search size={14} className={styles.searchIcon} />
+                            <input
+                              type="text"
+                              className={styles.searchInput}
+                              value={traceSearch}
+                              onChange={(event) => setTraceSearch(event.target.value)}
+                              placeholder="Search pulled entries, titles, aliases, outcomes, or indexed text"
+                            />
+                          </label>
+                          <div className={styles.traceSearchMeta}>
+                            {traceSearch.trim()
+                              ? `${filteredVectorTrace.length} of ${diagnostics.vector_trace.length} pulled candidates match "${traceSearch.trim()}".`
+                              : `${diagnostics.vector_trace.length} pulled candidates available.`}
+                          </div>
+                          {filteredVectorTrace.length === 0 ? (
+                            <div className={styles.emptyStateSmall}>
+                              No pulled vector candidates match the current search.
+                            </div>
+                          ) : (
+                            <div className={clsx(styles.scrollPanel, styles.traceScrollPanel)}>
+                              <div className={styles.hitList}>
+                                {filteredVectorTrace.map((hit) => (
+                                  <DiagnosticCandidateCard
+                                    key={`trace-${hit.entry_id}`}
+                                    hit={hit}
+                                    keywordHitIds={keywordHitIds}
+                                  />
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                        </>
+                      )}
+                    </div>
+                  </details>
                 </div>
 
                 <div className={styles.sideColumn}>
@@ -821,12 +992,28 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
                         <span className={styles.factValue}>{diagnostics.retrieval.top_k}</span>
                       </div>
                       <div className={styles.factRow}>
+                        <span className={styles.factLabel}>Pulled candidates</span>
+                        <span className={styles.factValue}>{pulledTraceCount}</span>
+                      </div>
+                      <div className={styles.factRow}>
                         <span className={styles.factLabel}>Rejected by similarity threshold</span>
                         <span className={styles.factValue}>{diagnostics.retrieval.threshold_rejected}</span>
                       </div>
                       <div className={styles.factRow}>
+                        <span className={styles.factLabel}>Passed similarity threshold</span>
+                        <span className={styles.factValue}>{diagnostics.retrieval.hits_after_threshold}</span>
+                      </div>
+                      <div className={styles.factRow}>
                         <span className={styles.factLabel}>Rejected by rerank cutoff</span>
                         <span className={styles.factValue}>{diagnostics.retrieval.rerank_rejected}</span>
+                      </div>
+                      <div className={styles.factRow}>
+                        <span className={styles.factLabel}>Cleared rerank cutoff</span>
+                        <span className={styles.factValue}>{diagnostics.retrieval.hits_after_rerank_cutoff}</span>
+                      </div>
+                      <div className={styles.factRow}>
+                        <span className={styles.factLabel}>Shown in shortlist</span>
+                        <span className={styles.factValue}>{diagnostics.vector_hits.length}</span>
                       </div>
                       <div className={styles.factRow}>
                         <span className={styles.factLabel}>Activated before budget</span>
@@ -845,7 +1032,7 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
                         <span className={styles.factValue}>{freshSemanticCount}</span>
                       </div>
                       <div className={styles.factRow}>
-                        <span className={styles.factLabel}>Displaced vector candidates</span>
+                        <span className={styles.factLabel}>Displaced shortlist candidates</span>
                         <span className={styles.factValue}>{displacedSemanticCount}</span>
                       </div>
                     </div>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -230,6 +230,7 @@ export interface ConnectionTestResult {
 }
 
 export interface ConnectionModelsResult {
+  model_labels?: Record<string, string>
   models: string[]
   provider: string
   error?: string
@@ -530,6 +531,7 @@ export interface WorldBookDiagnostics {
       focusMissPenalty: number;
     };
     search_text_preview: string;
+    rerank_rank: number | null;
     final_outcome_code:
       | 'injected_vector'
       | 'already_keyword'
@@ -538,7 +540,50 @@ export interface WorldBookDiagnostics {
       | 'blocked_by_max_entries'
       | 'blocked_by_token_budget'
       | 'deduplicated'
-      | 'blocked_during_final_assembly';
+      | 'blocked_during_final_assembly'
+      | 'trimmed_by_top_k'
+      | 'rejected_by_rerank_cutoff'
+      | 'rejected_by_similarity_threshold';
+    final_outcome_label: string;
+    final_outcome_reason: string;
+  }>;
+  vector_trace: Array<{
+    entry_id: string;
+    comment: string;
+    score: number;
+    distance: number;
+    final_score: number;
+    lexical_candidate_score: number | null;
+    matched_primary_keys: string[];
+    matched_secondary_keys: string[];
+    matched_comment: string | null;
+    score_breakdown: {
+      vectorSimilarity: number;
+      primaryExact: number;
+      primaryPartial: number;
+      secondaryExact: number;
+      secondaryPartial: number;
+      commentExact: number;
+      commentPartial: number;
+      focusBoost: number;
+      priority: number;
+      broadPenalty: number;
+      focusMissPenalty: number;
+    };
+    search_text_preview: string;
+    rerank_rank: number | null;
+    final_outcome_code:
+      | 'injected_vector'
+      | 'already_keyword'
+      | 'blocked_by_group'
+      | 'blocked_by_min_priority'
+      | 'blocked_by_max_entries'
+      | 'blocked_by_token_budget'
+      | 'deduplicated'
+      | 'blocked_during_final_assembly'
+      | 'trimmed_by_top_k'
+      | 'rejected_by_rerank_cutoff'
+      | 'rejected_by_similarity_threshold';
     final_outcome_label: string;
     final_outcome_reason: string;
   }>;

--- a/src/routes/world-books.routes.ts
+++ b/src/routes/world-books.routes.ts
@@ -29,7 +29,10 @@ type DiagnosticVectorHitOutcomeCode =
   | "blocked_by_max_entries"
   | "blocked_by_token_budget"
   | "deduplicated"
-  | "blocked_during_final_assembly";
+  | "blocked_during_final_assembly"
+  | "trimmed_by_top_k"
+  | "rejected_by_rerank_cutoff"
+  | "rejected_by_similarity_threshold";
 
 interface DiagnosticVectorHitOutcome {
   code: DiagnosticVectorHitOutcomeCode;
@@ -37,7 +40,31 @@ interface DiagnosticVectorHitOutcome {
   reason: string;
 }
 
-type VectorHitEntry = Awaited<ReturnType<typeof collectVectorActivatedWorldInfoDetailed>>["entries"][number];
+type VectorHitEntry = Awaited<ReturnType<typeof collectVectorActivatedWorldInfoDetailed>>["candidateTrace"][number];
+type VectorTraceEntry = Awaited<ReturnType<typeof collectVectorActivatedWorldInfoDetailed>>["candidateTrace"][number];
+
+function formatDiagnosticMetric(value: number | null | undefined): string {
+  return typeof value === "number" && Number.isFinite(value) ? value.toFixed(3) : "0.000";
+}
+
+function buildRerankLead(options: {
+  rerankRank?: number | null;
+  finalScore?: number | null;
+  distance?: number | null;
+}): string {
+  const score = typeof options.finalScore === "number" && Number.isFinite(options.finalScore)
+    ? `rerank ${formatDiagnosticMetric(options.finalScore)}`
+    : null;
+  const distance = typeof options.distance === "number" && Number.isFinite(options.distance)
+    ? `distance ${formatDiagnosticMetric(options.distance)}`
+    : null;
+  const metrics = [score, distance].filter((value): value is string => Boolean(value));
+  const metricText = metrics.length > 0 ? ` (${metrics.join(", ")})` : "";
+  if (typeof options.rerankRank === "number" && Number.isFinite(options.rerankRank)) {
+    return `It ranked #${options.rerankRank} after reranking${metricText}.`;
+  }
+  return `This candidate was pulled from vector search${metricText}.`;
+}
 
 function getWorldInfoGroupKey(entry: WorldBookEntry): string | null {
   const groupName = typeof entry.group_name === "string" ? entry.group_name.trim() : "";
@@ -54,47 +81,59 @@ function buildDiagnosticVectorOutcome(
     conflictingSource?: "keyword" | "vector";
     keptEntryComment?: string;
     dedupTier?: "exact" | "near-exact" | "fuzzy";
+    rerankRank?: number | null;
+    finalScore?: number | null;
+    distance?: number | null;
+    topK?: number;
+    rerankCutoff?: number;
+    similarityThreshold?: number;
   } = {},
 ): DiagnosticVectorHitOutcome {
+  const rerankLead = buildRerankLead({
+    rerankRank: options.rerankRank,
+    finalScore: options.finalScore,
+    distance: options.distance,
+  });
   switch (code) {
     case "injected_vector":
       return {
         code,
         label: "Made final prompt",
-        reason: "This vector hit survived reranking and final prompt assembly as a vector-activated entry.",
+        reason: `${rerankLead} It survived final prompt assembly as a vector-activated entry.`,
       };
     case "already_keyword":
       return {
         code,
         label: "Already keyword-active",
-        reason: "This same entry was already activated by keyword logic, so vector retrieval did not add a second copy.",
+        reason: `${rerankLead} The same entry was already activated by keyword logic, so vector retrieval did not add a second copy.`,
       };
     case "blocked_by_group": {
       const conflicting = options.conflictingEntry?.comment?.trim() || "another entry";
       const source = options.conflictingSource === "vector" ? "another vector hit" : "keyword activation";
+      const groupName = options.entry?.group_name?.trim() || "this mutually exclusive group";
       return {
         code,
         label: "Blocked by group rule",
-        reason: `This entry shares a mutually exclusive group with "${conflicting}", which had already claimed the slot via ${source}.`,
+        reason: `${rerankLead} ${groupName} was already occupied by "${conflicting}" via ${source}.`,
       };
     }
     case "blocked_by_min_priority":
       return {
         code,
         label: "Below minimum priority",
-        reason: `This entry's priority (${options.entry?.priority ?? 0}) is below the current World Info minimum priority (${options.minPriority ?? 0}).`,
+        reason: `${rerankLead} Its priority (${options.entry?.priority ?? 0}) is below the current World Info minimum priority (${options.minPriority ?? 0}).`,
       };
     case "blocked_by_max_entries":
       return {
         code,
         label: "No room under entry cap",
-        reason: `The final World Info list had already reached the ${options.maxActivatedEntries ?? 0}-entry cap before this vector hit could be added.`,
+        reason: `${rerankLead} The final World Info list had already reached the ${options.maxActivatedEntries ?? 0}-entry cap before this entry could be added.`,
       };
     case "blocked_by_token_budget":
       return {
         code,
         label: "No room under token budget",
-        reason: "Adding this entry would have pushed the World Info prompt past the current token budget, so earlier entries kept the room.",
+        reason: `${rerankLead} Adding it would have pushed the World Info prompt past the current token budget, so earlier entries kept the room.`,
       };
     case "deduplicated": {
       const kept = options.keptEntryComment?.trim() || "another entry";
@@ -106,15 +145,33 @@ function buildDiagnosticVectorOutcome(
       return {
         code,
         label: "Removed as duplicate",
-        reason: `This vector hit initially made the merged set, but it was removed as a ${tier} of "${kept}".`,
+        reason: `${rerankLead} It initially made the merged set, but it was removed as a ${tier} of "${kept}".`,
       };
     }
+    case "trimmed_by_top_k":
+      return {
+        code,
+        label: "Outside returned top-k",
+        reason: `${rerankLead} It cleared the rerank cutoff, but only the top ${options.topK ?? 0} reranked candidates are kept in the shortlist shown here.`,
+      };
+    case "rejected_by_rerank_cutoff":
+      return {
+        code,
+        label: "Below rerank cutoff",
+        reason: `It was pulled from vector search (rerank ${formatDiagnosticMetric(options.finalScore)}, distance ${formatDiagnosticMetric(options.distance)}), but the rerank score stayed below the current cutoff (${formatDiagnosticMetric(options.rerankCutoff)}).`,
+      };
+    case "rejected_by_similarity_threshold":
+      return {
+        code,
+        label: "Above similarity threshold",
+        reason: `It was pulled from vector search at distance ${formatDiagnosticMetric(options.distance)}, but that exceeded the current similarity threshold (${formatDiagnosticMetric(options.similarityThreshold)}), so reranking never got a chance to keep it.`,
+      };
     case "blocked_during_final_assembly":
     default:
       return {
         code: "blocked_during_final_assembly",
         label: "Lost during final assembly",
-        reason: "This vector hit survived retrieval, but later prompt-assembly rules left no room for it in the final World Info list.",
+        reason: `${rerankLead} Later prompt-assembly rules still left no room for it in the final World Info list.`,
       };
   }
 }
@@ -157,7 +214,12 @@ function traceDiagnosticVectorHitOutcomes(
 
   for (const item of vectorEntries) {
     if (seen.has(item.entry.id)) {
-      outcomes.set(item.entry.id, buildDiagnosticVectorOutcome("already_keyword"));
+      outcomes.set(item.entry.id, buildDiagnosticVectorOutcome("already_keyword", {
+        entry: item.entry,
+        rerankRank: item.rerankRank,
+        finalScore: item.finalScore,
+        distance: item.distance,
+      }));
       continue;
     }
 
@@ -165,6 +227,9 @@ function traceDiagnosticVectorHitOutcomes(
       outcomes.set(item.entry.id, buildDiagnosticVectorOutcome("blocked_by_min_priority", {
         entry: item.entry,
         minPriority: settings.minPriority,
+        rerankRank: item.rerankRank,
+        finalScore: item.finalScore,
+        distance: item.distance,
       }));
       continue;
     }
@@ -174,8 +239,12 @@ function traceDiagnosticVectorHitOutcomes(
       const occupied = occupiedGroups.get(groupKey);
       if (occupied) {
         outcomes.set(item.entry.id, buildDiagnosticVectorOutcome("blocked_by_group", {
+          entry: item.entry,
           conflictingEntry: occupied.entry,
           conflictingSource: occupied.source,
+          rerankRank: item.rerankRank,
+          finalScore: item.finalScore,
+          distance: item.distance,
         }));
         continue;
       }
@@ -184,6 +253,9 @@ function traceDiagnosticVectorHitOutcomes(
     if (finalized.activatedEntries.length >= maxActivatedTarget && !item.entry.constant) {
       outcomes.set(item.entry.id, buildDiagnosticVectorOutcome("blocked_by_max_entries", {
         maxActivatedEntries: settings.maxActivatedEntries,
+        rerankRank: item.rerankRank,
+        finalScore: item.finalScore,
+        distance: item.distance,
       }));
       continue;
     }
@@ -199,6 +271,11 @@ function traceDiagnosticVectorHitOutcomes(
     if (!itemSurvived || (!grewActivationSet && !item.entry.constant)) {
       outcomes.set(item.entry.id, buildDiagnosticVectorOutcome(
         settings.maxTokenBudget > 0 ? "blocked_by_token_budget" : "blocked_during_final_assembly",
+        {
+          rerankRank: item.rerankRank,
+          finalScore: item.finalScore,
+          distance: item.distance,
+        },
       ));
       continue;
     }
@@ -208,7 +285,11 @@ function traceDiagnosticVectorHitOutcomes(
     sources.set(item.entry.id, { source: "vector", score: item.finalScore });
     if (groupKey) occupiedGroups.set(groupKey, { entry: item.entry, source: "vector" });
     finalized = nextFinalized;
-    outcomes.set(item.entry.id, buildDiagnosticVectorOutcome("injected_vector"));
+    outcomes.set(item.entry.id, buildDiagnosticVectorOutcome("injected_vector", {
+      rerankRank: item.rerankRank,
+      finalScore: item.finalScore,
+      distance: item.distance,
+    }));
   }
 
   const dedupResult = deduplicateWorldInfoEntries(mergedEntries, sources);
@@ -221,6 +302,50 @@ function traceDiagnosticVectorHitOutcomes(
   }
 
   return outcomes;
+}
+
+function resolveDiagnosticVectorTraceOutcome(
+  item: VectorTraceEntry,
+  shortlistedOutcomes: Map<string, DiagnosticVectorHitOutcome>,
+  options: {
+    topK: number;
+    rerankCutoff: number;
+    similarityThreshold: number;
+  },
+): DiagnosticVectorHitOutcome {
+  if (item.retrievalStage === "rejected_by_similarity_threshold") {
+    return buildDiagnosticVectorOutcome("rejected_by_similarity_threshold", {
+      entry: item.entry,
+      distance: item.distance,
+      similarityThreshold: options.similarityThreshold,
+    });
+  }
+
+  if (item.retrievalStage === "rejected_by_rerank_cutoff") {
+    return buildDiagnosticVectorOutcome("rejected_by_rerank_cutoff", {
+      entry: item.entry,
+      distance: item.distance,
+      finalScore: item.finalScore,
+      rerankCutoff: options.rerankCutoff,
+    });
+  }
+
+  if (item.retrievalStage === "trimmed_by_top_k") {
+    return buildDiagnosticVectorOutcome("trimmed_by_top_k", {
+      entry: item.entry,
+      rerankRank: item.rerankRank,
+      finalScore: item.finalScore,
+      distance: item.distance,
+      topK: options.topK,
+    });
+  }
+
+  return shortlistedOutcomes.get(item.entry.id) ?? buildDiagnosticVectorOutcome("blocked_during_final_assembly", {
+    entry: item.entry,
+    rerankRank: item.rerankRank,
+    finalScore: item.finalScore,
+    distance: item.distance,
+  });
 }
 
 app.get("/", (c) => {
@@ -363,6 +488,7 @@ app.post("/:id/diagnostics", async (c) => {
     ? await collectVectorActivatedWorldInfoDetailed(userId, [bookId], bookEntries, messages)
       : {
         entries: [],
+        candidateTrace: [],
         queryPreview,
         eligibleCount: 0,
         hitsBeforeThreshold: 0,
@@ -384,9 +510,33 @@ app.post("/:id/diagnostics", async (c) => {
   );
   const vectorHitOutcomes = traceDiagnosticVectorHitOutcomes(
     wiResult.activatedEntries,
-    vectorDetail.entries,
+    vectorDetail.candidateTrace.filter((item) => item.retrievalStage === "shortlisted"),
     worldInfoSettings,
   );
+  const vectorTrace = vectorDetail.candidateTrace.map((item) => {
+    const outcome = resolveDiagnosticVectorTraceOutcome(item, vectorHitOutcomes, {
+      topK: vectorDetail.topK,
+      rerankCutoff: embeddings.rerank_cutoff,
+      similarityThreshold: embeddings.similarity_threshold,
+    });
+    return {
+      entry_id: item.entry.id,
+      comment: item.entry.comment || "",
+      score: item.score,
+      distance: item.distance,
+      final_score: item.finalScore,
+      lexical_candidate_score: item.lexicalCandidateScore,
+      matched_primary_keys: item.matchedPrimaryKeys,
+      matched_secondary_keys: item.matchedSecondaryKeys,
+      matched_comment: item.matchedComment,
+      score_breakdown: item.scoreBreakdown,
+      search_text_preview: item.searchTextPreview,
+      rerank_rank: item.rerankRank,
+      final_outcome_code: outcome.code,
+      final_outcome_label: outcome.label,
+      final_outcome_reason: outcome.reason,
+    };
+  });
 
   const keywordHits = mergedWorldInfo.activatedWorldInfo
     .filter((entry) => entry.source === "keyword")
@@ -498,23 +648,12 @@ app.post("/:id/diagnostics", async (c) => {
       rerank_rejected: vectorDetail.rerankRejected,
     },
     keyword_hits: keywordHits,
-    vector_hits: vectorDetail.entries.map((item) => ({
-      entry_id: item.entry.id,
-      comment: item.entry.comment || "",
-      score: item.score,
-      distance: item.distance,
-      final_score: item.finalScore,
-      lexical_candidate_score: item.lexicalCandidateScore,
-      matched_primary_keys: item.matchedPrimaryKeys,
-      matched_secondary_keys: item.matchedSecondaryKeys,
-      matched_comment: item.matchedComment,
-      score_breakdown: item.scoreBreakdown,
-      search_text_preview: item.searchTextPreview,
-      final_outcome_code: vectorHitOutcomes.get(item.entry.id)?.code ?? "blocked_during_final_assembly",
-      final_outcome_label: vectorHitOutcomes.get(item.entry.id)?.label ?? "Lost during final assembly",
-      final_outcome_reason: vectorHitOutcomes.get(item.entry.id)?.reason
-        ?? "This vector hit survived retrieval, but later prompt-assembly rules left no room for it in the final World Info list.",
-    })),
+    vector_hits: vectorTrace.filter((item) =>
+      item.final_outcome_code !== "rejected_by_similarity_threshold" &&
+      item.final_outcome_code !== "rejected_by_rerank_cutoff" &&
+      item.final_outcome_code !== "trimmed_by_top_k"
+    ),
+    vector_trace: vectorTrace,
     blocker_messages: Array.from(new Set(blockerMessages)),
     deduplication: mergedWorldInfo.deduplicated > 0 ? {
       removed_count: mergedWorldInfo.deduplicated,

--- a/src/services/prompt-assembly.service.ts
+++ b/src/services/prompt-assembly.service.ts
@@ -1289,6 +1289,7 @@ export interface VectorActivatedEntry {
 
 export interface VectorWorldInfoRetrievalResult {
   entries: VectorActivatedEntry[];
+  candidateTrace: VectorRetrievalTraceEntry[];
   queryPreview: string;
   eligibleCount: number;
   hitsBeforeThreshold: number;
@@ -1299,6 +1300,17 @@ export interface VectorWorldInfoRetrievalResult {
   topK: number;
   cap: number;
   blockerMessages: string[];
+}
+
+export type VectorRetrievalTraceStage =
+  | "shortlisted"
+  | "trimmed_by_top_k"
+  | "rejected_by_rerank_cutoff"
+  | "rejected_by_similarity_threshold";
+
+export interface VectorRetrievalTraceEntry extends VectorActivatedEntry {
+  retrievalStage: VectorRetrievalTraceStage;
+  rerankRank: number | null;
 }
 
 export interface MergedWorldInfoEntriesResult {
@@ -2284,6 +2296,7 @@ export async function collectVectorActivatedWorldInfoDetailed(
 ): Promise<VectorWorldInfoRetrievalResult> {
   const emptyResult: VectorWorldInfoRetrievalResult = {
     entries: [],
+    candidateTrace: [],
     queryPreview: "",
     eligibleCount: 0,
     hitsBeforeThreshold: 0,
@@ -2368,18 +2381,20 @@ export async function collectVectorActivatedWorldInfoDetailed(
 
     const pooledCandidates = Array.from(candidates.values());
     const hitsBeforeThreshold = pooledCandidates.length;
-    const filteredCandidates = cfg.similarity_threshold > 0
-      ? pooledCandidates.filter((item) => item.candidate.distance <= cfg.similarity_threshold)
-      : pooledCandidates;
-    const hitsAfterThreshold = filteredCandidates.length;
-    const thresholdRejected = hitsBeforeThreshold - hitsAfterThreshold;
     const specificityState = buildPhraseSpecificityState(eligibleEntries);
     const queryState = buildVectorQueryLexicalState(queryText, specificityState);
-    const scored = filteredCandidates.map(({ entry, candidate }) =>
+    const scoredCandidates = pooledCandidates.map(({ entry, candidate }) =>
       scoreVectorWorldInfoCandidate(entry, candidate, queryState, preset)
     );
-
-    scored.sort((a, b) => {
+    const thresholdPassed = cfg.similarity_threshold > 0
+      ? scoredCandidates.filter((item) => item.distance <= cfg.similarity_threshold)
+      : scoredCandidates;
+    const thresholdRejectedCandidates = cfg.similarity_threshold > 0
+      ? scoredCandidates.filter((item) => item.distance > cfg.similarity_threshold)
+      : [];
+    const hitsAfterThreshold = thresholdPassed.length;
+    const thresholdRejected = hitsBeforeThreshold - hitsAfterThreshold;
+    thresholdPassed.sort((a, b) => {
       if (b.finalScore !== a.finalScore) return b.finalScore - a.finalScore;
       if (a.distance !== b.distance) return a.distance - b.distance;
       if (b.entry.priority !== a.entry.priority) return b.entry.priority - a.entry.priority;
@@ -2387,15 +2402,48 @@ export async function collectVectorActivatedWorldInfoDetailed(
     });
 
     const rerankFiltered = cfg.rerank_cutoff > 0
-      ? scored.filter((item) => item.finalScore >= cfg.rerank_cutoff)
-      : scored;
+      ? thresholdPassed.filter((item) => item.finalScore >= cfg.rerank_cutoff)
+      : thresholdPassed;
+    const rerankRejectedCandidates = cfg.rerank_cutoff > 0
+      ? thresholdPassed.filter((item) => item.finalScore < cfg.rerank_cutoff)
+      : [];
     const hitsAfterRerankCutoff = rerankFiltered.length;
-    const rerankRejected = scored.length - hitsAfterRerankCutoff;
+    const rerankRejected = thresholdPassed.length - hitsAfterRerankCutoff;
 
     const cap = topK;
+    const shortlistedEntries = rerankFiltered.slice(0, cap);
+    const topKTrimmedEntries = rerankFiltered.slice(cap);
+    const rerankRankById = new Map<string, number>(
+      thresholdPassed.map((item, index) => [item.entry.id, index + 1]),
+    );
+    const candidateTrace: VectorRetrievalTraceEntry[] = [
+      ...shortlistedEntries.map((item) => ({
+        ...item,
+        retrievalStage: "shortlisted" as const,
+        rerankRank: rerankRankById.get(item.entry.id) ?? null,
+      })),
+      ...topKTrimmedEntries.map((item) => ({
+        ...item,
+        retrievalStage: "trimmed_by_top_k" as const,
+        rerankRank: rerankRankById.get(item.entry.id) ?? null,
+      })),
+      ...rerankRejectedCandidates.map((item) => ({
+        ...item,
+        retrievalStage: "rejected_by_rerank_cutoff" as const,
+        rerankRank: rerankRankById.get(item.entry.id) ?? null,
+      })),
+      ...thresholdRejectedCandidates
+        .sort((a, b) => a.distance - b.distance)
+        .map((item) => ({
+          ...item,
+          retrievalStage: "rejected_by_similarity_threshold" as const,
+          rerankRank: null,
+        })),
+    ];
 
     return {
-      entries: rerankFiltered.slice(0, cap),
+      entries: shortlistedEntries,
+      candidateTrace,
       queryPreview: queryText,
       eligibleCount: eligibleEntries.length,
       hitsBeforeThreshold,

--- a/src/types/world-book.ts
+++ b/src/types/world-book.ts
@@ -132,6 +132,7 @@ export interface WorldBookDiagnostics {
       focusMissPenalty: number;
     };
     search_text_preview: string;
+    rerank_rank: number | null;
     final_outcome_code:
       | "injected_vector"
       | "already_keyword"
@@ -140,7 +141,50 @@ export interface WorldBookDiagnostics {
       | "blocked_by_max_entries"
       | "blocked_by_token_budget"
       | "deduplicated"
-      | "blocked_during_final_assembly";
+      | "blocked_during_final_assembly"
+      | "trimmed_by_top_k"
+      | "rejected_by_rerank_cutoff"
+      | "rejected_by_similarity_threshold";
+    final_outcome_label: string;
+    final_outcome_reason: string;
+  }>;
+  vector_trace: Array<{
+    entry_id: string;
+    comment: string;
+    score: number;
+    distance: number;
+    final_score: number;
+    lexical_candidate_score: number | null;
+    matched_primary_keys: string[];
+    matched_secondary_keys: string[];
+    matched_comment: string | null;
+    score_breakdown: {
+      vectorSimilarity: number;
+      primaryExact: number;
+      primaryPartial: number;
+      secondaryExact: number;
+      secondaryPartial: number;
+      commentExact: number;
+      commentPartial: number;
+      focusBoost: number;
+      priority: number;
+      broadPenalty: number;
+      focusMissPenalty: number;
+    };
+    search_text_preview: string;
+    rerank_rank: number | null;
+    final_outcome_code:
+      | "injected_vector"
+      | "already_keyword"
+      | "blocked_by_group"
+      | "blocked_by_min_priority"
+      | "blocked_by_max_entries"
+      | "blocked_by_token_budget"
+      | "deduplicated"
+      | "blocked_during_final_assembly"
+      | "trimmed_by_top_k"
+      | "rejected_by_rerank_cutoff"
+      | "rejected_by_similarity_threshold";
     final_outcome_label: string;
     final_outcome_reason: string;
   }>;


### PR DESCRIPTION
## Summary
- Add a full pulled-candidate vector trace to World Book diagnostics, instead of only showing the final shortlist.
- Make diagnostics outcomes more specific so entries explain exactly why they were kept, dropped, trimmed, or rejected.
- Improve diagnostics UX by making the reranked shortlist scrollable and moving the full candidate trace into a searchable collapsed section.

## What Changed
- `collectVectorActivatedWorldInfoDetailed` now returns a full candidate trace covering:
  - shortlisted entries
  - candidates trimmed by top-k
  - candidates rejected by rerank cutoff
  - candidates rejected by similarity threshold
- Diagnostics backend now maps those pulled candidates to clearer user-facing outcomes such as:
  - `Made final prompt`
  - `Already keyword-active`
  - `Blocked by group rule`
  - `No room under entry cap`
  - `No room under token budget`
  - `Removed as duplicate`
  - `Outside returned top-k`
  - `Below rerank cutoff`
  - `Above similarity threshold`
- Diagnostics modal now includes:
  - a shorter scrollable reranked shortlist
  - a collapsed `All pulled vector candidates` section
  - a search bar inside that section for filtering by title, aliases, outcomes, or indexed text
  - clearer retrieval summary copy around pulled candidates vs shortlist vs final prompt

## Files Touched
- `frontend/src/components/panels/world-book/WorldBookDiagnosticsModal.module.css`
- `frontend/src/components/panels/world-book/WorldBookDiagnosticsModal.tsx`
- `frontend/src/types/api.ts`
- `src/routes/world-books.routes.ts`
- `src/services/prompt-assembly.service.ts`
- `src/types/world-book.ts`