### PR TITLE
feat: impersonate draft mode — stream into input box instead of creating a message

### DIFF
--- a/frontend/src/api/generate.ts
+++ b/frontend/src/api/generate.ts
@@ -22,6 +22,8 @@ export interface GenerateRequest {
   impersonate_mode?: ImpersonateMode
   /** For impersonate: free-form text from the input box, appended to the impersonation prompt. */
   impersonate_input?: string
+  /** For impersonate: stream to input box instead of creating a message. */
+  impersonate_draft?: boolean
   target_character_id?: string
   regen_feedback?: string
   regen_feedback_position?: 'system' | 'user'

--- a/frontend/src/components/chat/InputArea.tsx
+++ b/frontend/src/components/chat/InputArea.tsx
@@ -118,6 +118,10 @@ export default function InputArea({ chatId }: InputAreaProps) {
   const setMentionQueue = useStore((s) => s.setMentionQueue)
   const expressionDisplay = useStore((s) => s.expressionDisplay)
   const setExpressionDisplay = useStore((s) => s.setExpressionDisplay)
+  const impersonateDraftContent = useStore((s) => s.impersonateDraftContent)
+  const setImpersonateDraftContent = useStore((s) => s.setImpersonateDraftContent)
+  const streamingContent = useStore((s) => s.streamingContent)
+  const streamingGenerationType = useStore((s) => s.streamingGenerationType)
 
   // Track whether the active character has expressions configured
   const [hasExpressions, setHasExpressions] = useState(false)
@@ -298,6 +302,24 @@ export default function InputArea({ chatId }: InputAreaProps) {
     ta.setSelectionRange(pendingSelection.start, pendingSelection.end, pendingSelection.direction)
     syncTextareaMirrorScroll()
   }, [text, resizeTextarea, syncTextareaMirrorScroll])
+
+  // ── Impersonate draft streaming into textarea ────────────────────────
+  // Stream impersonate draft tokens into the textarea live
+  useEffect(() => {
+    if (streamingGenerationType === 'impersonate_draft' && streamingContent) {
+      setText(streamingContent)
+      requestAnimationFrame(() => resizeTextarea(textareaRef.current))
+    }
+  }, [streamingContent, streamingGenerationType, resizeTextarea])
+
+  // When an impersonate draft completes, ensure final content is in the textarea
+  useEffect(() => {
+    if (impersonateDraftContent) {
+      setText(impersonateDraftContent)
+      setImpersonateDraftContent(null)
+      requestAnimationFrame(() => resizeTextarea(textareaRef.current))
+    }
+  }, [impersonateDraftContent, setImpersonateDraftContent, resizeTextarea])
 
   // ── Draft input persistence ──────────────────────────────────────────
   const draftTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -885,7 +907,7 @@ export default function InputArea({ chatId }: InputAreaProps) {
     if (isStreaming) return
     const nonce = ++generationNonceRef.current
     const impersonateInput = text.trim()
-    beginStreaming(undefined, 'impersonate')
+    beginStreaming(undefined, 'impersonate_draft')
     // Stash the input so the user can restore it after the run, and clear the box.
     if (impersonateInput) {
       setLastImpersonateInput(impersonateInput)
@@ -904,6 +926,7 @@ export default function InputArea({ chatId }: InputAreaProps) {
         generation_type: 'impersonate',
         impersonate_mode: mode,
         impersonate_input: impersonateInput || undefined,
+        impersonate_draft: true,
       })
       if (generationNonceRef.current !== nonce) return
       startStreaming(res.generationId)

--- a/frontend/src/components/chat/MessageList.tsx
+++ b/frontend/src/components/chat/MessageList.tsx
@@ -138,6 +138,7 @@ export default function MessageList({ messages, chatId, isStreaming }: MessageLi
   const streamingGenerationType = useStore((s) => s.streamingGenerationType)
   const bubbleUserAlign = useStore((s) => s.bubbleUserAlign)
   const isImpersonateStream = streamingGenerationType === 'impersonate'
+  const isImpersonateDraft = streamingGenerationType === 'impersonate_draft'
   const impersonateUserLeft = isImpersonateStream && bubbleUserAlign === 'left'
 
   // The store's appendStreamToken state machine already separates reasoning
@@ -648,7 +649,7 @@ export default function MessageList({ messages, chatId, isStreaming }: MessageLi
       {isGroupChat && isNudgeLoopActive && <GroupChatProgressBar />}
 
       {/* Streaming message bubble — shows tokens as they arrive (only for new messages, not regeneration or continue) */}
-      {isStreaming && !regeneratingMessageId && streamingGenerationType !== 'continue' && (streamDisplay || !streamingError) && (() => {
+      {isStreaming && !regeneratingMessageId && streamingGenerationType !== 'continue' && !isImpersonateDraft && (streamDisplay || !streamingError) && (() => {
         const bubbleName = isImpersonateStream ? userName : streamDisplayName
         const bubbleStyleClass = isImpersonateStream ? bubbleStyles.user : bubbleStyles.character
         const nameStyleClass = isImpersonateStream ? bubbleStyles.nameUser : bubbleStyles.nameChar

--- a/frontend/src/store/slices/chat.ts
+++ b/frontend/src/store/slices/chat.ts
@@ -71,6 +71,7 @@ export const createChatSlice: StateCreator<ChatSlice> = (set, get) => {
     streamingGenerationType: null,
     lastPooledSeq: null,
     totalChatLength: 0,
+    impersonateDraftContent: null,
 
     setActiveChat: (chatId, characterId = null) => {
       endedGenerationIds.clear()
@@ -293,6 +294,8 @@ export const createChatSlice: StateCreator<ChatSlice> = (set, get) => {
         if (first) endedGenerationIds.delete(first)
       }
     },
+
+    setImpersonateDraftContent: (content) => set({ impersonateDraftContent: content }),
 
     // Message selection mode for bulk operations
     messageSelectMode: false,

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -19,6 +19,8 @@ export interface ChatSlice {
   streamingGenerationType: string | null
   lastPooledSeq: number | null
   totalChatLength: number
+  /** Content from an impersonate-draft generation, ready to populate the input box */
+  impersonateDraftContent: string | null
   setActiveChat: (chatId: string | null, characterId?: string | null) => void
   setActiveChatWallpaper: (wallpaper: WallpaperRef | null) => void
   setActiveChatAvatarId: (imageId: string | null) => void
@@ -42,6 +44,8 @@ export interface ChatSlice {
   setRegeneratingMessageId: (messageId: string | null) => void
   /** Mark a generation ID as ended (prevents zombie resurrection from late HTTP responses) */
   markGenerationEnded: (generationId: string) => void
+  /** Set impersonate draft content (from completed impersonate-draft generation) */
+  setImpersonateDraftContent: (content: string | null) => void
 
   // Message selection mode for bulk operations
   messageSelectMode: boolean

--- a/frontend/src/ws/useWebSocket.ts
+++ b/frontend/src/ws/useWebSocket.ts
@@ -376,6 +376,15 @@ export function useWebSocket() {
               triggerTTSAutoPlay(payload.messageId, payload.content)
             }
 
+            // Impersonate draft: stash the streamed content for the input box
+            // instead of reconciling messages (no message was created on the backend).
+            if ((payload as any).impersonateDraft) {
+              const draftContent = state.streamingContent
+              state.endStreaming()
+              state.setImpersonateDraftContent(draftContent)
+              return
+            }
+
             // End streaming immediately, then reconcile the full message list
             // from backend source-of-truth to avoid id/index race conditions.
             // Image gen is deferred until AFTER reconciliation completes so its

--- a/src/services/generate.service.ts
+++ b/src/services/generate.service.ts
@@ -118,6 +118,8 @@ interface GenerateInput {
   impersonate_mode?: ImpersonateMode;
   /** For impersonate: free-form text from the user's input box, appended to the impersonation prompt. */
   impersonate_input?: string;
+  /** For impersonate: stream tokens to the frontend but do NOT create a message. The user edits and sends manually. */
+  impersonate_draft?: boolean;
   target_character_id?: string;
   regen_feedback?: string;
   regen_feedback_position?: "system" | "user";
@@ -153,6 +155,8 @@ interface GenerationLifecycle {
   personaName?: string;
   /** Active persona id (for impersonate message metadata) */
   personaId?: string;
+  /** For impersonate draft: stream tokens but do not create a message */
+  impersonateDraft?: boolean;
   /** Target character id (for group chat message attribution) */
   targetCharacterId?: string;
   /** Chat history messages snapshot (used for accurate tokenization in breakdown) */
@@ -1248,6 +1252,7 @@ export async function startGeneration(
       personaId: resolvedPersona?.id,
       personaName: resolvedPersona?.name || "User",
       targetCharacterId: targetCharId,
+      impersonateDraft: genType === "impersonate" && !!input.impersonate_draft,
     };
 
     let excludeMessageId: string | undefined;
@@ -2408,6 +2413,9 @@ async function runGeneration(
         ...(continueExtra ? { extra: continueExtra } : {}),
       });
       messageId = lifecycle.continueMessageId;
+    } else if (lifecycle.impersonateDraft) {
+      // Impersonate draft: do not persist the partial content as a message.
+      // The streamed text is already in the frontend's input box.
     } else if (closedContent) {
       const isImpersonate = lifecycle.generationType === "impersonate";
       const extra: Record<string, any> = {};
@@ -2724,6 +2732,10 @@ async function runGeneration(
           ...(stagedExtra ? { extra: stagedExtra } : {}),
         });
         messageId = lifecycle.stagedMessageId;
+      } else if (lifecycle.impersonateDraft) {
+        // Impersonate draft: tokens were streamed to the frontend but we do NOT
+        // create a message. The user will edit the text in the input box and
+        // send it manually. messageId stays undefined.
       } else {
         // Normal / swipe: create assistant message, impersonate: create user message
         const isImpersonate = lifecycle.generationType === "impersonate";
@@ -2784,6 +2796,7 @@ async function runGeneration(
           content: fullContent,
           usage: streamUsage,
           generationType: lifecycle.generationType,
+          impersonateDraft: lifecycle.impersonateDraft || undefined,
         },
         userId,
       );


### PR DESCRIPTION
## Summary

Impersonate now streams generated text directly into the chat input box instead of creating a user message. The user can read, edit, and send (or discard) the generated text manually.

## What changed

**Backend (`src/services/generate.service.ts`):**
- Added `impersonate_draft` flag to `StartGenerationInput` and `GenerationLifecycle`
- When `impersonate_draft` is true, the completion and abort paths skip message creation entirely — tokens are streamed to the frontend but nothing is persisted
- `GENERATION_ENDED` payload includes `impersonateDraft: true` so the frontend can handle it differently

**Frontend:**
- `generate.ts` — Added `impersonate_draft` to `GenerateRequest` type
- `InputArea.tsx` — Both impersonate buttons now pass `impersonate_draft: true` and use `'impersonate_draft'` as streaming generation type. Two `useEffect` hooks pipe streaming tokens into the textarea live (~30fps) and ensure final content lands on completion
- `MessageList.tsx` — Streaming bubble is suppressed when `streamingGenerationType === 'impersonate_draft'`
- `useWebSocket.ts` — `GENERATION_ENDED` handler detects `impersonateDraft` in the payload, grabs accumulated `streamingContent`, stashes it in `impersonateDraftContent` store field, and skips message reconciliation
- `store/slices/chat.ts` + `types/store.ts` — Added `impersonateDraftContent` state field and `setImpersonateDraftContent` setter

## How it works

1. User clicks either impersonate button (Preset Prompts or One-liner)
2. Generation starts with `generation_type: 'impersonate'` + `impersonate_draft: true`
3. Tokens stream into the textarea in real-time (user watches the text build)
4. On completion, backend does NOT create a message — text sits in the input box
5. User can edit and send normally, or clear the input to discard

## Notes

- This branch also includes the guided CoT fix from PR #95 (parent branch)
- No changes to existing non-draft impersonate behavior — `impersonate_draft` defaults to `undefined`/falsy
