### PR TITLE
Additional Spindle API Hooks

### DIFF
--- a/developer-docs/docs/backend-api/index.md
+++ b/developer-docs/docs/backend-api/index.md
@@ -16,6 +16,7 @@ declare const spindle: import('lumiverse-spindle-types').SpindleAPI
 | [Macros](macros.md) | Free | Register custom `{{macros}}` for prompts |
 | [Interceptors](interceptors.md) | `interceptor` | Modify the prompt before it reaches the LLM |
 | [Context Handlers](context-handlers.md) | `context_handler` | Enrich the generation context before assembly |
+| [Macro Interceptor](macro-interceptor.md) | `macro_interceptor` | Transform raw templates before macro parsing/dispatch |
 | [Message Content Processor](message-content-processor.md) | `chat_mutation` | Transform message content before it is written to the database |
 | [LLM Tools](llm-tools.md) | `tools` | Register function-calling tools + Council-eligible tools |
 | [Generation](generation.md) | `generation` | Fire LLM generations + inspect connections |

--- a/developer-docs/docs/backend-api/index.md
+++ b/developer-docs/docs/backend-api/index.md
@@ -16,6 +16,7 @@ declare const spindle: import('lumiverse-spindle-types').SpindleAPI
 | [Macros](macros.md) | Free | Register custom `{{macros}}` for prompts |
 | [Interceptors](interceptors.md) | `interceptor` | Modify the prompt before it reaches the LLM |
 | [Context Handlers](context-handlers.md) | `context_handler` | Enrich the generation context before assembly |
+| [Message Content Processor](message-content-processor.md) | `chat_mutation` | Transform message content before it is written to the database |
 | [LLM Tools](llm-tools.md) | `tools` | Register function-calling tools + Council-eligible tools |
 | [Generation](generation.md) | `generation` | Fire LLM generations + inspect connections |
 | [Image Generation](image-generation.md) | `image_gen` | Generate images via image gen connection profiles |

--- a/developer-docs/docs/backend-api/macro-interceptor.md
+++ b/developer-docs/docs/backend-api/macro-interceptor.md
@@ -1,0 +1,59 @@
+# Macro Interceptor
+
+!!! warning "Permission required: `macro_interceptor`"
+
+Macro interceptors run at the top of `MacroEvaluator.evaluate()`, once per fixed-point iteration, before Lumi parses the template. They receive the raw template plus a read-only env snapshot, and return a transformed template or `void` to pass through.
+
+```ts
+spindle.registerMacroInterceptor(async (ctx) => {
+  if (!ctx.template.includes('{{my_macro')) return
+  return myInWorkerEvaluator(ctx.template, ctx.env)
+}, 100)
+```
+
+Use this when per-macro RPC cost dominates iteration-heavy templates (`{{#each LARGE_LIST}}…{{my_macro}}…{{/each}}`). For single macros, prefer `registerMacro`.
+
+## Parameters
+
+| Param | Type | Description |
+|---|---|---|
+| `handler` | `(ctx: MacroInterceptorCtx) => Promise<string \| void>` | Returns the transformed template, or `void` to pass through |
+| `priority` | `number` | Optional. Lower values run first. Default: `100` |
+
+One interceptor per extension; a second registration replaces the first.
+
+## Context Object
+
+```ts
+interface MacroInterceptorCtx {
+  template: string
+  env: { commit, names, character, chat, system, variables: { local, global, chat }, extra }
+  commit: boolean
+  phase: "prompt" | "display" | "response" | "other"
+  sourceHint?: string
+  userId?: string
+}
+```
+
+`env` is a structured-clone snapshot. Persist state via `spindle.variables.*`, not the snapshot.
+
+## Composition Order
+
+Multiple interceptors run in priority order (lower first), with registration order as the tie-breaker. Each interceptor receives the previous one's returned template.
+
+If a returned template no longer contains `{{`, the iteration's parse and dispatch are skipped.
+
+## Timeout
+
+Each interceptor runs inside a 10-second wall-clock budget. On timeout or thrown error: the chain logs the failure and forwards the previous template to the next handler. Macro evaluation itself never aborts.
+
+!!! warning "Users notice the wait"
+    The interceptor fires inside every macro evaluation, including prompt assembly. Slow handlers add visible latency before the first streamed token.
+
+## Macro Interceptor vs Interceptor vs Context Handler
+
+| Hook | When it fires | What it changes |
+| --- | --- | --- |
+| **Macro Interceptor** | Per template, before parse | The raw template |
+| [Context Handler](context-handlers.md) | Before prompt assembly | The generation context |
+| [Interceptor](interceptors.md) | After assembly, before LLM call | The outgoing message array |

--- a/developer-docs/docs/backend-api/message-content-processor.md
+++ b/developer-docs/docs/backend-api/message-content-processor.md
@@ -1,0 +1,85 @@
+# Message Content Processor
+
+!!! warning "Permission required: `chat_mutation`"
+
+Message content processors run before a user-initiated message write reaches the database. They can transform `content` and `extra` so the stored row and every WebSocket subscriber see the transformed version on first paint.
+
+```ts
+spindle.registerMessageContentProcessor(async (ctx) => {
+  if (!ctx.content.includes('{{my_macro}}')) return
+
+  return {
+    content: ctx.content.replaceAll('{{my_macro}}', 'resolved value'),
+  }
+}, 50) // priority: lower runs first (default: 100)
+```
+
+Use this when the transform belongs on the stored message itself, not just on the in-flight LLM call.
+
+## Parameters
+
+| Param | Type | Description |
+| --- | --- | --- |
+| `handler` | `(ctx: MessageContentProcessorCtx) => Promise<MessageContentProcessorResult \| void>` | Receives the about-to-be-committed content; returns a patch, or `void` to pass through |
+| `priority` | `number` | Optional. Lower values run first. Default: `100` |
+
+## Context Object
+
+```ts
+interface MessageContentProcessorCtx {
+  chatId: string
+  messageId?: string                              // undefined for "create"
+  content: string
+  extra?: Record<string, unknown>
+  origin: "create" | "update" | "swipe_add" | "swipe_update"
+  swipeIndex?: number                             // set for "swipe_update"
+  userId: string                                  // pass to operator-scoped Spindle calls
+}
+```
+
+### Origin values
+
+| Origin | Route | Notes |
+| --- | --- | --- |
+| `"create"` | `POST /api/v1/chats/:chatId/messages` | New message row. |
+| `"create"` | `POST /chats`, `POST /group`, `POST /:id/members/:characterId` | Auto-inserted greeting. The chain fires after insert; a follow-up update is written if the handler modifies content or extra. |
+| `"update"` | `PUT /api/v1/chats/:chatId/messages/:id` | Edits an existing message's content or extra. |
+| `"swipe_add"` | `POST /api/v1/chats/:chatId/messages/:id/swipe` (with `content`) | Appends a new swipe. |
+| `"swipe_update"` | `PUT /api/v1/chats/:chatId/messages/:id/swipe/:idx` | Rewrites the swipe at `swipeIndex`. |
+
+Returned `extra` is ignored on swipe origins: swipes share the parent message's `extra`, which `addSwipe` and `updateSwipe` cannot patch. Only `content` is honored.
+
+Cycling through existing swipes (`{direction: "left"|"right"}`) does not fire the hook; no content changes.
+
+## Return Value
+
+```ts
+interface MessageContentProcessorResult {
+  content?: string
+  extra?: Record<string, unknown>
+}
+```
+
+Return `undefined` or `void` to pass through. Otherwise:
+
+- `content`: if present, replaces the content for downstream processors and the database write.
+- `extra`: if present, shallow-merges into the existing `extra` (omitted keys preserved, included keys overwrite).
+
+## Composition Order
+
+Multiple processors run in priority order (lower first, default `100`), with registration order as the tie-breaker. Each processor sees the previous one's returned patch.
+
+## Timeout
+
+Each processor runs inside a 10-second wall-clock budget. On timeout or thrown error: the chain logs the failure and forwards the previous content to the next handler. The write still proceeds.
+
+!!! warning "Users notice the wait"
+    The processor fires before the database write. Every millisecond of handler work is a millisecond of visible latency on send, edit, or swipe. Keep the hook tight.
+
+## Message Content Processor vs Interceptor vs Context Handler
+
+| Hook | When it fires | What it changes |
+| --- | --- | --- |
+| [Context Handler](context-handlers.md) | Before prompt assembly | The generation context |
+| [Interceptor](interceptors.md) | After assembly, before LLM call | The outgoing message array |
+| **Message Content Processor** | Before the message row is written to the database | The content and extra of a user-initiated message write |

--- a/developer-docs/docs/frontend-api/html-islands.md
+++ b/developer-docs/docs/frontend-api/html-islands.md
@@ -1,0 +1,33 @@
+# HTML Islands
+
+Self-contained styled HTML in chat messages is auto-extracted into a Shadow DOM container ("island"). This isolates card `<style>` rules from the chat UI and prevents markdown from corrupting interactive markup.
+
+## Detection
+
+A block-level element (`<div>`, `<section>`, `<article>`, `<aside>`, `<nav>`, `<main>`, `<header>`, `<footer>`, `<form>`, `<fieldset>`, `<figure>`, `<details>`) becomes an island when its content contains either a `<style>` tag or three or more `style="..."` attributes.
+
+Standalone `<style>` blocks not inside a wrapper element are extracted together with any subsequent sibling HTML.
+
+## Opting out with `data-no-island`
+
+Add `data-no-island` to the outer block element's opening tag to render its content inline instead of inside a shadow root:
+
+```html
+<div data-no-island>
+  <style>
+    .my-panel { color: red; }
+  </style>
+  <div class="my-panel">Inline with the rest of the message.</div>
+</div>
+```
+
+Useful when content needs:
+
+- document-level click delegation (e.g. `[data-extension-trigger]` listeners on `document`)
+- CSS cascade into surrounding DOM
+- access from a `MutationObserver` watching the message subtree
+
+The attribute may appear anywhere on the opening tag, including across multiple lines. Standalone `<style>` blocks cannot be opted out directly. Wrap them in a `<div data-no-island>` if you need them inline.
+
+!!! warning "You own scoping and safety"
+    Opting out disables both style isolation and the markdown-safety wrapper. Scope your selectors with a unique class prefix to avoid collisions with the chat UI, and ensure markdown will not misinterpret your content.

--- a/developer-docs/docs/frontend-api/index.md
+++ b/developer-docs/docs/frontend-api/index.md
@@ -32,6 +32,7 @@ export function teardown() {
 | Category | Permission | Description |
 |----------|-----------|-------------|
 | [DOM Helper](dom-helper.md) | Free | Inject sanitized HTML and CSS |
+| [HTML Islands](html-islands.md) | Free | Auto-isolation of styled HTML in messages, and how to opt out |
 | [Events](events.md) | Free | Subscribe to WebSocket events, emit custom events |
 | [UI Placement](ui-placement.md) | Varies | Drawer tabs, float widgets, dock panels, modals, context menus, input bar actions |
 | [Backend Communication](backend-communication.md) | Free | Send/receive messages to/from backend worker |

--- a/frontend/src/components/chat/MessageContent.tsx
+++ b/frontend/src/components/chat/MessageContent.tsx
@@ -295,6 +295,7 @@ const HTML_ISLAND_TOKEN = 'LUMIVERSE_HTML_ISLAND'
 const ISLAND_RE = new RegExp(`<!--${HTML_ISLAND_TOKEN}_(\\d+)-->`, 'g')
 const BLOCK_ELEMENT_RE = /^<(div|section|article|aside|nav|main|header|footer|form|fieldset|figure|details)\b/i
 const INLINE_STYLE_ATTR_RE = /\bstyle\s*=/gi
+const NO_ISLAND_ATTR_RE = /\bdata-no-island\b/i
 
 /** Detect HTML blocks with enough inline styling to warrant island extraction. */
 function hasSignificantInlineStyles(html: string): boolean {
@@ -366,6 +367,13 @@ function extractHtmlIslands(
       }
 
       const blockContent = blockLines.join('\n')
+
+      const openingTagEnd = blockContent.indexOf('>')
+      const openingTag = openingTagEnd >= 0 ? blockContent.slice(0, openingTagEnd) : blockContent
+      if (NO_ISLAND_ATTR_RE.test(openingTag)) {
+        output.push(...blockLines)
+        continue
+      }
 
       // Isolate if balanced and contains <style> or significant inline styling
       if (depth <= 0 && (/<style[\s>]/i.test(blockContent) || hasSignificantInlineStyles(blockContent))) {

--- a/src/macros/MacroEvaluator.ts
+++ b/src/macros/MacroEvaluator.ts
@@ -10,6 +10,10 @@ import type {
 } from "./types";
 import { parse, ESCAPED_OPEN, ESCAPED_CLOSE } from "./MacroParser";
 import { MacroRegistry } from "./MacroRegistry";
+import {
+  macroInterceptorChain,
+  type MacroInterceptorPhase,
+} from "../spindle/macro-interceptor";
 
 const MAX_NESTING_DEPTH = 20;
 const LEGACY_MACRO_MAP: Record<string, string> = {
@@ -17,6 +21,11 @@ const LEGACY_MACRO_MAP: Record<string, string> = {
   "<BOT>": "{{char}}",
   "<CHAR>": "{{char}}",
 };
+
+export interface EvaluateOptions {
+  phase?: MacroInterceptorPhase;
+  sourceHint?: string;
+}
 
 /**
  * Evaluate a macro template string, resolving all macros using the provided
@@ -26,6 +35,7 @@ export async function evaluate(
   input: string,
   env: MacroEnv,
   registry: MacroRegistry,
+  options?: EvaluateOptions,
 ): Promise<EvaluateResult> {
   if (!input) return { text: "", diagnostics: [] };
 
@@ -41,6 +51,11 @@ export async function evaluate(
   const diagnostics: MacroDiagnostic[] = [];
   let text = processed;
 
+  const userId = typeof env.extra?.userId === "string" ? env.extra.userId : undefined;
+  const runInterceptors = macroInterceptorChain.count > 0;
+  const phase = options?.phase ?? "other";
+  const sourceHint = options?.sourceHint;
+
   // Iterative evaluation: most macros are now recursively expanded inline
   // (see evaluateMacroNode). The outer loop acts as a safety net for the
   // rare case where a macro result depends on state mutated by a later macro
@@ -48,6 +63,19 @@ export async function evaluate(
   const MAX_ITERATIONS = 2;
   for (let i = 0; i < MAX_ITERATIONS; i++) {
     if (env.signal?.aborted) throw env.signal.reason ?? new DOMException("Aborted", "AbortError");
+
+    if (runInterceptors) {
+      text = await macroInterceptorChain.run({
+        template: text,
+        env: snapshotEnvForInterceptor(env),
+        commit: env.commit !== false,
+        phase,
+        ...(sourceHint ? { sourceHint } : {}),
+        ...(userId !== undefined ? { userId } : {}),
+      });
+      if (!text.includes("{{")) break;
+    }
+
     const ast = parse(text);
     const result = await evaluateNodes(ast, env, registry, 0, 0, diagnostics);
     if (result === text) break; // No change — converged
@@ -325,6 +353,34 @@ function buildExecContext(
     warn: (message: string) => {
       diagnostics.push({ level: "warn", message, macroName: node.name, offset: node.offset });
     },
+  };
+}
+
+function snapshotEnvForInterceptor(env: MacroEnv): {
+  commit: boolean;
+  names: MacroEnv["names"];
+  character: MacroEnv["character"];
+  chat: MacroEnv["chat"];
+  system: MacroEnv["system"];
+  variables: {
+    local: Record<string, string>;
+    global: Record<string, string>;
+    chat: Record<string, string>;
+  };
+  extra: Record<string, unknown>;
+} {
+  return {
+    commit: env.commit !== false,
+    names: { ...env.names },
+    character: { ...env.character },
+    chat: { ...env.chat },
+    system: { ...env.system },
+    variables: {
+      local: Object.fromEntries(env.variables.local),
+      global: Object.fromEntries(env.variables.global),
+      chat: Object.fromEntries(env.variables.chat),
+    },
+    extra: { ...env.extra },
   };
 }
 

--- a/src/routes/chats.routes.ts
+++ b/src/routes/chats.routes.ts
@@ -5,6 +5,43 @@ import * as charactersSvc from "../services/characters.service";
 import { parsePagination } from "../services/pagination";
 import { RECENT_CHATS_DEFAULT_LIMIT } from "../types/pagination";
 import { parseStChatJsonl, parseStGroupChatJsonl } from "../migration/st-reader";
+import {
+  messageContentProcessorChain,
+  type MessageContentProcessorCtx,
+} from "../spindle/message-content-processor";
+
+async function runMessageContentProcessors(
+  ctx: MessageContentProcessorCtx,
+  userId: string
+): Promise<MessageContentProcessorCtx> {
+  if (messageContentProcessorChain.count === 0) return ctx;
+  return messageContentProcessorChain.run(ctx, userId);
+}
+
+// Auto-greetings are inserted by service-layer createMessage calls that
+// bypass the per-route processor hook; run the chain explicitly so the
+// DB holds resolved content before MESSAGE_SENT broadcasts.
+async function processChatGreeting(userId: string, chat: { id: string }) {
+  if (messageContentProcessorChain.count === 0) return;
+  const msgs = svc.listMessagesTail(userId, chat.id, 1);
+  const greeting = msgs.data[0];
+  if (!greeting || greeting.is_user || greeting.extra?.greeting !== true) return;
+  const ctx: MessageContentProcessorCtx = {
+    chatId: chat.id,
+    messageId: greeting.id,
+    content: greeting.content,
+    extra: greeting.extra,
+    origin: "create",
+    userId,
+  };
+  const processed = await messageContentProcessorChain.run(ctx, userId);
+  const update: { content?: string; extra?: Record<string, unknown> } = {};
+  if (processed.content !== greeting.content) update.content = processed.content;
+  if (processed.extra && processed.extra !== greeting.extra) update.extra = processed.extra;
+  if (update.content !== undefined || update.extra !== undefined) {
+    svc.updateMessage(userId, greeting.id, update);
+  }
+}
 
 const app = new Hono();
 
@@ -49,6 +86,7 @@ app.post("/", async (c) => {
   const body = await c.req.json();
   if (!body.character_id) return c.json({ error: "character_id is required" }, 400);
   const chat = svc.createChat(userId, body);
+  await processChatGreeting(userId, chat);
   return c.json(chat, 201);
 });
 
@@ -59,6 +97,7 @@ app.post("/group", async (c) => {
     return c.json({ error: "character_ids must be an array with at least 2 entries" }, 400);
   }
   const chat = svc.createGroupChat(userId, body);
+  await processChatGreeting(userId, chat);
   return c.json(chat, 201);
 });
 
@@ -86,6 +125,7 @@ app.post("/:id/members/:characterId", async (c) => {
     greeting_index: body.greeting_index,
   });
   if (!updated) return c.json({ error: "Not found, not a group chat, character not found, or already a member" }, 400);
+  if (!body.skip_greeting) await processChatGreeting(userId, updated);
   return c.json(updated);
 });
 
@@ -434,14 +474,40 @@ app.post("/:chatId/messages", async (c) => {
     return c.json({ error: "name and content are required" }, 400);
   }
 
+  const processed = await runMessageContentProcessors(
+    { chatId, content: body.content, extra: body.extra, origin: "create", userId },
+    userId
+  );
+  body.content = processed.content;
+  if (processed.extra !== undefined) body.extra = processed.extra;
+
   const msg = svc.createMessage(chatId, body, userId);
   return c.json(msg, 201);
 });
 
 app.put("/:chatId/messages/:id", async (c) => {
   const userId = c.get("userId");
+  const chatId = c.req.param("chatId");
+  const messageId = c.req.param("id");
   const body = await c.req.json();
-  const msg = svc.updateMessage(userId, c.req.param("id"), body);
+
+  if (body.content !== undefined) {
+    const processed = await runMessageContentProcessors(
+      {
+        chatId,
+        messageId,
+        content: body.content,
+        extra: body.extra,
+        origin: "update",
+        userId,
+      },
+      userId
+    );
+    body.content = processed.content;
+    if (processed.extra !== undefined) body.extra = processed.extra;
+  }
+
+  const msg = svc.updateMessage(userId, messageId, body);
   if (!msg) return c.json({ error: "Not found" }, 404);
   return c.json(msg);
 });
@@ -455,13 +521,25 @@ app.delete("/:chatId/messages/:id", (c) => {
 
 app.post("/:chatId/messages/:id/swipe", async (c) => {
   const userId = c.get("userId");
+  const chatId = c.req.param("chatId");
+  const messageId = c.req.param("id");
   const body = await c.req.json();
   let msg = null;
 
   if (body.direction === "left" || body.direction === "right") {
-    msg = svc.cycleSwipe(userId, c.req.param("id"), body.direction);
+    msg = svc.cycleSwipe(userId, messageId, body.direction);
   } else if (body.content !== undefined) {
-    msg = svc.addSwipe(userId, c.req.param("id"), body.content);
+    const processed = await runMessageContentProcessors(
+      {
+        chatId,
+        messageId,
+        content: body.content,
+        origin: "swipe_add",
+        userId,
+      },
+      userId
+    );
+    msg = svc.addSwipe(userId, messageId, processed.content);
   } else {
     return c.json({ error: "direction or content is required" }, 400);
   }
@@ -472,10 +550,25 @@ app.post("/:chatId/messages/:id/swipe", async (c) => {
 
 app.put("/:chatId/messages/:id/swipe/:idx", async (c) => {
   const userId = c.get("userId");
+  const chatId = c.req.param("chatId");
+  const messageId = c.req.param("id");
   const body = await c.req.json();
   if (body.content === undefined) return c.json({ error: "content is required" }, 400);
   const idx = parseInt(c.req.param("idx"), 10);
-  const msg = svc.updateSwipe(userId, c.req.param("id"), idx, body.content);
+
+  const processed = await runMessageContentProcessors(
+    {
+      chatId,
+      messageId,
+      content: body.content,
+      origin: "swipe_update",
+      swipeIndex: idx,
+      userId,
+    },
+    userId
+  );
+
+  const msg = svc.updateSwipe(userId, messageId, idx, processed.content);
   if (!msg) return c.json({ error: "Not found or invalid swipe index" }, 404);
   return c.json(msg);
 });

--- a/src/spindle/macro-interceptor.ts
+++ b/src/spindle/macro-interceptor.ts
@@ -1,0 +1,97 @@
+import type { MacroEnv } from "../macros/types";
+
+export type MacroInterceptorPhase =
+  | "prompt"
+  | "display"
+  | "response"
+  | "other";
+
+export interface MacroInterceptorEnv {
+  readonly commit: boolean;
+  readonly names: MacroEnv["names"];
+  readonly character: MacroEnv["character"];
+  readonly chat: MacroEnv["chat"];
+  readonly system: MacroEnv["system"];
+  readonly variables: {
+    readonly local: Record<string, string>;
+    readonly global: Record<string, string>;
+    readonly chat: Record<string, string>;
+  };
+  readonly extra: Record<string, unknown>;
+}
+
+export interface MacroInterceptorCtx {
+  readonly template: string;
+  readonly env: MacroInterceptorEnv;
+  readonly commit: boolean;
+  readonly phase: MacroInterceptorPhase;
+  readonly sourceHint?: string;
+  readonly userId?: string;
+}
+
+export type MacroInterceptorResult = string | void;
+
+export interface MacroInterceptor {
+  extensionId: string;
+  userId?: string | null;
+  priority: number;
+  handler: (ctx: MacroInterceptorCtx) => Promise<MacroInterceptorResult>;
+}
+
+const INTERCEPTOR_TIMEOUT_MS = 10_000;
+
+class MacroInterceptorChain {
+  private handlers: MacroInterceptor[] = [];
+
+  register(handler: MacroInterceptor): () => void {
+    this.handlers.push(handler);
+    this.handlers.sort((a, b) => a.priority - b.priority);
+
+    return () => {
+      const idx = this.handlers.indexOf(handler);
+      if (idx !== -1) this.handlers.splice(idx, 1);
+    };
+  }
+
+  unregisterByExtension(extensionId: string): void {
+    this.handlers = this.handlers.filter((h) => h.extensionId !== extensionId);
+  }
+
+  async run(ctx: MacroInterceptorCtx): Promise<string> {
+    let template = ctx.template;
+
+    for (const handler of this.handlers) {
+      if (handler.userId && handler.userId !== ctx.userId) continue;
+      try {
+        const next = await Promise.race([
+          handler.handler({ ...ctx, template }),
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () =>
+                reject(
+                  new Error(
+                    `Macro interceptor from ${handler.extensionId} timed out (${INTERCEPTOR_TIMEOUT_MS / 1000}s)`
+                  )
+                ),
+              INTERCEPTOR_TIMEOUT_MS
+            )
+          ),
+        ]);
+        if (typeof next === "string") template = next;
+      } catch (err) {
+        console.error(
+          `[Spindle] Macro interceptor error from ${handler.extensionId}:`,
+          err
+        );
+      }
+    }
+
+    return template;
+  }
+
+  get count(): number {
+    return this.handlers.length;
+  }
+}
+
+export const macroInterceptorChain = new MacroInterceptorChain();

--- a/src/spindle/manager.service.ts
+++ b/src/spindle/manager.service.ts
@@ -208,6 +208,7 @@ export const PRIVILEGED_PERMISSIONS = new Set([
   "generation",
   "interceptor",
   "context_handler",
+  "macro_interceptor",
   "characters",
   "chats",
   "world_books",
@@ -793,7 +794,7 @@ export function grantPermission(
   identifier: string,
   permission: string
 ): void {
-  if (!isValidPermission(permission)) {
+  if (!isValidPermission(permission) && !PRIVILEGED_PERMISSIONS.has(permission)) {
     throw new Error(`Invalid permission: ${permission}`);
   }
 

--- a/src/spindle/message-content-processor.ts
+++ b/src/spindle/message-content-processor.ts
@@ -1,0 +1,102 @@
+export type MessageContentProcessorOrigin =
+  | "create"
+  | "update"
+  | "swipe_add"
+  | "swipe_update";
+
+export interface MessageContentProcessorCtx {
+  chatId: string;
+  messageId?: string;
+  content: string;
+  extra?: Record<string, unknown>;
+  origin: MessageContentProcessorOrigin;
+  swipeIndex?: number;
+  userId: string;
+}
+
+export interface MessageContentProcessorResult {
+  content?: string;
+  extra?: Record<string, unknown>;
+}
+
+export interface MessageContentProcessor {
+  extensionId: string;
+  userId?: string | null;
+  priority: number;
+  handler: (
+    ctx: MessageContentProcessorCtx
+  ) => Promise<MessageContentProcessorResult | void>;
+}
+
+class MessageContentProcessorChain {
+  private handlers: MessageContentProcessor[] = [];
+
+  register(handler: MessageContentProcessor): () => void {
+    this.handlers.push(handler);
+    this.handlers.sort((a, b) => a.priority - b.priority);
+
+    return () => {
+      const idx = this.handlers.indexOf(handler);
+      if (idx !== -1) this.handlers.splice(idx, 1);
+    };
+  }
+
+  unregisterByExtension(extensionId: string): void {
+    this.handlers = this.handlers.filter(
+      (h) => h.extensionId !== extensionId
+    );
+  }
+
+  async run(
+    ctx: MessageContentProcessorCtx,
+    userId?: string | null
+  ): Promise<MessageContentProcessorCtx> {
+    let result = ctx;
+
+    for (const handler of this.handlers) {
+      if (handler.userId && handler.userId !== userId) {
+        continue;
+      }
+      try {
+        const patch = await Promise.race([
+          handler.handler(result),
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () =>
+                reject(
+                  new Error(
+                    `Message content processor from ${handler.extensionId} timed out (10s)`
+                  )
+                ),
+              10_000
+            )
+          ),
+        ]);
+        if (patch) {
+          const nextExtra =
+            patch.extra !== undefined
+              ? { ...(result.extra ?? {}), ...patch.extra }
+              : result.extra;
+          result = {
+            ...result,
+            ...(patch.content !== undefined ? { content: patch.content } : {}),
+            ...(nextExtra !== result.extra ? { extra: nextExtra } : {}),
+          };
+        }
+      } catch (err) {
+        console.error(
+          `[Spindle] Message content processor error from ${handler.extensionId}:`,
+          err
+        );
+      }
+    }
+
+    return result;
+  }
+
+  get count(): number {
+    return this.handlers.length;
+  }
+}
+
+export const messageContentProcessorChain = new MessageContentProcessorChain();

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -34,6 +34,11 @@ import {
   type MessageContentProcessorCtx,
   type MessageContentProcessorResult,
 } from "./message-content-processor";
+import {
+  macroInterceptorChain,
+  type MacroInterceptorCtx,
+  type MacroInterceptorResult,
+} from "./macro-interceptor";
 import { toolRegistry } from "./tool-registry";
 import * as managerSvc from "./manager.service";
 import * as generateSvc from "../services/generate.service";
@@ -144,6 +149,12 @@ type RuntimeWorkerToHost =
       type: "message_content_processor_result";
       requestId: string;
       result: unknown;
+    }
+  | { type: "register_macro_interceptor"; priority?: number }
+  | {
+      type: "macro_interceptor_result";
+      requestId: string;
+      result: unknown;
     };
 
 type RuntimeHostToWorker =
@@ -152,6 +163,11 @@ type RuntimeHostToWorker =
       type: "message_content_processor_request";
       requestId: string;
       ctx: MessageContentProcessorCtx;
+    }
+  | {
+      type: "macro_interceptor_request";
+      requestId: string;
+      ctx: MacroInterceptorCtx;
     };
 
 let cachedBackendVersion: string | null = null;
@@ -365,6 +381,7 @@ export class WorkerHost {
   private interceptorUnregister: (() => void) | null = null;
   private contextHandlerUnregister: (() => void) | null = null;
   private messageContentProcessorUnregister: (() => void) | null = null;
+  private macroInterceptorUnregister: (() => void) | null = null;
   private registeredMacroNames = new Set<string>();
   private macroValueCache = new Map<string, string>();
   private toastTimestamps: number[] = [];
@@ -549,6 +566,9 @@ export class WorkerHost {
     this.messageContentProcessorUnregister?.();
     this.messageContentProcessorUnregister = null;
 
+    this.macroInterceptorUnregister?.();
+    this.macroInterceptorUnregister = null;
+
     // Unregister all tools for this extension
     toolRegistry.unregisterByExtension(this.extensionId);
 
@@ -573,6 +593,7 @@ export class WorkerHost {
     interceptorPipeline.unregisterByExtension(this.extensionId);
     contextHandlerChain.unregisterByExtension(this.extensionId);
     messageContentProcessorChain.unregisterByExtension(this.extensionId);
+    macroInterceptorChain.unregisterByExtension(this.extensionId);
 
     // Reject pending requests
     for (const [, pending] of this.pendingRequests) {
@@ -929,6 +950,12 @@ export class WorkerHost {
         this.handleRegisterMessageContentProcessor(msg.priority);
         break;
       case "message_content_processor_result":
+        this.resolveRequest(msg.requestId, msg.result);
+        break;
+      case "register_macro_interceptor":
+        this.handleRegisterMacroInterceptor(msg.priority);
+        break;
+      case "macro_interceptor_result":
         this.resolveRequest(msg.requestId, msg.result);
         break;
       case "tool_invocation_result":
@@ -3907,6 +3934,58 @@ export class WorkerHost {
             resolve: (val) => {
               clearTimeout(timeout);
               resolve(val as MessageContentProcessorResult | undefined);
+            },
+            reject: (err) => {
+              clearTimeout(timeout);
+              reject(err);
+            },
+          });
+        });
+      },
+    });
+  }
+
+  private handleRegisterMacroInterceptor(priority?: number): void {
+    if (!managerSvc.hasPermission(this.manifest.identifier, "macro_interceptor")) {
+      console.warn(
+        `[Spindle:${this.manifest.identifier}] macro_interceptor permission not granted for registerMacroInterceptor`
+      );
+      this.postToWorker({
+        type: "permission_denied",
+        permission: "macro_interceptor",
+        operation: "registerMacroInterceptor",
+      });
+      return;
+    }
+
+    this.macroInterceptorUnregister?.();
+    this.macroInterceptorUnregister = macroInterceptorChain.register({
+      extensionId: this.extensionId,
+      userId: this.getScopedUserId(),
+      priority: priority ?? 100,
+      handler: async (ctx: MacroInterceptorCtx) => {
+        const requestId = crypto.randomUUID();
+
+        this.postToWorker({
+          type: "macro_interceptor_request",
+          requestId,
+          ctx,
+        });
+
+        return new Promise<MacroInterceptorResult | void>((resolve, reject) => {
+          const timeout = setTimeout(() => {
+            this.pendingRequests.delete(requestId);
+            reject(
+              new Error(
+                `Macro interceptor timeout from ${this.manifest.identifier}`
+              )
+            );
+          }, 10_000);
+
+          this.pendingRequests.set(requestId, {
+            resolve: (val) => {
+              clearTimeout(timeout);
+              resolve(val as MacroInterceptorResult | undefined);
             },
             reject: (err) => {
               clearTimeout(timeout);

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -29,6 +29,11 @@ import { EventType } from "../ws/events";
 import { registry as macroRegistry } from "../macros";
 import { interceptorPipeline, type InterceptorResult } from "./interceptor-pipeline";
 import { contextHandlerChain } from "./context-handler";
+import {
+  messageContentProcessorChain,
+  type MessageContentProcessorCtx,
+  type MessageContentProcessorResult,
+} from "./message-content-processor";
 import { toolRegistry } from "./tool-registry";
 import * as managerSvc from "./manager.service";
 import * as generateSvc from "../services/generate.service";
@@ -133,6 +138,20 @@ type RuntimeWorkerToHost =
       model?: string;
       modelSource?: TokenModelSource;
       userId?: string;
+    }
+  | { type: "register_message_content_processor"; priority?: number }
+  | {
+      type: "message_content_processor_result";
+      requestId: string;
+      result: unknown;
+    };
+
+type RuntimeHostToWorker =
+  | HostToWorker
+  | {
+      type: "message_content_processor_request";
+      requestId: string;
+      ctx: MessageContentProcessorCtx;
     };
 
 let cachedBackendVersion: string | null = null;
@@ -345,6 +364,7 @@ export class WorkerHost {
   private generationAbortControllers = new Map<string, AbortController>();
   private interceptorUnregister: (() => void) | null = null;
   private contextHandlerUnregister: (() => void) | null = null;
+  private messageContentProcessorUnregister: (() => void) | null = null;
   private registeredMacroNames = new Set<string>();
   private macroValueCache = new Map<string, string>();
   private toastTimestamps: number[] = [];
@@ -525,6 +545,10 @@ export class WorkerHost {
     this.contextHandlerUnregister?.();
     this.contextHandlerUnregister = null;
 
+    // Unregister message content processor
+    this.messageContentProcessorUnregister?.();
+    this.messageContentProcessorUnregister = null;
+
     // Unregister all tools for this extension
     toolRegistry.unregisterByExtension(this.extensionId);
 
@@ -548,6 +572,7 @@ export class WorkerHost {
     // Unregister interceptors and context handlers
     interceptorPipeline.unregisterByExtension(this.extensionId);
     contextHandlerChain.unregisterByExtension(this.extensionId);
+    messageContentProcessorChain.unregisterByExtension(this.extensionId);
 
     // Reject pending requests
     for (const [, pending] of this.pendingRequests) {
@@ -565,7 +590,7 @@ export class WorkerHost {
     this.worker = null;
   }
 
-  private postToWorker(msg: HostToWorker): void {
+  private postToWorker(msg: RuntimeHostToWorker): void {
     this.worker?.postMessage(msg);
   }
 
@@ -899,6 +924,12 @@ export class WorkerHost {
         break;
       case "context_handler_result":
         this.resolveRequest(msg.requestId, msg.context);
+        break;
+      case "register_message_content_processor":
+        this.handleRegisterMessageContentProcessor(msg.priority);
+        break;
+      case "message_content_processor_result":
+        this.resolveRequest(msg.requestId, msg.result);
         break;
       case "tool_invocation_result":
         if (msg.error) {
@@ -3822,6 +3853,60 @@ export class WorkerHost {
             resolve: (val) => {
               clearTimeout(timeout);
               resolve(val);
+            },
+            reject: (err) => {
+              clearTimeout(timeout);
+              reject(err);
+            },
+          });
+        });
+      },
+    });
+  }
+
+  // ─── Message content processor ───────────────────────────────────────
+
+  private handleRegisterMessageContentProcessor(priority?: number): void {
+    if (!managerSvc.hasPermission(this.manifest.identifier, "chat_mutation")) {
+      console.warn(
+        `[Spindle:${this.manifest.identifier}] chat_mutation permission not granted for registerMessageContentProcessor`
+      );
+      this.postToWorker({
+        type: "permission_denied",
+        permission: "chat_mutation",
+        operation: "registerMessageContentProcessor",
+      });
+      return;
+    }
+
+    this.messageContentProcessorUnregister?.();
+    this.messageContentProcessorUnregister = messageContentProcessorChain.register({
+      extensionId: this.extensionId,
+      userId: this.getScopedUserId(),
+      priority: priority ?? 100,
+      handler: async (ctx: MessageContentProcessorCtx) => {
+        const requestId = crypto.randomUUID();
+
+        this.postToWorker({
+          type: "message_content_processor_request",
+          requestId,
+          ctx,
+        });
+
+        return new Promise<MessageContentProcessorResult | void>((resolve, reject) => {
+          const timeout = setTimeout(() => {
+            this.pendingRequests.delete(requestId);
+            reject(
+              new Error(
+                `Message content processor timeout from ${this.manifest.identifier}`
+              )
+            );
+          }, 10_000);
+
+          this.pendingRequests.set(requestId, {
+            resolve: (val) => {
+              clearTimeout(timeout);
+              resolve(val as MessageContentProcessorResult | undefined);
             },
             reject: (err) => {
               clearTimeout(timeout);

--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -83,9 +83,34 @@ type RuntimeWorkerToHost =
       model?: string;
       modelSource?: TokenModelSource;
       userId?: string;
+    }
+  | { type: "register_message_content_processor"; priority?: number }
+  | {
+      type: "message_content_processor_result";
+      requestId: string;
+      result: unknown;
+    };
+
+type RuntimeHostToWorker =
+  | HostToWorker
+  | {
+      type: "message_content_processor_request";
+      requestId: string;
+      ctx: unknown;
     };
 
 type RuntimeSpindleAPI = SpindleAPI & {
+  registerMessageContentProcessor(
+    handler: (ctx: {
+      chatId: string;
+      messageId?: string;
+      content: string;
+      extra?: Record<string, unknown>;
+      origin: "create" | "update" | "swipe_add" | "swipe_update";
+      swipeIndex?: number;
+    }) => Promise<{ content?: string; extra?: Record<string, unknown> } | void>,
+    priority?: number
+  ): void;
   tokens: {
     countText(text: string, options?: { model?: string; modelSource?: TokenModelSource; userId?: string }): Promise<TokenCountResult>;
     countMessages(
@@ -129,6 +154,9 @@ let interceptHandler:
     ) => Promise<LlmMessageDTO[] | InterceptorResultDTO>)
   | null = null;
 let contextHandlerFn: ((context: unknown) => Promise<unknown>) | null = null;
+let messageContentProcessorFn:
+  | ((ctx: unknown) => Promise<unknown>)
+  | null = null;
 let oauthCallbackHandler:
   | ((params: Record<string, string>) => Promise<{ html?: string } | void>)
   | null = null;
@@ -1601,6 +1629,12 @@ const spindleApi: RuntimeSpindleAPI = {
     post({ type: "register_context_handler", priority });
   },
 
+  registerMessageContentProcessor(handler, priority?): void {
+    assertMutationAllowed("spindle.registerMessageContentProcessor()");
+    messageContentProcessorFn = handler as (ctx: unknown) => Promise<unknown>;
+    post({ type: "register_message_content_processor", priority });
+  },
+
   sendToFrontend(payload: unknown, userId?: string): void {
     post({ type: "frontend_message", payload, userId });
   },
@@ -1761,7 +1795,7 @@ const spindleApi: RuntimeSpindleAPI = {
 
 // ─── Message handler (host → worker) ─────────────────────────────────────
 
-self.onmessage = async (event: MessageEvent<HostToWorker>) => {
+self.onmessage = async (event: MessageEvent<RuntimeHostToWorker>) => {
   const msg = event.data;
 
   switch (msg.type) {
@@ -1948,6 +1982,31 @@ self.onmessage = async (event: MessageEvent<HostToWorker>) => {
             type: "context_handler_result",
             requestId: msg.requestId,
             context: msg.context,
+          });
+        }
+      }
+      break;
+    }
+
+    case "message_content_processor_request": {
+      if (messageContentProcessorFn) {
+        try {
+          const result = await messageContentProcessorFn(msg.ctx);
+          post({
+            type: "message_content_processor_result",
+            requestId: msg.requestId,
+            result,
+          });
+        } catch (err: any) {
+          post({
+            type: "log",
+            level: "error",
+            message: `Message content processor error: ${err.message}`,
+          });
+          post({
+            type: "message_content_processor_result",
+            requestId: msg.requestId,
+            result: undefined,
           });
         }
       }

--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -89,12 +89,23 @@ type RuntimeWorkerToHost =
       type: "message_content_processor_result";
       requestId: string;
       result: unknown;
+    }
+  | { type: "register_macro_interceptor"; priority?: number }
+  | {
+      type: "macro_interceptor_result";
+      requestId: string;
+      result: unknown;
     };
 
 type RuntimeHostToWorker =
   | HostToWorker
   | {
       type: "message_content_processor_request";
+      requestId: string;
+      ctx: unknown;
+    }
+  | {
+      type: "macro_interceptor_request";
       requestId: string;
       ctx: unknown;
     };
@@ -109,6 +120,29 @@ type RuntimeSpindleAPI = SpindleAPI & {
       origin: "create" | "update" | "swipe_add" | "swipe_update";
       swipeIndex?: number;
     }) => Promise<{ content?: string; extra?: Record<string, unknown> } | void>,
+    priority?: number
+  ): void;
+  registerMacroInterceptor(
+    handler: (ctx: {
+      template: string;
+      env: {
+        commit: boolean;
+        names: Record<string, string>;
+        character: Record<string, unknown>;
+        chat: Record<string, unknown>;
+        system: Record<string, unknown>;
+        variables: {
+          local: Record<string, string>;
+          global: Record<string, string>;
+          chat: Record<string, string>;
+        };
+        extra: Record<string, unknown>;
+      };
+      commit: boolean;
+      phase: "prompt" | "display" | "response" | "other";
+      sourceHint?: string;
+      userId?: string;
+    }) => Promise<string | void>,
     priority?: number
   ): void;
   tokens: {
@@ -155,6 +189,9 @@ let interceptHandler:
   | null = null;
 let contextHandlerFn: ((context: unknown) => Promise<unknown>) | null = null;
 let messageContentProcessorFn:
+  | ((ctx: unknown) => Promise<unknown>)
+  | null = null;
+let macroInterceptorFn:
   | ((ctx: unknown) => Promise<unknown>)
   | null = null;
 let oauthCallbackHandler:
@@ -1635,6 +1672,12 @@ const spindleApi: RuntimeSpindleAPI = {
     post({ type: "register_message_content_processor", priority });
   },
 
+  registerMacroInterceptor(handler, priority?): void {
+    assertMutationAllowed("spindle.registerMacroInterceptor()");
+    macroInterceptorFn = handler as (ctx: unknown) => Promise<unknown>;
+    post({ type: "register_macro_interceptor", priority });
+  },
+
   sendToFrontend(payload: unknown, userId?: string): void {
     post({ type: "frontend_message", payload, userId });
   },
@@ -2005,6 +2048,31 @@ self.onmessage = async (event: MessageEvent<RuntimeHostToWorker>) => {
           });
           post({
             type: "message_content_processor_result",
+            requestId: msg.requestId,
+            result: undefined,
+          });
+        }
+      }
+      break;
+    }
+
+    case "macro_interceptor_request": {
+      if (macroInterceptorFn) {
+        try {
+          const result = await macroInterceptorFn(msg.ctx);
+          post({
+            type: "macro_interceptor_result",
+            requestId: msg.requestId,
+            result,
+          });
+        } catch (err: any) {
+          post({
+            type: "log",
+            level: "error",
+            message: `Macro interceptor error: ${err.message}`,
+          });
+          post({
+            type: "macro_interceptor_result",
             requestId: msg.requestId,
             result: undefined,
           });


### PR DESCRIPTION
This PR has 3 changes. They are isolated to extension-side behavior. Please rewrite them up as you see fit. I tried to include the reasoning here, and some AI assisted docs in the PR so that hopefully I can communicate the operational requirement (they don't seem too bad ig). 

1. 3034101b35ef0f5b90bcf8f08c809aab8b00af03 Adds a per-write hook that fires synchronously inside the four content-write REST routes plus the auto-greeting paths, before the row reaches SQLite. The purpose is to allow extensions to modify message content before they are committed to the store so as to be able to process things before they hit the display regex pipeline. Extensions with the existing `chat_mutation` permission can transform message `content` and `extra` so the stored row and every `MESSAGE_SENT` / `MESSAGE_EDITED` / `MESSAGE_SWIPED` subscriber observes the transformed version on first paint.

2. ead290b909f8edd5dd59dcaf29eb93e851d67633 Is not really a spindle change. This adds a `data-no-island` HTML attribute that opts a block-level element out of Lumi's automatic Shadow-DOM extraction in chat messages. Block elements carrying `data-no-island` on their opening tag are passed through to the markdown renderer and rendered inline in the message DOM instead of extracted into a `<div class="htmlIsland">` shadow root. There are benefits to using this over api.ui.dom.inject, it keeps the content in the message's light DOM, so chat-scope CSS, markdown processing, and click delegation work without shadow-boundary workarounds.

3. 53fbf5b37d28e396f17b2606cb3cd378fc5ea4b4 Allows extension owned macros to resolve in bulk rather than one by one. This might seem like a strange change, but is a non-optional requirement when dealing with iteration-heavy templates that can balloon RPC costs. An example is reducing a 15 second render to .05 seconds on the greeting macro set of [this card](https://realm.risuai.net/character/93e332f9-5117-4e88-8189-41d971edc587), which requires extension-side macro resolution to parse behind #each branches. 


---

Notes:

`macro_interceptor` technically gives access to system prompts, jailbreaks, persona descriptions (including user PII), character fields, all variable scopes, lorebook content, other extensions' env.extra, and the full assembled prompt template, which it can rewrite before LLM dispatch. This is why I named it an interceptor.

Default timeouts are hardcoded to 10s.

`messageContentProcessor` is not directly involved in spindle.chat.* to prevent loops. Including these would require something to prevent extension handlers from recursively re-firing on their own writes. 

I want to mention that privileged permissions (interceptor, macro_interceptor) granted to an already enabled extension take effect only after toggling the extension off and on, because hook registration runs once at extension boot and the permission denial isn't re-attempted when grants change at runtime. Could be something to fix as I can see it causing confusion. 

Spindle types needs to be updated, then you can revert the `src/spindle/manager.service.ts:797` changes.