### PR TITLE
Add world info interceptor

### DIFF
--- a/developer-docs/docs/backend-api/index.md
+++ b/developer-docs/docs/backend-api/index.md
@@ -17,6 +17,7 @@ declare const spindle: import('lumiverse-spindle-types').SpindleAPI
 | [Interceptors](interceptors.md) | `interceptor` | Modify the prompt before it reaches the LLM |
 | [Context Handlers](context-handlers.md) | `context_handler` | Enrich the generation context before assembly |
 | [Macro Interceptor](macro-interceptor.md) | `macro_interceptor` | Transform raw templates before macro parsing/dispatch |
+| [World Info Interceptor](world-info-interceptor.md) | `generation` | Disable world info entries or override their content before activation |
 | [Message Content Processor](message-content-processor.md) | `chat_mutation` | Transform message content before it is written to the database |
 | [LLM Tools](llm-tools.md) | `tools` | Register function-calling tools + Council-eligible tools |
 | [Generation](generation.md) | `generation` | Fire LLM generations + inspect connections |

--- a/developer-docs/docs/backend-api/world-info-interceptor.md
+++ b/developer-docs/docs/backend-api/world-info-interceptor.md
@@ -1,0 +1,115 @@
+# World Info Interceptor
+
+!!! warning "Permission required: `generation`"
+
+World info interceptors run *before* world info activation. They receive the candidate entries plus the current chat state, and return a list of entry IDs to disable for this turn and/or per-entry content overrides.
+
+```ts
+spindle.registerWorldInfoInterceptor(async (ctx) => {
+  const disabled: string[] = []
+  for (const entry of ctx.entries) {
+    if (entry.constant && ctx.chatTurn < 5) disabled.push(entry.id)
+  }
+  return { disabled }
+}, 100)
+```
+
+Use this when an entry's stored fields can't express the activation rule (turn-based gates, sticky flags, external state lookups, content rewrites driven by retrieval).
+
+## Parameters
+
+| Param | Type | Description |
+| --- | --- | --- |
+| `handler` | `(ctx: WorldInfoInterceptorCtx) => Promise<WorldInfoInterceptorResult \| void>` | Returns disable + content-override decisions, or `void` to pass through |
+| `priority` | `number` | Optional. Lower values run first. Default:`100` |
+
+One interceptor per extension; a second registration replaces the first.
+
+## Context Object
+
+```ts
+interface WorldInfoInterceptorCtx {
+  chatId: string
+  characterId: string
+  userId?: string
+  entries: WorldInfoInterceptorEntry[]
+  messages: WorldInfoInterceptorMessage[]
+  chatTurn: number
+  chatMetadata: Record<string, unknown>
+}
+
+interface WorldInfoInterceptorEntry {
+  id: string
+  world_book_id: string
+  comment: string
+  disabled: boolean
+  constant: boolean
+  extensions: Record<string, unknown>
+  key: string[]
+  keysecondary: string[]
+  position: number
+  depth: number
+  priority: number
+  probability: number
+  use_probability: boolean
+  content: string
+}
+
+interface WorldInfoInterceptorMessage {
+  role: "system" | "user" | "assistant"
+  content: string
+}
+```
+
+`entries` reflects the current state of the chain: each interceptor sees the previous one's mutations. `disabled: true` on an incoming entry can mean either "stored as disabled" or "an earlier interceptor disabled it"; use `extensions` to mark your own provenance if you need to tell them apart.
+
+`chatMetadata` is the chat-level metadata blob. Persist cross-turn state here via `spindle.chats.update`; the snapshot is read-only.
+
+## Return Value
+
+```ts
+interface WorldInfoInterceptorResult {
+  disabled?: string[]
+  enabled?: string[]
+  forced?: string[]
+  mutated?: { id: string; content?: string }[]
+}
+```
+
+Return `void` (or omit all arrays) for a no-op pass-through. The four axes are independent:
+
+| Field | Effect |
+| --- | --- |
+| `disabled` | Forces `disabled: true`. Wins against any `enabled`/`forced` vote anywhere in the chain. |
+| `enabled` | Un-flips a stored `disabled: true`. No effect on entries already enabled or on entries any handler voted to disable. |
+| `forced` | Sets `constant: true` for this turn (activates regardless of key match). No effect if any handler voted to disable. Independent of `enabled`. To force a stored-disabled entry, vote both `enabled` and `forced`. |
+| `mutated` | Replaces `content` for this turn only; the stored entry is unchanged. Applies regardless of activation state. |
+
+Mutating an entry that another interceptor disabled is allowed but inert.
+
+## Composition Order
+
+Multiple interceptors run in priority order (lower first), with registration order as the tie-breaker. Each interceptor receives the previous one's mutations applied to the entry list. There is no cap on chain depth.
+
+Vote-off precedence is the chain's invariant: once any handler votes `disabled` for an entry, no later handler's `enabled` or `forced` can revive it. This makes per-handler reasoning order-independent on the disable axis.
+
+Content overrides accumulate last-write-wins: if two handlers set `content` for the same entry, the higher-priority handler (later in the chain) wins.
+
+## Permission Scope
+
+`registerWorldInfoInterceptor` requires the `generation` permission — the same gate that covers `registerInterceptor` and `registerContextHandler`. No additional permission is needed for content overrides.
+
+## Timeout
+
+Each interceptor runs inside a 10-second wall-clock budget. On timeout or thrown error: the chain logs the failure and forwards the previous entry list to the next handler. World info activation itself never aborts.
+
+!!! warning "Users notice the wait"
+    The interceptor fires before activation, which fires before prompt assembly, which fires before the LLM call. Slow handlers add visible latency before the first streamed token.
+
+## World Info Interceptor vs Context Handler vs Interceptor
+
+| Hook | When it fires | What it changes |
+| --- | --- | --- |
+| **World Info Interceptor** | Before world info activation | Per-entry disable + content overrides |
+| [Context Handler](context-handlers.md) | Before prompt assembly | The generation context |
+| [Interceptor](interceptors.md) | After assembly, before LLM call | The outgoing message array |

--- a/src/services/prompt-assembly.service.ts
+++ b/src/services/prompt-assembly.service.ts
@@ -49,6 +49,7 @@ import {
   type FinalizedWorldInfoEntries,
   normalizeWorldInfoSettings,
 } from "./world-info-activation.service";
+import { worldInfoInterceptorChain } from "../spindle/world-info-interceptor";
 import * as chatsSvc from "./chats.service";
 import { stripReasoningTags } from "./chats.service";
 import {
@@ -1072,8 +1073,37 @@ export async function assemblePrompt(
       | Partial<WorldInfoSettings>
       | undefined) ??
     {};
+  const intercepted = await worldInfoInterceptorChain.run(
+    wiEntries,
+    {
+      chatId: ctx.chatId,
+      characterId: character.id,
+      userId: ctx.userId,
+      messages: messages.map((m) => {
+        const extra = (m.extra ?? {}) as { greeting?: unknown; greeting_index?: unknown };
+        const isGreeting = extra.greeting === true;
+        const greetingIndex =
+          isGreeting && typeof extra.greeting_index === "number"
+            ? extra.greeting_index
+            : undefined;
+        return {
+          id: m.id,
+          role: m.is_user ? ("user" as const) : ("assistant" as const),
+          content: m.content,
+          is_user: m.is_user,
+          is_greeting: isGreeting,
+          ...(greetingIndex !== undefined ? { greeting_index: greetingIndex } : {}),
+          swipe_id: m.swipe_id,
+          index_in_chat: m.index_in_chat,
+        };
+      }),
+      chatTurn: messages.length,
+      chatMetadata: chat.metadata ?? {},
+    },
+    ctx.userId
+  );
   const wiResult = activateWorldInfo({
-    entries: wiEntries,
+    entries: intercepted,
     messages,
     chatTurn: messages.length,
     wiState,

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -44,6 +44,11 @@ import {
   type MacroInterceptorCtx,
   type MacroInterceptorResult,
 } from "./macro-interceptor";
+import {
+  worldInfoInterceptorChain,
+  type WorldInfoInterceptorCtxDTO,
+  type WorldInfoInterceptorResultDTO,
+} from "./world-info-interceptor";
 import { toolRegistry } from "./tool-registry";
 import * as managerSvc from "./manager.service";
 import * as generateSvc from "../services/generate.service";
@@ -396,6 +401,12 @@ type RuntimeWorkerToHost =
       requestId: string;
       result: unknown;
     }
+  | { type: "register_world_info_interceptor"; priority?: number }
+  | {
+      type: "world_info_interceptor_result";
+      requestId: string;
+      result: unknown;
+    }
   | {
       type: "frontend_process_spawn";
       requestId: string;
@@ -479,6 +490,11 @@ type RuntimeHostToWorker =
       type: "macro_interceptor_request";
       requestId: string;
       ctx: MacroInterceptorCtx;
+    }
+  | {
+      type: "world_info_interceptor_request";
+      requestId: string;
+      ctx: WorldInfoInterceptorCtxDTO;
     }
   | { type: "frontend_process_lifecycle"; event: FrontendProcessLifecycleEvent }
   | { type: "frontend_process_message"; processId: string; payload: unknown; userId: string }
@@ -754,6 +770,7 @@ export class WorkerHost {
   private contextHandlerUnregister: (() => void) | null = null;
   private messageContentProcessorUnregister: (() => void) | null = null;
   private macroInterceptorUnregister: (() => void) | null = null;
+  private worldInfoInterceptorUnregister: (() => void) | null = null;
   private registeredMacroNames = new Set<string>();
   private macroValueCache = new Map<string, string>();
   private toastTimestamps: number[] = [];
@@ -1534,6 +1551,9 @@ export class WorkerHost {
     this.macroInterceptorUnregister?.();
     this.macroInterceptorUnregister = null;
 
+    this.worldInfoInterceptorUnregister?.();
+    this.worldInfoInterceptorUnregister = null;
+
     // Unregister all tools for this extension
     toolRegistry.unregisterByExtension(this.extensionId);
 
@@ -1559,6 +1579,7 @@ export class WorkerHost {
     contextHandlerChain.unregisterByExtension(this.extensionId);
     messageContentProcessorChain.unregisterByExtension(this.extensionId);
     macroInterceptorChain.unregisterByExtension(this.extensionId);
+    worldInfoInterceptorChain.unregisterByExtension(this.extensionId);
     unregisterSharedRpcEndpointsByOwner(this.manifest.identifier);
 
     // Reject pending requests
@@ -2105,6 +2126,12 @@ export class WorkerHost {
         this.handleRegisterMacroInterceptor(msg.priority);
         break;
       case "macro_interceptor_result":
+        this.resolveRequest(msg.requestId, msg.result);
+        break;
+      case "register_world_info_interceptor":
+        this.handleRegisterWorldInfoInterceptor(msg.priority);
+        break;
+      case "world_info_interceptor_result":
         this.resolveRequest(msg.requestId, msg.result);
         break;
       case "tool_invocation_result":
@@ -5297,6 +5324,58 @@ export class WorkerHost {
             resolve: (val) => {
               clearTimeout(timeout);
               resolve(val as MacroInterceptorResult | undefined);
+            },
+            reject: (err) => {
+              clearTimeout(timeout);
+              reject(err);
+            },
+          });
+        });
+      },
+    });
+  }
+
+  private handleRegisterWorldInfoInterceptor(priority?: number): void {
+    if (!managerSvc.hasPermission(this.manifest.identifier, "generation")) {
+      console.warn(
+        `[Spindle:${this.manifest.identifier}] generation permission not granted for registerWorldInfoInterceptor`
+      );
+      this.postToWorker({
+        type: "permission_denied",
+        permission: "generation",
+        operation: "registerWorldInfoInterceptor",
+      });
+      return;
+    }
+
+    this.worldInfoInterceptorUnregister?.();
+    this.worldInfoInterceptorUnregister = worldInfoInterceptorChain.register({
+      extensionId: this.extensionId,
+      userId: this.getScopedUserId(),
+      priority: priority ?? 100,
+      handler: async (ctx: WorldInfoInterceptorCtxDTO) => {
+        const requestId = crypto.randomUUID();
+
+        this.postToWorker({
+          type: "world_info_interceptor_request",
+          requestId,
+          ctx,
+        });
+
+        return new Promise<WorldInfoInterceptorResultDTO | void>((resolve, reject) => {
+          const timeout = setTimeout(() => {
+            this.pendingRequests.delete(requestId);
+            reject(
+              new Error(
+                `World-info interceptor timeout from ${this.manifest.identifier}`
+              )
+            );
+          }, 10_000);
+
+          this.pendingRequests.set(requestId, {
+            resolve: (val) => {
+              clearTimeout(timeout);
+              resolve(val as WorldInfoInterceptorResultDTO | undefined);
             },
             reject: (err) => {
               clearTimeout(timeout);

--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -264,6 +264,12 @@ type RuntimeWorkerToHost =
       requestId: string;
       result: unknown;
     }
+  | { type: "register_world_info_interceptor"; priority?: number }
+  | {
+      type: "world_info_interceptor_result";
+      requestId: string;
+      result: unknown;
+    }
   | {
       type: "frontend_process_spawn";
       requestId: string;
@@ -348,6 +354,11 @@ type RuntimeHostToWorker =
       requestId: string;
       ctx: unknown;
     }
+  | {
+      type: "world_info_interceptor_request";
+      requestId: string;
+      ctx: unknown;
+    }
   | { type: "frontend_process_lifecycle"; event: FrontendProcessLifecycleEvent }
   | { type: "frontend_process_message"; processId: string; payload: unknown; userId: string }
   | { type: "backend_process_lifecycle"; event: BackendProcessLifecycleEvent }
@@ -386,6 +397,58 @@ type RuntimeSpindleAPI = SpindleAPI & {
       sourceHint?: string;
       userId?: string;
     }) => Promise<string | void>,
+    priority?: number
+  ): void;
+  registerWorldInfoInterceptor(
+    handler: (ctx: {
+      chatId: string;
+      characterId: string;
+      userId?: string;
+      entries: ReadonlyArray<{
+        id: string;
+        world_book_id: string;
+        comment: string;
+        disabled: boolean;
+        constant: boolean;
+        extensions: Readonly<Record<string, unknown>>;
+        key: readonly string[];
+        keysecondary: readonly string[];
+        position: number;
+        depth: number;
+        priority: number;
+        probability: number;
+        use_probability: boolean;
+        content: string;
+        automation_id: string | null;
+        selective: boolean;
+        selective_logic: number;
+        match_whole_words: boolean;
+        case_sensitive: boolean;
+        use_regex: boolean;
+        prevent_recursion: boolean;
+        exclude_recursion: boolean;
+        delay_until_recursion: boolean;
+        scan_depth: number | null;
+        order_value: number;
+      }>;
+      messages: ReadonlyArray<{
+        id: string;
+        role: "system" | "user" | "assistant";
+        content: string;
+        is_user: boolean;
+        is_greeting: boolean;
+        greeting_index?: number;
+        swipe_id: number;
+        index_in_chat: number;
+      }>;
+      chatTurn: number;
+      chatMetadata: Readonly<Record<string, unknown>>;
+    }) => Promise<{
+      disabled?: readonly string[];
+      enabled?: readonly string[];
+      forced?: readonly string[];
+      mutated?: ReadonlyArray<{ id: string; content?: string }>;
+    } | void>,
     priority?: number
   ): void;
   tokens: {
@@ -498,6 +561,9 @@ let messageContentProcessorFn:
   | ((ctx: unknown) => Promise<unknown>)
   | null = null;
 let macroInterceptorFn:
+  | ((ctx: unknown) => Promise<unknown>)
+  | null = null;
+let worldInfoInterceptorFn:
   | ((ctx: unknown) => Promise<unknown>)
   | null = null;
 let oauthCallbackHandler:
@@ -2283,6 +2349,12 @@ const spindleApi: RuntimeSpindleAPI = {
     post({ type: "register_macro_interceptor", priority });
   },
 
+  registerWorldInfoInterceptor(handler, priority?): void {
+    assertMutationAllowed("spindle.registerWorldInfoInterceptor()");
+    worldInfoInterceptorFn = handler as (ctx: unknown) => Promise<unknown>;
+    post({ type: "register_world_info_interceptor", priority });
+  },
+
   sendToFrontend(payload: unknown, userId?: string): void {
     post({ type: "frontend_message", payload, userId });
   },
@@ -2802,6 +2874,31 @@ async function handleHostMessage(msg: RuntimeHostToWorker): Promise<void> {
           });
           post({
             type: "macro_interceptor_result",
+            requestId: msg.requestId,
+            result: undefined,
+          });
+        }
+      }
+      break;
+    }
+
+    case "world_info_interceptor_request": {
+      if (worldInfoInterceptorFn) {
+        try {
+          const result = await worldInfoInterceptorFn(msg.ctx);
+          post({
+            type: "world_info_interceptor_result",
+            requestId: msg.requestId,
+            result,
+          });
+        } catch (err: any) {
+          post({
+            type: "log",
+            level: "error",
+            message: `World-info interceptor error: ${err.message}`,
+          });
+          post({
+            type: "world_info_interceptor_result",
             requestId: msg.requestId,
             result: undefined,
           });

--- a/src/spindle/world-info-interceptor.ts
+++ b/src/spindle/world-info-interceptor.ts
@@ -1,0 +1,209 @@
+import type { WorldBookEntry } from "../types/world-book";
+
+export interface WorldInfoInterceptorEntryDTO {
+  readonly id: string;
+  readonly world_book_id: string;
+  readonly comment: string;
+  readonly disabled: boolean;
+  readonly constant: boolean;
+  readonly extensions: Readonly<Record<string, unknown>>;
+  readonly key: readonly string[];
+  readonly keysecondary: readonly string[];
+  readonly position: number;
+  readonly depth: number;
+  readonly priority: number;
+  readonly probability: number;
+  readonly use_probability: boolean;
+  readonly content: string;
+  readonly automation_id: string | null;
+  readonly selective: boolean;
+  readonly selective_logic: number;
+  readonly match_whole_words: boolean;
+  readonly case_sensitive: boolean;
+  readonly use_regex: boolean;
+  readonly prevent_recursion: boolean;
+  readonly exclude_recursion: boolean;
+  readonly delay_until_recursion: boolean;
+  readonly scan_depth: number | null;
+  readonly order_value: number;
+}
+
+export interface WorldInfoInterceptorMessageDTO {
+  readonly id: string;
+  readonly role: "system" | "user" | "assistant";
+  readonly content: string;
+  readonly is_user: boolean;
+  readonly is_greeting: boolean;
+  readonly greeting_index?: number;
+  readonly swipe_id: number;
+  readonly index_in_chat: number;
+}
+
+export interface WorldInfoInterceptorCtxDTO {
+  readonly chatId: string;
+  readonly characterId: string;
+  readonly userId?: string;
+  readonly entries: readonly WorldInfoInterceptorEntryDTO[];
+  readonly messages: readonly WorldInfoInterceptorMessageDTO[];
+  readonly chatTurn: number;
+  readonly chatMetadata: Readonly<Record<string, unknown>>;
+}
+
+export interface WorldInfoInterceptorMutationDTO {
+  readonly id: string;
+  readonly content?: string;
+}
+
+export interface WorldInfoInterceptorResultDTO {
+  readonly disabled?: readonly string[];
+  readonly enabled?: readonly string[];
+  readonly forced?: readonly string[];
+  readonly mutated?: readonly WorldInfoInterceptorMutationDTO[];
+}
+
+export interface WorldInfoInterceptor {
+  extensionId: string;
+  userId?: string | null;
+  priority: number;
+  handler: (
+    ctx: WorldInfoInterceptorCtxDTO
+  ) => Promise<WorldInfoInterceptorResultDTO | void>;
+}
+
+const INTERCEPTOR_TIMEOUT_MS = 10_000;
+
+class WorldInfoInterceptorChain {
+  private handlers: WorldInfoInterceptor[] = [];
+
+  register(handler: WorldInfoInterceptor): () => void {
+    this.handlers.push(handler);
+    this.handlers.sort((a, b) => a.priority - b.priority);
+
+    return () => {
+      const idx = this.handlers.indexOf(handler);
+      if (idx !== -1) this.handlers.splice(idx, 1);
+    };
+  }
+
+  unregisterByExtension(extensionId: string): void {
+    this.handlers = this.handlers.filter((h) => h.extensionId !== extensionId);
+  }
+
+  async run(
+    entries: readonly WorldBookEntry[],
+    ctx: Omit<WorldInfoInterceptorCtxDTO, "entries">,
+    userId?: string | null
+  ): Promise<WorldBookEntry[]> {
+    if (this.handlers.length === 0) return [...entries];
+
+    const buildDto = (
+      src: readonly WorldBookEntry[]
+    ): WorldInfoInterceptorEntryDTO[] =>
+      src.map((e) => ({
+        id: e.id,
+        world_book_id: e.world_book_id,
+        comment: e.comment,
+        disabled: e.disabled,
+        constant: e.constant,
+        extensions: e.extensions ?? {},
+        key: e.key,
+        keysecondary: e.keysecondary,
+        position: e.position,
+        depth: e.depth,
+        priority: e.priority,
+        probability: e.probability,
+        use_probability: e.use_probability,
+        content: e.content,
+        automation_id: e.automation_id,
+        selective: e.selective,
+        selective_logic: e.selective_logic,
+        match_whole_words: e.match_whole_words,
+        case_sensitive: e.case_sensitive,
+        use_regex: e.use_regex,
+        prevent_recursion: e.prevent_recursion,
+        exclude_recursion: e.exclude_recursion,
+        delay_until_recursion: e.delay_until_recursion,
+        scan_depth: e.scan_depth,
+        order_value: e.order_value,
+      }));
+
+    const disabledByChain = new Set<string>();
+    const enabledByChain = new Set<string>();
+    const forcedByChain = new Set<string>();
+    const contentOverrides = new Map<string, string>();
+
+    let working: WorldBookEntry[] = [...entries];
+
+    const rebuildWorking = (): WorldBookEntry[] =>
+      entries.map((e) => {
+        const isDisabled = disabledByChain.has(e.id);
+        const wantsEnable = !isDisabled && enabledByChain.has(e.id) && e.disabled;
+        const wantsForce = !isDisabled && forcedByChain.has(e.id);
+        const newContent = contentOverrides.get(e.id);
+        if (!isDisabled && !wantsEnable && !wantsForce && newContent === undefined) {
+          return e;
+        }
+        return {
+          ...e,
+          ...(isDisabled ? { disabled: true } : {}),
+          ...(wantsEnable ? { disabled: false } : {}),
+          ...(wantsForce ? { constant: true } : {}),
+          ...(newContent !== undefined ? { content: newContent } : {}),
+        };
+      });
+
+    for (const handler of this.handlers) {
+      if (handler.userId && handler.userId !== userId) continue;
+      try {
+        const result = await Promise.race([
+          handler.handler({ ...ctx, entries: buildDto(working) }),
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () =>
+                reject(
+                  new Error(
+                    `World-info interceptor from ${handler.extensionId} timed out (${INTERCEPTOR_TIMEOUT_MS / 1000}s)`
+                  )
+                ),
+              INTERCEPTOR_TIMEOUT_MS
+            )
+          ),
+        ]);
+        const disabledList = result?.disabled ?? [];
+        const enabledList = result?.enabled ?? [];
+        const forcedList = result?.forced ?? [];
+        const mutatedList = result?.mutated ?? [];
+        if (
+          disabledList.length === 0 &&
+          enabledList.length === 0 &&
+          forcedList.length === 0 &&
+          mutatedList.length === 0
+        ) {
+          continue;
+        }
+
+        for (const id of disabledList) disabledByChain.add(id);
+        for (const id of enabledList) enabledByChain.add(id);
+        for (const id of forcedList) forcedByChain.add(id);
+        for (const m of mutatedList) {
+          if (m.content !== undefined) contentOverrides.set(m.id, m.content);
+        }
+
+        working = rebuildWorking();
+      } catch (err) {
+        console.error(
+          `[Spindle] World-info interceptor error from ${handler.extensionId}:`,
+          err
+        );
+      }
+    }
+
+    return working;
+  }
+
+  get count(): number {
+    return this.handlers.length;
+  }
+}
+
+export const worldInfoInterceptorChain = new WorldInfoInterceptorChain();


### PR DESCRIPTION
This PR adds 1 hook. It unblocks spindle extensions that want to implement their own lorebook management semantics on top of Lumi's world-info pipeline. Existing extensions are unaffected. Lumi behaviour is unchanged when no handler registers. Shouldn't break anything existing.

- a28b531e25ac45fa5c72f271eb2642c2a3ebe661 Purpose is to let extensions deactivate or content-override world-info entries before activation runs, so card-format-specific families can be implemented extension-side without Lumi awareness. Adds spindle.registerWorldInfoInterceptor(handler, priority?) plus a chain that fires inside assemblePrompt right before activateWorldInfo is called. Handler receives the candidate entries plus context (messages, chatTurn, chat metadata) and returns {disabled?: string[], mutated?: [{id, content?}]}. Disabled drops the entry from activation (so token-budget calc is correct), mutated overrides content for this prompt only. Multiple handlers chain in priority order and handler B sees handler A's mutations, which is what makes cross-entry injection patterns (one entry merges its content into another then disables itself) tractable in a single hook. See this [google doc](https://docs.google.com/document/d/19qoKRUQy8M9UXMMOs3Dh_CxUsfurtgaLt6jSwl4HSPU/edit?usp=sharing) for an example of things that I would want this hook for to make possible (scroll a bit).

---

Notes:

- Uses the existing generation perm.
- Fires before activateWorldInfo so deactivated entries don't pollute token budget calc.
- Per-handler 10s timeout, errors get console.error'd and the chain continues
- Each entry DTO carries the Lumi-native fields a handler is likely to want to read.

## Update spindle types
New DTOs: `WorldInfoInterceptorEntryDTO`, `WorldInfoInterceptorMessageDTO`, `WorldInfoInterceptorCtxDTO`, `WorldInfoInterceptorMutationDTO`, `WorldInfoInterceptorResultDTO`
New method on SpindleAPI: `registerWorldInfoInterceptor(handler, priority?)`