### PR TITLE
Add spindle regex scripts read API

### DIFF
--- a/developer-docs/docs/backend-api/events.md
+++ b/developer-docs/docs/backend-api/events.md
@@ -147,6 +147,15 @@ No `action` discriminator is provided — if you need add/update/delete/navigate
 | `IMAGE_UPLOADED` | `{ imageId }` |
 | `IMAGE_DELETED` | `{ imageId }` |
 
+### Regex Scripts
+
+!!! warning "Permission required: `regex_scripts`"
+
+| Event | Payload |
+|-------|---------|
+| `REGEX_SCRIPT_CHANGED` | `{ id, script }` — fires on create, update, duplicate, reorder, and enable/disable. `script` is a `RegexScriptDTO`. |
+| `REGEX_SCRIPT_DELETED` | `{ id }` |
+
 ### Expressions
 
 | Event | Payload |

--- a/developer-docs/docs/backend-api/index.md
+++ b/developer-docs/docs/backend-api/index.md
@@ -31,6 +31,7 @@ declare const spindle: import('lumiverse-spindle-types').SpindleAPI
 | [Characters](characters.md) | `characters` | CRUD on character cards |
 | [Chats](chats.md) | `chats` | CRUD on chat sessions + active chat |
 | [World Books](world-books.md) | `world_books` | CRUD on world books and entries |
+| [Regex Scripts](regex-scripts.md) | `regex_scripts` | CRUD on regex scripts (find/replace rules) |
 | [Databanks](databanks.md) | `databanks` | CRUD on databanks and their documents |
 | [Personas](personas.md) | `personas` | CRUD on personas + active switching + attached world books |
 | [Council](council.md) | Free | Read the active council members and configuration |

--- a/developer-docs/docs/backend-api/regex-scripts.md
+++ b/developer-docs/docs/backend-api/regex-scripts.md
@@ -1,0 +1,171 @@
+# Regex Scripts
+
+!!! warning "Permission required: `regex_scripts`"
+
+Full CRUD access to the user's regex scripts plus a context-aware active-rule resolver. Use this for extensions that manage, analyze, or batch-edit find/replace rules — card-format compatibility shims, regex analytics, debug tooling, or anything that needs to mirror the resolution Lumiverse uses internally during prompt assembly, response baking, and display rendering.
+
+## Usage
+
+```ts
+// List regex scripts (paginated)
+const { data, total } = await spindle.regex_scripts.list({ limit: 50, offset: 0 })
+
+// List only character-scoped rules attached to a specific character
+const charRules = await spindle.regex_scripts.list({
+  scope: 'character',
+  scopeId: 'character-id',
+})
+
+// List only display-target rules
+const displayRules = await spindle.regex_scripts.list({ target: 'display' })
+
+// Get a single script
+const script = await spindle.regex_scripts.get('script-id')
+if (script) {
+  spindle.log.info(`${script.name}: /${script.find_regex}/${script.flags}`)
+}
+
+// Create a script
+const newScript = await spindle.regex_scripts.create({
+  name: 'Strip OOC blocks',
+  find_regex: '\\(\\(.*?\\)\\)',
+  replace_string: '',
+  flags: 'g',
+  placement: ['ai_output'],
+  target: 'display',
+  scope: 'character',
+  scope_id: 'character-id',
+})
+
+// Update a script
+const updated = await spindle.regex_scripts.update(newScript.id, {
+  disabled: true,
+})
+
+// Delete a script
+const deleted = await spindle.regex_scripts.delete(newScript.id)
+
+// Resolve the rules that would actually fire for a given context
+const active = await spindle.regex_scripts.getActive({
+  target: 'display',
+  characterId: 'character-id',
+  chatId: 'chat-id',
+})
+```
+
+## Methods
+
+| Method | Returns | Description |
+|---|---|---|
+| `list(options?)` | `Promise<{ data: RegexScriptDTO[], total: number }>` | List scripts with strict scope filtering. Options: `{ scope?, scopeId?, target?, limit?, offset?, userId? }`. Defaults: limit 50, max 200. |
+| `get(scriptId)` | `Promise<RegexScriptDTO \| null>` | Get a script by ID. Returns `null` if not found. |
+| `create(input)` | `Promise<RegexScriptDTO>` | Create a new regex script. `name` and `find_regex` are required. |
+| `update(scriptId, input)` | `Promise<RegexScriptDTO>` | Update a script. All fields are optional. Throws if the script is not found. |
+| `delete(scriptId)` | `Promise<boolean>` | Delete a script. Returns `true` if deleted. |
+| `getActive(options)` | `Promise<RegexScriptDTO[]>` | Resolve enabled scripts that would fire for a given target plus character/chat context. Merges global + character + chat scopes and orders them by scope tier then `sort_order`. |
+
+## RegexScriptListOptionsDTO
+
+| Field | Type | Description |
+|---|---|---|
+| `scope` | `"global" \| "character" \| "chat"` | Filter to a single scope. Omit to include all scopes. |
+| `scopeId` | `string` | Required when `scope` is `character` or `chat` to narrow to a single entity. Ignored otherwise. |
+| `target` | `"prompt" \| "response" \| "display"` | Filter by execution target. |
+| `limit` | `number` | Page size. Default 50, max 200. |
+| `offset` | `number` | Pagination offset. |
+| `userId` | `string` | For operator-scoped extensions only. |
+
+## RegexScriptActiveOptionsDTO
+
+| Field | Type | Description |
+|---|---|---|
+| `target` | `"prompt" \| "response" \| "display"` | **Required.** The execution target to resolve for. |
+| `characterId` | `string` | Include character-scoped rules attached to this character. |
+| `chatId` | `string` | Include chat-scoped rules attached to this chat. |
+| `userId` | `string` | For operator-scoped extensions only. |
+
+`getActive` always includes global rules. Disabled rules are excluded.
+
+## RegexScriptCreateDTO
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Display name shown in the regex panel. |
+| `find_regex` | `string` | Yes | Pattern compiled with the JavaScript regex engine. Validated at create time. |
+| `replace_string` | `string` | No | Replacement template. Supports `$1` / `$&` / `$<name>` capture references. Default `""`. |
+| `flags` | `string` | No | Any subset of `gimsu`. Default `"gi"`. |
+| `placement` | `RegexPlacementDTO[]` | No | Which message roles the rule applies to. Default `["ai_output"]`. |
+| `scope` | `"global" \| "character" \| "chat"` | No | Default `"global"`. |
+| `scope_id` | `string \| null` | No | Required when `scope` is non-global. |
+| `target` | `"prompt" \| "response" \| "display"` | No | When the rule fires. Default `"response"`. |
+| `min_depth` | `number \| null` | No | Lower bound on chat-history depth (0 = latest). |
+| `max_depth` | `number \| null` | No | Upper bound on chat-history depth. |
+| `trim_strings` | `string[]` | No | Additional substrings stripped from output after the regex pass. |
+| `run_on_edit` | `boolean` | No | Re-run the rule when a message is edited. |
+| `substitute_macros` | `"none" \| "raw" \| "escaped"` | No | How CBS / `{{...}}` macros inside the rule resolve. Default `"none"`. |
+| `disabled` | `boolean` | No | Create as disabled. |
+| `sort_order` | `number` | No | Lower values run earlier within the same scope tier. Default `0`. |
+| `description` | `string` | No | Free-form note. |
+| `folder` | `string` | No | Folder label shown in the regex panel. |
+| `metadata` | `Record<string, unknown>` | No | Arbitrary metadata namespaced to your extension. |
+| `script_id` | `string` | No | Stable identifier (normalized to lowercase + underscores) for cross-instance references. |
+
+## RegexScriptUpdateDTO
+
+Same fields as `RegexScriptCreateDTO`, all optional.
+
+## RegexScriptDTO
+
+```ts
+{
+  id: string
+  name: string
+  script_id: string             // stable, normalized identifier (lowercase, _-only)
+  find_regex: string
+  replace_string: string
+  flags: string                 // any subset of "gimsu"
+  placement: ("user_input" | "ai_output" | "world_info" | "reasoning")[]
+  scope: "global" | "character" | "chat"
+  scope_id: string | null       // character ID or chat ID when scoped
+  target: "prompt" | "response" | "display"
+  min_depth: number | null      // chat-history depth bound, or null
+  max_depth: number | null
+  trim_strings: string[]        // additional substrings stripped from output
+  run_on_edit: boolean
+  substitute_macros: "none" | "raw" | "escaped"
+  disabled: boolean
+  sort_order: number            // lower runs earlier within the same scope tier
+  description: string
+  folder: string
+  metadata: Record<string, unknown>
+  created_at: number            // unix epoch seconds
+  updated_at: number
+}
+```
+
+!!! note "Targets and where they fire"
+    - **`prompt`** rules run during prompt assembly, against each message before it goes to the LLM. They do not modify stored content.
+    - **`response`** rules run once after the LLM stream ends, against the full assistant message. The result is written back to chat storage.
+    - **`display`** rules run per render in the frontend. They do not modify stored content.
+
+!!! note "What `getActive` returns"
+    `getActive` mirrors the resolution Lumiverse uses internally during a generation: only enabled rules, only rules whose `target` matches, and only rules whose scope applies to the supplied context. Use `list` instead when you need the raw, unfiltered view (including disabled rules) for management or analytics.
+
+---
+
+## Reacting to changes
+
+Users can edit, reorder, enable, disable, and delete regex scripts at any time through the regex panel. Subscribe to the script lifecycle events to keep extension-side caches in sync.
+
+```ts
+spindle.on('REGEX_SCRIPT_CHANGED', (payload) => {
+  // payload: { id: string, script: RegexScriptDTO }
+  // fires on create, update, duplicate, reorder, and enable/disable.
+})
+
+spindle.on('REGEX_SCRIPT_DELETED', (payload) => {
+  // payload: { id: string }
+})
+```
+
+A common pattern: cache `spindle.regex_scripts.getActive(...)` per chat, invalidate the cache on either event, and re-fetch lazily on the next read.

--- a/src/services/regex-scripts.service.ts
+++ b/src/services/regex-scripts.service.ts
@@ -280,7 +280,7 @@ function normalizeScriptId(raw: string): string {
 export function listRegexScripts(
   userId: string,
   pagination: PaginationParams,
-  filters?: { scope?: RegexScope; target?: RegexTarget; character_id?: string; chat_id?: string }
+  filters?: { scope?: RegexScope; scope_id?: string; target?: RegexTarget; character_id?: string; chat_id?: string }
 ) {
   const conditions = ["user_id = ?"];
   const params: any[] = [userId];
@@ -288,6 +288,10 @@ export function listRegexScripts(
   if (filters?.scope) {
     conditions.push("scope = ?");
     params.push(filters.scope);
+  }
+  if (filters?.scope_id) {
+    conditions.push("scope_id = ?");
+    params.push(filters.scope_id);
   }
   if (filters?.target) {
     conditions.push("target = ?");

--- a/src/spindle/manager.service.ts
+++ b/src/spindle/manager.service.ts
@@ -272,6 +272,7 @@ export const PRIVILEGED_PERMISSIONS = new Set([
   "characters",
   "chats",
   "world_books",
+  "regex_scripts",
   "databanks",
   "personas",
   "push_notification",

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -12,6 +12,9 @@ import type {
   ChatDTO,
   WorldBookDTO,
   WorldBookEntryDTO,
+  RegexScriptDTO,
+  RegexScopeDTO,
+  RegexTargetDTO,
   DatabankDTO,
   DatabankDocumentDTO,
   DatabankDocumentCreateDTO,
@@ -55,6 +58,7 @@ import {
   setCharacterWorldBookIds,
 } from "../utils/character-world-books";
 import * as worldBooksSvc from "../services/world-books.service";
+import * as regexScriptsSvc from "../services/regex-scripts.service";
 import * as databanksSvc from "../services/databank";
 import * as filesSvc from "../services/files.service";
 import * as personasSvc from "../services/personas.service";
@@ -2319,6 +2323,39 @@ export class WorkerHost {
       // ─── Activated World Info (gated: "world_books") ─────────────────
       case "world_books_get_activated":
         this.handleWorldBooksGetActivated(msg.requestId, msg.chatId, msg.userId);
+        break;
+      // ─── Regex Scripts (gated: "regex_scripts") ──────────────────────
+      case "regex_scripts_list":
+        this.handleRegexScriptsList(
+          msg.requestId,
+          msg.scope,
+          msg.scopeId,
+          msg.target,
+          msg.limit,
+          msg.offset,
+          msg.userId,
+        );
+        break;
+      case "regex_scripts_get":
+        this.handleRegexScriptsGet(msg.requestId, msg.scriptId, msg.userId);
+        break;
+      case "regex_scripts_get_active":
+        this.handleRegexScriptsGetActive(
+          msg.requestId,
+          msg.target,
+          msg.characterId,
+          msg.chatId,
+          msg.userId,
+        );
+        break;
+      case "regex_scripts_create":
+        this.handleRegexScriptsCreate(msg.requestId, msg.input, msg.userId);
+        break;
+      case "regex_scripts_update":
+        this.handleRegexScriptsUpdate(msg.requestId, msg.scriptId, msg.input, msg.userId);
+        break;
+      case "regex_scripts_delete":
+        this.handleRegexScriptsDelete(msg.requestId, msg.scriptId, msg.userId);
         break;
       // ─── Databanks (gated: "databanks") ─────────────────────────────
       case "databanks_list":
@@ -6919,6 +6956,186 @@ export class WorkerHost {
       }));
 
       this.postToWorker({ type: "response", requestId, result });
+    } catch (err: any) {
+      this.postToWorker({ type: "response", requestId, error: err.message });
+    }
+  }
+
+  // ─── Regex Scripts (gated: "regex_scripts") ──────────────────────────
+
+  private toRegexScriptDTO(s: any): RegexScriptDTO {
+    return {
+      id: s.id,
+      name: s.name,
+      script_id: s.script_id || "",
+      find_regex: s.find_regex,
+      replace_string: s.replace_string,
+      flags: s.flags,
+      placement: s.placement,
+      scope: s.scope,
+      scope_id: s.scope_id,
+      target: s.target,
+      min_depth: s.min_depth,
+      max_depth: s.max_depth,
+      trim_strings: s.trim_strings,
+      run_on_edit: !!s.run_on_edit,
+      substitute_macros: s.substitute_macros,
+      disabled: !!s.disabled,
+      sort_order: s.sort_order,
+      description: s.description || "",
+      folder: s.folder || "",
+      metadata: s.metadata || {},
+      created_at: s.created_at,
+      updated_at: s.updated_at,
+    };
+  }
+
+  private handleRegexScriptsList(
+    requestId: string,
+    scope?: RegexScopeDTO,
+    scopeId?: string,
+    target?: RegexTargetDTO,
+    limit?: number,
+    offset?: number,
+    userId?: string,
+  ): void {
+    try {
+      if (!managerSvc.hasPermission(this.manifest.identifier, "regex_scripts")) {
+        throw new Error(`${PERMISSION_DENIED_PREFIX} regex_scripts — Regex Scripts permission not granted`);
+      }
+      const resolvedUserId = this.resolveEffectiveUserId(userId);
+      if (!resolvedUserId) throw new Error("userId is required for operator-scoped extensions");
+      this.enforceScopedUser(resolvedUserId);
+
+      if (scope !== undefined && scope !== "global" && scope !== "character" && scope !== "chat") {
+        throw new Error("scope must be 'global', 'character', or 'chat'");
+      }
+      if (target !== undefined && target !== "prompt" && target !== "response" && target !== "display") {
+        throw new Error("target must be 'prompt', 'response', or 'display'");
+      }
+
+      const filters: { scope?: RegexScopeDTO; scope_id?: string; target?: RegexTargetDTO } = {};
+      if (target) filters.target = target;
+      if (scope) filters.scope = scope;
+      if (scopeId) filters.scope_id = scopeId;
+
+      const result = regexScriptsSvc.listRegexScripts(
+        resolvedUserId,
+        { limit: Math.min(limit || 50, 200), offset: offset || 0 },
+        filters,
+      );
+      this.postToWorker({
+        type: "response",
+        requestId,
+        result: {
+          data: result.data.map((s) => this.toRegexScriptDTO(s)),
+          total: result.total,
+        },
+      });
+    } catch (err: any) {
+      this.postToWorker({ type: "response", requestId, error: err.message });
+    }
+  }
+
+  private handleRegexScriptsGet(requestId: string, scriptId: string, userId?: string): void {
+    try {
+      if (!managerSvc.hasPermission(this.manifest.identifier, "regex_scripts")) {
+        throw new Error(`${PERMISSION_DENIED_PREFIX} regex_scripts — Regex Scripts permission not granted`);
+      }
+      const resolvedUserId = this.resolveEffectiveUserId(userId);
+      if (!resolvedUserId) throw new Error("userId is required for operator-scoped extensions");
+      this.enforceScopedUser(resolvedUserId);
+
+      const s = regexScriptsSvc.getRegexScript(resolvedUserId, scriptId);
+      this.postToWorker({ type: "response", requestId, result: s ? this.toRegexScriptDTO(s) : null });
+    } catch (err: any) {
+      this.postToWorker({ type: "response", requestId, error: err.message });
+    }
+  }
+
+  private handleRegexScriptsGetActive(
+    requestId: string,
+    target: RegexTargetDTO,
+    characterId?: string,
+    chatId?: string,
+    userId?: string,
+  ): void {
+    try {
+      if (!managerSvc.hasPermission(this.manifest.identifier, "regex_scripts")) {
+        throw new Error(`${PERMISSION_DENIED_PREFIX} regex_scripts — Regex Scripts permission not granted`);
+      }
+      const resolvedUserId = this.resolveEffectiveUserId(userId);
+      if (!resolvedUserId) throw new Error("userId is required for operator-scoped extensions");
+      this.enforceScopedUser(resolvedUserId);
+
+      if (target !== "prompt" && target !== "response" && target !== "display") {
+        throw new Error("target must be 'prompt', 'response', or 'display'");
+      }
+
+      const scripts = regexScriptsSvc.getActiveScripts(resolvedUserId, { characterId, chatId, target });
+      this.postToWorker({
+        type: "response",
+        requestId,
+        result: scripts.map((s) => this.toRegexScriptDTO(s)),
+      });
+    } catch (err: any) {
+      this.postToWorker({ type: "response", requestId, error: err.message });
+    }
+  }
+
+  private handleRegexScriptsCreate(requestId: string, input: any, userId?: string): void {
+    try {
+      if (!managerSvc.hasPermission(this.manifest.identifier, "regex_scripts")) {
+        throw new Error(`${PERMISSION_DENIED_PREFIX} regex_scripts — Regex Scripts permission not granted`);
+      }
+      const resolvedUserId = this.resolveEffectiveUserId(userId);
+      if (!resolvedUserId) throw new Error("userId is required for operator-scoped extensions");
+      this.enforceScopedUser(resolvedUserId);
+
+      if (!input?.name || typeof input.name !== "string" || !input.name.trim()) {
+        throw new Error("Regex script name is required");
+      }
+      if (typeof input.find_regex !== "string") {
+        throw new Error("find_regex is required");
+      }
+
+      const result = regexScriptsSvc.createRegexScript(resolvedUserId, input);
+      if (typeof result === "string") throw new Error(result);
+      this.postToWorker({ type: "response", requestId, result: this.toRegexScriptDTO(result) });
+    } catch (err: any) {
+      this.postToWorker({ type: "response", requestId, error: err.message });
+    }
+  }
+
+  private handleRegexScriptsUpdate(requestId: string, scriptId: string, input: any, userId?: string): void {
+    try {
+      if (!managerSvc.hasPermission(this.manifest.identifier, "regex_scripts")) {
+        throw new Error(`${PERMISSION_DENIED_PREFIX} regex_scripts — Regex Scripts permission not granted`);
+      }
+      const resolvedUserId = this.resolveEffectiveUserId(userId);
+      if (!resolvedUserId) throw new Error("userId is required for operator-scoped extensions");
+      this.enforceScopedUser(resolvedUserId);
+
+      const result = regexScriptsSvc.updateRegexScript(resolvedUserId, scriptId, input || {});
+      if (result === null) throw new Error("Regex script not found");
+      if (typeof result === "string") throw new Error(result);
+      this.postToWorker({ type: "response", requestId, result: this.toRegexScriptDTO(result) });
+    } catch (err: any) {
+      this.postToWorker({ type: "response", requestId, error: err.message });
+    }
+  }
+
+  private handleRegexScriptsDelete(requestId: string, scriptId: string, userId?: string): void {
+    try {
+      if (!managerSvc.hasPermission(this.manifest.identifier, "regex_scripts")) {
+        throw new Error(`${PERMISSION_DENIED_PREFIX} regex_scripts — Regex Scripts permission not granted`);
+      }
+      const resolvedUserId = this.resolveEffectiveUserId(userId);
+      if (!resolvedUserId) throw new Error("userId is required for operator-scoped extensions");
+      this.enforceScopedUser(resolvedUserId);
+
+      const deleted = regexScriptsSvc.deleteRegexScript(resolvedUserId, scriptId);
+      this.postToWorker({ type: "response", requestId, result: deleted });
     } catch (err: any) {
       this.postToWorker({ type: "response", requestId, error: err.message });
     }

--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -26,6 +26,11 @@ import type {
   WorldBookEntryDTO,
   WorldBookEntryCreateDTO,
   WorldBookEntryUpdateDTO,
+  RegexScriptDTO,
+  RegexScriptCreateDTO,
+  RegexScriptUpdateDTO,
+  RegexScriptListOptionsDTO,
+  RegexScriptActiveOptionsDTO,
   DatabankDTO,
   DatabankCreateDTO,
   DatabankUpdateDTO,
@@ -1918,6 +1923,58 @@ const spindleApi: RuntimeSpindleAPI = {
         userId,
       });
       return result as import("lumiverse-spindle-types").ActivatedWorldInfoEntryDTO[];
+    },
+  },
+
+  regex_scripts: {
+    async list(options?: RegexScriptListOptionsDTO): Promise<{ data: RegexScriptDTO[]; total: number }> {
+      const requestId = crypto.randomUUID();
+      const result = await request({
+        type: "regex_scripts_list",
+        requestId,
+        scope: options?.scope,
+        scopeId: options?.scopeId,
+        target: options?.target,
+        limit: options?.limit,
+        offset: options?.offset,
+        userId: options?.userId,
+      });
+      return result as { data: RegexScriptDTO[]; total: number };
+    },
+    async get(scriptId: string, userId?: string): Promise<RegexScriptDTO | null> {
+      const requestId = crypto.randomUUID();
+      const result = await request({ type: "regex_scripts_get", requestId, scriptId, userId });
+      return result as RegexScriptDTO | null;
+    },
+    async create(input: RegexScriptCreateDTO, userId?: string): Promise<RegexScriptDTO> {
+      assertMutationAllowed("spindle.regex_scripts.create()");
+      const requestId = crypto.randomUUID();
+      const result = await request({ type: "regex_scripts_create", requestId, input, userId });
+      return result as RegexScriptDTO;
+    },
+    async update(scriptId: string, input: RegexScriptUpdateDTO, userId?: string): Promise<RegexScriptDTO> {
+      assertMutationAllowed("spindle.regex_scripts.update()");
+      const requestId = crypto.randomUUID();
+      const result = await request({ type: "regex_scripts_update", requestId, scriptId, input, userId });
+      return result as RegexScriptDTO;
+    },
+    async delete(scriptId: string, userId?: string): Promise<boolean> {
+      assertMutationAllowed("spindle.regex_scripts.delete()");
+      const requestId = crypto.randomUUID();
+      const result = await request({ type: "regex_scripts_delete", requestId, scriptId, userId });
+      return result as boolean;
+    },
+    async getActive(options: RegexScriptActiveOptionsDTO): Promise<RegexScriptDTO[]> {
+      const requestId = crypto.randomUUID();
+      const result = await request({
+        type: "regex_scripts_get_active",
+        requestId,
+        target: options.target,
+        characterId: options.characterId,
+        chatId: options.chatId,
+        userId: options.userId,
+      });
+      return result as RegexScriptDTO[];
     },
   },
 

--- a/user-docs/docs/extensions/index.md
+++ b/user-docs/docs/extensions/index.md
@@ -55,6 +55,7 @@ Extensions request specific permissions for what they can access:
 | **Characters** | Read/write character data |
 | **Chats** | Read/write chat data |
 | **World Books** | Read/write world book data |
+| **Regex Scripts** | Read/write regex scripts (find/replace rules) |
 | **Personas** | Read/write persona data |
 | **CORS Proxy** | Make HTTP requests through the server |
 | **Interceptor** | Modify prompts before generation |


### PR DESCRIPTION
Please dress up as you see fit <3

This PR adds 1 read/write API namespace + plumbs 2 existing internal events. Mirrors the world_books / databanks shape. Existing extensions and Lumi behaviour are unchanged.

- 6388479a21aa0174ddaec136d81841ae868b0a56 Adds `spindle.regex_scripts` gated on a new `regex_scripts` privileged permission with `list / get / create / update / delete` plus `getActive` (mirrors Lumi's internal `getActiveScripts` resolver). Also exposes the existing internal `REGEX_SCRIPT_CHANGED` / `_DELETED` events through `CoreEventType` so extensions can react to user edits without polling.

## Update spindle types
The PR is Here: https://github.com/prolix-oc/lumiverse-spindle-types/pull/7
