### PR TITLE
fix: enforce maxPasswordLength (128) on all password endpoints

### DIFF
--- a/src/routes/users.routes.ts
+++ b/src/routes/users.routes.ts
@@ -30,8 +30,8 @@ app.post("/me/password", passwordLimiter, async (c) => {
     return c.json({ error: "currentPassword and newPassword are required" }, 400);
   }
 
-  if (body.newPassword.length < 8) {
-    return c.json({ error: "Password must be at least 8 characters" }, 400);
+  if (body.newPassword.length < 8 || body.newPassword.length > 128) {
+    return c.json({ error: "Password must be between 8 and 128 characters" }, 400);
   }
 
   const account = getDb()
@@ -87,6 +87,10 @@ admin.post("/", async (c) => {
     return c.json({ error: "username and password are required" }, 400);
   }
 
+  if (body.password.length < 8 || body.password.length > 128) {
+    return c.json({ error: "Password must be between 8 and 128 characters" }, 400);
+  }
+
   // Reject arbitrary role strings up front — only the roles registered with
   // BetterAuth's admin plugin are valid.
   if (body.role !== undefined && !VALID_ROLES.has(body.role)) {
@@ -124,8 +128,8 @@ admin.post("/:id/reset-password", passwordLimiter, async (c) => {
     return c.json({ error: "newPassword is required" }, 400);
   }
 
-  if (body.newPassword.length < 8) {
-    return c.json({ error: "Password must be at least 8 characters" }, 400);
+  if (body.newPassword.length < 8 || body.newPassword.length > 128) {
+    return c.json({ error: "Password must be between 8 and 128 characters" }, 400);
   }
 
   const hashed = await hashPassword(body.newPassword);


### PR DESCRIPTION
## Summary

- Adds a **128-character upper bound** to password validation on the three user-routes endpoints that were missing it: self-service password change (`/me/password`), admin password reset (`/:id/reset-password`), and admin user creation (`POST /`).
- Matches the `maxPasswordLength: 128` already configured in BetterAuth's `emailAndPassword` settings, which only guards the `/api/auth/sign-up` path.

## Why

Without an upper bound, an attacker (or misbehaving client) could submit an arbitrarily long password string to any of these endpoints and force the server to scrypt-hash it, burning CPU on the libuv thread pool. The existing rate limiter caps volume, but each individual request still consumes thread-pool time proportional to input length. A simple length check before `hashPassword()` eliminates the vector entirely.

## Changes

**`src/routes/users.routes.ts`**
- `POST /me/password` — `< 8` check → `< 8 || > 128`
- `POST /:id/reset-password` — `< 8` check → `< 8 || > 128`
- `POST /` (create user) — added `< 8 || > 128` check before `signUpEmail` call
- Error messages unified to `"Password must be between 8 and 128 characters"`
