### PR TITLE
Reduce chat image flicker during streaming and re-renders

### DIFF
--- a/frontend/src/components/chat/MessageContent.tsx
+++ b/frontend/src/components/chat/MessageContent.tsx
@@ -525,6 +525,46 @@ function IsolatedHtml({ html }: { html: string }) {
   return <div ref={ref} className={styles.htmlIsland} />
 }
 
+/**
+ * dangerouslySetInnerHTML wrapper that preserves IMG element identity by
+ * src across innerHTML replacements, so images don't redo the cache lookup,
+ * decode, paint cycle on every chat re-render.
+ */
+function ProseHtml({ html, className }: { html: string; className?: string }) {
+  const ref = useRef<HTMLDivElement>(null)
+  const lastHtmlRef = useRef<string | null>(null)
+
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (!el) return
+    if (lastHtmlRef.current === html) return
+
+    const stableImgs = new Map<string, HTMLImageElement>()
+    if (lastHtmlRef.current !== null) {
+      for (const img of el.querySelectorAll<HTMLImageElement>('img[src]')) {
+        const src = img.getAttribute('src')
+        if (src && !stableImgs.has(src)) stableImgs.set(src, img)
+      }
+    }
+
+    el.innerHTML = html
+    lastHtmlRef.current = html
+
+    if (stableImgs.size === 0) return
+    for (const newImg of el.querySelectorAll<HTMLImageElement>('img[src]')) {
+      const src = newImg.getAttribute('src')
+      if (!src) continue
+      const preserved = stableImgs.get(src)
+      if (preserved && newImg.parentNode) {
+        newImg.replaceWith(preserved)
+        stableImgs.delete(src)
+      }
+    }
+  }, [html])
+
+  return <div ref={ref} className={className} />
+}
+
 // Risu <img="AssetName"> tag pattern — resolved at display time using character's asset map
 const RISU_IMG_TAG_RE = /<img="([^"]+)">/gi
 
@@ -754,7 +794,7 @@ export default function MessageContent({
             elements.push(
               piece.type === 'island'
                 ? <IsolatedHtml key={`${i}-island-${p}`} html={piece.content} />
-                : <div key={`${i}-${p}`} className={styles.prose} dangerouslySetInnerHTML={{ __html: piece.content }} />
+                : <ProseHtml key={`${i}-${p}`} className={styles.prose} html={piece.content} />
             )
           }
         }
@@ -775,7 +815,7 @@ export default function MessageContent({
             elements.push(
               piece.type === 'island'
                 ? <IsolatedHtml key={`${i}-island-${p}`} html={piece.content} />
-                : <div key={`${i}-${p}`} className={styles.prose} dangerouslySetInnerHTML={{ __html: piece.content }} />
+                : <ProseHtml key={`${i}-${p}`} className={styles.prose} html={piece.content} />
             )
           }
         }

--- a/frontend/src/hooks/useDisplayRegex.ts
+++ b/frontend/src/hooks/useDisplayRegex.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, useSyncExternalStore } from 'react'
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import { useStore } from '@/store'
 import { applyDisplayRegex, applyDisplayRegexAsync } from '@/lib/regex/compiler'
 import { resolveMacrosBatch } from '@/api/macros'
@@ -33,6 +33,8 @@ const displayRegexResolutionCache = new Map<string, DisplayRegexCacheEntry>()
 const displayRegexContentCache = new Map<string, DisplayRegexContentCacheEntry>()
 const displayRegexCacheListeners = new Set<() => void>()
 let displayRegexCacheVersion = 0
+
+const RAW_MACRO_RE = /\{\{(?!\s*(?:user|char|bot|notChar|not_char|charName)\s*\}\})/
 
 /** Quick check for macro syntax in a string. */
 function hasMacroSyntax(s: string): boolean {
@@ -365,7 +367,19 @@ export function useDisplayRegex(content: string, isUser: boolean, depth: number,
     contentCacheKey,
   ])
 
-  return cachedResolvedContent
+  // Carry the previous resolved value forward across cv-bumps and per-chunk
+  // content churn so the sync fallback's raw {{...}} doesn't flash through
+  // during the async re-resolve window.
+  const lastResolvedRef = useRef<{ content: string; value: string } | null>(null)
+  const liveResolved = cachedResolvedContent
     ?? (resolvedContentState?.key === contentCacheKey ? resolvedContentState.value : undefined)
-    ?? fallbackContent
+  if (liveResolved !== undefined) {
+    lastResolvedRef.current = { content, value: liveResolved }
+  }
+  const stale = lastResolvedRef.current
+  const staleResolved = stale && (stale.content === content || RAW_MACRO_RE.test(fallbackContent))
+    ? stale.value
+    : undefined
+
+  return liveResolved ?? staleResolved ?? fallbackContent
 }


### PR DESCRIPTION
This PR contains two fixes to chat content render flicker of assets.

1. b33ca6ca52fbffb617c313f251d120f3ca1898ff Adds a stale-fallback layer that carries the previous resolved values of non-trivial macro resolutions forward across cv-bumps with unchanged content and across per-chunk content churn during streaming. If content has no raw macros, the code introduced here never fires. Lumiverse doesn't resolve non-trivial macros during render time, so this would be an extension-side change for extensions that do (please) 🙏. 

2. 0c83dda8809f892ee3cb0457d43484a18c85bc2c Adds a ProseHtml wrapper that preserves img element identity by src across innerHTML replacements. Without it, every chat re-render destroys and recreates each <img>, forcing the browser through cache lookup, decode, paint per element. Without this change, it takes around 1-7ms per img via Service Worker, visible as per-chunk flicker during streaming and updates (especially noticeable on high-refresh displays). This is mainly noticeable when <img> tags are inserted via display regex as display regex injected <img> tags also flicker on every cv-bump after streaming ends, while literal <img> tags only flicker during the streaming itself."
