### PR TITLE
fix: capture full-document HTML islands with leading doctype or head tag

### DIFF
--- a/frontend/src/components/chat/MessageContent.tsx
+++ b/frontend/src/components/chat/MessageContent.tsx
@@ -339,6 +339,14 @@ function extractHtmlIslands(
   const hasStyleTag = /<style[\s>]/i.test(raw)
   if (!hasStyleTag && !/\bstyle\s*=/i.test(raw)) return { content: raw, islands: [] }
 
+  const trimmedRaw = raw.trim()
+  if (
+    /^(?:<!doctype\b|<html\b|<head\b)/i.test(trimmedRaw)
+    && /<\/(?:html|body|head)>$/i.test(trimmedRaw)
+  ) {
+    return { content: `<!--${HTML_ISLAND_TOKEN}_0-->`, islands: [raw] }
+  }
+
   const islands: string[] = []
   const lines = raw.split('\n')
   const output: string[] = []


### PR DESCRIPTION
Thanks Claude:

## Problem

`extractHtmlIslands` in `MessageContent.tsx` heuristically detects styled HTML
blocks and routes them to Shadow-DOM islanding so their `<style>` tags survive
sanitization. After `db9ef7c` (relax hyphenated style and data types
restrictions, capture wider range of style tag content), `BLOCK_ELEMENT_RE`
catches `<html>`- and `<body>`-leading content, and `normalizeDocumentHtml`
in `richHtmlSanitizer.ts` correctly lifts head `<style>` blocks to body context
when the islanded content reaches the sanitizer.

Two shapes still fall through to the non-island path (`sanitizeRichHtml`,
`allowStyleTag=false`) where the `<style>` is stripped:

1. **Single-line documents prefixed with `<!DOCTYPE html>`.** Strategy 1's
   `BLOCK_ELEMENT_RE` requires the trimmed line to begin with `<html`/`<body>`
   etc.; the doctype prefix on the same line blocks the match. Strategy 2
   requires the line to begin with `<style`, which a doctype-prefixed line
   also doesn't.

2. **Documents shaped as `<head>...</head><body>...</body>` with no `<html>`
   wrapper.** `<head>` isn't in `BLOCK_ELEMENT_RE`, and the line doesn't lead
   with `<style>` either.

Both shapes already parse cleanly through `normalizeDocumentHtml`'s
`DOMParser`-based extraction once they reach the sanitizer — they just never
get there because the islanding pass routes them elsewhere first.

## Fix

Add a fast-path at the top of `extractHtmlIslands`, after the existing
`hasStyleTag`/inline-style early-exit: when the trimmed input both begins
with `<!doctype`/`<html`/`<head>` AND ends with `</html>`/`</body>`/`</head>`,
emit the entire raw string as a single island so it routes through the
existing `sanitizeHtmlIsland` → `normalizeDocumentHtml` path.