### PR TITLE
fix: respect X-Forwarded-Proto/Host in BetterAuth URL rewrite

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -248,12 +248,15 @@ app.use("*", async (c, next) => {
 // BetterAuth handler — BEFORE auth middleware
 // Rewrite the request URL to use the actual Host header so BetterAuth
 // constructs the correct redirect URLs and cookie domains when accessed via
-// a LAN IP instead of localhost
+// a LAN IP instead of localhost. Respect X-Forwarded-Proto/Host from reverse
+// proxies (Cloudflare, nginx, HuggingFace Spaces) so BetterAuth generates
+// https:// callback URLs when served behind TLS termination.
 app.on(["POST", "GET"], "/api/auth/*", (c) => {
-  const host = c.req.header("host");
+  const host = c.req.header("x-forwarded-host") || c.req.header("host");
+  const proto = c.req.header("x-forwarded-proto") || "http";
   if (host) {
     const url = new URL(c.req.url);
-    const rewritten = new URL(url.pathname + url.search, `http://${host}`);
+    const rewritten = new URL(url.pathname + url.search, `${proto}://${host}`);
     return auth.handler(new Request(rewritten.toString(), c.req.raw));
   }
   return auth.handler(c.req.raw);


### PR DESCRIPTION
## Summary

- Reads `X-Forwarded-Proto` and `X-Forwarded-Host` headers in the BetterAuth URL rewrite handler, so BetterAuth constructs correct `https://` callback URLs when behind a TLS-terminating reverse proxy.

## Why

The auth handler hardcoded `http://${host}` when rewriting request URLs for BetterAuth. Behind a reverse proxy that terminates TLS (Cloudflare, nginx, Caddy, HuggingFace Spaces), the proxy sets `X-Forwarded-Proto: https` and sometimes `X-Forwarded-Host`, but the rewrite ignored both — causing BetterAuth to generate `http://` callback URLs and cookie domains, which breaks auth redirects.

The HuggingFace deployment guide already has a [Dockerfile patch](https://github.com/prolix-oc/Lumiverse/blob/staging/README.md#L86-L120) that applies this exact fix at the container level. This PR fixes it at the source so the patch is no longer needed.

## Changes

**`src/app.ts`**
- Read `X-Forwarded-Host` with fallback to `Host`
- Read `X-Forwarded-Proto` with fallback to `http`
- Construct rewritten URL as `${proto}://${host}` instead of `http://${host}`
