### PR TITLE
fix: skip auto-summarization when triggered by impersonate generation

### DIFF
--- a/frontend/src/hooks/useAutoSummarization.ts
+++ b/frontend/src/hooks/useAutoSummarization.ts
@@ -31,6 +31,7 @@ export function useAutoSummarization() {
   const mode = useStore((s) => s.summarization.mode)
   const autoInterval = useStore((s) => s.summarization.autoInterval)
   const isStreaming = useStore((s) => s.isStreaming)
+  const lastGenerationType = useStore((s) => s.lastCompletedGenerationType)
 
   // Per-chat in-flight tracking so the global `isSummarizing` flag is no longer
   // the sole gate. Multiple chats can be mid-summary across tabs; what matters
@@ -69,6 +70,10 @@ export function useAutoSummarization() {
     if (!activeChatId) return
     if (isStreaming) return
     if (messageCount === 0) return
+    // Don't trigger summarization from impersonate generations — they create
+    // user messages that bump totalChatLength but aren't narrative content
+    // worth summarizing over. The next real generation will trigger if needed.
+    if (lastGenerationType === 'impersonate') return
 
     // Capture the values this effect tick is reasoning about. Everything the
     // kickoff does is keyed off these locals, not the live store.
@@ -149,5 +154,5 @@ export function useAutoSummarization() {
     }
 
     queueMicrotask(kickoff)
-  }, [activeChatId, messageCount, mode, autoInterval, isStreaming])
+  }, [activeChatId, messageCount, mode, autoInterval, isStreaming, lastGenerationType])
 }

--- a/frontend/src/store/slices/chat.ts
+++ b/frontend/src/store/slices/chat.ts
@@ -69,6 +69,7 @@ export const createChatSlice: StateCreator<ChatSlice> = (set, get) => {
     activeGenerationId: null,
     regeneratingMessageId: null,
     streamingGenerationType: null,
+    lastCompletedGenerationType: null,
     lastPooledSeq: null,
     totalChatLength: 0,
     impersonateDraftContent: null,
@@ -264,7 +265,9 @@ export const createChatSlice: StateCreator<ChatSlice> = (set, get) => {
       rawStreamContent = ''
       rawStreamReasoning = ''
       reasoningStartedAt = 0
-      set({ isStreaming: false, streamingContent: '', streamingReasoning: '', streamingReasoningDuration: null, streamingReasoningStartedAt: null, streamingError: null, activeGenerationId: null, regeneratingMessageId: null, streamingGenerationType: null, lastPooledSeq: null })
+      // Preserve the generation type before clearing — auto-summarization
+      // needs to know what kind of generation just finished.
+      set({ isStreaming: false, streamingContent: '', streamingReasoning: '', streamingReasoningDuration: null, streamingReasoningStartedAt: null, streamingError: null, activeGenerationId: null, regeneratingMessageId: null, lastCompletedGenerationType: get().streamingGenerationType, streamingGenerationType: null, lastPooledSeq: null })
     },
 
     stopStreaming: () => {

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -17,6 +17,8 @@ export interface ChatSlice {
   activeGenerationId: string | null
   regeneratingMessageId: string | null
   streamingGenerationType: string | null
+  /** The generation type of the last completed generation — survives endStreaming() */
+  lastCompletedGenerationType: string | null
   lastPooledSeq: number | null
   totalChatLength: number
   /** Content from an impersonate-draft generation, ready to populate the input box */


### PR DESCRIPTION
## Summary

Fixes auto-summarization firing after impersonate generations. Standard impersonate creates a user message that increments `totalChatLength`, which triggers the `useAutoSummarization` effect if the count crosses the auto-interval threshold. The summarization pipeline had no `generationType` awareness — it only watched message count changes.

## The bug

1. Standard impersonate creates a user message (`is_user: true`) in `generate.service.ts`
2. `GENERATION_ENDED` fires, frontend calls `fetchLatestMessages` → `setMessages(res.data, res.total)`
3. `totalChatLength` increments in the chat store
4. `useAutoSummarization` effect fires because `messageCount` changed
5. `shouldAutoSummarize` only checks count thresholds — no generation type check anywhere
6. Summary fires unexpectedly after an impersonate

Note: impersonate *draft* mode is unaffected — it early-returns before `fetchLatestMessages` so `totalChatLength` never updates.

## The fix

- Added `lastCompletedGenerationType` to the chat store slice (`types/store.ts`, `store/slices/chat.ts`)
- `endStreaming()` now preserves `streamingGenerationType` into `lastCompletedGenerationType` before clearing it
- `useAutoSummarization` reads `lastCompletedGenerationType` and skips when it's `'impersonate'`
- The next real generation (normal, continue, regen) will update `lastCompletedGenerationType` and allow summarization to proceed normally
