### PR TITLE
Add display render hooks + dynamic_macros pass-through for display-regex

### DIFF
--- a/developer-docs/docs/backend-api/macro-interceptor.md
+++ b/developer-docs/docs/backend-api/macro-interceptor.md
@@ -27,7 +27,7 @@ One interceptor per extension; a second registration replaces the first.
 ```ts
 interface MacroInterceptorCtx {
   template: string
-  env: { commit, names, character, chat, system, variables: { local, global, chat }, extra }
+  env: { commit, names, character, chat, system, variables: { local, global, chat }, dynamicMacros, extra }
   commit: boolean
   phase: "prompt" | "display" | "response" | "other"
   sourceHint?: string
@@ -36,6 +36,8 @@ interface MacroInterceptorCtx {
 ```
 
 `env` is a structured-clone snapshot. Persist state via `spindle.variables.*`, not the snapshot.
+
+`env.dynamicMacros` carries per-call macro overrides supplied by the caller (`Record<string, string>`). The display-regex pipeline (`phase: "display"`) sets `chat_index` to the rendered message's index in the chat, which lets handlers compute per-message context that registered macros cannot reach on their own. Other callers may set additional fields.
 
 ## Composition Order
 

--- a/developer-docs/docs/backend-api/message-content-processor.md
+++ b/developer-docs/docs/backend-api/message-content-processor.md
@@ -20,8 +20,8 @@ Use this when the transform belongs on the stored message itself, not just on th
 
 | Param | Type | Description |
 | --- | --- | --- |
-| `handler` | `(ctx: MessageContentProcessorCtx) => Promise<MessageContentProcessorResult \| void>` | Receives the about-to-be-committed content; returns a patch, or `void` to pass through |
-| `priority` | `number` | Optional. Lower values run first. Default: `100` |
+| `handler`  | `(ctx: MessageContentProcessorCtx) => Promise<MessageContentProcessorResult \| void>` | Receives the about-to-be-committed content; returns a patch, or `void` to pass through |
+| `priority` | `number` | Optional. Lower values run first. Default:`100` |
 
 ## Context Object
 
@@ -30,8 +30,8 @@ interface MessageContentProcessorCtx {
   chatId: string
   messageId?: string                              // undefined for "create"
   content: string
-  extra?: Record<string, unknown>
-  origin: "create" | "update" | "swipe_add" | "swipe_update"
+  extra?: Record<string, unknown>                 // populated with { role, is_user } for "render"
+  origin: "create" | "update" | "swipe_add" | "swipe_update" | "render"
   swipeIndex?: number                             // set for "swipe_update"
   userId: string                                  // pass to operator-scoped Spindle calls
 }
@@ -46,10 +46,34 @@ interface MessageContentProcessorCtx {
 | `"update"` | `PUT /api/v1/chats/:chatId/messages/:id` | Edits an existing message's content or extra. |
 | `"swipe_add"` | `POST /api/v1/chats/:chatId/messages/:id/swipe` (with `content`) | Appends a new swipe. |
 | `"swipe_update"` | `PUT /api/v1/chats/:chatId/messages/:id/swipe/:idx` | Rewrites the swipe at `swipeIndex`. |
+| `"render"` | `POST /api/v1/chats/:chatId/display-preprocess` | Per-render transform for display only. Output feeds the display-regex pass and final paint. Does not write to the message row. |
 
 Returned `extra` is ignored on swipe origins: swipes share the parent message's `extra`, which `addSwipe` and `updateSwipe` cannot patch. Only `content` is honored.
 
+Returned `extra` is also ignored on `render`. There is no row to mutate, so only `content` is honored.
+
 Cycling through existing swipes (`{direction: "left"|"right"}`) does not fire the hook; no content changes.
+
+### Render origin
+
+`render` is a non-persisting origin. The frontend calls `POST /api/v1/chats/:chatId/display-preprocess` once per visible message, the chain runs in the same priority order as write-time origins, and the returned content feeds into the display-regex pass before the host's `richHtmlSanitizer` paints it.
+
+The transformed content is visible only on the rendered message. It is invisible to:
+
+- `spindle.chat.getMessages()` and any other read of the stored row
+- write-time origins (`create`, `update`, `swipe_add`, `swipe_update`)
+- chat memory embeddings, prompt assembly, and exports
+
+Use `render` for per-render rewrites that depend on transient or per-message context (chat-var values, the message's own position, etc.) and would pollute history if persisted. Use a write-time origin when the transform belongs on the stored message itself.
+
+The render context populates `extra` with hints from the calling frontend:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `extra.role`| `string` | `"user"`, `"assistant"`, or `"system"`. |
+| `extra.is_user` | `boolean` | Mirror of `role === "user"`. |
+
+`messageId` is set on the context when the rendered message has one. The route accepts an optional `messageIndex` body field that lands on `extra.messageIndex` if supplied by the caller.
 
 ## Return Value
 

--- a/frontend/src/components/chat/MessageContent.tsx
+++ b/frontend/src/components/chat/MessageContent.tsx
@@ -1206,7 +1206,13 @@ export default function MessageContent({
   const interceptorCleanedContent = interceptedMessageTags.content
 
   const macroCtx = useMemo(() => ({ charName, userName }), [charName, userName])
-  const regexAppliedContent = useDisplayRegex(interceptorCleanedContent, isUser, depth, macroCtx)
+  const preprocessOpts = useMemo(
+    () => (messageId
+      ? { messageId, role: (isUser ? 'user' : 'assistant') as 'user' | 'assistant' }
+      : undefined),
+    [messageId, isUser],
+  )
+  const regexAppliedContent = useDisplayRegex(interceptorCleanedContent, isUser, depth, macroCtx, preprocessOpts)
 
   const risuResolvedContent = useMemo(
     () => {
@@ -1281,6 +1287,7 @@ export default function MessageContent({
     observer.observe(container)
     return () => observer.disconnect()
   }, [isStreaming, lockStreamingHeight])
+
 
   const renderedBlocks = useMemo(() => {
     const elements: React.ReactNode[] = []

--- a/frontend/src/hooks/useDisplayRegex.ts
+++ b/frontend/src/hooks/useDisplayRegex.ts
@@ -19,6 +19,11 @@ interface DisplayRegexContentCacheEntry {
   promise?: Promise<string>
 }
 
+export interface DisplayPreprocessOpts {
+  messageId: string
+  role: 'user' | 'assistant' | 'system'
+}
+
 interface ResolvedTemplatesState {
   key: string
   value: ResolvedDisplayRegexTemplates
@@ -31,8 +36,112 @@ interface ResolvedContentState {
 
 const displayRegexResolutionCache = new Map<string, DisplayRegexCacheEntry>()
 const displayRegexContentCache = new Map<string, DisplayRegexContentCacheEntry>()
+const displayPreprocessCache = new Map<string, { value?: string; promise?: Promise<string> }>()
+const DISPLAY_PREPROCESS_CACHE_MAX = 500
 const displayRegexCacheListeners = new Set<() => void>()
 let displayRegexCacheVersion = 0
+
+function fnv1a(s: string): string {
+  let h = 0x811c9dc5
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i)
+    h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0
+  }
+  return h.toString(16)
+}
+
+async function fetchDisplayPreprocess(
+  chatId: string,
+  body: { messageId: string; role: string; rawContent: string },
+): Promise<string> {
+  try {
+    const res = await fetch(`/api/v1/chats/${encodeURIComponent(chatId)}/display-preprocess`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      credentials: 'include',
+    })
+    if (!res.ok) return body.rawContent
+    const json = (await res.json()) as { content?: unknown }
+    return typeof json.content === 'string' ? json.content : body.rawContent
+  } catch {
+    return body.rawContent
+  }
+}
+
+export function useDisplayPreprocessed(
+  content: string,
+  chatId: string | null,
+  opts: DisplayPreprocessOpts | undefined,
+): string {
+  const cacheVersion = useSyncExternalStore(
+    subscribeDisplayRegexCache,
+    getDisplayRegexCacheVersion,
+    getDisplayRegexCacheVersion,
+  )
+
+  const key = useMemo(() => {
+    if (!opts?.messageId || !chatId) return null
+    return `${cacheVersion}|${chatId}|${opts.messageId}|${opts.role}|${content.length}|${fnv1a(content)}`
+  }, [content, opts?.messageId, opts?.role, chatId, cacheVersion])
+
+  const cached = key ? displayPreprocessCache.get(key)?.value : undefined
+  const [state, setState] = useState<{ key: string; value: string } | null>(() =>
+    key && cached !== undefined ? { key, value: cached } : null,
+  )
+
+  const lastRef = useRef<{ raw: string; value: string } | null>(null)
+  if (key && cached !== undefined) lastRef.current = { raw: content, value: cached }
+  else if (key && state?.key === key) lastRef.current = { raw: content, value: state.value }
+
+  useEffect(() => {
+    if (!key || !opts?.messageId || !chatId) {
+      setState((cur) => (cur === null ? cur : null))
+      return
+    }
+    let cancelled = false
+    const apply = (next: string) => {
+      if (!cancelled) setState({ key, value: next })
+    }
+    const existing = displayPreprocessCache.get(key)
+    if (existing?.value !== undefined) {
+      apply(existing.value)
+      return () => { cancelled = true }
+    }
+    if (!existing?.promise) {
+      const promise = fetchDisplayPreprocess(chatId, {
+        messageId: opts.messageId,
+        role: opts.role,
+        rawContent: content,
+      })
+        .then((next) => {
+          displayPreprocessCache.set(key, { value: next })
+          if (displayPreprocessCache.size > DISPLAY_PREPROCESS_CACHE_MAX) {
+            const drop = displayPreprocessCache.size - DISPLAY_PREPROCESS_CACHE_MAX
+            let i = 0
+            for (const k of displayPreprocessCache.keys()) {
+              if (i++ >= drop) break
+              displayPreprocessCache.delete(k)
+            }
+          }
+          return next
+        })
+        .catch(() => {
+          displayPreprocessCache.delete(key)
+          return content
+        })
+      displayPreprocessCache.set(key, { promise })
+    }
+    displayPreprocessCache.get(key)?.promise?.then(apply)
+    return () => { cancelled = true }
+  }, [key, opts?.messageId, opts?.role, chatId, content])
+
+  if (!key) return content
+  if (cached !== undefined) return cached
+  if (state?.key === key) return state.value
+  if (lastRef.current?.raw === content) return lastRef.current.value
+  return content
+}
 
 const RAW_MACRO_RE = /\{\{(?!\s*(?:user|char|bot|notChar|not_char|charName)\s*\}\})/
 
@@ -63,6 +172,7 @@ export function invalidateDisplayRegexCache(): void {
   displayRegexCacheVersion += 1
   displayRegexResolutionCache.clear()
   displayRegexContentCache.clear()
+  displayPreprocessCache.clear()
   for (const listener of displayRegexCacheListeners) listener()
 }
 
@@ -91,7 +201,13 @@ async function resolveMacrosBatchChunked(
   return Object.assign({}, ...chunks)
 }
 
-export function useDisplayRegex(content: string, isUser: boolean, depth: number, macroCtx?: DisplayMacroContext): string {
+export function useDisplayRegex(
+  rawContent: string,
+  isUser: boolean,
+  depth: number,
+  macroCtx?: DisplayMacroContext,
+  preprocessOpts?: DisplayPreprocessOpts,
+): string {
   const regexScripts = useStore((s) => s.regexScripts)
   const activeCharacterId = useStore((s) => s.activeCharacterId)
   const activeChatId = useStore((s) => s.activeChatId)
@@ -101,6 +217,8 @@ export function useDisplayRegex(content: string, isUser: boolean, depth: number,
     getDisplayRegexCacheVersion,
     getDisplayRegexCacheVersion,
   )
+
+  const content = useDisplayPreprocessed(rawContent, activeChatId, preprocessOpts)
 
   const displayScripts = useMemo(
     () =>

--- a/frontend/src/hooks/useDisplayRegex.ts
+++ b/frontend/src/hooks/useDisplayRegex.ts
@@ -212,11 +212,20 @@ export function useDisplayRegex(
   const activeCharacterId = useStore((s) => s.activeCharacterId)
   const activeChatId = useStore((s) => s.activeChatId)
   const activePersonaId = useStore((s) => s.activePersonaId)
+  const messageIndex = useStore((s) => {
+    if (!preprocessOpts?.messageId) return -1
+    return s.messages.findIndex((m) => m.id === preprocessOpts.messageId)
+  })
   const cacheVersion = useSyncExternalStore(
     subscribeDisplayRegexCache,
     getDisplayRegexCacheVersion,
     getDisplayRegexCacheVersion,
   )
+
+  const dynamicMacros = useMemo(() => {
+    if (messageIndex < 0) return undefined
+    return { chat_index: String(messageIndex) }
+  }, [messageIndex])
 
   const content = useDisplayPreprocessed(rawContent, activeChatId, preprocessOpts)
 
@@ -359,9 +368,10 @@ export function useDisplayRegex(
         macroCtx,
         resolvedFindPatterns: resolvedTemplates.resolvedFindPatterns,
         resolvedReplacements: resolvedTemplates.resolvedReplacements,
+        dynamicMacros,
       })
     },
-    [content, displayScripts, isUser, depth, macroCtx, resolvedTemplates],
+    [content, displayScripts, isUser, depth, macroCtx, resolvedTemplates, dynamicMacros],
   )
 
   const hasRawMacroScripts = useMemo(
@@ -391,6 +401,7 @@ export function useDisplayRegex(
       charName: macroCtx?.charName ?? null,
       content,
       resolvedTemplateKey,
+      dynamicMacros: dynamicMacros ?? null,
       scripts: displayScripts.map((s) => [
         s.id,
         s.updated_at,
@@ -416,6 +427,7 @@ export function useDisplayRegex(
     macroCtx,
     content,
     resolvedTemplateKey,
+    dynamicMacros,
   ])
 
   const cachedResolvedContent = contentCacheKey ? displayRegexContentCache.get(contentCacheKey)?.value : undefined
@@ -450,6 +462,7 @@ export function useDisplayRegex(
           macroCtx,
           resolvedFindPatterns: resolvedTemplates.resolvedFindPatterns,
           resolvedReplacements: resolvedTemplates.resolvedReplacements,
+          dynamicMacros,
         },
         (templates) => resolveMacrosBatchChunked(templates, {
           chat_id: activeChatId ?? undefined,
@@ -486,6 +499,7 @@ export function useDisplayRegex(
     activeCharacterId,
     activePersonaId,
     contentCacheKey,
+    dynamicMacros,
   ])
 
   // Carry the previous resolved value forward across cv-bumps and per-chunk

--- a/frontend/src/lib/regex/compiler.ts
+++ b/frontend/src/lib/regex/compiler.ts
@@ -138,6 +138,7 @@ interface ApplyDisplayRegexContext {
   macroCtx?: DisplayMacroContext
   resolvedFindPatterns?: Map<string, string>
   resolvedReplacements?: Map<string, string>
+  dynamicMacros?: Record<string, string>
 }
 
 function mapToRecord(map?: Map<string, string>): Record<string, string> | undefined {
@@ -160,6 +161,7 @@ async function applyDisplayRegexOnBackend(
         scripts,
         resolved_find_patterns: mapToRecord(context.resolvedFindPatterns),
         resolved_replacements: mapToRecord(context.resolvedReplacements),
+        dynamic_macros: context.dynamicMacros,
         context: {
           chat_id: context.chatId,
           character_id: context.characterId,

--- a/src/macros/MacroEnv.ts
+++ b/src/macros/MacroEnv.ts
@@ -161,6 +161,17 @@ function resolveChatGreeting(character: Character, chat: Chat, messages: Message
   return character.first_mes || "";
 }
 
+export function mergeDynamicMacros(
+  env: MacroEnv,
+  overrides: Record<string, string>,
+): void {
+  if (!overrides) return;
+  for (const k of Object.keys(overrides)) {
+    env.dynamicMacros[k] = overrides[k];
+  }
+  env._dynamicMacrosLower = buildDynamicLookup(env.dynamicMacros);
+}
+
 /** Build a lowercase-keyed Map from dynamicMacros for O(1) lookup. */
 function buildDynamicLookup(
   macros?: Record<string, string | import("./types").MacroHandler | import("./types").MacroDefinition>,

--- a/src/macros/MacroEvaluator.ts
+++ b/src/macros/MacroEvaluator.ts
@@ -359,8 +359,14 @@ function snapshotEnvForInterceptor(env: MacroEnv): {
     global: Record<string, string>;
     chat: Record<string, string>;
   };
+  dynamicMacros: Record<string, string>;
   extra: Record<string, unknown>;
 } {
+  const dyn: Record<string, string> = {};
+  for (const k of Object.keys(env.dynamicMacros || {})) {
+    const v = env.dynamicMacros[k];
+    if (typeof v === "string") dyn[k] = v;
+  }
   return {
     commit: env.commit !== false,
     names: { ...env.names },
@@ -372,6 +378,7 @@ function snapshotEnvForInterceptor(env: MacroEnv): {
       global: Object.fromEntries(env.variables.global),
       chat: Object.fromEntries(env.variables.chat),
     },
+    dynamicMacros: dyn,
     extra: { ...env.extra },
   };
 }

--- a/src/macros/index.ts
+++ b/src/macros/index.ts
@@ -1,5 +1,5 @@
 export { evaluate } from "./MacroEvaluator";
-export { buildEnv, cloneEnv, resolveGroupCharacterNames, type BuildEnvContext } from "./MacroEnv";
+export { buildEnv, cloneEnv, mergeDynamicMacros, resolveGroupCharacterNames, type BuildEnvContext } from "./MacroEnv";
 export { registry } from "./MacroRegistry";
 export type {
   MacroEnv,

--- a/src/routes/chats.routes.ts
+++ b/src/routes/chats.routes.ts
@@ -592,4 +592,34 @@ app.delete("/:chatId/messages/:id/swipe/:idx", (c) => {
   return c.json(msg);
 });
 
+app.post("/:chatId/display-preprocess", async (c) => {
+  const userId = c.get("userId");
+  const chatId = c.req.param("chatId");
+  const body = (await c.req.json().catch(() => null)) as {
+    messageId?: unknown;
+    messageIndex?: unknown;
+    role?: unknown;
+    rawContent?: unknown;
+  } | null;
+  if (!body || typeof body.rawContent !== "string") {
+    return c.json({ error: "rawContent (string) required" }, 400);
+  }
+  if (messageContentProcessorChain.count === 0) {
+    return c.json({ content: body.rawContent });
+  }
+  const role = typeof body.role === "string" ? body.role : undefined;
+  const processed = await messageContentProcessorChain.run({
+    chatId,
+    content: body.rawContent,
+    origin: "render",
+    userId,
+    ...(typeof body.messageId === "string" ? { messageId: body.messageId } : {}),
+    extra: {
+      ...(typeof body.messageIndex === "number" ? { messageIndex: body.messageIndex } : {}),
+      ...(role ? { role, is_user: role === "user" } : {}),
+    },
+  }, userId);
+  return c.json({ content: processed.content ?? body.rawContent });
+});
+
 export { app as chatsRoutes };

--- a/src/routes/regex-scripts.routes.ts
+++ b/src/routes/regex-scripts.routes.ts
@@ -166,6 +166,10 @@ app.post("/apply", async (c) => {
   const context = body.context;
   if (!isStringRecord(context)) return c.json({ error: "context is required" }, 400);
 
+  const dynamicMacros = isStringRecord(body.dynamic_macros)
+    ? Object.fromEntries(Object.entries(body.dynamic_macros).filter(([, v]) => typeof v === "string")) as Record<string, string>
+    : undefined;
+
   const result = await applyDisplayRegex({
     content,
     scripts: scripts.filter((script) => !script.disabled),
@@ -179,6 +183,7 @@ app.post("/apply", async (c) => {
     userId,
     resolvedFindPatterns: normalizeResolvedMap(body.resolved_find_patterns),
     resolvedReplacements: normalizeResolvedMap(body.resolved_replacements),
+    dynamicMacros,
   });
 
   return c.json({ result });

--- a/src/services/display-regex.service.ts
+++ b/src/services/display-regex.service.ts
@@ -1,4 +1,4 @@
-import { buildEnv, initMacros, resolveGroupCharacterNames } from "../macros";
+import { buildEnv, initMacros, mergeDynamicMacros, resolveGroupCharacterNames } from "../macros";
 import type { MacroEnv } from "../macros";
 import { getEffectiveCharacterName } from "../types/character";
 import type { Chat } from "../types/chat";
@@ -27,6 +27,7 @@ export interface ApplyDisplayRegexInput {
   userId: string;
   resolvedFindPatterns?: Map<string, string>;
   resolvedReplacements?: Map<string, string>;
+  dynamicMacros?: Record<string, string>;
 }
 
 function buildEnvFromContext(userId: string, ctx: DisplayRegexContext): MacroEnv | undefined {
@@ -149,6 +150,9 @@ function buildEnvFromContext(userId: string, ctx: DisplayRegexContext): MacroEnv
 export async function applyDisplayRegex(input: ApplyDisplayRegexInput): Promise<string> {
   const placement: RegexPlacement = input.context.is_user ? "user_input" : "ai_output";
   const env = buildEnvFromContext(input.userId, input.context);
+  if (env && input.dynamicMacros) {
+    mergeDynamicMacros(env, input.dynamicMacros);
+  }
   return applyRegexScripts(
     input.content,
     input.scripts,

--- a/src/spindle/macro-interceptor.ts
+++ b/src/spindle/macro-interceptor.ts
@@ -17,6 +17,7 @@ export interface MacroInterceptorEnv {
     readonly global: Record<string, string>;
     readonly chat: Record<string, string>;
   };
+  readonly dynamicMacros: Record<string, string>;
   readonly extra: Record<string, unknown>;
 }
 

--- a/src/spindle/message-content-processor.ts
+++ b/src/spindle/message-content-processor.ts
@@ -2,7 +2,8 @@ export type MessageContentProcessorOrigin =
   | "create"
   | "update"
   | "swipe_add"
-  | "swipe_update";
+  | "swipe_update"
+  | "render";
 
 export interface MessageContentProcessorCtx {
   chatId: string;

--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -360,7 +360,7 @@ type RuntimeSpindleAPI = SpindleAPI & {
       messageId?: string;
       content: string;
       extra?: Record<string, unknown>;
-      origin: "create" | "update" | "swipe_add" | "swipe_update";
+      origin: "create" | "update" | "swipe_add" | "swipe_update" | "render";
       swipeIndex?: number;
     }) => Promise<{ content?: string; extra?: Record<string, unknown> } | void>,
     priority?: number


### PR DESCRIPTION
This PR has 2 changes. Both unblock card-format compatibility pipeline hooks Lumi didn't previously expose. Existing extensions are unaffected. Lumi behaviour is unchanged.

1. 1bc1a46ccf06965c7be003f6fa860ab5afb7c3f4 Purpose is to let extensions transform a message's content per render without persisting it, which is a non-persisting symmetric counterpart to the existing write-time origins (create / edit / swipe / greeting). Adds a 'render' origin to the existing messageContentProcessor plus a POST /api/v1/chats/:chatId/display-preprocess route. The transformed content becomes the input to display-regex and final paint, but is invisible to chat.getMessages and to other write-time origins, so card hooks that rewrite text per render based on chat-var state stop polluting message history.

2. 9176e7326dc5619078e8e9c341ba6c2ab45ad575 Purpose is to let extensions inject per-call overrides for macros the registered handler can't compute on its own (per-message context being the common case). Threads per-call dynamic_macros through the /regex-scripts/apply route into the macro env, and adds the field to the MacroInterceptorEnv snapshot so registered macroInterceptor handlers can read it. It seems like you might have been meaning to add this but never got around to it? I mostly want this so that I can have macros in a message resolve per-message chat_index properly.

---

Notes: 

- Render origin uses chat_mutation perm.
- Render origin goes through richHtmlSanitizer before paint
- Render origin is read and transform only, and won't write anything
- MacroInterceptorEnv adds dynamicMacros: Record<string, string> as a required field on the interface. Shouldn't break anything existing though.

### update spindle types
MessageContentProcessorOrigin needs `render` added
MacroInterceptorEnvDTO needs a new field `readonly dynamicMacros: Record<string, string>` added