### PR TITLE
Added WS message handling for Spindle modal

### DIFF
--- a/src/ws/handler.ts
+++ b/src/ws/handler.ts
@@ -146,6 +146,16 @@ export const wsHandler = upgradeWebSocket((c) => {
           return;
         }
 
+        if (data.type === "SPINDLE_MODAL_RESULT") {
+          if (userId && data.requestId) {
+            eventBus.emit(EventType.SPINDLE_MODAL_RESULT, {
+              requestId: data.requestId,
+              dismissedBy: data.dismissedBy,
+            }, userId);
+          }
+          return;
+        }
+
         if (data.type === "SPINDLE_INPUT_PROMPT_RESULT") {
           if (userId && data.requestId) {
             eventBus.emit(EventType.SPINDLE_INPUT_PROMPT_RESULT, {


### PR DESCRIPTION
`src/ws/handler.ts` `onMessage` is missing a handler for `SPINDLE_MODAL_RESULT`. This is the identical pattern to the already-merged `SPINDLE_CONFIRM_RESULT` fix.

`closeSpindleModal` in the frontend store correctly sends:
```ts
wsClient.send({ type: 'SPINDLE_MODAL_RESULT', requestId, dismissedBy })
```
when the user closes the modal (close button, backdrop, or Escape). The server's `handleModalOpen` subscribes to `EventType.SPINDLE_MODAL_RESULT` on the event bus and waits for `msg.payload.dismissedBy`. Since the WS message is never translated to the event bus event, the Promise hangs indefinitely.