### PR TITLE
fix: add size guard before WebSocket JSON.parse

### DIFF
--- a/src/ws/handler.ts
+++ b/src/ws/handler.ts
@@ -116,7 +116,14 @@ export const wsHandler = upgradeWebSocket((c) => {
         const raw = (ws as any).raw as import("bun").ServerWebSocket<unknown>;
         if (raw) eventBus.touchClient(raw);
 
-        const data = JSON.parse(event.data as string);
+        // Guard against oversized payloads — legitimate client messages are
+        // small control frames (ping, visibility, spindle results). 64 KB is
+        // generous; anything larger is either a bug or an attack attempting to
+        // burn GC time via a deeply nested JSON parse.
+        const raw_data = event.data as string;
+        if (raw_data.length > 65_536) return;
+
+        const data = JSON.parse(raw_data);
         if (data.type === "ping") {
           ws.send(JSON.stringify({ type: "pong", timestamp: Date.now() }));
           return;


### PR DESCRIPTION
## Summary

- Adds a **64 KB size guard** before `JSON.parse` in the WebSocket `onMessage` handler, silently dropping oversized payloads.

## Why

All legitimate client-to-server WS messages are small control frames — `ping`, `visibility`, `stream_focus`, and Spindle interaction results. None should approach even 1 KB in practice.

Without a size check, a malicious client can send a multi-megabyte JSON payload that gets parsed into a deeply nested object, causing GC pressure and potentially stalling the event loop. The check is a single string-length comparison before any parsing work happens — zero cost on the happy path.

## Changes

**`src/ws/handler.ts`**
- Added `raw_data.length > 65_536` guard before `JSON.parse(event.data)` (line 119)
- Oversized messages are silently dropped (same as existing malformed-JSON behavior)
