### PR TITLE
Wire SPINDLE_CONFIRM_RESULT from WebSocket to event bus

### DIFF
--- a/src/ws/handler.ts
+++ b/src/ws/handler.ts
@@ -136,6 +136,16 @@ export const wsHandler = upgradeWebSocket((c) => {
           return;
         }
 
+        if (data.type === "SPINDLE_CONFIRM_RESULT") {
+          if (userId && data.requestId) {
+            eventBus.emit(EventType.SPINDLE_CONFIRM_RESULT, {
+              requestId: data.requestId,
+              confirmed: !!data.confirmed,
+            }, userId);
+          }
+          return;
+        }
+
         if (data.type === "SPINDLE_BACKEND_MSG") {
           const extensionId = typeof data.extensionId === "string" ? data.extensionId : null;
           if (!extensionId) return;


### PR DESCRIPTION
### Root Cause

`spindle.modal.confirm()` hangs indefinitely when the user clicks **Cancel** (or any button). The dialog closes in the UI, but the awaiting Promise in the extension worker never resolves.

`SpindleConfirm` (frontend) correctly calls `closeSpindleConfirm(requestId, confirmed)` for both the Confirm **and** Cancel buttons. That function sends `{ type: 'SPINDLE_CONFIRM_RESULT', requestId, confirmed }` via WebSocket. However, the server-side `onMessage` handler has no case for this message type and silently drops it.

`WorkerHost.handleConfirmOpen()` registers a listener on `EventType.SPINDLE_CONFIRM_RESULT` that resolves the worker's pending `request()` Promise. Since the event is never emitted, the Promise hangs forever regardless of which button the user clicked.

### Impact

All extensions that call `spindle.modal.confirm()` or `ctx.ui.showConfirm()` are currently broken, as the call never resolves after either button is clicked. This fix unblocks the API for all extensions.