### PR TITLE
fix: resolve {{user}} correctly in macros and display-regex

### DIFF
--- a/src/routes/macros.routes.ts
+++ b/src/routes/macros.routes.ts
@@ -192,8 +192,7 @@ function buildEnvFromIds(userId: string, body: {
     }
   }
 
-  // Minimal fallback env
-  const persona = personasSvc.getDefaultPersona(userId);
+  const persona = personasSvc.resolvePersonaOrDefault(userId, body.persona_id);
   const connection = connectionsSvc.getDefaultConnection(userId);
 
   return {

--- a/src/services/display-regex.service.ts
+++ b/src/services/display-regex.service.ts
@@ -85,7 +85,7 @@ function buildEnvFromContext(userId: string, ctx: DisplayRegexContext): MacroEnv
     }
   }
 
-  const persona = personasSvc.getDefaultPersona(userId);
+  const persona = personasSvc.resolvePersonaOrDefault(userId, ctx.persona_id);
   const connection = connectionsSvc.getDefaultConnection(userId);
   return {
     commit: true,

--- a/src/services/personas.service.ts
+++ b/src/services/personas.service.ts
@@ -4,6 +4,7 @@ import { EventType } from "../ws/events";
 import type { Persona, CreatePersonaInput, UpdatePersonaInput } from "../types/persona";
 import type { PaginationParams, PaginatedResult } from "../types/pagination";
 import { paginatedQuery } from "./pagination";
+import { getSetting as getUserSetting } from "./settings.service";
 
 function rowToPersona(row: any): Persona {
   return {
@@ -237,6 +238,13 @@ export function resolvePersonaOrDefault(userId: string, personaId?: string | nul
     const requested = getPersona(userId, personaId);
     if (requested) return requested;
   }
+  try {
+    const active = getUserSetting(userId, "activePersonaId");
+    if (active && typeof active.value === "string" && active.value.length > 0) {
+      const fromSetting = getPersona(userId, active.value);
+      if (fromSetting) return fromSetting;
+    }
+  } catch { /* */ }
   return getDefaultPersona(userId);
 }
 


### PR DESCRIPTION
{{user}} will always evaluate to `User` in display-regex / `/macros/resolve-batch` paths.

The generate path (`generate.service.ts`) manually reads `activePersonaId` from settings before calling `resolvePersonaOrDefault`, which is why prompt-assembly + dry-run paths work today. The display-regex / `/macros/resolve-batch` paths skip that fallback. They are added in this PR.

You can test with the following commands:

```curl -X POST <HOST>/api/v1/macros/resolve-batch -H "Content-Type: application/json" -H "Origin: <HOST>" -H "Cookie: better-auth.session_token=<SESSION_TOKEN>" -d '{"templates": {"t": "Hello {{user}}!"}}'```

```curl -X POST <HOST>/api/v1/macros/resolve-batch -H "Content-Type: application/json" -H "Origin: <HOST>" -H "Cookie: better-auth.session_token=<SESSION_TOKEN>" -d '{"templates": {"t": "Hello {{user}}!"}, "chat_id": "<ANY_CHAT_ID>"}'```

```curl -X POST <HOST>/api/v1/macros/resolve-batch -H "Content-Type: application/json" -H "Origin: <HOST>" -H "Cookie: better-auth.session_token=<SESSION_TOKEN>" -d '{"templates": {"t": "Hello {{user}}!"}, "persona_id": "<PERSONA_ID>"}'```