### PR TITLE
fix: skip inline tool injection for impersonate generations

### DIFF
--- a/src/services/generate.service.ts
+++ b/src/services/generate.service.ts
@@ -1521,7 +1521,7 @@ export async function startGeneration(
           councilActive &&
           councilSettings.members.some((m) => m.tools.length > 0);
 
-        if (councilHasTools) {
+        if (councilHasTools && genType !== "impersonate") {
           pool.setPoolStatus(generationId, "council");
           if (councilSettings.toolsSettings.mode === "inline") {
             // Inline mode requires enableFunctionCalling in the preset's completion
@@ -1892,7 +1892,12 @@ export async function startGeneration(
         // Extensions can register tools with `inline_available: true` to make
         // them callable by the primary model via native function calling, even
         // when no Council is configured. Gated by the same preset toggle.
-        const extensionInlineTools = toolRegistry.getInlineAvailableTools();
+        // Skip for impersonate — it generates user messages, not assistant
+        // messages with tool-use capability.
+        const extensionInlineTools =
+          genType !== "impersonate"
+            ? toolRegistry.getInlineAvailableTools()
+            : [];
         if (extensionInlineTools.length > 0) {
           const presetId = input.preset_id || connection.preset_id;
           const preset = presetId


### PR DESCRIPTION
## Summary

Prevents inline tools (both council and extension) from being injected into impersonate generation requests. Impersonate generates user messages, not assistant messages with tool-use capability — offering tools to the model during impersonate causes it to attempt tool calls that fail and cascade into unintended side effects.

## The bug

1. User triggers impersonate generation
2. `generate.service.ts` injects all inline tools (council + extension) into the request — no `genType` check
3. Model sees tool definitions (e.g., `recall_scene`, `update_whiteboard`) and may call them
4. Tool calls trigger `spindle.generate.quiet()` which fails for operator-scoped extensions (no userId in tool invocations)
5. The impersonate generation still creates a user message, incrementing `totalChatLength`
6. If the count crosses the auto-summarize threshold, summarization fires unexpectedly

## The fix

Two guards added in `generate.service.ts`:

1. **Council inline tools** (line ~1524): `if (councilHasTools && genType !== "impersonate")` — skips the entire council tools block for impersonate
2. **Extension inline tools** (line ~1891): `genType !== "impersonate" ? toolRegistry.getInlineAvailableTools() : []` — returns empty tool list for impersonate

Both paths already had `enableFunctionCalling` preset checks but no generation type awareness. The impersonate guard is the missing gate.

## Related

- PR #103 addresses the downstream effect (auto-summarization firing from impersonate's `totalChatLength` bump)
- This PR addresses the upstream cause (tools being offered to impersonate in the first place)
