### PR TITLE
fix: guided CoT re-initialization after inline tool call continuation

### DIFF
--- a/src/services/generate.service.ts
+++ b/src/services/generate.service.ts
@@ -2569,10 +2569,17 @@ async function runGeneration(
         break;
       }
 
+      // Reconstruct the full assistant output including any guided CoT
+      // reasoning block so the model sees its own <think>...</think> on
+      // continuation rounds and doesn't re-enter the planning phase.
+      const fullAssistantOutput = fullReasoning
+        ? `${cotDelimiters.prefix}${fullReasoning}${cotDelimiters.suffix}\n${fullContent}`
+        : fullContent;
+
       const inlineContextMessages = [
         ...generationMessages,
-        ...(fullContent
-          ? [{ role: "assistant", content: fullContent } satisfies LlmMessage]
+        ...(fullAssistantOutput
+          ? [{ role: "assistant", content: fullAssistantOutput } satisfies LlmMessage]
           : []),
       ];
 
@@ -2594,8 +2601,8 @@ async function runGeneration(
 
       generationMessages = [
         ...generationMessages,
-        ...(fullContent
-          ? [{ role: "assistant", content: fullContent } satisfies LlmMessage]
+        ...(fullAssistantOutput
+          ? [{ role: "assistant", content: fullAssistantOutput } satisfies LlmMessage]
           : []),
         {
           role: "system",


### PR DESCRIPTION
## Summary

When extensions use inline function calling (`inline_available: true`) and the user has guided Chain-of-Thought enabled (e.g. `<think>` tags via reasoning settings), the model re-enters the `<think>` planning phase on every tool call continuation round instead of resuming prose output.

## Root Cause

The inline tool call loop in `runGeneration()` reconstructs the assistant message for continuation rounds using only `fullContent` — which has been stripped of the `<think>...</think>` block by `GuidedReasoningStreamParser`. The model sees:

1. System prompt: *"Always start with `<think>`..."*
2. Assistant message: *(prose only — no `<think>` block visible)*
3. System message: *tool results*

From the model's perspective, it never produced a `<think>` block, so it obediently re-enters the planning phase — re-running the entire reasoning protocol from scratch, burning tokens, and potentially producing conflicting outputs.

## Fix

Reconstruct `fullAssistantOutput` by prepending the guided CoT block (`prefix + fullReasoning + suffix`) to `fullContent` when `fullReasoning` exists. This is used in both the `inlineContextMessages` (passed to tool execution for context) and the `generationMessages` continuation array.

The model now sees its own complete output — thinking AND prose — and continues naturally after the tool results.

## Affected code

`src/services/generate.service.ts` — the inline tool call loop (~line 2572), both the context message construction and the continuation message array.

## Testing

Tested with a Spindle extension (`novelist-memory`) that registers `inline_available` tools (`update_whiteboard`, `recall_by_range`, `recall_scene`). Before this fix, the primary model re-entered `<think>` after every tool call return. After the fix, it resumes prose output directly.
