### PR TITLE
Smarter display regex cache invalidation

### DIFF
--- a/developer-docs/docs/backend-api/macros.md
+++ b/developer-docs/docs/backend-api/macros.md
@@ -67,6 +67,16 @@ This is primarily useful when your macro has separate display-only and state-mut
 | `returnType` | `"string" \| "integer" \| "number" \| "boolean"` | Optional. Default: `"string"` |
 | `args` | `Array<{ name, description?, required? }>` | Optional argument definitions |
 | `handler` | `function \| ""` | Optional macro handler. Use a function for pull-model macros, or an empty string when using the push model. |
+| `volatile` | `boolean` | Optional. Set `true` when the macro returns different output across calls with the same args (time, randomness, idle duration, etc.) so the display-regex cache doesn't store the result as static. |
+
+!!! note "Reading variables inside a handler"
+    If your handler reads `ctx.env.variables.local` (or `.global`/`.chat`), use `.get(key)` and `.has(key)`. Iteration (`.entries()`, `.keys()`, `for...of`) isn't recorded in the per-resolution dependency fingerprint, so the cached output may be stale longer than expected when those vars change.
+
+!!! note "When to set `volatile: true`"
+    Set the flag when the handler's output isn't a pure function of its args and tracked env reads.
+    **Needs the flag:** time based output (`Date.now()`, `new Date()`), random output (`Math.random()`), stateful side effects (read then write to a var, mutable internal counters), or external calls (HTTP, files, anything outside the env).
+    **Doesn't need the flag (auto invalidates):** variable reads via `.get(key)` / `.has(key)` (the fingerprint records the dependency and the cache invalidates when that var changes), static fields on `env` (character, persona, scenario), and computed-from-tracked-inputs handlers (math, conditionals, string ops) where args evaluate through the same fingerprint mechanism so dependencies propagate.
+    Rule of thumb: if the handler only touches `ctx.args` and `env.variables.<scope>.get(...)`, leave the flag off. If it reaches for `Date`, `Math.random`, or mutates state, set it.
 
 ## Methods
 

--- a/frontend/src/hooks/useDisplayRegex.ts
+++ b/frontend/src/hooks/useDisplayRegex.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import { useStore } from '@/store'
 import { applyDisplayRegex, applyDisplayRegexAsync } from '@/lib/regex/compiler'
 import { resolveMacrosBatch } from '@/api/macros'
@@ -20,6 +20,8 @@ interface DisplayRegexCacheEntry {
 interface DisplayRegexContentCacheEntry {
   value?: string
   promise?: Promise<string>
+  touchedVars?: ReadonlySet<string>
+  messageId?: string
 }
 
 export interface DisplayPreprocessOpts {
@@ -46,11 +48,22 @@ interface SlowRegexReport {
 
 const displayRegexResolutionCache = new Map<string, DisplayRegexCacheEntry>()
 const displayRegexContentCache = new Map<string, DisplayRegexContentCacheEntry>()
-const displayPreprocessCache = new Map<string, { value?: string; promise?: Promise<string> }>()
+const displayPreprocessCache = new Map<string, { value?: string; promise?: Promise<string>; touchedVars?: ReadonlySet<string>; messageId?: string }>()
 const DISPLAY_PREPROCESS_CACHE_MAX = 500
 const displayRegexCacheListeners = new Set<() => void>()
-let displayRegexCacheVersion = 0
+let displayRegexGlobalCv = 0
+const displayRegexPerMessageCv = new Map<string, number>()
 const slowDisplayRegexToastKeys = new Set<string>()
+
+function bumpGlobalCv(): void {
+  displayRegexGlobalCv += 1
+  for (const listener of displayRegexCacheListeners) listener()
+}
+
+function bumpPerMessageCv(messageId: string): void {
+  displayRegexPerMessageCv.set(messageId, (displayRegexPerMessageCv.get(messageId) ?? 0) + 1)
+  for (const listener of displayRegexCacheListeners) listener()
+}
 
 function formatElapsedMs(elapsedMs: number): string {
   if (elapsedMs >= 1000) return `${(elapsedMs / 1000).toFixed(1)}s`
@@ -110,16 +123,21 @@ export function useDisplayPreprocessed(
   chatId: string | null,
   opts: DisplayPreprocessOpts | undefined,
 ): string {
-  const cacheVersion = useSyncExternalStore(
+  const messageIdForSnapshot = opts?.messageId ?? null
+  const getSnapshotForThisMessage = useCallback(
+    () => getDisplayRegexCacheSnapshot(messageIdForSnapshot),
+    [messageIdForSnapshot],
+  )
+  const cvSnapshot = useSyncExternalStore(
     subscribeDisplayRegexCache,
-    getDisplayRegexCacheVersion,
-    getDisplayRegexCacheVersion,
+    getSnapshotForThisMessage,
+    getSnapshotForThisMessage,
   )
 
   const key = useMemo(() => {
     if (!opts?.messageId || !chatId) return null
-    return `${cacheVersion}|${chatId}|${opts.messageId}|${opts.role}|${content.length}|${fnv1a(content)}`
-  }, [content, opts?.messageId, opts?.role, chatId, cacheVersion])
+    return `${chatId}|${opts.messageId}|${opts.role}|${content.length}|${fnv1a(content)}`
+  }, [content, opts?.messageId, opts?.role, chatId])
 
   const cached = key ? displayPreprocessCache.get(key)?.value : undefined
   const [state, setState] = useState<{ key: string; value: string } | null>(() =>
@@ -145,32 +163,39 @@ export function useDisplayPreprocessed(
       return () => { cancelled = true }
     }
     if (!existing?.promise) {
+      const messageIdForEntry = opts.messageId
+      let assignedPromise: Promise<string>
       const promise = fetchDisplayPreprocess(chatId, {
         messageId: opts.messageId,
         role: opts.role,
         rawContent: content,
       })
         .then((next) => {
-          displayPreprocessCache.set(key, { value: next })
-          if (displayPreprocessCache.size > DISPLAY_PREPROCESS_CACHE_MAX) {
-            const drop = displayPreprocessCache.size - DISPLAY_PREPROCESS_CACHE_MAX
-            let i = 0
-            for (const k of displayPreprocessCache.keys()) {
-              if (i++ >= drop) break
-              displayPreprocessCache.delete(k)
+          if (displayPreprocessCache.get(key)?.promise === assignedPromise) {
+            displayPreprocessCache.set(key, { value: next, messageId: messageIdForEntry })
+            if (displayPreprocessCache.size > DISPLAY_PREPROCESS_CACHE_MAX) {
+              const drop = displayPreprocessCache.size - DISPLAY_PREPROCESS_CACHE_MAX
+              let i = 0
+              for (const k of displayPreprocessCache.keys()) {
+                if (i++ >= drop) break
+                displayPreprocessCache.delete(k)
+              }
             }
           }
           return next
         })
         .catch(() => {
-          displayPreprocessCache.delete(key)
+          if (displayPreprocessCache.get(key)?.promise === assignedPromise) {
+            displayPreprocessCache.delete(key)
+          }
           return content
         })
-      displayPreprocessCache.set(key, { promise })
+      assignedPromise = promise
+      displayPreprocessCache.set(key, { promise, messageId: messageIdForEntry })
     }
     displayPreprocessCache.get(key)?.promise?.then(apply)
     return () => { cancelled = true }
-  }, [key, opts?.messageId, opts?.role, chatId, content])
+  }, [key, opts?.messageId, opts?.role, chatId, content, cvSnapshot])
 
   if (!key) return content
   if (cached !== undefined) return cached
@@ -200,16 +225,64 @@ function subscribeDisplayRegexCache(listener: () => void): () => void {
   return () => displayRegexCacheListeners.delete(listener)
 }
 
-function getDisplayRegexCacheVersion(): number {
-  return displayRegexCacheVersion
+function getDisplayRegexCacheSnapshot(messageId: string | null): string {
+  const perMsg = messageId ? (displayRegexPerMessageCv.get(messageId) ?? 0) : 0
+  return `${displayRegexGlobalCv}|${perMsg}`
 }
 
 export function invalidateDisplayRegexCache(): void {
-  displayRegexCacheVersion += 1
   displayRegexResolutionCache.clear()
   displayRegexContentCache.clear()
   displayPreprocessCache.clear()
-  for (const listener of displayRegexCacheListeners) listener()
+  bumpGlobalCv()
+}
+
+export function invalidateDisplayRegexCacheForMessage(messageId: string): void {
+  let removed = 0
+  for (const [key, entry] of displayRegexContentCache) {
+    if (entry.messageId === messageId) { displayRegexContentCache.delete(key); removed++ }
+  }
+  for (const [key, entry] of displayPreprocessCache) {
+    if (entry.messageId === messageId) { displayPreprocessCache.delete(key); removed++ }
+  }
+  if (removed > 0) bumpPerMessageCv(messageId)
+}
+
+export function invalidateDisplayRegexCacheForVars(changedVars: ReadonlySet<string>): void {
+  if (changedVars.size === 0) return
+  const affectedMessages = new Set<string>()
+  for (const [key, entry] of displayRegexContentCache) {
+    const fp = entry.touchedVars
+    if (!fp) {
+      displayRegexContentCache.delete(key)
+      if (entry.messageId) affectedMessages.add(entry.messageId)
+      continue
+    }
+    for (const v of fp) {
+      if (changedVars.has(v)) {
+        displayRegexContentCache.delete(key)
+        if (entry.messageId) affectedMessages.add(entry.messageId)
+        break
+      }
+    }
+  }
+  for (const [key, entry] of displayPreprocessCache) {
+    const fp = entry.touchedVars
+    if (!fp) {
+      displayPreprocessCache.delete(key)
+      if (entry.messageId) affectedMessages.add(entry.messageId)
+      continue
+    }
+    for (const v of fp) {
+      if (changedVars.has(v)) {
+        displayPreprocessCache.delete(key)
+        if (entry.messageId) affectedMessages.add(entry.messageId)
+        break
+      }
+    }
+  }
+  displayRegexResolutionCache.clear()
+  for (const messageId of affectedMessages) bumpPerMessageCv(messageId)
 }
 
 async function resolveMacrosBatchChunked(
@@ -252,10 +325,15 @@ export function useDisplayRegex(
     if (!preprocessOpts?.messageId) return -1
     return s.messages.findIndex((m) => m.id === preprocessOpts.messageId)
   })
-  const cacheVersion = useSyncExternalStore(
+  const messageIdForSnapshot = preprocessOpts?.messageId ?? null
+  const getSnapshotForThisMessage = useCallback(
+    () => getDisplayRegexCacheSnapshot(messageIdForSnapshot),
+    [messageIdForSnapshot],
+  )
+  const cvSnapshot = useSyncExternalStore(
     subscribeDisplayRegexCache,
-    getDisplayRegexCacheVersion,
-    getDisplayRegexCacheVersion,
+    getSnapshotForThisMessage,
+    getSnapshotForThisMessage,
   )
 
   const dynamicMacros = useMemo(() => {
@@ -305,7 +383,6 @@ export function useDisplayRegex(
     if (templateEntries.length === 0) return null
 
     return JSON.stringify({
-      cacheVersion,
       activeChatId,
       activeCharacterId,
       activePersonaId,
@@ -317,7 +394,7 @@ export function useDisplayRegex(
         s.substitute_macros,
       ]),
     })
-  }, [scriptsNeedingResolution, activeChatId, activeCharacterId, activePersonaId, cacheVersion])
+  }, [scriptsNeedingResolution, activeChatId, activeCharacterId, activePersonaId])
 
   const cachedTemplates = templateCacheKey ? displayRegexResolutionCache.get(templateCacheKey)?.value : undefined
   const [resolvedTemplatesState, setResolvedTemplatesState] = useState<ResolvedTemplatesState | null>(() => (
@@ -365,6 +442,7 @@ export function useDisplayRegex(
     }
 
     if (!cached?.promise) {
+      let assignedPromise: Promise<ResolvedDisplayRegexTemplates>
       const promise = resolveMacrosBatch({
         templates,
         chat_id: activeChatId ?? undefined,
@@ -380,13 +458,18 @@ export function useDisplayRegex(
               next.resolvedReplacements.set(key.slice(8), value)
             }
           }
-          displayRegexResolutionCache.set(templateCacheKey, { value: next })
+          if (displayRegexResolutionCache.get(templateCacheKey)?.promise === assignedPromise) {
+            displayRegexResolutionCache.set(templateCacheKey, { value: next })
+          }
           return next
         })
         .catch(() => {
-          displayRegexResolutionCache.delete(templateCacheKey)
+          if (displayRegexResolutionCache.get(templateCacheKey)?.promise === assignedPromise) {
+            displayRegexResolutionCache.delete(templateCacheKey)
+          }
           return createEmptyResolvedTemplates()
         })
+      assignedPromise = promise
 
       displayRegexResolutionCache.set(templateCacheKey, { promise })
     }
@@ -445,7 +528,6 @@ export function useDisplayRegex(
     if (displayScripts.length === 0 || !hasRawMacroScripts) return null
 
     return JSON.stringify({
-      cacheVersion,
       activeChatId,
       activeCharacterId,
       activePersonaId,
@@ -472,7 +554,6 @@ export function useDisplayRegex(
   }, [
     displayScripts,
     hasRawMacroScripts,
-    cacheVersion,
     activeChatId,
     activeCharacterId,
     activePersonaId,
@@ -504,6 +585,11 @@ export function useDisplayRegex(
     }
 
     if (!cached?.promise) {
+      // Captured once so the .then/.catch handlers can verify the cache
+      // entry hasn't been replaced or invalidated by a CHAT_CHANGED in flight.
+      // Without this guard, an invalidation between the initial set and the
+      // resolve would let the stale fetch result clobber the live key.
+      let assignedPromise: Promise<string>
       const promise = applyDisplayRegexAsync(
         content,
         displayScripts,
@@ -524,16 +610,32 @@ export function useDisplayRegex(
           persona_id: activePersonaId ?? undefined,
         }),
       )
-        .then((next) => {
-          displayRegexContentCache.set(contentCacheKey, { value: next })
+        .then(({ result: next, touchedVars, cacheable }) => {
+          if (displayRegexContentCache.get(contentCacheKey)?.promise === assignedPromise) {
+            if (cacheable !== false) {
+              displayRegexContentCache.set(contentCacheKey, {
+                value: next,
+                ...(touchedVars ? { touchedVars } : {}),
+                ...(preprocessOpts?.messageId ? { messageId: preprocessOpts.messageId } : {}),
+              })
+            } else {
+              displayRegexContentCache.delete(contentCacheKey)
+            }
+          }
           return next
         })
         .catch(() => {
-          displayRegexContentCache.delete(contentCacheKey)
+          if (displayRegexContentCache.get(contentCacheKey)?.promise === assignedPromise) {
+            displayRegexContentCache.delete(contentCacheKey)
+          }
           return fallbackContent
         })
+      assignedPromise = promise
 
-      displayRegexContentCache.set(contentCacheKey, { promise })
+      displayRegexContentCache.set(contentCacheKey, {
+        promise,
+        ...(preprocessOpts?.messageId ? { messageId: preprocessOpts.messageId } : {}),
+      })
     }
 
     displayRegexContentCache.get(contentCacheKey)?.promise?.then(applyResolvedContent)
@@ -554,6 +656,7 @@ export function useDisplayRegex(
     activePersonaId,
     contentCacheKey,
     dynamicMacros,
+    cvSnapshot,
   ])
 
   // Carry the previous resolved value forward across cv-bumps and per-chunk

--- a/frontend/src/hooks/useDisplayRegex.ts
+++ b/frontend/src/hooks/useDisplayRegex.ts
@@ -204,7 +204,7 @@ export function useDisplayPreprocessed(
   return content
 }
 
-const RAW_MACRO_RE = /\{\{(?!\s*(?:user|char|bot|notChar|not_char|charName)\s*\}\})/
+const RAW_MACRO_RE = /\{\{(?!\s*(?:user|char|bot|notChar|not_char|charName)\s*\}\})/i
 
 /** Quick check for macro syntax in a string. */
 function hasMacroSyntax(s: string): boolean {
@@ -672,6 +672,11 @@ export function useDisplayRegex(
   const staleResolved = stale && (stale.content === content || RAW_MACRO_RE.test(fallbackContent))
     ? stale.value
     : undefined
+
+  // No stale to carry forward (first render of a streaming bubble), so raw input renders cleaner than panel HTML with unresolved macros.
+  if (liveResolved === undefined && staleResolved === undefined && RAW_MACRO_RE.test(fallbackContent)) {
+    return content
+  }
 
   return liveResolved ?? staleResolved ?? fallbackContent
 }

--- a/frontend/src/lib/regex/compiler.ts
+++ b/frontend/src/lib/regex/compiler.ts
@@ -168,11 +168,17 @@ function mapToRecord(map?: Map<string, string>): Record<string, string> | undefi
   return Object.fromEntries(map.entries())
 }
 
+export interface DisplayRegexBackendResult {
+  result: string
+  touchedVars?: ReadonlySet<string>
+  cacheable?: boolean
+}
+
 async function applyDisplayRegexOnBackend(
   content: string,
   scripts: RegexScript[],
   context: ApplyDisplayRegexContext,
-): Promise<string | null> {
+): Promise<DisplayRegexBackendResult | null> {
   try {
     const res = await fetch('/api/v1/regex-scripts/apply', {
       method: 'POST',
@@ -194,8 +200,13 @@ async function applyDisplayRegexOnBackend(
       }),
     })
     if (!res.ok) return null
-    const body = await res.json() as { result?: string }
-    return typeof body.result === 'string' ? body.result : null
+    const body = await res.json() as { result?: string; touched_vars?: string[]; cacheable?: boolean }
+    if (typeof body.result !== 'string') return null
+    return {
+      result: body.result,
+      touchedVars: Array.isArray(body.touched_vars) ? new Set(body.touched_vars) : undefined,
+      cacheable: typeof body.cacheable === 'boolean' ? body.cacheable : undefined,
+    }
   } catch {
     return null
   }
@@ -293,7 +304,7 @@ export async function applyDisplayRegexAsync(
   scripts: RegexScript[],
   context: ApplyDisplayRegexContext,
   resolveRawTemplates: (templates: Record<string, string>) => Promise<Record<string, string>>,
-): Promise<string> {
+): Promise<DisplayRegexBackendResult> {
   const backendResult = await applyDisplayRegexOnBackend(content, scripts, context)
   if (backendResult !== null) return backendResult
 
@@ -375,5 +386,5 @@ export async function applyDisplayRegexAsync(
     }
   }
 
-  return result
+  return { result, cacheable: false }
 }

--- a/frontend/src/types/ws-events.ts
+++ b/frontend/src/types/ws-events.ts
@@ -298,6 +298,10 @@ export interface ChatChangedPayload {
   chat?: import('./api').Chat
   chatId?: string
   reattributedUserMessages?: number
+  /** Dot-paths of fields that differ between prior and new chat row.
+   *  Optional; older servers omit it, in which case consumers fall back
+   *  to treating the chat as fully changed. */
+  changedFields?: string[]
 }
 
 export interface ChatSwitchedPayload {

--- a/frontend/src/ws/useWebSocket.ts
+++ b/frontend/src/ws/useWebSocket.ts
@@ -10,7 +10,11 @@ import { imageGenApi } from '@/api/image-gen'
 import { generateApi } from '@/api/generate'
 import { operatorApi } from '@/api/operator'
 import { toast } from '@/lib/toast'
-import { invalidateDisplayRegexCache } from '@/hooks/useDisplayRegex'
+import {
+  invalidateDisplayRegexCache,
+  invalidateDisplayRegexCacheForMessage,
+  invalidateDisplayRegexCacheForVars,
+} from '@/hooks/useDisplayRegex'
 import { triggerTTSAutoPlay } from '@/hooks/useTTSAutoPlay'
 import { recoverPooledGeneration } from '@/lib/generation-recovery'
 import type {
@@ -43,6 +47,35 @@ function isLocalStreamPlaceholderId(id: string | null | undefined) {
     id.startsWith(LOCAL_STREAM_PLACEHOLDER_PREFIX)
     || id.startsWith(LOCAL_REGEN_PLACEHOLDER_PREFIX)
   )
+}
+
+const MACRO_VARS_PREFIX = 'metadata.macro_variables.'
+const CHAT_VARS_PREFIX = 'metadata.chat_variables.'
+
+interface VarChangeSummary {
+  bagWideVarChange: boolean
+  changedVars: ReadonlySet<string>
+}
+
+function summarizeVarChanges(changedFields: readonly string[]): VarChangeSummary {
+  const changedVars = new Set<string>()
+  let sawBareBag = false
+  for (const f of changedFields) {
+    if (f === 'metadata.macro_variables' || f === 'metadata.chat_variables') {
+      sawBareBag = true
+      continue
+    }
+    if (f.startsWith(MACRO_VARS_PREFIX)) {
+      const tail = f.slice(MACRO_VARS_PREFIX.length)
+      const dot = tail.indexOf('.')
+      if (dot > 0) changedVars.add(`${tail.slice(0, dot)}:${tail.slice(dot + 1)}`)
+    } else if (f.startsWith(CHAT_VARS_PREFIX)) {
+      changedVars.add(`chat:${f.slice(CHAT_VARS_PREFIX.length)}`)
+    }
+  }
+  // Bare bag path is bag-wide only when no leaves describe the change (BE emits both).
+  const bagWideVarChange = sawBareBag && changedVars.size === 0
+  return { bagWideVarChange, changedVars }
 }
 
 /**
@@ -127,7 +160,7 @@ export function useWebSocket() {
       wsClient.on(EventType.MESSAGE_SENT, (payload: MessageSentPayload) => {
         const state = store.getState()
         if (payload.chatId === state.activeChatId) {
-          invalidateDisplayRegexCache()
+          if (payload.message?.id) invalidateDisplayRegexCacheForMessage(payload.message.id)
 
           // Suppress completed assistant messages while streaming — the streaming
           // card already displays the content. GENERATION_ENDED will reconcile
@@ -169,7 +202,7 @@ export function useWebSocket() {
       wsClient.on(EventType.MESSAGE_EDITED, (payload: MessageEditedPayload) => {
         const state = store.getState()
         if (payload.chatId === state.activeChatId) {
-          invalidateDisplayRegexCache()
+          if (payload.message?.id) invalidateDisplayRegexCacheForMessage(payload.message.id)
 
           // During a continue, the backend updates the target message with combined
           // content right before GENERATION_ENDED. Skip the update while streaming
@@ -190,7 +223,7 @@ export function useWebSocket() {
         const state = store.getState()
         if (payload.chatId === state.activeChatId) {
           state.removeMessage(payload.messageId)
-          invalidateDisplayRegexCache()
+          if (payload.messageId) invalidateDisplayRegexCacheForMessage(payload.messageId)
         }
       }),
 
@@ -198,14 +231,26 @@ export function useWebSocket() {
         const state = store.getState()
         if (payload.chatId === state.activeChatId) {
           state.updateMessage(payload.message.id, payload.message)
-          invalidateDisplayRegexCache()
+          if (payload.message?.id) invalidateDisplayRegexCacheForMessage(payload.message.id)
         }
       }),
 
       wsClient.on(EventType.CHAT_CHANGED, (payload: ChatChangedPayload) => {
         const state = store.getState()
         const changedChatId = payload.chat?.id ?? payload.chatId
-        if (changedChatId === state.activeChatId) {
+        if (changedChatId !== state.activeChatId) return
+
+        const changedFields = payload.changedFields
+        if (changedFields === undefined) {
+          invalidateDisplayRegexCache()
+          return
+        }
+        const { bagWideVarChange, changedVars } = summarizeVarChanges(changedFields)
+        if (changedVars.size > 0 && !bagWideVarChange) {
+          invalidateDisplayRegexCacheForVars(changedVars)
+          return
+        }
+        if (bagWideVarChange) {
           invalidateDisplayRegexCache()
         }
       }),

--- a/src/macros/MacroEvaluator.ts
+++ b/src/macros/MacroEvaluator.ts
@@ -34,12 +34,12 @@ export async function evaluate(
   registry: MacroRegistry,
   options?: EvaluateOptions,
 ): Promise<EvaluateResult> {
-  if (!input) return { text: "", diagnostics: [] };
+  if (!input) return { text: "", diagnostics: [], touchedVars: EMPTY_TOUCHED_VARS, cacheable: true };
 
   // Fast-path: skip the entire lex/parse/evaluate pipeline when there are
   // no macro markers in the input (the vast majority of stored chat messages).
   if (!HAS_MACRO_RE.test(input)) {
-    return { text: input, diagnostics: [] };
+    return { text: input, diagnostics: [], touchedVars: EMPTY_TOUCHED_VARS, cacheable: true };
   }
 
   // Pre-process: legacy syntax conversion
@@ -53,6 +53,11 @@ export async function evaluate(
   const phase = options?.phase ?? "other";
   const sourceHint = options?.sourceHint;
 
+  // Fingerprint accumulator. Wrapped env records var reads via
+  // env.variables.*.get/has; volatile macros flip cacheable=false.
+  const fingerprint = { touched: new Set<string>(), cacheable: true };
+  const recordingEnv = wrapEnvForFingerprint(env, fingerprint);
+
   // Iterative evaluation: most macros are now recursively expanded inline
   // (see evaluateMacroNode). The outer loop acts as a safety net for the
   // rare case where a macro result depends on state mutated by a later macro
@@ -62,6 +67,7 @@ export async function evaluate(
     if (env.signal?.aborted) throw env.signal.reason ?? new DOMException("Aborted", "AbortError");
 
     if (runInterceptors) {
+      const beforeInterceptor = text;
       text = await macroInterceptorChain.run({
         template: text,
         env: snapshotEnvForInterceptor(env),
@@ -70,11 +76,12 @@ export async function evaluate(
         ...(sourceHint ? { sourceHint } : {}),
         ...(userId !== undefined ? { userId } : {}),
       });
+      if (text !== beforeInterceptor) fingerprint.cacheable = false;
       if (!text.includes("{{")) break;
     }
 
     const ast = parse(text);
-    const result = await evaluateNodes(ast, env, registry, 0, 0, diagnostics);
+    const result = await evaluateNodes(ast, recordingEnv, registry, 0, 0, diagnostics);
     if (result === text) break; // No change — converged
     text = result;
     if (!text.includes("{{")) break; // No more macros to resolve
@@ -83,7 +90,56 @@ export async function evaluate(
   // Post-process: unescape remaining escaped braces
   const final = postprocess(text);
 
-  return { text: final, diagnostics };
+  return { text: final, diagnostics, touchedVars: fingerprint.touched, cacheable: fingerprint.cacheable };
+}
+
+const EMPTY_TOUCHED_VARS: ReadonlySet<string> = new Set<string>();
+
+function wrapEnvForFingerprint(
+  env: MacroEnv,
+  fingerprint: { touched: Set<string>; cacheable: boolean },
+): MacroEnv {
+  const wrappedVars = {
+    local: makeRecordingMap(env.variables.local, "local", fingerprint.touched),
+    global: makeRecordingMap(env.variables.global, "global", fingerprint.touched),
+    chat: makeRecordingMap(env.variables.chat, "chat", fingerprint.touched),
+  };
+  return new Proxy(env, {
+    get(target, prop, receiver) {
+      if (prop === "variables") return wrappedVars;
+      if (prop === "_fingerprint") return fingerprint;
+      return Reflect.get(target, prop, receiver);
+    },
+    set(target, prop, value, receiver) {
+      if (prop === "variables" || prop === "_fingerprint") return true;
+      return Reflect.set(target, prop, value, receiver);
+    },
+  }) as MacroEnv;
+}
+
+function makeRecordingMap(
+  source: Map<string, string>,
+  scope: "local" | "global" | "chat",
+  sink: Set<string>,
+): Map<string, string> {
+  return new Proxy(source, {
+    get(target, prop, receiver) {
+      if (prop === "get") {
+        return (key: string) => {
+          sink.add(`${scope}:${key}`);
+          return target.get(key);
+        };
+      }
+      if (prop === "has") {
+        return (key: string) => {
+          sink.add(`${scope}:${key}`);
+          return target.has(key);
+        };
+      }
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
 }
 
 function preprocessLegacy(input: string): string {
@@ -147,6 +203,7 @@ async function evaluateMacroNode(
   const dynamicKey = node.name.toLowerCase();
   const dynamicLookup = env._dynamicMacrosLower;
   if (!def && dynamicLookup && dynamicLookup.has(dynamicKey)) {
+    if (env._fingerprint) env._fingerprint.cacheable = false;
     const dynamic = dynamicLookup.get(dynamicKey)!;
     let rawResult: string;
     if (typeof dynamic === "string") {
@@ -175,6 +232,8 @@ async function evaluateMacroNode(
     // Unknown macro — pass through as-is
     return reconstructMacro(node);
   }
+
+  if (def.volatile && env._fingerprint) env._fingerprint.cacheable = false;
 
   // Resolve arguments (unless handler wants raw AST)
   let resolvedArgs: string[];

--- a/src/macros/definitions/chat-utils.ts
+++ b/src/macros/definitions/chat-utils.ts
@@ -53,6 +53,7 @@ export function registerChatUtilsMacros(): void {
   registry.registerMacro({
     builtIn: true,
     terminal: true,
+    volatile: true,
     name: "chatAge",
     category: "Chat Utils",
     description: "Human-readable time since the chat was created",
@@ -69,6 +70,7 @@ export function registerChatUtilsMacros(): void {
   registry.registerMacro({
     builtIn: true,
     terminal: true,
+    volatile: true,
     name: "counter",
     category: "Chat Utils",
     description: "Increment a named counter (local variable) and return the new value",
@@ -87,6 +89,7 @@ export function registerChatUtilsMacros(): void {
   registry.registerMacro({
     builtIn: true,
     terminal: true,
+    volatile: true,
     name: "toggle",
     category: "Chat Utils",
     description: "Toggle a named boolean (local variable) and return the new value",

--- a/src/macros/definitions/entropy.ts
+++ b/src/macros/definitions/entropy.ts
@@ -4,6 +4,7 @@ export function registerRandomMacros(): void {
   registry.registerMacro({
     builtIn: true,
     terminal: true,
+    volatile: true,
     name: "random",
     category: "Random",
     description:
@@ -38,6 +39,7 @@ export function registerRandomMacros(): void {
   registry.registerMacro({
     builtIn: true,
     terminal: true,
+    volatile: true,
     name: "pick",
     category: "Random",
     description: "Pick a random item from a list of arguments. Stable per evaluation when seeded.",
@@ -53,6 +55,7 @@ export function registerRandomMacros(): void {
   registry.registerMacro({
     builtIn: true,
     terminal: true,
+    volatile: true,
     name: "roll",
     category: "Random",
     description: "Roll dice in NdS format (e.g., 2d6). Returns total.",

--- a/src/macros/definitions/lumia.ts
+++ b/src/macros/definitions/lumia.ts
@@ -634,6 +634,7 @@ export function registerLumiaMacros(): void {
   // ---- randomLumia ----
   registry.registerMacro({
     builtIn: true,
+    volatile: true,
     name: "randomLumia",
     category: "Lumia",
     description: "Random Lumia from all loaded packs. Optional arg: name, phys, pers, behav.",

--- a/src/macros/definitions/temporal.ts
+++ b/src/macros/definitions/temporal.ts
@@ -4,6 +4,7 @@ export function registerTimeMacros(): void {
   registry.registerMacro({
     builtIn: true,
     terminal: true,
+    volatile: true,
     name: "time",
     category: "Time",
     description: "Current time (HH:MM). Accepts optional UTC offset argument.",
@@ -29,6 +30,7 @@ export function registerTimeMacros(): void {
   registry.registerMacro({
     builtIn: true,
     terminal: true,
+    volatile: true,
     name: "date",
     category: "Time",
     description: "Current date (Month Day, Year)",
@@ -41,6 +43,7 @@ export function registerTimeMacros(): void {
   registry.registerMacro({
     builtIn: true,
     terminal: true,
+    volatile: true,
     name: "weekday",
     category: "Time",
     description: "Current day of the week",
@@ -53,6 +56,7 @@ export function registerTimeMacros(): void {
   registry.registerMacro({
     builtIn: true,
     terminal: true,
+    volatile: true,
     name: "isotime",
     category: "Time",
     description: "Current date and time in ISO 8601 format",
@@ -63,6 +67,7 @@ export function registerTimeMacros(): void {
   registry.registerMacro({
     builtIn: true,
     terminal: true,
+    volatile: true,
     name: "isodate",
     category: "Time",
     description: "Current date in ISO format (YYYY-MM-DD)",
@@ -76,6 +81,7 @@ export function registerTimeMacros(): void {
   registry.registerMacro({
     builtIn: true,
     terminal: true,
+    volatile: true,
     name: "datetimeformat",
     category: "Time",
     description: "Format current date/time with a custom Intl pattern",
@@ -103,6 +109,7 @@ export function registerTimeMacros(): void {
   registry.registerMacro({
     builtIn: true,
     terminal: true,
+    volatile: true,
     name: "idleDuration",
     category: "Time",
     description: "Human-readable time since last message",
@@ -119,6 +126,7 @@ export function registerTimeMacros(): void {
   registry.registerMacro({
     builtIn: true,
     terminal: true,
+    volatile: true,
     name: "timeDiff",
     category: "Time",
     description: "Human-readable difference between two ISO date strings",

--- a/src/macros/types.ts
+++ b/src/macros/types.ts
@@ -88,6 +88,9 @@ export interface MacroDefinition {
    *  unresolved macro markers ({{...}}). Skips the post-handler recursive
    *  expansion check for a small performance win on hot-path macros. */
   terminal?: boolean;
+  /** Output depends on state outside MacroEnv (Date.now, Math.random,
+   *  per-call dynamicMacros). Caching the result would serve stale output. */
+  volatile?: boolean;
   handler: MacroHandler;
 }
 
@@ -190,6 +193,9 @@ export interface MacroEnv {
   };
   /** Set to true when any chat variable macro mutates state. Used to trigger persistence. */
   _chatVarsDirty?: boolean;
+  /** Internal: fingerprint accumulator stashed by evaluate(). Surfaced back
+   *  via EvaluateResult.touchedVars / cacheable. */
+  _fingerprint?: { touched: Set<string>; cacheable: boolean };
   dynamicMacros: Record<string, string | MacroHandler | MacroDefinition>;
   /** Pre-normalized lowercase key → value map for O(1) dynamic macro lookup.
    *  Built automatically by buildEnv(); kept in sync if dynamicMacros changes. */
@@ -220,4 +226,10 @@ export interface MacroDiagnostic {
 export interface EvaluateResult {
   text: string;
   diagnostics: MacroDiagnostic[];
+  /** `<scope>:<key>` strings naming every var observed via
+   *  env.variables.*.get/has during evaluation. */
+  touchedVars: ReadonlySet<string>;
+  /** False when any volatile macro fired or an interceptor handled the
+   *  template. Consumers must not cache the result when false. */
+  cacheable: boolean;
 }

--- a/src/routes/macros.routes.ts
+++ b/src/routes/macros.routes.ts
@@ -37,7 +37,12 @@ app.post("/resolve", async (c) => {
   const env = buildEnvFromIds(userId, body);
 
   const result = await evaluate(body.template, env, registry);
-  return c.json({ text: result.text, diagnostics: result.diagnostics });
+  return c.json({
+    text: result.text,
+    diagnostics: result.diagnostics,
+    touched_vars: Array.from(result.touchedVars),
+    cacheable: result.cacheable,
+  });
 });
 
 /**
@@ -74,17 +79,23 @@ app.post("/resolve-batch", async (c) => {
   // Build environment once and reuse for all templates
   const env = buildEnvFromIds(userId, body);
   const resolved: Record<string, string> = {};
+  const touchedVars: Record<string, string[]> = {};
+  const cacheable: Record<string, boolean> = {};
 
   for (const [key, template] of entries) {
     if (!template) {
       resolved[key] = "";
+      touchedVars[key] = [];
+      cacheable[key] = true;
       continue;
     }
     const result = await evaluate(template, env, registry);
     resolved[key] = result.text;
+    touchedVars[key] = Array.from(result.touchedVars);
+    cacheable[key] = result.cacheable;
   }
 
-  return c.json({ resolved });
+  return c.json({ resolved, touched_vars: touchedVars, cacheable });
 });
 
 /**

--- a/src/routes/regex-scripts.routes.ts
+++ b/src/routes/regex-scripts.routes.ts
@@ -170,7 +170,7 @@ app.post("/apply", async (c) => {
     ? Object.fromEntries(Object.entries(body.dynamic_macros).filter(([, v]) => typeof v === "string")) as Record<string, string>
     : undefined;
 
-  const result = await applyDisplayRegex({
+  const applied = await applyDisplayRegex({
     content,
     scripts: scripts.filter((script) => !script.disabled),
     context: {
@@ -186,7 +186,11 @@ app.post("/apply", async (c) => {
     dynamicMacros,
   });
 
-  return c.json({ result });
+  return c.json({
+    result: applied.result,
+    touched_vars: Array.from(applied.touchedVars),
+    cacheable: applied.cacheable,
+  });
 });
 
 // POST /test — test regex

--- a/src/services/chats.service.ts
+++ b/src/services/chats.service.ts
@@ -696,6 +696,75 @@ export function deleteChat(userId: string, id: string): boolean {
   return result.changes > 0;
 }
 
+function diffChatChangedFields(prev: Chat, next: Chat): string[] {
+  const changed: string[] = [];
+
+  if (prev.name !== next.name) changed.push("name");
+  if (prev.character_id !== next.character_id) changed.push("character_id");
+
+  const prevMeta = (prev.metadata ?? {}) as Record<string, unknown>;
+  const nextMeta = (next.metadata ?? {}) as Record<string, unknown>;
+  const allKeys = new Set([...Object.keys(prevMeta), ...Object.keys(nextMeta)]);
+  for (const key of allKeys) {
+    const a = prevMeta[key];
+    const b = nextMeta[key];
+    if (a === b) continue;
+    if (!(key in prevMeta) || !(key in nextMeta)) {
+      changed.push(`metadata.${key}`);
+      if (key === "macro_variables" || key === "chat_variables") {
+        diffVarBagInto(changed, a, b, `metadata.${key}`);
+      }
+      continue;
+    }
+    if (typeof a !== "object" && typeof b !== "object") {
+      changed.push(`metadata.${key}`);
+      continue;
+    }
+    let aStr: string;
+    let bStr: string;
+    try { aStr = JSON.stringify(a); } catch { aStr = String(a); }
+    try { bStr = JSON.stringify(b); } catch { bStr = String(b); }
+    if (aStr !== bStr) {
+      changed.push(`metadata.${key}`);
+      if (key === "macro_variables" || key === "chat_variables") {
+        diffVarBagInto(changed, a, b, `metadata.${key}`);
+      }
+    }
+  }
+
+  return changed;
+}
+
+function diffVarBagInto(out: string[], prev: unknown, next: unknown, prefix: string): void {
+  const a = (prev && typeof prev === "object" ? prev : {}) as Record<string, unknown>;
+  const b = (next && typeof next === "object" ? next : {}) as Record<string, unknown>;
+
+  if (prefix === "metadata.macro_variables") {
+    for (const scope of ["local", "global", "chat"] as const) {
+      diffLeafBagInto(out, a[scope], b[scope], `${prefix}.${scope}`);
+    }
+    return;
+  }
+  diffLeafBagInto(out, a, b, prefix);
+}
+
+function diffLeafBagInto(out: string[], prev: unknown, next: unknown, prefix: string): void {
+  const a = (prev && typeof prev === "object" ? prev : {}) as Record<string, unknown>;
+  const b = (next && typeof next === "object" ? next : {}) as Record<string, unknown>;
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const k of keys) {
+    if (a[k] === b[k]) continue;
+    if (typeof a[k] === "object" || typeof b[k] === "object") {
+      let aStr: string;
+      let bStr: string;
+      try { aStr = JSON.stringify(a[k]); } catch { aStr = String(a[k]); }
+      try { bStr = JSON.stringify(b[k]); } catch { bStr = String(b[k]); }
+      if (aStr === bStr) continue;
+    }
+    out.push(`${prefix}.${k}`);
+  }
+}
+
 export function updateChat(userId: string, id: string, input: UpdateChatInput): Chat | null {
   const existing = getChat(userId, id);
   if (!existing) return null;
@@ -716,7 +785,8 @@ export function updateChat(userId: string, id: string, input: UpdateChatInput): 
 
   getDb().query(`UPDATE chats SET ${fields.join(", ")} WHERE id = ? AND user_id = ?`).run(...values);
   const updated = getChat(userId, id)!;
-  eventBus.emit(EventType.CHAT_CHANGED, { chat: updated }, userId);
+  const changedFields = diffChatChangedFields(existing, updated);
+  eventBus.emit(EventType.CHAT_CHANGED, { chat: updated, changedFields }, userId);
 
   // Detect avatar switch and emit specific event for theme resampling / extensions
   const oldAvatarId = existing.metadata?.active_avatar_id as string | undefined;

--- a/src/services/display-regex.service.ts
+++ b/src/services/display-regex.service.ts
@@ -147,13 +147,20 @@ function buildEnvFromContext(userId: string, ctx: DisplayRegexContext): MacroEnv
   };
 }
 
-export async function applyDisplayRegex(input: ApplyDisplayRegexInput): Promise<string> {
+export interface ApplyDisplayRegexResult {
+  result: string;
+  touchedVars: ReadonlySet<string>;
+  cacheable: boolean;
+}
+
+export async function applyDisplayRegex(input: ApplyDisplayRegexInput): Promise<ApplyDisplayRegexResult> {
   const placement: RegexPlacement = input.context.is_user ? "user_input" : "ai_output";
   const env = buildEnvFromContext(input.userId, input.context);
   if (env && input.dynamicMacros) {
     mergeDynamicMacros(env, input.dynamicMacros);
   }
-  return applyRegexScripts(
+  const fingerprint = { touchedVars: new Set<string>(), cacheable: true };
+  const result = await applyRegexScripts(
     input.content,
     input.scripts,
     placement,
@@ -163,6 +170,11 @@ export async function applyDisplayRegex(input: ApplyDisplayRegexInput): Promise<
       resolvedFindPatterns: input.resolvedFindPatterns,
       resolvedReplacements: input.resolvedReplacements,
     },
-    { source: "display_backend" },
+    { source: "display_backend", outFingerprint: fingerprint },
   );
+  return {
+    result,
+    touchedVars: fingerprint.touchedVars,
+    cacheable: fingerprint.cacheable,
+  };
 }

--- a/src/services/regex-scripts.service.ts
+++ b/src/services/regex-scripts.service.ts
@@ -56,6 +56,7 @@ interface RegexPerformanceReportResult {
 interface ApplyRegexScriptOptions {
   source?: RegexPerformanceSource;
   onPerformanceIssue?: (issue: RegexPerformanceIssue) => void;
+  outFingerprint?: { touchedVars: Set<string>; cacheable: boolean };
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -868,13 +869,25 @@ function rebuildFromMatches(
  * Resolve macros in a regex find pattern based on the substitute_macros mode.
  * The result stays as plain regex source, so `$` is not escaped here.
  */
+function foldFingerprint(
+  acc: { touchedVars: Set<string>; cacheable: boolean } | undefined,
+  result: { touchedVars: ReadonlySet<string>; cacheable: boolean },
+): void {
+  if (!acc) return;
+  for (const v of result.touchedVars) acc.touchedVars.add(v);
+  if (!result.cacheable) acc.cacheable = false;
+}
+
 async function resolveFindMacros(
   findRegex: string,
   mode: RegexScript["substitute_macros"],
   macroEnv: MacroEnv,
+  outFingerprint?: { touchedVars: Set<string>; cacheable: boolean },
 ): Promise<string> {
   if (mode === "none") return findRegex;
-  return (await evaluate(findRegex, macroEnv, registry)).text;
+  const result = await evaluate(findRegex, macroEnv, registry);
+  foldFingerprint(outFingerprint, result);
+  return result.text;
 }
 
 /**
@@ -887,10 +900,13 @@ async function resolveReplacementMacros(
   replaceString: string,
   mode: RegexScript["substitute_macros"],
   macroEnv: MacroEnv,
+  outFingerprint?: { touchedVars: Set<string>; cacheable: boolean },
 ): Promise<string> {
   if (mode === "none") return replaceString;
 
-  const resolved = (await evaluate(replaceString, macroEnv, registry)).text;
+  const result = await evaluate(replaceString, macroEnv, registry);
+  foldFingerprint(outFingerprint, result);
+  const resolved = result.text;
 
   if (mode === "escaped") {
     // Escape $ so regex replacement doesn't interpret $1, $&, etc.
@@ -942,7 +958,7 @@ export async function applyRegexScripts(
       if (preResolvedFind !== undefined) {
         findRegex = preResolvedFind;
       } else if (macroEnv && script.substitute_macros !== "none") {
-        findRegex = await resolveFindMacros(findRegex, script.substitute_macros, macroEnv);
+        findRegex = await resolveFindMacros(findRegex, script.substitute_macros, macroEnv, options?.outFingerprint);
       }
 
       if (macroEnv && script.substitute_macros === "raw") {
@@ -962,7 +978,9 @@ export async function applyRegexScripts(
               const withCaptures = substituteRegexCaptures(
                 script.replace_string, fullMatch, groups, index, result, namedGroups,
               );
-              return (await evaluate(withCaptures, macroEnv, registry)).text;
+              const evalResult = await evaluate(withCaptures, macroEnv, registry);
+              foldFingerprint(options?.outFingerprint, evalResult);
+              return evalResult.text;
             }),
           );
           result = rebuildFromMatches(result, matches, replacements);
@@ -977,7 +995,7 @@ export async function applyRegexScripts(
             ? preResolvedReplacement.replace(/\$/g, "$$$$")
             : preResolvedReplacement;
         } else if (macroEnv && script.substitute_macros !== "none") {
-          replaceString = await resolveReplacementMacros(replaceString, script.substitute_macros, macroEnv);
+          replaceString = await resolveReplacementMacros(replaceString, script.substitute_macros, macroEnv, options?.outFingerprint);
         }
         result = await regexReplaceSandboxed(
           findRegex,


### PR DESCRIPTION
Makes display-regex cache invalidation selective per-message. That way one messages (i.e. the streaming one) doesn't necessitate displayRegex running on all of them. It also invalidates the cache on messages who's display regexes that fire on them contain variable macros that have changed (potentially causing the regex replace string to change). 

Existing extensions are unaffected. Vanilla users see fewer redundant fetches, no behavioral change other than perf speedup. Upper bound speedup is n less rerenders where n = # messages. Worst case performance is the same if all display regexes contain variables that change every streaming chunk (which would be ridiculous).

- 5b10d29b0817fd28f094ea3ae38789567e038ecd Purpose is to give the FE enough info to skip refetches when nothing relevant changed. CHAT_CHANGED now carries changedFields: string[] listing which fields actually differed, and each macro evaluation reports which vars it read in EvaluateResult.touchedVars plus a cacheable boolean. Adds a volatile flag to `time`, `random`, `chatAge`, `counter`, `toggle`, and `randomLumia` macros so their output isn't cached as static. This flag is needed

- 1e23e41978add3ea25ec6da522fac6ed30ddac3a Purpose is to consume the BE info so only messages that depend on what actually changed refetch. Admin-field changes (last_message_id, avatar, name) leave the cache alone, var changes invalidate only matching entries, bag-shape changes still wholesale-wipe. Per-message version counter replaces the global one so editing one bubble doesn't rerender the others. Also fixes a race where a fetch finishing right after invalidation could clobber the cache with stale content.

- adb47382b69a23b09b2e7c42c77a8a2c93bebd14 Purpose is to stop raw {{...}} flashing into panels during streaming. The sync regex fallback only resolves a few core macros locally and leaves the rest raw until the server returns. Now the hook shows raw input briefly instead of the broken intermediate state, until async resolution lands. This is much cleaner than showing unresolved macros, and sometimes broken HTML.

---

Notes:
- Extension macro handlers that want to iterate variables.local should use .get() and .has(), not iteration. Iteration isn't recorded in the fingerprint so the cached output may be stale longer than expected. 
- Volatile flag is a manual annotation for macro developers. The volatile annotation will allow macros authors to state that all display regexes containing their macro are to be rerendered no matter the value of the macro. Currently this exists by default on existing macros that need it. When to use it is in the docs. I put this as off by default, not sure what you prefer.
- Recording Proxy adds about 6x per Map.get call. <1ms downside for normal use.
