### PR TITLE
fix: set idleTimeout to 255s to mitigate slowloris attacks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,16 +122,18 @@ await startAllExtensions().catch((err) => {
 console.log(`Lumiverse Backend starting on port ${env.port}...`);
 
 // Use explicit Bun.serve() so we get the Server reference for native pub/sub.
-// idleTimeout: 0 disables Bun's default 30-second idle connection cutoff so that
-// long-running generation requests (image gen, heavy LLM calls) are not terminated
-// prematurely. Application-level AbortSignal timeouts guard against hung providers.
+// idleTimeout: 255 (Bun's maximum) guards against slowloris-style attacks where
+// a malicious client holds a TCP connection open indefinitely without exchanging
+// data. Active streaming responses (LLM token streaming, image gen) continuously
+// send data and reset the idle timer, so they are unaffected. The previous value
+// of 0 (disabled) left the server exposed to connection exhaustion.
 const server = Bun.serve({
   port: env.port,
   hostname: "::",
   fetch: app.fetch,
   websocket,
   maxRequestBodySize: 1000 * 1024 * 1024, // 1000 MB — matches MAX_CHARX_SIZE in character-card.service.ts
-  idleTimeout: 0,
+  idleTimeout: 255,
 });
 
 // Give the EventBus access to the server for native topic-based publish().


### PR DESCRIPTION
## Summary

- Sets `idleTimeout` from `0` (disabled) to `255` (Bun's maximum) in `Bun.serve()` to close the slowloris attack surface.

## Why

With `idleTimeout: 0`, a malicious client can open TCP connections and hold them indefinitely without sending or receiving any data. Enough of these saturate the server's connection pool and deny service to legitimate users (slowloris-style attack).

Setting `idleTimeout: 255` (4 minutes 15 seconds) reclaims truly idle connections while remaining generous for all legitimate use cases. Bun's idle timer resets whenever data is sent or received on the connection, so:

- **LLM token streaming** — continuously sends data, timer resets on every token chunk
- **Image generation** — sends the response when ready, timer resets
- **WebSocket** — has its own keepalive (30s ping interval), timer resets on every frame
- **Long uploads** — data flowing in resets the timer

The only connections affected are those sitting in `ESTABLISHED` with zero data exchange for 4+ minutes — which is exclusively malicious or broken.

## Changes

**`src/index.ts`**
- `idleTimeout: 0` → `idleTimeout: 255`
- Updated comment to explain the rationale
