### PR TITLE
fix: prevent extractHtmlIslands broken HTML

### DIFF
--- a/frontend/src/components/chat/MessageContent.tsx
+++ b/frontend/src/components/chat/MessageContent.tsx
@@ -828,6 +828,15 @@ function getIslandEndAt(raw: string, start: number, isStreaming: boolean): numbe
     return element.end
   }
 
+  let peekStart = skipWhitespace(raw, element.end)
+  while (raw.startsWith('</', peekStart)) {
+    const closeEnd = raw.indexOf('>', peekStart + 2)
+    if (closeEnd < 0) break
+    peekStart = skipWhitespace(raw, closeEnd + 1)
+  }
+  const trailingStyleEnd = findStyleBlockEnd(raw, peekStart)
+  if (trailingStyleEnd != null) return extendThroughAdjacentHtmlSiblings(raw, trailingStyleEnd)
+
   return null
 }
 


### PR DESCRIPTION
Pair an HTML element with its trailing \<style> block in extractHtmlIslands.



When there is a left split unstyled HTML element immediately followed by a <style> that targets it, it goes through markdown and CommonMark's indented-code-block rule fires on any 4-space-indented inner line after a blank line, rendering the inner HTML as a code fence.

Repro: a card greeting with `<div class="container">…<div>…</div>\n\n    <div>indented</div>…</div><style>.container{…}</style>` rendered the indented inner \<div> as a syntax-highlighted code block. 