### PR TITLE
Display regex bulk serverside resolution

### DIFF
--- a/frontend/src/hooks/useDisplayRegex.ts
+++ b/frontend/src/hooks/useDisplayRegex.ts
@@ -1,27 +1,11 @@
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import { useStore } from '@/store'
 import { applyDisplayRegex, applyDisplayRegexAsync } from '@/lib/regex/compiler'
-import { resolveMacrosBatch } from '@/api/macros'
 import type { DisplayMacroContext } from '@/lib/resolveDisplayMacros'
-
-interface ResolvedDisplayRegexTemplates {
-  resolvedFindPatterns: Map<string, string>
-  resolvedReplacements: Map<string, string>
-}
-
-interface DisplayRegexCacheEntry {
-  value?: ResolvedDisplayRegexTemplates
-  promise?: Promise<ResolvedDisplayRegexTemplates>
-}
 
 interface DisplayRegexContentCacheEntry {
   value?: string
   promise?: Promise<string>
-}
-
-interface ResolvedTemplatesState {
-  key: string
-  value: ResolvedDisplayRegexTemplates
 }
 
 interface ResolvedContentState {
@@ -29,26 +13,15 @@ interface ResolvedContentState {
   value: string
 }
 
-const displayRegexResolutionCache = new Map<string, DisplayRegexCacheEntry>()
 const displayRegexContentCache = new Map<string, DisplayRegexContentCacheEntry>()
 const displayRegexCacheListeners = new Set<() => void>()
 let displayRegexCacheVersion = 0
 
 const RAW_MACRO_RE = /\{\{(?!\s*(?:user|char|bot|notChar|not_char|charName)\s*\}\})/
 
-/** Quick check for macro syntax in a string. */
 function hasMacroSyntax(s: string): boolean {
   return s.includes('{{') || s.includes('<USER>') || s.includes('<BOT>') || s.includes('<CHAR>')
 }
-
-function createEmptyResolvedTemplates(): ResolvedDisplayRegexTemplates {
-  return {
-    resolvedFindPatterns: new Map(),
-    resolvedReplacements: new Map(),
-  }
-}
-
-const EMPTY_RESOLVED_TEMPLATES = createEmptyResolvedTemplates()
 
 function subscribeDisplayRegexCache(listener: () => void): () => void {
   displayRegexCacheListeners.add(listener)
@@ -61,34 +34,8 @@ function getDisplayRegexCacheVersion(): number {
 
 export function invalidateDisplayRegexCache(): void {
   displayRegexCacheVersion += 1
-  displayRegexResolutionCache.clear()
   displayRegexContentCache.clear()
   for (const listener of displayRegexCacheListeners) listener()
-}
-
-async function resolveMacrosBatchChunked(
-  templates: Record<string, string>,
-  context: {
-    chat_id?: string
-    character_id?: string
-    persona_id?: string
-  },
-): Promise<Record<string, string>> {
-  const entries = Object.entries(templates)
-  if (entries.length === 0) return {}
-
-  const chunkPromises: Array<Promise<Record<string, string>>> = []
-  for (let i = 0; i < entries.length; i += 100) {
-    chunkPromises.push(
-      resolveMacrosBatch({
-        templates: Object.fromEntries(entries.slice(i, i + 100)),
-        ...context,
-      }).then((res) => res.resolved),
-    )
-  }
-
-  const chunks = await Promise.all(chunkPromises)
-  return Object.assign({}, ...chunks)
 }
 
 export function useDisplayRegex(content: string, isUser: boolean, depth: number, macroCtx?: DisplayMacroContext): string {
@@ -115,153 +62,24 @@ export function useDisplayRegex(content: string, isUser: boolean, depth: number,
     [regexScripts, activeCharacterId, activeChatId],
   )
 
-  // Collect display scripts that need backend macro resolution
-  const scriptsNeedingResolution = useMemo(
+  const needsBackend = useMemo(
     () =>
-      displayScripts.filter(
+      displayScripts.some(
         (s) => s.substitute_macros !== 'none' && (hasMacroSyntax(s.find_regex) || hasMacroSyntax(s.replace_string)),
       ),
     [displayScripts],
   )
 
-  // Pre-resolve find patterns and non-raw replacement strings via the backend macro engine.
-  // Raw replacements stay per-match so capture groups remain available before macro evaluation.
-  const templateCacheKey = useMemo(() => {
-    const templates: Record<string, string> = {}
-    for (const s of scriptsNeedingResolution) {
-      if (hasMacroSyntax(s.find_regex)) {
-        templates[`find:${s.id}`] = s.find_regex
-      }
-      if (s.substitute_macros !== 'raw' && hasMacroSyntax(s.replace_string)) {
-        templates[`replace:${s.id}`] = s.replace_string
-      }
-    }
-
-    const templateEntries = Object.entries(templates)
-    if (templateEntries.length === 0) return null
-
-    return JSON.stringify({
-      cacheVersion,
-      activeChatId,
-      activeCharacterId,
-      activePersonaId,
-      scripts: scriptsNeedingResolution.map((s) => [
-        s.id,
-        s.updated_at,
-        s.find_regex,
-        s.replace_string,
-        s.substitute_macros,
-      ]),
-    })
-  }, [scriptsNeedingResolution, activeChatId, activeCharacterId, activePersonaId, cacheVersion])
-
-  const cachedTemplates = templateCacheKey ? displayRegexResolutionCache.get(templateCacheKey)?.value : undefined
-  const [resolvedTemplatesState, setResolvedTemplatesState] = useState<ResolvedTemplatesState | null>(() => (
-    templateCacheKey && cachedTemplates ? { key: templateCacheKey, value: cachedTemplates } : null
-  ))
-
-  const resolvedTemplates = cachedTemplates
-    ?? (resolvedTemplatesState?.key === templateCacheKey ? resolvedTemplatesState.value : undefined)
-    ?? EMPTY_RESOLVED_TEMPLATES
-
-  const [resolvedContentState, setResolvedContentState] = useState<ResolvedContentState | null>(null)
-
-  useEffect(() => {
-    if (!templateCacheKey) {
-      setResolvedTemplatesState((current) => current === null ? current : null)
-      return
-    }
-
-    const templates: Record<string, string> = {}
-    for (const s of scriptsNeedingResolution) {
-      if (hasMacroSyntax(s.find_regex)) {
-        templates[`find:${s.id}`] = s.find_regex
-      }
-      if (s.substitute_macros !== 'raw' && hasMacroSyntax(s.replace_string)) {
-        templates[`replace:${s.id}`] = s.replace_string
-      }
-    }
-
-    const templateEntries = Object.entries(templates)
-    if (templateEntries.length === 0) {
-      setResolvedTemplatesState((current) => current === null ? current : null)
-      return
-    }
-
-    let cancelled = false
-
-    const applyResolvedTemplates = (next: ResolvedDisplayRegexTemplates) => {
-      if (!cancelled) setResolvedTemplatesState({ key: templateCacheKey, value: next })
-    }
-
-    const cached = displayRegexResolutionCache.get(templateCacheKey)
-    if (cached?.value) {
-      applyResolvedTemplates(cached.value)
-      return () => { cancelled = true }
-    }
-
-    if (!cached?.promise) {
-      const promise = resolveMacrosBatch({
-        templates,
-        chat_id: activeChatId ?? undefined,
-        character_id: activeCharacterId ?? undefined,
-        persona_id: activePersonaId ?? undefined,
-      })
-        .then((res) => {
-          const next = createEmptyResolvedTemplates()
-          for (const [key, value] of Object.entries(res.resolved)) {
-            if (key.startsWith('find:')) {
-              next.resolvedFindPatterns.set(key.slice(5), value)
-            } else if (key.startsWith('replace:')) {
-              next.resolvedReplacements.set(key.slice(8), value)
-            }
-          }
-          displayRegexResolutionCache.set(templateCacheKey, { value: next })
-          return next
-        })
-        .catch(() => {
-          displayRegexResolutionCache.delete(templateCacheKey)
-          return createEmptyResolvedTemplates()
-        })
-
-      displayRegexResolutionCache.set(templateCacheKey, { promise })
-    }
-
-    displayRegexResolutionCache.get(templateCacheKey)?.promise?.then(applyResolvedTemplates)
-
-    return () => { cancelled = true }
-  }, [scriptsNeedingResolution, templateCacheKey, activeChatId, activeCharacterId, activePersonaId])
-
   const fallbackContent = useMemo(
     () => {
       if (displayScripts.length === 0) return content
-      return applyDisplayRegex(content, displayScripts, {
-        isUser,
-        depth,
-        macroCtx,
-        resolvedFindPatterns: resolvedTemplates.resolvedFindPatterns,
-        resolvedReplacements: resolvedTemplates.resolvedReplacements,
-      })
+      return applyDisplayRegex(content, displayScripts, { isUser, depth, macroCtx })
     },
-    [content, displayScripts, isUser, depth, macroCtx, resolvedTemplates],
-  )
-
-  const hasRawMacroScripts = useMemo(
-    () => displayScripts.some((s) => s.substitute_macros === 'raw'),
-    [displayScripts],
-  )
-
-  const resolvedTemplateKey = useMemo(
-    () => JSON.stringify({
-      find: Array.from(resolvedTemplates.resolvedFindPatterns.entries()),
-      replace: Array.from(resolvedTemplates.resolvedReplacements.entries()),
-    }),
-    [resolvedTemplates],
+    [content, displayScripts, isUser, depth, macroCtx],
   )
 
   const contentCacheKey = useMemo(() => {
-    if (displayScripts.length === 0 || !hasRawMacroScripts) return null
-
+    if (displayScripts.length === 0 || !needsBackend) return null
     return JSON.stringify({
       cacheVersion,
       activeChatId,
@@ -272,7 +90,6 @@ export function useDisplayRegex(content: string, isUser: boolean, depth: number,
       userName: macroCtx?.userName ?? null,
       charName: macroCtx?.charName ?? null,
       content,
-      resolvedTemplateKey,
       scripts: displayScripts.map((s) => [
         s.id,
         s.updated_at,
@@ -288,7 +105,7 @@ export function useDisplayRegex(content: string, isUser: boolean, depth: number,
     })
   }, [
     displayScripts,
-    hasRawMacroScripts,
+    needsBackend,
     cacheVersion,
     activeChatId,
     activeCharacterId,
@@ -297,9 +114,9 @@ export function useDisplayRegex(content: string, isUser: boolean, depth: number,
     depth,
     macroCtx,
     content,
-    resolvedTemplateKey,
   ])
 
+  const [resolvedContentState, setResolvedContentState] = useState<ResolvedContentState | null>(null)
   const cachedResolvedContent = contentCacheKey ? displayRegexContentCache.get(contentCacheKey)?.value : undefined
 
   useEffect(() => {
@@ -320,22 +137,14 @@ export function useDisplayRegex(content: string, isUser: boolean, depth: number,
     }
 
     if (!cached?.promise) {
-      const promise = applyDisplayRegexAsync(
-        content,
-        displayScripts,
-        {
-          isUser,
-          depth,
-          macroCtx,
-          resolvedFindPatterns: resolvedTemplates.resolvedFindPatterns,
-          resolvedReplacements: resolvedTemplates.resolvedReplacements,
-        },
-        (templates) => resolveMacrosBatchChunked(templates, {
-          chat_id: activeChatId ?? undefined,
-          character_id: activeCharacterId ?? undefined,
-          persona_id: activePersonaId ?? undefined,
-        }),
-      )
+      const promise = applyDisplayRegexAsync(content, displayScripts, {
+        isUser,
+        depth,
+        chatId: activeChatId ?? undefined,
+        characterId: activeCharacterId ?? undefined,
+        personaId: activePersonaId ?? undefined,
+        macroCtx,
+      })
         .then((next) => {
           displayRegexContentCache.set(contentCacheKey, { value: next })
           return next
@@ -358,9 +167,6 @@ export function useDisplayRegex(content: string, isUser: boolean, depth: number,
     macroCtx,
     fallbackContent,
     displayScripts,
-    hasRawMacroScripts,
-    resolvedTemplateKey,
-    resolvedTemplates,
     activeChatId,
     activeCharacterId,
     activePersonaId,

--- a/frontend/src/lib/regex/compiler.ts
+++ b/frontend/src/lib/regex/compiler.ts
@@ -212,89 +212,77 @@ export function applyDisplayRegex(
   return result
 }
 
+export interface ApplyDisplayRegexAsyncContext {
+  isUser: boolean
+  depth: number
+  chatId?: string
+  characterId?: string
+  personaId?: string
+  macroCtx?: DisplayMacroContext
+}
+
+function anyScriptNeedsBackend(scripts: RegexScript[]): boolean {
+  for (const s of scripts) {
+    if (s.substitute_macros !== 'none' && (hasMacroSyntax(s.find_regex) || hasMacroSyntax(s.replace_string))) {
+      return true
+    }
+  }
+  return false
+}
+
 export async function applyDisplayRegexAsync(
   content: string,
   scripts: RegexScript[],
-  context: ApplyDisplayRegexContext,
-  resolveRawTemplates: (templates: Record<string, string>) => Promise<Record<string, string>>,
+  context: ApplyDisplayRegexAsyncContext,
 ): Promise<string> {
-  let result = content
+  if (scripts.length === 0) return content
 
-  for (const script of scripts) {
-    const placement: RegexPlacement = context.isUser ? 'user_input' : 'ai_output'
-    if (!script.placement.includes(placement)) continue
-
-    if (script.min_depth !== null && context.depth < script.min_depth) continue
-    if (script.max_depth !== null && context.depth > script.max_depth) continue
-
-    let findRegex = script.find_regex
-    if (script.substitute_macros !== 'none') {
-      const preResolvedFind = context.resolvedFindPatterns?.get(script.id)
-      if (preResolvedFind !== undefined) {
-        findRegex = preResolvedFind
-      } else if (context.macroCtx) {
-        findRegex = resolveRegexStringMacros(findRegex, context.macroCtx)
-      }
-    }
-
-    const regex = compileRegex(findRegex, script.flags)
-    if (!regex) continue
-
-    try {
-      if (script.substitute_macros === 'raw') {
-        const matches = collectRegexMatches(result, regex)
-        if (matches.length > 0) {
-          const templates: Record<string, string> = {}
-          const fallbackReplacements = matches.map((match, index) => {
-            const withCaptures = substituteRegexCaptures(
-              script.replace_string,
-              match.fullMatch,
-              match.groups,
-              match.offset,
-              result,
-              match.namedGroups,
-            )
-            if (hasMacroSyntax(withCaptures)) {
-              templates[`${script.id}:${index}`] = withCaptures
-            }
-            return withCaptures
-          })
-
-          const resolvedTemplates = Object.keys(templates).length > 0
-            ? await resolveRawTemplates(templates)
-            : {}
-
-          result = rebuildFromMatches(
-            result,
-            matches,
-            fallbackReplacements.map((value, index) => resolvedTemplates[`${script.id}:${index}`] ?? value),
-          )
-        }
-      } else {
-        let replaceString = script.replace_string
-        if (script.substitute_macros !== 'none') {
-          const preResolved = context.resolvedReplacements?.get(script.id)
-          if (preResolved !== undefined) {
-            replaceString = script.substitute_macros === 'escaped'
-              ? preResolved.replace(/\$/g, '$$$$')
-              : preResolved
-          } else if (context.macroCtx) {
-            replaceString = resolveReplacementMacros(replaceString, script.substitute_macros, context.macroCtx)
-          }
-        }
-
-        result = result.replace(regex, replaceString)
-      }
-
-      for (const trim of script.trim_strings) {
-        while (result.includes(trim)) {
-          result = result.replaceAll(trim, '')
-        }
-      }
-    } catch {
-      // Skip invalid regex silently
-    }
+  if (!anyScriptNeedsBackend(scripts)) {
+    return applyDisplayRegex(content, scripts, {
+      isUser: context.isUser,
+      depth: context.depth,
+      macroCtx: context.macroCtx,
+    })
   }
 
-  return result
+  try {
+    const res = await fetch('/api/v1/regex-scripts/apply', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        content,
+        scripts,
+        context: {
+          chat_id: context.chatId,
+          character_id: context.characterId,
+          persona_id: context.personaId,
+          is_user: context.isUser,
+          depth: context.depth,
+        },
+      }),
+    })
+    if (!res.ok) {
+      return applyDisplayRegex(content, scripts, {
+        isUser: context.isUser,
+        depth: context.depth,
+        macroCtx: context.macroCtx,
+      })
+    }
+    const body = await res.json() as { result?: string }
+    if (typeof body.result !== 'string') {
+      return applyDisplayRegex(content, scripts, {
+        isUser: context.isUser,
+        depth: context.depth,
+        macroCtx: context.macroCtx,
+      })
+    }
+    return body.result
+  } catch {
+    return applyDisplayRegex(content, scripts, {
+      isUser: context.isUser,
+      depth: context.depth,
+      macroCtx: context.macroCtx,
+    })
+  }
 }

--- a/src/routes/regex-scripts.routes.ts
+++ b/src/routes/regex-scripts.routes.ts
@@ -1,7 +1,8 @@
 import { Hono } from "hono";
 import * as svc from "../services/regex-scripts.service";
 import { parsePagination } from "../services/pagination";
-import type { RegexScope, RegexTarget } from "../types/regex-script";
+import type { RegexScope, RegexTarget, RegexScript } from "../types/regex-script";
+import { applyDisplayRegex } from "../services/display-regex.service";
 
 const app = new Hono();
 
@@ -57,6 +58,47 @@ app.post("/", async (c) => {
   const result = svc.createRegexScript(userId, input, { activePresetId: active_preset_id ?? null });
   if (typeof result === "string") return c.json({ error: result }, 400);
   return c.json(result, 201);
+});
+
+// POST /apply — bulk-apply display-regex pipeline.
+app.post("/apply", async (c) => {
+  const userId = c.get("userId");
+  const body = await c.req.json<{
+    content: string;
+    scripts: RegexScript[];
+    context: {
+      chat_id?: string;
+      character_id?: string;
+      persona_id?: string;
+      is_user: boolean;
+      depth: number;
+    };
+  }>();
+
+  if (typeof body.content !== "string") {
+    return c.json({ error: "content is required" }, 400);
+  }
+  if (!Array.isArray(body.scripts)) {
+    return c.json({ error: "scripts must be an array" }, 400);
+  }
+  if (!body.context || typeof body.context !== "object") {
+    return c.json({ error: "context is required" }, 400);
+  }
+
+  const result = await applyDisplayRegex({
+    content: body.content,
+    scripts: body.scripts,
+    context: {
+      chat_id: body.context.chat_id,
+      character_id: body.context.character_id,
+      persona_id: body.context.persona_id,
+      is_user: !!body.context.is_user,
+      depth: typeof body.context.depth === "number" ? body.context.depth : 0,
+    },
+    userId,
+  });
+
+  return c.json({ result });
 });
 
 // POST /test — test regex

--- a/src/services/display-regex.service.ts
+++ b/src/services/display-regex.service.ts
@@ -1,0 +1,236 @@
+import { evaluate, buildEnv, registry, resolveGroupCharacterNames } from "../macros";
+import type { MacroEnv } from "../macros";
+import * as chatsSvc from "./chats.service";
+import * as charactersSvc from "./characters.service";
+import * as personasSvc from "./personas.service";
+import * as connectionsSvc from "./connections.service";
+import { populateLumiaLoomContext } from "./prompt-assembly.service";
+import { getEffectiveCharacterName } from "../types/character";
+import type { Chat } from "../types/chat";
+import type { RegexScript, RegexPlacement } from "../types/regex-script";
+
+export interface ApplyDisplayRegexContext {
+  chat_id?: string;
+  character_id?: string;
+  persona_id?: string;
+  is_user: boolean;
+  depth: number;
+}
+
+export interface ApplyDisplayRegexInput {
+  content: string;
+  scripts: RegexScript[];
+  context: ApplyDisplayRegexContext;
+  userId: string;
+}
+
+interface DisplayRegexMatch {
+  fullMatch: string;
+  groups: Array<string | undefined>;
+  offset: number;
+  namedGroups?: Record<string, string>;
+}
+
+const MACRO_TOKEN_RE = /\{\{|<USER>|<BOT>|<CHAR>/;
+
+function hasMacroSyntax(value: string): boolean {
+  return MACRO_TOKEN_RE.test(value);
+}
+
+function compileRegex(pattern: string, flags: string): RegExp | null {
+  try {
+    return new RegExp(pattern, flags);
+  } catch {
+    return null;
+  }
+}
+
+function collectRegexMatches(input: string, regex: RegExp): DisplayRegexMatch[] {
+  const matches: DisplayRegexMatch[] = [];
+  input.replace(regex, (fullMatch, ...args) => {
+    const last = args[args.length - 1];
+    const hasNamedGroups = typeof last === "object" && last !== null;
+    const namedGroups = hasNamedGroups ? (args.pop() as Record<string, string>) : undefined;
+    args.pop() as string;
+    const offset = args.pop() as number;
+    const groups = args as Array<string | undefined>;
+    matches.push({ fullMatch, groups, offset, namedGroups });
+    return fullMatch;
+  });
+  return matches;
+}
+
+function substituteRegexCaptures(
+  template: string,
+  fullMatch: string,
+  groups: Array<string | undefined>,
+  offset: number,
+  input: string,
+  namedGroups?: Record<string, string>,
+): string {
+  return template.replace(/\$(?:(\$)|(&)|(`)|(')|(\d{1,2})|<([^>]*)>)/g,
+    (token, dollar, amp, backtick, quote, digits, name) => {
+      if (dollar !== undefined) return "$";
+      if (amp !== undefined) return fullMatch;
+      if (backtick !== undefined) return input.slice(0, offset);
+      if (quote !== undefined) return input.slice(offset + fullMatch.length);
+      if (digits !== undefined) {
+        const idx = Number.parseInt(digits, 10);
+        if (idx >= 1 && idx <= groups.length) return groups[idx - 1] ?? "";
+        return token;
+      }
+      if (name !== undefined && namedGroups) return namedGroups[name] ?? token;
+      return token;
+    });
+}
+
+function rebuildFromMatches(input: string, matches: DisplayRegexMatch[], replacements: string[]): string {
+  let output = "";
+  let lastIndex = 0;
+  for (let i = 0; i < matches.length; i += 1) {
+    output += input.slice(lastIndex, matches[i].offset);
+    output += replacements[i];
+    lastIndex = matches[i].offset + matches[i].fullMatch.length;
+  }
+  output += input.slice(lastIndex);
+  return output;
+}
+
+function buildEnvFromContext(userId: string, ctx: ApplyDisplayRegexContext): MacroEnv | null {
+  if (ctx.chat_id) {
+    const chat = chatsSvc.getChat(userId, ctx.chat_id);
+    if (chat) {
+      const messages = chatsSvc.getMessages(userId, ctx.chat_id);
+      const character = charactersSvc.getCharacter(userId, chat.character_id);
+      if (character) {
+        const persona = personasSvc.resolvePersonaOrDefault(userId, ctx.persona_id);
+        const connection = connectionsSvc.getDefaultConnection(userId);
+        const groupCharacterNames = resolveGroupCharacterNames(chat, (cid) => {
+          const c = charactersSvc.getCharacter(userId, cid);
+          return c ? getEffectiveCharacterName(c) : undefined;
+        });
+        const isGroup = !!chat.metadata?.group;
+        const env = buildEnv({
+          character,
+          persona,
+          chat,
+          messages,
+          generationType: "normal",
+          connection,
+          groupCharacterNames,
+          targetCharacterName: isGroup ? getEffectiveCharacterName(character) : undefined,
+        });
+        populateLumiaLoomContext(env, userId, chat);
+        return env;
+      }
+    }
+  }
+  if (ctx.character_id) {
+    const character = charactersSvc.getCharacter(userId, ctx.character_id);
+    if (character) {
+      const persona = personasSvc.resolvePersonaOrDefault(userId, ctx.persona_id);
+      const connection = connectionsSvc.getDefaultConnection(userId);
+      const chat: Chat = {
+        id: "",
+        character_id: character.id,
+        name: "",
+        metadata: {},
+        created_at: 0,
+        updated_at: 0,
+      };
+      const env = buildEnv({
+        character,
+        persona,
+        chat,
+        messages: [],
+        generationType: "normal",
+        connection,
+      });
+      populateLumiaLoomContext(env, userId, chat);
+      return env;
+    }
+  }
+  return null;
+}
+
+export async function applyDisplayRegex(input: ApplyDisplayRegexInput): Promise<string> {
+  const { content, scripts, context, userId } = input;
+  let result = content;
+
+  let env: MacroEnv | null = null;
+  let envBuilt = false;
+  const ensureEnv = (): MacroEnv | null => {
+    if (!envBuilt) {
+      env = buildEnvFromContext(userId, context);
+      envBuilt = true;
+    }
+    return env;
+  };
+
+  for (const script of scripts) {
+    const placement: RegexPlacement = context.is_user ? "user_input" : "ai_output";
+    if (!script.placement.includes(placement)) continue;
+    if (script.min_depth !== null && context.depth < script.min_depth) continue;
+    if (script.max_depth !== null && context.depth > script.max_depth) continue;
+
+    let findRegex = script.find_regex;
+    if (script.substitute_macros !== "none" && hasMacroSyntax(findRegex)) {
+      const e = ensureEnv();
+      if (e) {
+        const r = await evaluate(findRegex, e, registry);
+        findRegex = r.text;
+      }
+    }
+    const regex = compileRegex(findRegex, script.flags);
+    if (!regex) continue;
+
+    try {
+      if (script.substitute_macros === "raw") {
+        const matches = collectRegexMatches(result, regex);
+        if (matches.length > 0) {
+          const replacements: string[] = [];
+          for (const m of matches) {
+            const withCaptures = substituteRegexCaptures(
+              script.replace_string, m.fullMatch, m.groups, m.offset, result, m.namedGroups,
+            );
+            if (hasMacroSyntax(withCaptures)) {
+              const e = ensureEnv();
+              if (e) {
+                const r = await evaluate(withCaptures, e, registry);
+                replacements.push(r.text);
+              } else {
+                replacements.push(withCaptures);
+              }
+            } else {
+              replacements.push(withCaptures);
+            }
+          }
+          result = rebuildFromMatches(result, matches, replacements);
+        }
+      } else {
+        let replaceString = script.replace_string;
+        if (script.substitute_macros !== "none" && hasMacroSyntax(replaceString)) {
+          const e = ensureEnv();
+          if (e) {
+            const r = await evaluate(replaceString, e, registry);
+            replaceString = r.text;
+          }
+          if (script.substitute_macros === "escaped") {
+            replaceString = replaceString.replace(/\$/g, "$$$$");
+          }
+        }
+        result = result.replace(regex, replaceString);
+      }
+
+      for (const trim of script.trim_strings) {
+        while (result.includes(trim)) {
+          result = result.replaceAll(trim, "");
+        }
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
# Dear Prolix
Display regex rules with macros currently fire one HTTP call per rule per render. With cv bumps from streaming and CHAT_CHANGED, this can get up to 500s POSTs to `/macros/resolve-batch` in a 1-second post-send window for some regex configurations. In a 10 message chat, I had ~90k posts, and this value scales with the # of chat messages. Eventually it becomes insane.

This change moves the rule cascade server-side. New endpoint `POST /api/v1/regex-scripts/apply` takes `{ content, scripts, context }`, runs the loop calling `MacroEvaluator.evaluate` directly between rules, returns the final string. One HTTP per render rather than 1000s or even 10000s.

The cascade behavior is *theoretically* unchanged as each rule's `find_regex` still sees the previous rule's resolved output as they cascade sequentially. 

## Changes

**Frontend**
`applyDisplayRegexAsync` collapses to a fetch with sync-path fallback on network failure. `useDisplayRegex` drops the pre-resolve plumbing (`resolveMacrosBatchChunked`, `displayRegexResolutionCache`, `templateCacheKey`, and the `ResolvedDisplayRegexTemplates` state).

**Backend**
new `src/services/display-regex.service.ts` mirrors the cascade with in-process macro eval. New route in `src/routes/regex-scripts.routes.ts`.

## Impact

- Potentially two complexity classes more efficient with the number of messages, bringing O(n^2) down to O(1), which represents the round trips, the bulk of the slowdown.
- Near-zero browser CPU during the regex pass (no per-rule compile, no per-match capture substitution on the client)

### Note: Please validate this change before merging. This can mess up displayRegex rendering if it has a bug, potentially side effects given the complexity of the rendering pipeline and how it interacts with extensions.