### PR TITLE
Fix Memory Cortex diagnostics loading state and probe timeouts

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -16,6 +16,16 @@ export class ApiError extends Error {
   }
 }
 
+export class RequestTimeoutError extends Error {
+  constructor(
+    public url: string,
+    public timeoutMs: number
+  ) {
+    super(`Request timed out after ${timeoutMs}ms`)
+    this.name = 'RequestTimeoutError'
+  }
+}
+
 export interface RequestOptions {
   /** Override the default request timeout in milliseconds. 0 = no timeout. */
   timeout?: number
@@ -23,7 +33,7 @@ export interface RequestOptions {
   signal?: AbortSignal
 }
 
-function buildSignal(options?: RequestOptions): { signal: AbortSignal; cleanup: () => void } {
+function buildSignal(options?: RequestOptions): { signal: AbortSignal; cleanup: () => void; timeoutMs: number } {
   const timeoutMs = options?.timeout ?? DEFAULT_TIMEOUT_MS
   const controller = new AbortController()
 
@@ -44,8 +54,18 @@ function buildSignal(options?: RequestOptions): { signal: AbortSignal; cleanup: 
 
   return {
     signal: controller.signal,
+    timeoutMs,
     cleanup: () => { if (timer) clearTimeout(timer) },
   }
+}
+
+function maybeWrapTimeoutError(error: unknown, url: string, signal: AbortSignal, timeoutMs: number): Error | unknown {
+  const reason = (signal as AbortSignal & { reason?: unknown }).reason as { name?: string } | undefined
+  const timedOut = signal.aborted && reason?.name === 'TimeoutError'
+  if (timedOut) {
+    return new RequestTimeoutError(url, timeoutMs)
+  }
+  return error
 }
 
 async function handleResponse<T>(res: Response): Promise<T> {
@@ -69,7 +89,7 @@ export async function get<T>(path: string, params?: Record<string, any>, options
       if (v !== undefined && v !== null) url.searchParams.set(k, String(v))
     }
   }
-  const { signal, cleanup } = buildSignal(options)
+  const { signal, cleanup, timeoutMs } = buildSignal(options)
   try {
     const res = await fetch(url.toString(), {
       headers: { 'Accept': 'application/json' },
@@ -77,15 +97,18 @@ export async function get<T>(path: string, params?: Record<string, any>, options
       signal,
     })
     return handleResponse<T>(res)
+  } catch (error) {
+    throw maybeWrapTimeoutError(error, url.toString(), signal, timeoutMs)
   } finally {
     cleanup()
   }
 }
 
 export async function post<T>(path: string, body?: any, options?: RequestOptions): Promise<T> {
-  const { signal, cleanup } = buildSignal(options)
+  const { signal, cleanup, timeoutMs } = buildSignal(options)
+  const url = `${BASE_URL}${path}`
   try {
-    const res = await fetch(`${BASE_URL}${path}`, {
+    const res = await fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -96,15 +119,18 @@ export async function post<T>(path: string, body?: any, options?: RequestOptions
       signal,
     })
     return handleResponse<T>(res)
+  } catch (error) {
+    throw maybeWrapTimeoutError(error, url, signal, timeoutMs)
   } finally {
     cleanup()
   }
 }
 
 export async function put<T>(path: string, body?: any, options?: RequestOptions): Promise<T> {
-  const { signal, cleanup } = buildSignal(options)
+  const { signal, cleanup, timeoutMs } = buildSignal(options)
+  const url = `${BASE_URL}${path}`
   try {
-    const res = await fetch(`${BASE_URL}${path}`, {
+    const res = await fetch(url, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
@@ -115,30 +141,36 @@ export async function put<T>(path: string, body?: any, options?: RequestOptions)
       signal,
     })
     return handleResponse<T>(res)
+  } catch (error) {
+    throw maybeWrapTimeoutError(error, url, signal, timeoutMs)
   } finally {
     cleanup()
   }
 }
 
 export async function del<T>(path: string, options?: RequestOptions): Promise<T> {
-  const { signal, cleanup } = buildSignal(options)
+  const { signal, cleanup, timeoutMs } = buildSignal(options)
+  const url = `${BASE_URL}${path}`
   try {
-    const res = await fetch(`${BASE_URL}${path}`, {
+    const res = await fetch(url, {
       method: 'DELETE',
       headers: { 'Accept': 'application/json' },
       credentials: 'include',
       signal,
     })
     return handleResponse<T>(res)
+  } catch (error) {
+    throw maybeWrapTimeoutError(error, url, signal, timeoutMs)
   } finally {
     cleanup()
   }
 }
 
 export async function patch<T>(path: string, body?: any, options?: RequestOptions): Promise<T> {
-  const { signal, cleanup } = buildSignal(options)
+  const { signal, cleanup, timeoutMs } = buildSignal(options)
+  const url = `${BASE_URL}${path}`
   try {
-    const res = await fetch(`${BASE_URL}${path}`, {
+    const res = await fetch(url, {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
@@ -149,6 +181,8 @@ export async function patch<T>(path: string, body?: any, options?: RequestOption
       signal,
     })
     return handleResponse<T>(res)
+  } catch (error) {
+    throw maybeWrapTimeoutError(error, url, signal, timeoutMs)
   } finally {
     cleanup()
   }
@@ -161,7 +195,7 @@ export async function getBlob(path: string, params?: Record<string, any>, option
       if (v !== undefined && v !== null) url.searchParams.set(k, String(v))
     }
   }
-  const { signal, cleanup } = buildSignal(options)
+  const { signal, cleanup, timeoutMs } = buildSignal(options)
   try {
     const res = await fetch(url.toString(), { credentials: 'include', signal })
     if (!res.ok) {
@@ -170,21 +204,26 @@ export async function getBlob(path: string, params?: Record<string, any>, option
       throw new ApiError(res.status, res.statusText, body)
     }
     return res.blob()
+  } catch (error) {
+    throw maybeWrapTimeoutError(error, url.toString(), signal, timeoutMs)
   } finally {
     cleanup()
   }
 }
 
 export async function upload<T>(path: string, formData: FormData, options?: RequestOptions): Promise<T> {
-  const { signal, cleanup } = buildSignal(options)
+  const { signal, cleanup, timeoutMs } = buildSignal(options)
+  const url = `${BASE_URL}${path}`
   try {
-    const res = await fetch(`${BASE_URL}${path}`, {
+    const res = await fetch(url, {
       method: 'POST',
       credentials: 'include',
       body: formData,
       signal,
     })
     return handleResponse<T>(res)
+  } catch (error) {
+    throw maybeWrapTimeoutError(error, url, signal, timeoutMs)
   } finally {
     cleanup()
   }

--- a/frontend/src/api/memory-cortex.ts
+++ b/frontend/src/api/memory-cortex.ts
@@ -130,6 +130,15 @@ export interface CortexHealthCheck {
   message: string;
 }
 
+export interface CortexProbeStatus {
+  attempted: boolean;
+  success: boolean | null;
+  message: string;
+  durationMs?: number | null;
+  timedOut?: boolean;
+  error?: string | null;
+}
+
 export interface CortexHealthReport {
   generatedAt: string;
   healthy: boolean;
@@ -155,10 +164,7 @@ export interface CortexHealthReport {
     model: string;
     dimensions: number | null;
     ready: boolean;
-    connectivity: {
-      attempted: boolean;
-      success: boolean | null;
-      message: string;
+    connectivity: CortexProbeStatus & {
       dimension: number | null;
     };
   };
@@ -171,11 +177,7 @@ export interface CortexHealthReport {
     model: string | null;
     hasApiKey: boolean;
     ready: boolean;
-    connectivity: {
-      attempted: boolean;
-      success: boolean | null;
-      message: string;
-    };
+    connectivity: CortexProbeStatus;
   };
   chat: {
     id: string;

--- a/frontend/src/components/modals/MemoryCortexDiagnosticsModal.module.css
+++ b/frontend/src/components/modals/MemoryCortexDiagnosticsModal.module.css
@@ -351,13 +351,35 @@
 
 .errorState {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 10px;
   padding: 14px 16px;
   border-radius: 12px;
   border: 1px solid rgba(255, 107, 107, 0.25);
   background: rgba(255, 107, 107, 0.08);
   color: #ff6b6b;
+}
+
+.errorCopy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.errorTitle {
+  font-size: 13px;
+  font-weight: 700;
+  color: #ff8c8c;
+}
+
+.errorDetails {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: rgba(255, 214, 214, 0.95);
 }
 
 .spinning {

--- a/frontend/src/components/modals/MemoryCortexDiagnosticsModal.tsx
+++ b/frontend/src/components/modals/MemoryCortexDiagnosticsModal.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Activity, AlertTriangle, CheckCircle2, Copy, RefreshCw } from 'lucide-react'
 import clsx from 'clsx'
-import { memoryCortexApi, type CortexHealthCheck, type CortexHealthReport } from '@/api/memory-cortex'
+import { ApiError, RequestTimeoutError } from '@/api/client'
+import { memoryCortexApi, type CortexHealthCheck, type CortexHealthReport, type CortexProbeStatus } from '@/api/memory-cortex'
 import { ModalShell } from '@/components/shared/ModalShell'
 import { CloseButton } from '@/components/shared/CloseButton'
 import styles from './MemoryCortexDiagnosticsModal.module.css'
@@ -16,6 +17,80 @@ function formatCheckLabel(status: CortexHealthCheck['status']) {
       return 'Fail'
     default:
       return 'Info'
+  }
+}
+
+interface DiagnosticsErrorState {
+  summary: string
+  details: string[]
+}
+
+function formatProbeDuration(durationMs?: number | null): string | null {
+  if (typeof durationMs !== 'number' || !Number.isFinite(durationMs)) return null
+  return `${Math.max(0, Math.round(durationMs))}ms`
+}
+
+function formatProbeSummary(probe: CortexProbeStatus, fallback = 'Not run'): string {
+  if (!probe.attempted) return fallback
+  const parts = [probe.message]
+  const duration = formatProbeDuration(probe.durationMs)
+  if (duration) parts.push(duration)
+  if (probe.timedOut) parts.push('timed out')
+  return parts.join(' | ')
+}
+
+function stringifyBody(body: unknown): string | null {
+  if (!body) return null
+  if (typeof body === 'string') return body
+  if (typeof body === 'object') {
+    try {
+      return JSON.stringify(body)
+    } catch {
+      return null
+    }
+  }
+  return String(body)
+}
+
+function describeDiagnosticsError(error: unknown, chatId?: string | null): DiagnosticsErrorState {
+  if (error instanceof RequestTimeoutError) {
+    return {
+      summary: 'Diagnostics request timed out before the server finished the live health checks.',
+      details: [
+        `Request: ${error.url}`,
+        `Timeout: ${error.timeoutMs}ms`,
+        chatId ? `Chat: ${chatId}` : 'Chat: none',
+        'The backend health endpoint was still waiting on one or more live provider probes.',
+      ],
+    }
+  }
+
+  if (error instanceof ApiError) {
+    const bodyText = stringifyBody(error.body)
+    const bodyError = typeof error.body?.error === 'string' ? error.body.error : null
+    return {
+      summary: bodyError || 'Memory Cortex diagnostics request failed.',
+      details: [
+        `HTTP: ${error.status} ${error.statusText}`,
+        chatId ? `Chat: ${chatId}` : 'Chat: none',
+        ...(bodyText && bodyText !== bodyError ? [`Body: ${bodyText}`] : []),
+      ],
+    }
+  }
+
+  if (error instanceof Error) {
+    return {
+      summary: error.message || 'Failed to load Memory Cortex diagnostics.',
+      details: [
+        `Error type: ${error.name || 'Error'}`,
+        chatId ? `Chat: ${chatId}` : 'Chat: none',
+      ],
+    }
+  }
+
+  return {
+    summary: 'Failed to load Memory Cortex diagnostics.',
+    details: [chatId ? `Chat: ${chatId}` : 'Chat: none'],
   }
 }
 
@@ -80,16 +155,22 @@ function buildReportText(report: CortexHealthReport): string {
   lines.push(`- Vectorize chat messages: ${report.embeddings.vectorizeChatMessages ? 'Yes' : 'No'}`)
   lines.push(`- Provider/model: ${report.embeddings.provider || 'N/A'} / ${report.embeddings.model || 'N/A'}`)
   lines.push(`- Dimensions: ${report.embeddings.dimensions ?? 'Unknown'}`)
-  lines.push(`- Connectivity: ${report.embeddings.connectivity.message}`)
+  lines.push(`- Connectivity: ${formatProbeSummary(report.embeddings.connectivity, 'Not run')}`)
+  if (report.embeddings.connectivity.error && report.embeddings.connectivity.error !== report.embeddings.connectivity.message) {
+    lines.push(`- Probe error: ${report.embeddings.connectivity.error}`)
+  }
   lines.push('')
 
-  lines.push('Sidecard')
+  lines.push('Sidecar')
   lines.push(`- Required: ${report.sidecar.required ? 'Yes' : 'No'}`)
   lines.push(`- Configured: ${report.sidecar.configured ? 'Yes' : 'No'}`)
   lines.push(`- Connection: ${report.sidecar.connectionName ?? 'None'}`)
   lines.push(`- Provider/model: ${report.sidecar.provider ?? 'N/A'} / ${report.sidecar.model ?? 'Default'}`)
   lines.push(`- API key: ${report.sidecar.hasApiKey ? 'Ready' : 'Missing or not required'}`)
-  lines.push(`- Connectivity: ${report.sidecar.connectivity.message}`)
+  lines.push(`- Connectivity: ${formatProbeSummary(report.sidecar.connectivity, 'Not run')}`)
+  if (report.sidecar.connectivity.error && report.sidecar.connectivity.error !== report.sidecar.connectivity.message) {
+    lines.push(`- Probe error: ${report.sidecar.connectivity.error}`)
+  }
   lines.push('')
 
   lines.push('Chat')
@@ -136,21 +217,21 @@ interface Props {
 export default function MemoryCortexDiagnosticsModal({ chatId, onClose }: Props) {
   const [report, setReport] = useState<CortexHealthReport | null>(null)
   const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [error, setError] = useState<DiagnosticsErrorState | null>(null)
   const [copyState, setCopyState] = useState<'idle' | 'copied' | 'error'>('idle')
 
   const loadReport = useCallback(async () => {
     setLoading(true)
     setError(null)
+    setReport((current) => ((current?.chat?.id ?? null) === (chatId ?? null) ? current : null))
     try {
       const nextReport = await memoryCortexApi.getHealth({
         chatId: chatId || undefined,
         probeConnectivity: true,
       })
       setReport(nextReport)
-    } catch (err: any) {
-      setReport(null)
-      setError(err?.body?.error || err?.message || 'Failed to load Memory Cortex diagnostics.')
+    } catch (err: unknown) {
+      setError(describeDiagnosticsError(err, chatId))
     } finally {
       setLoading(false)
     }
@@ -180,6 +261,8 @@ export default function MemoryCortexDiagnosticsModal({ chatId, onClose }: Props)
     return 'pass'
   }, [report])
 
+  const waitingForInitialReport = loading && !report
+
   return (
     <ModalShell
       isOpen={true}
@@ -194,7 +277,7 @@ export default function MemoryCortexDiagnosticsModal({ chatId, onClose }: Props)
             <div className={styles.eyebrow}>Popup Diagnostics</div>
             <h2 className={styles.title}>Memory Cortex Diagnostics</h2>
             <p className={styles.subtitle}>
-              Focused health checks for cortex setup, embeddings, sidecard readiness, and the selected chat.
+              Focused health checks for cortex setup, embeddings, sidecar readiness, and the selected chat.
               {chatId ? ` Chat: ${chatId}` : ' Open this from an active chat for chat-specific checks.'}
             </p>
           </div>
@@ -224,12 +307,23 @@ export default function MemoryCortexDiagnosticsModal({ chatId, onClose }: Props)
         </div>
 
         <div className={styles.body}>
-          {error ? (
+          {error && (
             <div className={styles.errorState}>
               <AlertTriangle size={18} />
-              <span>{error}</span>
+              <div className={styles.errorCopy}>
+                <div className={styles.errorTitle}>{error.summary}</div>
+                {error.details.length > 0 && (
+                  <div className={styles.errorDetails}>
+                    {error.details.map((detail) => (
+                      <div key={detail}>{detail}</div>
+                    ))}
+                  </div>
+                )}
+              </div>
             </div>
-          ) : (
+          )}
+
+          {error && !report ? null : (
             <>
               <div
                 className={clsx(
@@ -273,7 +367,7 @@ export default function MemoryCortexDiagnosticsModal({ chatId, onClose }: Props)
 
               <div className={styles.section}>
                 <div className={styles.sectionHeader}>Checks</div>
-                {loading && !report ? (
+                {waitingForInitialReport ? (
                   <div className={styles.loadingRow}>Running diagnostics...</div>
                 ) : (
                   <div className={styles.checkListWrap}>
@@ -296,34 +390,50 @@ export default function MemoryCortexDiagnosticsModal({ chatId, onClose }: Props)
               <div className={styles.detailGrid}>
                 <div className={styles.section}>
                   <div className={styles.sectionHeader}>Embeddings</div>
-                  <div className={styles.metaList}>
-                    <div className={styles.metaRow}><span>Enabled</span><strong>{report?.embeddings.enabled ? 'Yes' : 'No'}</strong></div>
-                    <div className={styles.metaRow}><span>API key</span><strong>{report?.embeddings.hasApiKey ? 'Present' : 'Missing'}</strong></div>
-                    <div className={styles.metaRow}><span>Vectorize chat messages</span><strong>{report?.embeddings.vectorizeChatMessages ? 'Yes' : 'No'}</strong></div>
-                    <div className={styles.metaRow}><span>Provider</span><strong>{report?.embeddings.provider ?? 'N/A'}</strong></div>
-                    <div className={styles.metaRow}><span>Model</span><strong>{report?.embeddings.model ?? 'N/A'}</strong></div>
-                    <div className={styles.metaRow}><span>Dimensions</span><strong>{report?.embeddings.dimensions ?? 'Unknown'}</strong></div>
-                    <div className={styles.metaRow}><span>Live probe</span><strong>{report?.embeddings.connectivity.message ?? 'N/A'}</strong></div>
-                  </div>
+                  {!report ? (
+                    <div className={styles.loadingRow}>Waiting for diagnostics report...</div>
+                  ) : (
+                    <div className={styles.metaList}>
+                      <div className={styles.metaRow}><span>Enabled</span><strong>{report.embeddings.enabled ? 'Yes' : 'No'}</strong></div>
+                      <div className={styles.metaRow}><span>API key</span><strong>{report.embeddings.hasApiKey ? 'Present' : 'Missing'}</strong></div>
+                      <div className={styles.metaRow}><span>Vectorize chat messages</span><strong>{report.embeddings.vectorizeChatMessages ? 'Yes' : 'No'}</strong></div>
+                      <div className={styles.metaRow}><span>Provider</span><strong>{report.embeddings.provider || 'N/A'}</strong></div>
+                      <div className={styles.metaRow}><span>Model</span><strong>{report.embeddings.model || 'N/A'}</strong></div>
+                      <div className={styles.metaRow}><span>Dimensions</span><strong>{report.embeddings.dimensions ?? 'Unknown'}</strong></div>
+                      <div className={styles.metaRow}><span>Live probe</span><strong>{formatProbeSummary(report.embeddings.connectivity, 'Not run')}</strong></div>
+                      {report.embeddings.connectivity.error && report.embeddings.connectivity.error !== report.embeddings.connectivity.message && (
+                        <div className={styles.metaRow}><span>Probe error</span><strong>{report.embeddings.connectivity.error}</strong></div>
+                      )}
+                    </div>
+                  )}
                 </div>
 
                 <div className={styles.section}>
-                  <div className={styles.sectionHeader}>Sidecard</div>
-                  <div className={styles.metaList}>
-                    <div className={styles.metaRow}><span>Required</span><strong>{report?.sidecar.required ? 'Yes' : 'No'}</strong></div>
-                    <div className={styles.metaRow}><span>Configured</span><strong>{report?.sidecar.configured ? 'Yes' : 'No'}</strong></div>
-                    <div className={styles.metaRow}><span>Connection</span><strong>{report?.sidecar.connectionName ?? 'None'}</strong></div>
-                    <div className={styles.metaRow}><span>Provider</span><strong>{report?.sidecar.provider ?? 'N/A'}</strong></div>
-                    <div className={styles.metaRow}><span>Model</span><strong>{report?.sidecar.model ?? 'Default'}</strong></div>
-                    <div className={styles.metaRow}><span>API key</span><strong>{report?.sidecar.hasApiKey ? 'Ready' : 'Missing / not required'}</strong></div>
-                    <div className={styles.metaRow}><span>Live probe</span><strong>{report?.sidecar.connectivity.message ?? 'N/A'}</strong></div>
-                  </div>
+                  <div className={styles.sectionHeader}>Sidecar</div>
+                  {!report ? (
+                    <div className={styles.loadingRow}>Waiting for diagnostics report...</div>
+                  ) : (
+                    <div className={styles.metaList}>
+                      <div className={styles.metaRow}><span>Required</span><strong>{report.sidecar.required ? 'Yes' : 'No'}</strong></div>
+                      <div className={styles.metaRow}><span>Configured</span><strong>{report.sidecar.configured ? 'Yes' : 'No'}</strong></div>
+                      <div className={styles.metaRow}><span>Connection</span><strong>{report.sidecar.connectionName ?? 'None'}</strong></div>
+                      <div className={styles.metaRow}><span>Provider</span><strong>{report.sidecar.provider ?? 'N/A'}</strong></div>
+                      <div className={styles.metaRow}><span>Model</span><strong>{report.sidecar.model ?? 'Default'}</strong></div>
+                      <div className={styles.metaRow}><span>API key</span><strong>{report.sidecar.hasApiKey ? 'Ready' : 'Missing / not required'}</strong></div>
+                      <div className={styles.metaRow}><span>Live probe</span><strong>{formatProbeSummary(report.sidecar.connectivity, 'Not run')}</strong></div>
+                      {report.sidecar.connectivity.error && report.sidecar.connectivity.error !== report.sidecar.connectivity.message && (
+                        <div className={styles.metaRow}><span>Probe error</span><strong>{report.sidecar.connectivity.error}</strong></div>
+                      )}
+                    </div>
+                  )}
                 </div>
               </div>
 
               <div className={styles.section}>
                 <div className={styles.sectionHeader}>Selected Chat</div>
-                {!report?.chat ? (
+                {!report ? (
+                  <div className={styles.loadingRow}>Waiting for diagnostics report...</div>
+                ) : !report.chat ? (
                   <div className={styles.emptyRow}>No chat was selected when this popup was opened.</div>
                 ) : !report.chat.exists ? (
                   <div className={styles.emptyRow}>The requested chat could not be found.</div>

--- a/src/routes/memory-cortex.routes.ts
+++ b/src/routes/memory-cortex.routes.ts
@@ -79,6 +79,12 @@ app.get("/health", async (c) => {
     checks.push({ key, label, status, message });
   };
 
+  const getProbeErrorMessage = (err: unknown, fallback: string) => {
+    if (err instanceof Error && err.message.trim()) return err.message;
+    if (typeof err === "string" && err.trim()) return err;
+    return fallback;
+  };
+
   pushCheck(
     "cortex_enabled",
     "Memory Cortex enabled",
@@ -129,44 +135,49 @@ app.get("/health", async (c) => {
     success: boolean | null;
     message: string;
     dimension: number | null;
+    durationMs: number | null;
+    timedOut: boolean;
+    error: string | null;
   } = {
     attempted: false,
     success: null,
     message: "Live embedding probe not run.",
     dimension: embeddings.dimensions,
+    durationMs: null,
+    timedOut: false,
+    error: null,
   };
+  const embeddingProbePromise = (async () => {
+    if (!(probeConnectivity && embeddings.enabled && embeddings.has_api_key)) {
+      return embeddingConnectivity;
+    }
 
-  if (probeConnectivity && embeddings.enabled && embeddings.has_api_key) {
+    const startedAt = Date.now();
     try {
       const result = await embeddingsSvc.testEmbeddingConfig(userId, "Memory Cortex health check.");
-      embeddingConnectivity = {
+      const durationMs = Date.now() - startedAt;
+      return {
         attempted: true,
         success: true,
         message: `Embedding request succeeded (${result.dimension} dimensions).`,
         dimension: result.dimension,
+        durationMs,
+        timedOut: false,
+        error: null,
       };
-      pushCheck(
-        "embedding_probe",
-        "Embedding connectivity",
-        "pass",
-        embeddingConnectivity.message,
-      );
-    } catch (err: any) {
-      const message = err?.message || "Embedding probe failed.";
-      embeddingConnectivity = {
+    } catch (err: unknown) {
+      const message = getProbeErrorMessage(err, "Embedding probe failed.");
+      return {
         attempted: true,
         success: false,
         message,
         dimension: embeddings.dimensions,
+        durationMs: Date.now() - startedAt,
+        timedOut: err instanceof Error && err.name === "TimeoutError",
+        error: message,
       };
-      pushCheck(
-        "embedding_probe",
-        "Embedding connectivity",
-        "fail",
-        message,
-      );
     }
-  }
+  })();
 
   const sidecarConnectionId = config.sidecar?.connectionProfileId || null;
   const sidecarRequired =
@@ -187,51 +198,51 @@ app.get("/health", async (c) => {
   if (sidecarRequired && !sidecarConnectionId) {
     pushCheck(
       "sidecar_required",
-      "Sidecard connection",
+      "Sidecar connection",
       "fail",
-      "Sidecard-assisted cortex features are enabled, but no sidecard connection is selected.",
+      "Sidecar-assisted cortex features are enabled, but no sidecar connection is selected.",
     );
   } else if (sidecarConnectionId && !sidecarProfile) {
     pushCheck(
       "sidecar_exists",
-      "Sidecard connection",
+      "Sidecar connection",
       sidecarRequired ? "fail" : "warn",
-      "The selected sidecard connection profile no longer exists.",
+      "The selected sidecar connection profile no longer exists.",
     );
   } else if (sidecarConnectionId && !sidecarProvider) {
     pushCheck(
       "sidecar_provider",
-      "Sidecard provider",
+      "Sidecar provider",
       sidecarRequired ? "fail" : "warn",
       `The selected provider "${sidecarProfile?.provider}" is not available.`,
     );
   } else if (sidecarConnectionId && !sidecarHasApiKey) {
     pushCheck(
       "sidecar_api_key",
-      "Sidecard API key",
+      "Sidecar API key",
       sidecarRequired ? "fail" : "warn",
-      "The selected sidecard connection is missing its API key.",
+      "The selected sidecar connection is missing its API key.",
     );
   } else if (sidecarRequired) {
     pushCheck(
       "sidecar_ready",
-      "Sidecard readiness",
+      "Sidecar readiness",
       "pass",
-      "A valid sidecard connection is configured for cortex features that require it.",
+      "A valid sidecar connection is configured for cortex features that require it.",
     );
   } else if (sidecarConnectionId) {
     pushCheck(
       "sidecar_optional",
-      "Sidecard connection",
+      "Sidecar connection",
       "info",
-      "A sidecard connection is configured, but current cortex modes can still run in heuristic mode.",
+      "A sidecar connection is configured, but current cortex modes can still run in heuristic mode.",
     );
   } else {
     pushCheck(
       "sidecar_optional",
-      "Sidecard connection",
+      "Sidecar connection",
       "info",
-      "No sidecard connection is configured. Heuristic cortex mode can still run without it.",
+      "No sidecar connection is configured. Heuristic cortex mode can still run without it.",
     );
   }
 
@@ -239,24 +250,65 @@ app.get("/health", async (c) => {
     attempted: boolean;
     success: boolean | null;
     message: string;
+    durationMs: number | null;
+    timedOut: boolean;
+    error: string | null;
   } = {
     attempted: false,
     success: null,
-    message: "Live sidecard probe not run.",
+    message: "Live sidecar probe not run.",
+    durationMs: null,
+    timedOut: false,
+    error: null,
   };
+  const sidecarProbePromise = (async () => {
+    if (!(probeConnectivity && sidecarConnectionId && sidecarProfile)) {
+      return sidecarConnectivity;
+    }
 
-  if (probeConnectivity && sidecarConnectionId && sidecarProfile) {
-    const result = await connectionsSvc.testConnection(userId, sidecarConnectionId);
-    sidecarConnectivity = {
-      attempted: true,
-      success: result.success,
-      message: result.message,
-    };
+    try {
+      const result = await connectionsSvc.testConnection(userId, sidecarConnectionId);
+      return {
+        attempted: true,
+        success: result.success,
+        message: result.message,
+        durationMs: result.durationMs,
+        timedOut: result.timedOut,
+        error: result.error,
+      };
+    } catch (err: unknown) {
+      const message = getProbeErrorMessage(err, "Sidecar probe failed.");
+      return {
+        attempted: true,
+        success: false,
+        message,
+        durationMs: null,
+        timedOut: err instanceof Error && err.name === "TimeoutError",
+        error: message,
+      };
+    }
+  })();
+
+  [embeddingConnectivity, sidecarConnectivity] = await Promise.all([
+    embeddingProbePromise,
+    sidecarProbePromise,
+  ]);
+
+  if (embeddingConnectivity.attempted) {
+    pushCheck(
+      "embedding_probe",
+      "Embedding connectivity",
+      embeddingConnectivity.success ? "pass" : "fail",
+      embeddingConnectivity.message,
+    );
+  }
+
+  if (sidecarConnectivity.attempted) {
     pushCheck(
       "sidecar_probe",
-      "Sidecard connectivity",
-      result.success ? "pass" : "fail",
-      result.message,
+      "Sidecar connectivity",
+      sidecarConnectivity.success ? "pass" : "fail",
+      sidecarConnectivity.message,
     );
   }
 

--- a/src/services/connections.service.ts
+++ b/src/services/connections.service.ts
@@ -9,6 +9,50 @@ import type {
 import type { PaginationParams, PaginatedResult } from "../types/pagination";
 import { paginatedQuery } from "./pagination";
 
+const DEFAULT_CONNECTION_TEST_TIMEOUT_MS = 15_000;
+
+export interface ConnectionTestResult {
+  success: boolean;
+  message: string;
+  provider: string;
+  durationMs: number;
+  timedOut: boolean;
+  error: string | null;
+}
+
+function describeConnectionTestError(err: unknown): string {
+  if (err instanceof Error && err.message.trim()) return err.message;
+  if (typeof err === "string" && err.trim()) return err;
+  return "Connection test failed";
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  if (timeoutMs <= 0) return promise;
+
+  const TIMEOUT = Symbol("connection-test-timeout");
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let result: T | typeof TIMEOUT;
+  try {
+    result = await Promise.race([
+      promise,
+      new Promise<typeof TIMEOUT>((resolve) => {
+        timer = setTimeout(() => resolve(TIMEOUT), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+
+  if (result === TIMEOUT) {
+    const seconds = (timeoutMs / 1000).toFixed(timeoutMs % 1000 === 0 ? 0 : 1);
+    const error = new Error(`${label} timed out after ${seconds}s`);
+    error.name = "TimeoutError";
+    throw error;
+  }
+
+  return result as T;
+}
+
 /** Secret key for a connection's API key. */
 export function connectionSecretKey(id: string): string {
   return `connection_${id}_api_key`;
@@ -206,27 +250,73 @@ export async function clearConnectionApiKey(userId: string, id: string): Promise
     .run(Math.floor(Date.now() / 1000), id, userId);
 }
 
-export async function testConnection(userId: string, id: string): Promise<{ success: boolean; message: string; provider: string }> {
+export async function testConnection(
+  userId: string,
+  id: string,
+  options?: { timeoutMs?: number }
+): Promise<ConnectionTestResult> {
+  const startedAt = Date.now();
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_CONNECTION_TEST_TIMEOUT_MS;
   const profile = getConnection(userId, id);
-  if (!profile) return { success: false, message: "Connection not found", provider: "" };
+  if (!profile) {
+    return {
+      success: false,
+      message: "Connection not found",
+      provider: "",
+      durationMs: Date.now() - startedAt,
+      timedOut: false,
+      error: "Connection not found",
+    };
+  }
 
   const provider = getProvider(profile.provider);
-  if (!provider) return { success: false, message: `Unknown provider: ${profile.provider}`, provider: profile.provider };
+  if (!provider) {
+    return {
+      success: false,
+      message: `Unknown provider: ${profile.provider}`,
+      provider: profile.provider,
+      durationMs: Date.now() - startedAt,
+      timedOut: false,
+      error: `Unknown provider: ${profile.provider}`,
+    };
+  }
 
   const apiKey = await secretsSvc.getSecret(userId, connectionSecretKey(id));
   if (!apiKey && provider.capabilities.apiKeyRequired) {
-    return { success: false, message: `No API key for connection "${profile.name}"`, provider: profile.provider };
+    return {
+      success: false,
+      message: `No API key for connection "${profile.name}"`,
+      provider: profile.provider,
+      durationMs: Date.now() - startedAt,
+      timedOut: false,
+      error: `Missing API key for connection "${profile.name}"`,
+    };
   }
 
   try {
-    const valid = await provider.validateKey(apiKey || "", resolveEffectiveApiUrl(profile));
+    const valid = await withTimeout(
+      provider.validateKey(apiKey || "", resolveEffectiveApiUrl(profile)),
+      timeoutMs,
+      `Connection test for "${profile.name}" (${profile.provider})`
+    );
     return {
       success: valid,
       message: valid ? "Connection successful" : "API key validation failed",
       provider: profile.provider,
+      durationMs: Date.now() - startedAt,
+      timedOut: false,
+      error: valid ? null : "API key validation failed",
     };
   } catch (err: any) {
-    return { success: false, message: err.message || "Connection test failed", provider: profile.provider };
+    const timedOut = err?.name === "TimeoutError";
+    return {
+      success: false,
+      message: describeConnectionTestError(err),
+      provider: profile.provider,
+      durationMs: Date.now() - startedAt,
+      timedOut,
+      error: describeConnectionTestError(err),
+    };
   }
 }
 


### PR DESCRIPTION
## What changed

- keep the diagnostics modal in a true loading state until a health report exists
- preserve the last good report on refresh failures instead of replacing it with misleading fallback values
- improve diagnostics error output so request timeouts and API failures show useful context
- run embedding and sidecar live probes in parallel during `/memory-cortex/health`
- add a timeout around sidecar connection validation so one slow provider probe does not stall the whole diagnostics request
- rename diagnostics from `Sidecard` to `Sidecar`

## Why

The popup had two separate issues:
- while loading, it rendered `null` report data as real values like `No`, `Missing`, `N/A`, and `No chat was selected`
- live connectivity probes could block the diagnostics endpoint long enough for the frontend request to time out