### PR TITLE
Append input box text to impersonation prompt

### DIFF
--- a/frontend/src/api/generate.ts
+++ b/frontend/src/api/generate.ts
@@ -20,6 +20,8 @@ export interface GenerateRequest {
   force_name?: string
   generation_type?: GenerationType
   impersonate_mode?: ImpersonateMode
+  /** For impersonate: free-form text from the input box, appended to the impersonation prompt. */
+  impersonate_input?: string
   target_character_id?: string
   regen_feedback?: string
   regen_feedback_position?: 'system' | 'user'

--- a/frontend/src/components/chat/InputArea.tsx
+++ b/frontend/src/components/chat/InputArea.tsx
@@ -47,6 +47,7 @@ function slugifyName(name: string): string {
 export default function InputArea({ chatId }: InputAreaProps) {
   const navigate = useNavigate()
   const [text, setText] = useState('')
+  const [lastImpersonateInput, setLastImpersonateInput] = useState<string>('')
   const [dryRunning, setDryRunning] = useState(false)
   const [resolvingMacros, setResolvingMacros] = useState(false)
   const [authorsNoteOpen, setAuthorsNoteOpen] = useState(false)
@@ -271,6 +272,7 @@ export default function InputArea({ chatId }: InputAreaProps) {
 
   // Restore draft on mount or chat switch
   useEffect(() => {
+    setLastImpersonateInput('')
     if (!saveDraftInput) return
     try {
       const saved = localStorage.getItem(DRAFT_KEY_PREFIX + chatId)
@@ -854,7 +856,15 @@ export default function InputArea({ chatId }: InputAreaProps) {
   const handleImpersonate = useCallback(async (mode: import('@/api/generate').ImpersonateMode) => {
     if (isStreaming) return
     const nonce = ++generationNonceRef.current
+    const impersonateInput = text.trim()
     beginStreaming(undefined, 'impersonate')
+    // Stash the input so the user can restore it after the run, and clear the box.
+    if (impersonateInput) {
+      setLastImpersonateInput(impersonateInput)
+      setText('')
+      try { localStorage.removeItem(DRAFT_KEY_PREFIX + chatId) } catch {}
+      if (textareaRef.current) textareaRef.current.style.height = 'auto'
+    }
     try {
       const forcedPresetId = mode === 'oneliner' ? impersonationPresetId : null
       const res = await generateApi.start({
@@ -865,6 +875,7 @@ export default function InputArea({ chatId }: InputAreaProps) {
         force_preset_id: !!forcedPresetId,
         generation_type: 'impersonate',
         impersonate_mode: mode,
+        impersonate_input: impersonateInput || undefined,
       })
       if (generationNonceRef.current !== nonce) return
       startStreaming(res.generationId)
@@ -876,7 +887,7 @@ export default function InputArea({ chatId }: InputAreaProps) {
       setStreamingError(msg)
       toast.error(msg, { title: 'Impersonation Failed' })
     }
-  }, [chatId, isStreaming, activeProfileId, activePersonaId, impersonationPresetId, getActivePresetForGeneration, beginStreaming, startStreaming, setStreamingError, consumeOneshotGuides])
+  }, [chatId, isStreaming, text, activeProfileId, activePersonaId, impersonationPresetId, getActivePresetForGeneration, beginStreaming, startStreaming, setStreamingError, consumeOneshotGuides])
 
   const handleStop = useCallback(async () => {
     if (!isStreaming) return
@@ -1575,6 +1586,33 @@ export default function InputArea({ chatId }: InputAreaProps) {
             <div className={clsx(styles.popover, popoverClosing && styles.popoverClosing)}>
               <div className={styles.extrasSection}>
                 <div className={styles.quickSetName}>Impersonate</div>
+                {lastImpersonateInput && (
+                  <button
+                    type="button"
+                    className={styles.popRowBtn}
+                    title={lastImpersonateInput}
+                    onClick={() => {
+                      setOpenPopover(null)
+                      setText((prev) => prev ? `${prev}\n${lastImpersonateInput}` : lastImpersonateInput)
+                      setLastImpersonateInput('')
+                      requestAnimationFrame(() => {
+                        if (textareaRef.current) {
+                          textareaRef.current.style.height = 'auto'
+                          textareaRef.current.style.height = Math.min(textareaRef.current.scrollHeight, 180) + 'px'
+                          textareaRef.current.focus()
+                        }
+                      })
+                    }}
+                  >
+                    <span className={styles.personaMain}>
+                      <ScrollText size={14} />
+                      <span className={styles.personaNameGroup}>
+                        <span>Restore last input</span>
+                        <span className={styles.personaTitle}>{lastImpersonateInput.length > 60 ? lastImpersonateInput.slice(0, 60) + '…' : lastImpersonateInput}</span>
+                      </span>
+                    </span>
+                  </button>
+                )}
                 <button
                   type="button"
                   className={styles.popRowBtn}

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -116,6 +116,8 @@ export interface AssemblyContext {
   personaId?: string;
   /** For impersonate: controls how much of the preset is included. */
   impersonateMode?: ImpersonateMode;
+  /** For impersonate: free-form user text from the input box, appended to the impersonation prompt. */
+  impersonateInput?: string;
   /** For regenerate: exclude this message from chat history (it has a blank swipe). */
   excludeMessageId?: string;
   /** For group chats: generate a response as this specific character. */

--- a/src/services/generate.service.ts
+++ b/src/services/generate.service.ts
@@ -68,6 +68,8 @@ interface GenerateInput {
   parameters?: GenerationParameters;
   generation_type?: GenerationType;
   impersonate_mode?: ImpersonateMode;
+  /** For impersonate: free-form text from the user's input box, appended to the impersonation prompt. */
+  impersonate_input?: string;
   target_character_id?: string;
   regen_feedback?: string;
   regen_feedback_position?: "system" | "user";
@@ -525,6 +527,7 @@ async function runPromptPipeline(opts: {
   personaId?: string;
   generationType: string;
   impersonateMode?: ImpersonateMode;
+  impersonateInput?: string;
   inputMessages?: LlmMessage[];
   inputParameters?: GenerationParameters;
   excludeMessageId?: string;
@@ -601,6 +604,7 @@ async function runPromptPipeline(opts: {
       personaId: opts.personaId,
       generationType: opts.generationType as GenerationType,
       impersonateMode: opts.impersonateMode,
+      impersonateInput: opts.impersonateInput,
       excludeMessageId: opts.excludeMessageId,
       targetCharacterId: opts.targetCharacterId,
       councilToolResults: opts.councilToolResults,
@@ -1292,6 +1296,7 @@ export async function startGeneration(input: GenerateInput): Promise<{ generatio
       personaId: input.persona_id,
       generationType: genType,
       impersonateMode: genType === "impersonate" ? (input.impersonate_mode || "prompts") : undefined,
+      impersonateInput: genType === "impersonate" ? input.impersonate_input : undefined,
       inputMessages: input.messages,
       inputParameters: input.parameters,
       excludeMessageId,
@@ -1469,6 +1474,7 @@ export async function dryRunGeneration(input: GenerateInput): Promise<DryRunResu
     personaId: input.persona_id,
     generationType: genType,
     impersonateMode: genType === "impersonate" ? (input.impersonate_mode || "prompts") : undefined,
+    impersonateInput: genType === "impersonate" ? input.impersonate_input : undefined,
     inputMessages: input.messages,
     inputParameters: input.parameters,
     excludeMessageId: input.exclude_message_id,

--- a/src/services/prompt-assembly.service.ts
+++ b/src/services/prompt-assembly.service.ts
@@ -1457,12 +1457,17 @@ export async function assemblePrompt(ctx: AssemblyContext): Promise<AssemblyResu
   // Impersonate type: append impersonation prompt
   if (ctx.generationType === "impersonate") {
     const prompt = promptBehavior.impersonationPrompt;
+    const userInput = typeof ctx.impersonateInput === "string" ? ctx.impersonateInput.trim() : "";
+    let resolved = "";
     if (prompt) {
-      const resolved = (await evaluate(prompt, macroEnv, registry)).text;
-      if (resolved) {
-        result.push({ role: "system", content: resolved });
-        breakdown.push({ type: "utility", name: "Impersonation Prompt", role: "system", content: resolved });
-      }
+      resolved = (await evaluate(prompt, macroEnv, registry)).text;
+    }
+    if (userInput) {
+      resolved = resolved ? `${resolved}\n\n${userInput}` : userInput;
+    }
+    if (resolved) {
+      result.push({ role: "system", content: resolved });
+      breakdown.push({ type: "utility", name: "Impersonation Prompt", role: "system", content: resolved });
     }
   }
 
@@ -4430,12 +4435,17 @@ async function onelinerImpersonation(
 
   // Impersonation prompt
   const prompt = promptBehavior.impersonationPrompt;
+  const userInput = typeof ctx.impersonateInput === "string" ? ctx.impersonateInput.trim() : "";
+  let resolved = "";
   if (prompt) {
-    const resolved = (await evaluate(prompt, macroEnv, registry)).text;
-    if (resolved) {
-      result.push({ role: "system", content: resolved });
-      breakdown.push({ type: "utility", name: "Impersonation Prompt", role: "system", content: resolved });
-    }
+    resolved = (await evaluate(prompt, macroEnv, registry)).text;
+  }
+  if (userInput) {
+    resolved = resolved ? `${resolved}\n\n${userInput}` : userInput;
+  }
+  if (resolved) {
+    result.push({ role: "system", content: resolved });
+    breakdown.push({ type: "utility", name: "Impersonation Prompt", role: "system", content: resolved });
   }
 
   // assistantImpersonation prefill — sent as actual assistant message


### PR DESCRIPTION
## Summary

When the user fires an impersonate generation (Preset Prompts or One-liner), any text in the input box is now sent as `impersonate_input` and appended to the resolved impersonation prompt with a blank line separator. The textbox clears on send, and a **Restore last input** button in the Impersonate popover puts the previous text back so the user can refine and retry.

- Backend: new `impersonate_input` field on `GenerateInput`, threaded through lifecycle + `AssemblyContext`, appended to the impersonation prompt in both the full-preset branch (`assemblePrompt`) and `onelinerImpersonation`. Non-impersonate generations ignore it.
- Frontend: `handleImpersonate` captures the current textarea text, sends it, clears the box + purges the saved draft, and stashes it for restore. Restore button only renders when a stash exists, appears at the top of the Impersonate popover, and focuses the textarea on click.
- Fallback: if the preset has no `impersonationPrompt` configured but the user typed something, their text becomes the nudge on its own.

## Test plan

- [ ] Fire impersonate (Preset Prompts) with an empty textbox → behavior unchanged
- [ ] Fire impersonate (Preset Prompts) with text in the box → text appended to impersonation prompt as a system message, textbox clears
- [ ] Same thing with One-liner mode
- [ ] After an impersonate with input, the **Restore last input** row appears in the Impersonate popover with a truncated preview
- [ ] Clicking Restore puts the text back in the textarea, clears the stash, focuses the input
- [ ] Switching chats resets the stash
- [ ] Regenerate / continue / normal sends do not send `impersonate_input`

🤖 Generated with [Claude Code](https://claude.com/claude-code)