### PR TITLE
fix: prevent CoT content duplication when entire message is inside thinking tags

### DIFF
--- a/frontend/src/hooks/useMessageCard.ts
+++ b/frontend/src/hooks/useMessageCard.ts
@@ -87,7 +87,10 @@ export function useMessageCard(message: Message, chatId: string) {
   const { displayContent, parsedReasoning } = useMemo(() => {
     if (!autoParse || isUser) return { displayContent: rawContent, parsedReasoning: '' }
     const { cleaned, thoughts } = parseThinkingTags(rawContent)
-    return { displayContent: cleaned || rawContent, parsedReasoning: thoughts }
+    // When thoughts were extracted, trust cleaned even if empty — the entire
+    // message may have been inside <think> tags. Falling back to rawContent
+    // here re-displays the thinking content in the message body (duplication).
+    return { displayContent: thoughts ? cleaned : (cleaned || rawContent), parsedReasoning: thoughts }
   }, [rawContent, autoParse, isUser])
 
   // API-level reasoning takes priority; during regeneration use streaming reasoning;


### PR DESCRIPTION
## Summary

Fixes a bug where the model's chain-of-thought content renders **twice** — once in the collapsible Thinking/Reasoning block and again in the message body — when the model wraps its entire response inside `<think>` tags with no visible content outside them.

## The bug

`useMessageCard.ts` line 90:

```ts
return { displayContent: cleaned || rawContent, parsedReasoning: thoughts }
```

`parseThinkingTags()` correctly strips `<think>` blocks from `rawContent` and returns them as `thoughts`. When *all* content is inside `<think>` tags (common with models doing full CoT before any prose output), `cleaned` is an empty string.

Empty string is falsy in JS, so `cleaned || rawContent` falls back to `rawContent` — the original unstripped content, complete with `<think>` tags. The markdown renderer then strips the HTML-like tags and displays the inner text as regular message content, duplicating what's already shown in the `<ReasoningBlock>`.

## The fix

```ts
return { displayContent: thoughts ? cleaned : (cleaned || rawContent), parsedReasoning: thoughts }
```

If `thoughts` was extracted (the parser found and stripped thinking tags), trust `cleaned` unconditionally — even when empty. The `|| rawContent` fallback only fires when no thinking tags were found at all, preserving the existing behavior for messages without CoT.

## Reproduction

1. Use any Anthropic model with API Reasoning **off** and Auto-parse thoughts **on** (prefix: `<think>`, suffix: `</think>`)
2. Use a preset/system prompt that instructs the model to wrap its chain-of-thought in `<think>` tags (e.g., Lucid Loom)
3. Generate a response where the model's entire output is inside `<think>` tags before producing visible prose
4. The thinking content appears in both the Thinking disclosure block and the message body

After the fix, the message body correctly shows empty (or only the post-`</think>` prose) while the Thinking block contains the CoT.
