### PR TITLE
Add binary I/O, move, and stat methods to spindle.userStorage

### DIFF
--- a/developer-docs/docs/backend-api/storage.md
+++ b/developer-docs/docs/backend-api/storage.md
@@ -98,6 +98,12 @@ await spindle.userStorage.write('notes.txt', 'Hello world', userId)
 // Read raw text
 const text = await spindle.userStorage.read('notes.txt', userId)
 
+// Write raw bytes (per user)
+await spindle.userStorage.writeBinary('avatar.png', pngBytes, userId)
+
+// Read raw bytes (per user)
+const bytes = await spindle.userStorage.readBinary('avatar.png', userId)
+
 // List files
 const files = await spindle.userStorage.list(undefined, userId)
 
@@ -106,6 +112,12 @@ const exists = await spindle.userStorage.exists('config.json', userId)
 
 // Create directory
 await spindle.userStorage.mkdir('cache/', userId)
+
+// Move / rename within the user's scope
+await spindle.userStorage.move('notes.txt', 'archive/notes.txt', userId)
+
+// Metadata
+const meta = await spindle.userStorage.stat('archive/notes.txt', userId)
 
 // Delete
 await spindle.userStorage.delete('notes.txt', userId)
@@ -117,12 +129,18 @@ await spindle.userStorage.delete('notes.txt', userId)
 |---|---|---|
 | `read(path, userId?)` | `Promise<string>` | Read a file as UTF-8 text |
 | `write(path, data, userId?)` | `Promise<void>` | Write a UTF-8 text file (creates directories as needed) |
+| `readBinary(path, userId?)` | `Promise<Uint8Array>` | Read a file as raw bytes |
+| `writeBinary(path, data, userId?)` | `Promise<void>` | Write raw bytes to a file |
 | `delete(path, userId?)` | `Promise<void>` | Delete a file |
 | `list(prefix?, userId?)` | `Promise<string[]>` | List files, optionally under a prefix/directory |
 | `exists(path, userId?)` | `Promise<boolean>` | Check if a file or directory exists |
 | `mkdir(path, userId?)` | `Promise<void>` | Create a directory (recursive) |
+| `move(from, to, userId?)` | `Promise<void>` | Move or rename a file within the user's scope |
+| `stat(path, userId?)` | `Promise<StatResult>` | Get file metadata (see [StatResult](#statresult) above) |
 | `getJson<T>(path, options?)` | `Promise<T>` | Read and parse a JSON file. Options: `{ fallback?: T; userId?: string }` |
 | `setJson(path, value, options?)` | `Promise<void>` | Serialize and write a JSON file. Options: `{ indent?: number; userId?: string }` |
+
+`move` resolves both `from` and `to` under the same user's scope — cross-user moves are not supported.
 
 **Storage location:** `{DATA_DIR}/users/{userId}/extensions/{identifier}/`
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "hono": "^4.7.0",
     "js-tiktoken": "^1.0.16",
     "jsdom": "^29.0.1",
-    "lumiverse-spindle-types": "0.4.33",
+    "lumiverse-spindle-types": "0.4.34",
     "mute-stream": "^3.0.0",
     "sharp": "^0.34.5",
     "ssh2-sftp-client": "^12.1.1"

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -899,6 +899,17 @@ export class WorkerHost {
       case "user_storage_write":
         this.handleUserStorageWrite(msg.requestId, msg.path, msg.data, msg.userId);
         break;
+      case "user_storage_read_binary":
+        this.handleUserStorageReadBinary(msg.requestId, msg.path, msg.userId);
+        break;
+      case "user_storage_write_binary":
+        this.handleUserStorageWriteBinary(
+          msg.requestId,
+          msg.path,
+          msg.data,
+          msg.userId
+        );
+        break;
       case "user_storage_delete":
         this.handleUserStorageDelete(msg.requestId, msg.path, msg.userId);
         break;
@@ -910,6 +921,12 @@ export class WorkerHost {
         break;
       case "user_storage_mkdir":
         this.handleUserStorageMkdir(msg.requestId, msg.path, msg.userId);
+        break;
+      case "user_storage_move":
+        this.handleUserStorageMove(msg.requestId, msg.from, msg.to, msg.userId);
+        break;
+      case "user_storage_stat":
+        this.handleUserStorageStat(msg.requestId, msg.path, msg.userId);
         break;
       case "enclave_put":
         this.handleEnclavePut(msg.requestId, msg.key, msg.value, msg.userId);
@@ -2335,6 +2352,101 @@ export class WorkerHost {
       const fullPath = this.resolveUserStoragePath(path, resolvedUserId);
       mkdirSync(fullPath, { recursive: true });
       this.postToWorker({ type: "response", requestId, result: true });
+    } catch (err: any) {
+      this.postToWorker({ type: "response", requestId, error: err.message });
+    }
+  }
+
+  private handleUserStorageReadBinary(requestId: string, path: string, userId?: string): void {
+    try {
+      const resolvedUserId = this.resolveUserScopedUserId(userId);
+      const fullPath = this.resolveUserStoragePath(path, resolvedUserId);
+      if (!existsSync(fullPath)) {
+        this.postToWorker({ type: "response", requestId, error: "File not found" });
+        return;
+      }
+      const data = readFileSync(fullPath);
+      this.postToWorker({
+        type: "response",
+        requestId,
+        result: new Uint8Array(data),
+      });
+    } catch (err: any) {
+      this.postToWorker({ type: "response", requestId, error: err.message });
+    }
+  }
+
+  private handleUserStorageWriteBinary(
+    requestId: string,
+    path: string,
+    data: Uint8Array,
+    userId?: string
+  ): void {
+    try {
+      const resolvedUserId = this.resolveUserScopedUserId(userId);
+      const fullPath = this.resolveUserStoragePath(path, resolvedUserId);
+      const dir = resolve(fullPath, "..");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(fullPath, data);
+      this.postToWorker({ type: "response", requestId, result: true });
+    } catch (err: any) {
+      this.postToWorker({ type: "response", requestId, error: err.message });
+    }
+  }
+
+  private handleUserStorageMove(
+    requestId: string,
+    from: string,
+    to: string,
+    userId?: string
+  ): void {
+    try {
+      const resolvedUserId = this.resolveUserScopedUserId(userId);
+      const fromPath = this.resolveUserStoragePath(from, resolvedUserId);
+      const toPath = this.resolveUserStoragePath(to, resolvedUserId);
+      if (!existsSync(fromPath)) {
+        this.postToWorker({ type: "response", requestId, error: "File not found" });
+        return;
+      }
+      mkdirSync(resolve(toPath, ".."), { recursive: true });
+      renameSync(fromPath, toPath);
+      this.postToWorker({ type: "response", requestId, result: true });
+    } catch (err: any) {
+      this.postToWorker({ type: "response", requestId, error: err.message });
+    }
+  }
+
+  private handleUserStorageStat(requestId: string, path: string, userId?: string): void {
+    try {
+      const resolvedUserId = this.resolveUserScopedUserId(userId);
+      const fullPath = this.resolveUserStoragePath(path, resolvedUserId);
+      if (!existsSync(fullPath)) {
+        this.postToWorker({
+          type: "response",
+          requestId,
+          result: {
+            exists: false,
+            isFile: false,
+            isDirectory: false,
+            sizeBytes: 0,
+            modifiedAt: new Date(0).toISOString(),
+          },
+        });
+        return;
+      }
+
+      const stat = statSync(fullPath);
+      this.postToWorker({
+        type: "response",
+        requestId,
+        result: {
+          exists: true,
+          isFile: stat.isFile(),
+          isDirectory: stat.isDirectory(),
+          sizeBytes: stat.size,
+          modifiedAt: new Date(stat.mtimeMs).toISOString(),
+        },
+      });
     } catch (err: any) {
       this.postToWorker({ type: "response", requestId, error: err.message });
     }

--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -585,6 +585,27 @@ const spindleApi: RuntimeSpindleAPI = {
       const requestId = crypto.randomUUID();
       await request({ type: "user_storage_write", requestId, path, data, userId });
     },
+    async readBinary(path: string, userId?: string): Promise<Uint8Array> {
+      const requestId = crypto.randomUUID();
+      const result = await request({
+        type: "user_storage_read_binary",
+        requestId,
+        path,
+        userId,
+      });
+      return result as Uint8Array;
+    },
+    async writeBinary(path: string, data: Uint8Array, userId?: string): Promise<void> {
+      assertMutationAllowed("spindle.userStorage.writeBinary()");
+      const requestId = crypto.randomUUID();
+      await request({
+        type: "user_storage_write_binary",
+        requestId,
+        path,
+        data,
+        userId,
+      });
+    },
     async delete(path: string, userId?: string): Promise<void> {
       assertMutationAllowed("spindle.userStorage.delete()");
       const requestId = crypto.randomUUID();
@@ -609,6 +630,39 @@ const spindleApi: RuntimeSpindleAPI = {
       assertMutationAllowed("spindle.userStorage.mkdir()");
       const requestId = crypto.randomUUID();
       await request({ type: "user_storage_mkdir", requestId, path, userId });
+    },
+    async move(from: string, to: string, userId?: string): Promise<void> {
+      assertMutationAllowed("spindle.userStorage.move()");
+      const requestId = crypto.randomUUID();
+      await request({
+        type: "user_storage_move",
+        requestId,
+        from,
+        to,
+        userId,
+      });
+    },
+    async stat(path: string, userId?: string): Promise<{
+      exists: boolean;
+      isFile: boolean;
+      isDirectory: boolean;
+      sizeBytes: number;
+      modifiedAt: string;
+    }> {
+      const requestId = crypto.randomUUID();
+      const result = await request({
+        type: "user_storage_stat",
+        requestId,
+        path,
+        userId,
+      });
+      return result as {
+        exists: boolean;
+        isFile: boolean;
+        isDirectory: boolean;
+        sizeBytes: number;
+        modifiedAt: string;
+      };
     },
     async getJson<T>(
       path: string,


### PR DESCRIPTION
Brings userStorage to surface parity with storage by implementing readBinary / writeBinary / move / stat for per-user-scoped files. Each new handler uses the existing resolveUserScopedUserId + resolveUserStoragePath helpers, so path-traversal protection and user-scope inference are inherited from the existing user_storage_* methods. move resolves both `from` and `to` under the same user's scope — cross-user moves are not supported by design. Bumps lumiverse-spindle-types to 0.4.34 for the new WorkerToHost message variants.

Docs updated at developer-docs/docs/backend-api/storage.md.