### PR TITLE
fix(chat): apply display-regex before risu asset resolution

### DIFF
--- a/frontend/src/components/chat/MessageContent.tsx
+++ b/frontend/src/components/chat/MessageContent.tsx
@@ -771,26 +771,23 @@ export default function MessageContent({
 
   const interceptorCleanedContent = interceptedMessageTags.content
 
-  // Resolve Risu asset tags before regex/macro processing:
-  // 1. <img="AssetName"> (Risu custom syntax) → markdown image
-  // 2. <img src="AssetName"> (standard HTML with relative asset ref) → resolved src URL
-  // 3. ![alt](AssetName.ext) (markdown image with relative asset ref) → resolved src URL
+  const macroCtx = useMemo(() => ({ charName, userName }), [charName, userName])
+  const regexAppliedContent = useDisplayRegex(interceptorCleanedContent, isUser, depth, macroCtx)
+
   const risuResolvedContent = useMemo(
     () => {
-      if (!risuAssetMap) return interceptorCleanedContent
-      let resolved = resolveRisuAssetTags(interceptorCleanedContent, risuAssetMap)
+      if (!risuAssetMap) return regexAppliedContent
+      let resolved = resolveRisuAssetTags(regexAppliedContent, risuAssetMap)
       resolved = resolveImgSrcAssetTags(resolved, risuAssetMap)
       resolved = resolveMarkdownImgTags(resolved, risuAssetMap)
       return resolved
     },
-    [interceptorCleanedContent, risuAssetMap],
+    [regexAppliedContent, risuAssetMap],
   )
 
-  const macroCtx = useMemo(() => ({ charName, userName }), [charName, userName])
-  const regexAppliedContent = useDisplayRegex(risuResolvedContent, isUser, depth, macroCtx)
   const resolvedContent = useMemo(
-    () => resolveDisplayMacros(regexAppliedContent, { charName, userName }),
-    [regexAppliedContent, charName, userName],
+    () => resolveDisplayMacros(risuResolvedContent, { charName, userName }),
+    [risuResolvedContent, charName, userName],
   )
   const deferredResolvedContent = useDeferredValue(resolvedContent)
   const renderContent = isStreaming ? deferredResolvedContent : resolvedContent


### PR DESCRIPTION
This change has no effect on cards without a populated risu_asset_map. Only Risu cards.

The Risu asset resolvers (resolveRisuAssetTags, resolveImgSrcAssetTags, resolveMarkdownImgTags) ran in MessageContent.tsx before useDisplayRegex. That order corrupts Risu CharX cards whose display-regex rules use <img="X">, \<img src="X">, or \![alt]\(X.png) as an inner anchor of a larger find pattern. Which is a large part of cards.

This commit just swaps the order of evaluation.

