### PR TITLE
feat: Inline function calling for Spindle extension tools

### DIFF
--- a/src/services/generate.service.ts
+++ b/src/services/generate.service.ts
@@ -90,7 +90,9 @@ import {
   isCouncilToolInlineCallable,
   type RuntimeCouncilToolDefinition,
   getCouncilToolArgsSchema,
+  normalizeToolJsonSchema,
 } from "./council/tool-runtime";
+import { toolRegistry } from "../spindle/tool-registry";
 import { executeHostCouncilTool } from "./council/host-tools";
 import * as packsSvc from "./packs.service";
 import {
@@ -429,19 +431,35 @@ async function executeInlineCouncilToolCalls(
   toolCalls: ToolCallResult[],
   timeoutMs: number,
   toolsByName: Map<string, RuntimeCouncilToolDefinition>,
-  membersByPrefix: Map<string, CouncilMember>,
+  membersByPrefix: Map<string, CouncilMember> | undefined,
   contextMessages: LlmMessage[],
 ): Promise<InlineCouncilToolResult[]> {
   const results: InlineCouncilToolResult[] = [];
 
   for (const toolCall of toolCalls) {
+    // Try Council-prefixed tool name first (memberIdPrefix_toolName)
     const parsedName = parseInlineToolCallName(toolCall.name);
-    if (!parsedName) continue;
+    let tool: RuntimeCouncilToolDefinition | undefined;
+    let member: CouncilMember | undefined;
+    let resolvedQualifiedName: string;
 
-    const { memberIdPrefix, qualifiedName } = parsedName;
-    const tool = toolsByName.get(qualifiedName);
-    const member = membersByPrefix.get(memberIdPrefix);
-    if (!tool || !member) continue;
+    if (parsedName) {
+      const { memberIdPrefix, qualifiedName } = parsedName;
+      tool = toolsByName.get(qualifiedName);
+      member = membersByPrefix?.get(memberIdPrefix);
+      resolvedQualifiedName = qualifiedName;
+    }
+
+    // Fall back to direct lookup — extension inline tools use the sanitized
+    // name directly (extensionId__toolName) without a member prefix.
+    if (!tool) {
+      tool = toolsByName.get(toolCall.name);
+      resolvedQualifiedName = toolCall.name;
+    }
+
+    if (!tool) continue;
+    // Council tools require a member match; extension inline tools do not
+    if (parsedName && !member && membersByPrefix?.size) continue;
 
     const execution = getCouncilToolExecution(userId, tool);
     if (execution === "llm") continue;
@@ -449,7 +467,7 @@ async function executeInlineCouncilToolCalls(
     let result = "";
 
     if (execution === "mcp") {
-      const mcpMatch = parseMcpToolName(userId, qualifiedName);
+      const mcpMatch = parseMcpToolName(userId, resolvedQualifiedName!);
       if (!mcpMatch) continue;
 
       result = await getMcpClientManager().callTool(
@@ -460,17 +478,23 @@ async function executeInlineCouncilToolCalls(
         timeoutMs,
       );
     } else if (execution === "extension") {
-      const extToolReg = getExtensionToolRegistration(qualifiedName);
+      // Resolve the extension tool registration. For extension inline tools,
+      // the qualified name uses __ instead of : (sanitized for LLM function names).
+      const extQualified = resolvedQualifiedName!.replace(/__/g, ":");
+      const extToolReg = getExtensionToolRegistration(extQualified);
       if (!extToolReg) continue;
 
-      let lumiaItem: ReturnType<typeof packsSvc.getLumiaItem> = null;
-      try {
-        lumiaItem = packsSvc.getLumiaItem(userId, member.itemId);
-      } catch {
-        // Pack/item may have been removed mid-generation.
+      let memberContext: import("lumiverse-spindle-types").CouncilMemberContext | undefined;
+      if (member) {
+        let lumiaItem: ReturnType<typeof packsSvc.getLumiaItem> = null;
+        try {
+          lumiaItem = packsSvc.getLumiaItem(userId, member.itemId);
+        } catch {
+          // Pack/item may have been removed mid-generation.
+        }
+        memberContext = buildCouncilMemberContext(member, lumiaItem);
       }
 
-      const memberContext = buildCouncilMemberContext(member, lumiaItem);
       const contextSummary = contextMessages
         .map((m) => {
           const prefix = m.role === "system" ? "" : `${m.role}: `;
@@ -491,6 +515,7 @@ async function executeInlineCouncilToolCalls(
         contextMessages,
       );
     } else if (execution === "host") {
+      if (!member) continue; // Host tools require a council member
       let lumiaItem: ReturnType<typeof packsSvc.getLumiaItem> = null;
       try {
         lumiaItem = packsSvc.getLumiaItem(userId, member.itemId);
@@ -511,10 +536,10 @@ async function executeInlineCouncilToolCalls(
 
     results.push({
       callId: toolCall.call_id,
-      qualifiedName,
+      qualifiedName: resolvedQualifiedName!,
       toolName: tool.name,
       toolDisplayName: tool.displayName,
-      memberName: member.itemName,
+      memberName: member?.itemName,
       result,
     });
   }
@@ -1728,6 +1753,52 @@ export async function startGeneration(
           }
         }
 
+        // ── Extension Inline Tools (independent of Council) ──────────────
+        // Extensions can register tools with `inline_available: true` to make
+        // them callable by the primary model via native function calling, even
+        // when no Council is configured. Gated by the same preset toggle.
+        const extensionInlineTools = toolRegistry.getInlineAvailableTools();
+        if (extensionInlineTools.length > 0) {
+          const presetId = input.preset_id || connection.preset_id;
+          const preset = presetId
+            ? presetsSvc.getPreset(input.userId, presetId)
+            : null;
+          const completionSettings = preset?.prompts?.completionSettings;
+          if (completionSettings?.enableFunctionCalling !== false) {
+            if (!inlineTools) inlineTools = [];
+            if (!inlineToolDefsByName)
+              inlineToolDefsByName = new Map<
+                string,
+                RuntimeCouncilToolDefinition
+              >();
+
+            for (const extTool of extensionInlineTools) {
+              const qualifiedName = toolRegistry.getQualifiedName(extTool);
+              // Sanitize the qualified name for LLM function calling —
+              // some providers reject colons in function names.
+              const safeName = qualifiedName.replace(/:/g, "__");
+
+              // Wrap as RuntimeCouncilToolDefinition for the dispatch lookup
+              const runtimeDef: RuntimeCouncilToolDefinition = {
+                name: qualifiedName,
+                displayName: extTool.display_name,
+                description: extTool.description,
+                category: "extension",
+                execution: "extension",
+                inputSchema: extTool.parameters,
+              };
+
+              const argsSchema = normalizeToolJsonSchema(extTool.parameters);
+              inlineToolDefsByName.set(safeName, runtimeDef);
+              inlineTools.push({
+                name: safeName,
+                description: extTool.description,
+                parameters: argsSchema,
+              });
+            }
+          }
+        }
+
         // Wire staged message into lifecycle so GENERATION_STARTED includes it as
         // targetMessageId and runGeneration knows to update instead of create.
         if (stagedMessageId) {
@@ -2504,9 +2575,7 @@ async function runGeneration(
       ];
 
       const inlineCouncilResults =
-        pendingToolCalls?.length &&
-        inlineToolDefsByName &&
-        inlineMembersByPrefix
+        pendingToolCalls?.length && inlineToolDefsByName
           ? await executeInlineCouncilToolCalls(
               userId,
               pendingToolCalls,

--- a/src/services/generate.service.ts
+++ b/src/services/generate.service.ts
@@ -1353,6 +1353,7 @@ export async function startGeneration(
         targetMessageId: lifecycle.targetMessageId,
         characterId: targetCharId,
         characterName,
+        generationType: lifecycle.generationType,
       },
       input.userId,
     );
@@ -2047,6 +2048,7 @@ export async function startGeneration(
             generationId,
             chatId: input.chat_id,
             error: msg,
+            generationType: lifecycle.generationType,
           },
           input.userId,
         );
@@ -2774,6 +2776,7 @@ async function runGeneration(
           messageId,
           content: fullContent,
           usage: streamUsage,
+          generationType: lifecycle.generationType,
         },
         userId,
       );
@@ -2969,6 +2972,7 @@ async function runGeneration(
           messageId: savedMessageId,
           content: savedContent,
           error: msg,
+          generationType: lifecycle.generationType,
         },
         userId,
       );

--- a/src/spindle/tool-registry.ts
+++ b/src/spindle/tool-registry.ts
@@ -63,6 +63,11 @@ class ToolRegistry {
     return this.getTools().filter((t) => t.council_eligible);
   }
 
+  /** Get tools marked for inline availability with the primary model. */
+  getInlineAvailableTools(): ToolRegistration[] {
+    return this.getTools().filter((t) => t.inline_available);
+  }
+
   getToolsByExtension(extensionId: string): ToolRegistration[] {
     return this.getTools().filter((t) => t.extension_id === extensionId);
   }


### PR DESCRIPTION
## Summary

Adds a new `inline_available` flag to `ToolRegistration` / `ToolRegistrationDTO`, allowing Spindle extensions to register tools that are sent directly to the primary model as native function call schemas during generation — **independent of Council setup**.

This means extensions can expose tools that the primary LLM calls mid-generation via standard function calling (OpenAI `tool_calls`, Anthropic `tool_use`, Gemini `functionCall`), without requiring the user to configure Council, assign tools to members, or use sidecar/inline Council mode.

## Motivation

Extensions like persistent memory systems need to provide retrieval tools that the primary model can call during its thinking/planning phase. Currently, the only path to inline function calling is through Council inline mode — which requires Council to be enabled, members to be configured, and tools to be assigned to members. This is a heavyweight setup for what should be a simple "the model can call this function" capability.

## Changes

### `src/spindle/tool-registry.ts`
- Added `getInlineAvailableTools()` method — filters registered tools for `inline_available: true`

### `src/services/generate.service.ts`

**Extension inline tools injection (~line 1753):**
- After the existing Council tools block, queries `toolRegistry.getInlineAvailableTools()`
- If the preset's `completionSettings.enableFunctionCalling` is not `false`, builds `ToolDefinition[]` entries for each inline-available extension tool
- Tool names are sanitized from `extensionId:toolName` to `extensionId__toolName` (colons to double underscores) for LLM provider function name compatibility
- Wraps each as a `RuntimeCouncilToolDefinition` with `execution: "extension"` for dispatch lookup
- Appends to the existing `inlineTools` array (coexists with Council inline tools)

**Extended `executeInlineCouncilToolCalls` (~line 431):**
- `membersByPrefix` parameter changed to `Map | undefined` (extension-only tools have no Council member)
- Tool name resolution now tries Council prefix parsing first (`memberPrefix_toolName`), then falls back to direct `toolsByName` lookup for bare extension tool names
- Extension tools dispatch via `invokeExtensionCouncilTool` without council member context (`councilMember: undefined`)
- Host tools still require a Council member (guard added)

**Relaxed streaming loop dispatch (~line 2575):**
- Removed the `inlineMembersByPrefix` requirement from the tool dispatch gate — now fires when `inlineToolDefsByName` exists, covering extension-only inline tools without Council

## How extensions use it

```ts
spindle.registerTool({
  name: 'recall_scene',
  display_name: 'Recall Scene',
  description: 'Search the story archive for a past scene...',
  parameters: {
    type: 'object',
    properties: { query: { type: 'string' } },
    required: ['query'],
  },
  council_eligible: true,    // also available via Council
  inline_available: true,    // NEW — sent to primary model for inline function calling
})
```

## Gating

- Gated by the **same `enableFunctionCalling` toggle** in the preset's completion settings that gates Council inline tools
- Default behavior: allowed (the check is `=== false`, so `undefined`/`null` passes through)
- No new UI or settings needed — extensions opt in via the flag, users control via existing preset toggle

## Interaction with Council inline tools

Extension inline tools and Council inline tools coexist in the same `inlineTools` array sent to the LLM. They use different naming conventions:
- **Council tools:** `{memberIdPrefix}_{qualifiedToolName}` (8-char member ID prefix)
- **Extension tools:** `{extensionId}__{toolName}` (double underscore, no member prefix)

The dispatch function tries Council prefix parsing first, falls back to direct lookup. No ambiguity — the `_` vs `__` delimiter and the 8-char prefix constraint make collisions impossible.

## Provider compatibility

All providers already support `tools` in `GenerationRequest` and parse `tool_calls` from streaming responses. The existing 3-round inline tool execution loop handles pause/execute/resume. No provider-layer changes needed.

## Requires

`lumiverse-spindle-types` update to add `inline_available?: boolean` to:
- `ToolRegistration` interface (`src/tools.ts`)
- `ToolRegistrationDTO` interface (`src/api.ts`)
