### PR TITLE
fix: sanitize extension iconSvg in ViewportDrawer

### DIFF
--- a/frontend/src/components/panels/ViewportDrawer.tsx
+++ b/frontend/src/components/panels/ViewportDrawer.tsx
@@ -9,6 +9,7 @@ import ContextMenu, { type ContextMenuEntry, type ContextMenuPos } from '@/compo
 import { useLongPress } from '@/hooks/useLongPress'
 import { DRAWER_TABS, adaptExtensionTabs, sanitizeHiddenDrawerTabIds } from '@/lib/drawer-tab-registry'
 import styles from './ViewportDrawer.module.css'
+import DOMPurify from 'dompurify'
 import clsx from 'clsx'
 
 function ExtensionTabContent({ tabId }: { tabId: string }) {
@@ -235,7 +236,7 @@ export default function ViewportDrawer() {
                           {dt.iconSvg ? (
                             <span
                               className={styles.extIconSvg}
-                              dangerouslySetInnerHTML={{ __html: dt.iconSvg }}
+                              dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(dt.iconSvg) }}
                             />
                           ) : dt.iconUrl ? (
                             <img src={dt.iconUrl} alt="" width={20} height={20} className={styles.extIconImg} />


### PR DESCRIPTION
## Summary

- Sanitizes `iconSvg` via `DOMPurify.sanitize()` in **ViewportDrawer** to match the existing sanitization in **InputBarExtensionActions**.

## Why

`InputBarExtensionActions.tsx:52` already runs extension `iconSvg` through `DOMPurify.sanitize()`, but `ViewportDrawer.tsx:238` rendered the same field raw via `dangerouslySetInnerHTML`. An SVG with an inline event handler (e.g. `<svg onload="...">`) would execute in the page context.

## Changes

**`frontend/src/components/panels/ViewportDrawer.tsx`**
- Added `import DOMPurify from 'dompurify'`
- Changed `{{ __html: dt.iconSvg }}` → `{{ __html: DOMPurify.sanitize(dt.iconSvg) }}`
