### PR TITLE
Pre-cortex macro evaluation

### DIFF
--- a/src/routes/world-books.routes.ts
+++ b/src/routes/world-books.routes.ts
@@ -478,7 +478,7 @@ app.post("/:id/diagnostics", async (c) => {
   const worldBookVectorSettings = loadWorldBookVectorSettings(userId, {
     retrievalTopK: embeddings.retrieval_top_k,
   });
-  const queryPreview = await getWorldInfoVectorQueryPreview(userId, messages);
+  const queryPreview = await getWorldInfoVectorQueryPreview(userId, messages, chat.id);
   const blockerMessages: string[] = [];
 
   if (!isAttached) {

--- a/src/services/chat-memory-cache.service.ts
+++ b/src/services/chat-memory-cache.service.ts
@@ -1,7 +1,10 @@
 import { getDb } from "../db/connection";
 import * as embeddingsSvc from "./embeddings.service";
-import { sanitizeForVectorization, type SanitizeOptions } from "../utils/content-sanitizer";
+import { type SanitizeOptions } from "../utils/content-sanitizer";
 import { getReasoningStripOptions } from "../utils/reasoning-strip";
+import { type MacroEnv } from "../macros";
+import { resolveAndSanitizeForVectorization } from "./vectorization-content.service";
+import { buildMacroEnvForChat } from "./chats.service";
 
 const MAX_STALE_VISIBLE_MESSAGES = 2;
 const REFRESH_DEBOUNCE_MS = 100;
@@ -105,11 +108,12 @@ function truncateToContextSize(text: string, maxTokens: number): string {
   return text.slice(-maxChars);
 }
 
-function buildQueryText(
+async function buildQueryText(
   messages: MemoryMessageView[],
   settings: embeddingsSvc.ChatMemorySettings,
+  env: MacroEnv | null,
   reasoningStrip?: SanitizeOptions,
-): string {
+): Promise<string> {
   const visibleMessages = messages.filter(m => !(m.extra?.hidden) && m.content.trim().length > 0);
   const contextSize = Math.max(1, settings.queryContextSize);
 
@@ -117,29 +121,29 @@ function buildQueryText(
     case "last_user_message": {
       const lastUser = [...visibleMessages].reverse().find(m => m.is_user);
       if (!lastUser) return "";
+      const sanitized = await resolveAndSanitizeForVectorization(lastUser.content, env, reasoningStrip);
       return truncateToContextSize(
-        `[USER | ${lastUser.name}]: ${sanitizeForVectorization(lastUser.content, reasoningStrip)}`,
+        `[USER | ${lastUser.name}]: ${sanitized}`,
         settings.queryMaxTokens,
       );
     }
     case "weighted_recent": {
       const queryMessages = visibleMessages.slice(-contextSize);
-      const parts = queryMessages.map(m =>
-        `[${m.is_user ? "USER" : "CHARACTER"} | ${m.name}]: ${sanitizeForVectorization(m.content, reasoningStrip)}`,
-      );
+      const parts = await Promise.all(queryMessages.map(async m => {
+        const sanitized = await resolveAndSanitizeForVectorization(m.content, env, reasoningStrip);
+        return `[${m.is_user ? "USER" : "CHARACTER"} | ${m.name}]: ${sanitized}`;
+      }));
       if (parts.length > 0) parts.push(parts[parts.length - 1]);
       return truncateToContextSize(parts.join("\n").trim(), settings.queryMaxTokens);
     }
     case "recent_messages":
     default: {
       const queryMessages = visibleMessages.slice(-contextSize);
-      return truncateToContextSize(
-        queryMessages
-          .map(m => `[${m.is_user ? "USER" : "CHARACTER"} | ${m.name}]: ${sanitizeForVectorization(m.content, reasoningStrip)}`)
-          .join("\n")
-          .trim(),
-        settings.queryMaxTokens,
-      );
+      const parts = await Promise.all(queryMessages.map(async m => {
+        const sanitized = await resolveAndSanitizeForVectorization(m.content, env, reasoningStrip);
+        return `[${m.is_user ? "USER" : "CHARACTER"} | ${m.name}]: ${sanitized}`;
+      }));
+      return truncateToContextSize(parts.join("\n").trim(), settings.queryMaxTokens);
     }
   }
 }
@@ -340,7 +344,8 @@ async function computeFreshMemoryResult(
   const settingsSource: "global" | "per_chat" = perChatOverrides ? "per_chat" : "global";
   const sourceMessageCount = getVisibleMessageCount(messages);
   const reasoningStrip = getReasoningStripOptions(userId);
-  const queryText = buildQueryText(messages, settings, reasoningStrip);
+  const env = buildMacroEnvForChat(userId, chatId);
+  const queryText = await buildQueryText(messages, settings, env, reasoningStrip);
   const settingsKey = computeSettingsKey(settings, perChatOverrides, cfg.hybrid_weight_mode);
 
   const chunkStats = getDb()
@@ -569,7 +574,8 @@ export async function readCachedChatMemory(
   const settings = embeddingsSvc.resolveEffectiveChatMemorySettings(chatMemorySettings, cfg);
   const settingsSource: "global" | "per_chat" = perChatOverrides ? "per_chat" : "global";
   const reasoningStrip = getReasoningStripOptions(userId);
-  const queryText = buildQueryText(messageViews, settings, reasoningStrip);
+  const env = buildMacroEnvForChat(userId, chatId);
+  const queryText = await buildQueryText(messageViews, settings, env, reasoningStrip);
   if (!queryText) {
     return { ...EMPTY_RESULT, enabled: true, settingsSource };
   }

--- a/src/services/chats.service.ts
+++ b/src/services/chats.service.ts
@@ -13,8 +13,10 @@ import * as embeddingsSvc from "./embeddings.service";
 import * as memoryCortex from "./memory-cortex";
 import { removePoolEntriesForChat } from "./generation-pool.service";
 import { invalidateChatMemoryCache, scheduleChatMemoryRefresh } from "./chat-memory-cache.service";
-import { sanitizeForVectorization, type SanitizeOptions } from "../utils/content-sanitizer";
 import { getReasoningStripOptions } from "../utils/reasoning-strip";
+import { buildEnv, type MacroEnv } from "../macros";
+import { resolvePersonaOrDefault } from "./personas.service";
+import { resolveAndSanitizeForVectorization, contentHasMacroHints } from "./vectorization-content.service";
 
 // --- Chat helpers ---
 
@@ -2025,14 +2027,32 @@ async function shouldStartNewChunk(lastChunk: ChatChunk, newMessage: Message, us
   return false;
 }
 
-/**
- * Create a new chunk from a set of messages.
- */
-function createChatChunk(chatId: string, messages: Message[], reasoningStrip?: SanitizeOptions): ChatChunk {
+export function buildMacroEnvForChat(userId: string, chatId: string): MacroEnv | null {
+  try {
+    const chat = getChat(userId, chatId);
+    if (!chat) return null;
+    const character = getCharacter(userId, chat.character_id);
+    if (!character) return null;
+    const persona = resolvePersonaOrDefault(userId);
+    return buildEnv({
+      character,
+      persona,
+      chat,
+      messages: [],
+      generationType: "normal",
+      userId,
+      commit: false,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function createChatChunk(chatId: string, messages: Message[], sanitizedContents: string[]): ChatChunk {
   const now = Math.floor(Date.now() / 1000);
   const id = crypto.randomUUID();
-  const content = messages.map(m =>
-    `[${m.is_user ? "USER" : "CHARACTER"} | ${m.name}]: ${sanitizeForVectorization(m.content, reasoningStrip)}`
+  const content = messages.map((m, i) =>
+    `[${m.is_user ? "USER" : "CHARACTER"} | ${m.name}]: ${sanitizedContents[i] ?? ""}`
   ).join("\n");
   const tokenCount = estimateTokens(content);
   const messageIds = messages.map(m => m.id);
@@ -2060,17 +2080,14 @@ function createChatChunk(chatId: string, messages: Message[], reasoningStrip?: S
   return getDb().query("SELECT * FROM chat_chunks WHERE id = ?").get(id) as any;
 }
 
-/**
- * Append a message to an existing chunk.
- */
-function appendToChunk(chunkId: string, message: Message, reasoningStrip?: SanitizeOptions): void {
+function appendToChunk(chunkId: string, message: Message, sanitizedContent: string): void {
   const chunk = getDb().query("SELECT * FROM chat_chunks WHERE id = ?").get(chunkId) as any;
   if (!chunk) return;
 
   const messageIds = JSON.parse(chunk.message_ids);
   messageIds.push(message.id);
 
-  const newContent = chunk.content + `\n[${message.is_user ? "USER" : "CHARACTER"} | ${message.name}]: ${sanitizeForVectorization(message.content, reasoningStrip)}`;
+  const newContent = chunk.content + `\n[${message.is_user ? "USER" : "CHARACTER"} | ${message.name}]: ${sanitizedContent}`;
   const newTokenCount = estimateTokens(newContent);
   const now = Math.floor(Date.now() / 1000);
 
@@ -2092,24 +2109,22 @@ function appendToChunk(chunkId: string, message: Message, reasoningStrip?: Sanit
     .run(message.id, JSON.stringify(messageIds), newContent, newTokenCount, messageIds.length, now, chunkId);
 }
 
-/**
- * Update chunks incrementally when a new message is added.
- * This is called after message creation and only touches the last chunk.
- */
 async function updateChatChunks(userId: string, chatId: string, newMessage: Message): Promise<void> {
   const cfg = await embeddingsSvc.getEmbeddingConfig(userId);
   if (!cfg.enabled || !cfg.vectorize_chat_messages) return;
 
   const reasoningStrip = getReasoningStripOptions(userId);
+  const env = contentHasMacroHints(newMessage.content) ? buildMacroEnvForChat(userId, chatId) : null;
+  const sanitizedContent = await resolveAndSanitizeForVectorization(newMessage.content, env, reasoningStrip);
   const lastChunk = getLastChatChunk(chatId);
   let chunkId: string;
 
   if (!lastChunk || (await shouldStartNewChunk(lastChunk, newMessage, userId))) {
-    const newChunk = createChatChunk(chatId, [newMessage], reasoningStrip);
+    const newChunk = createChatChunk(chatId, [newMessage], [sanitizedContent]);
     chunkId = newChunk.id;
     vectorizationQueue.queueChunkVectorization(userId, chatId, newChunk.id, 5);
   } else {
-    appendToChunk(lastChunk.id, newMessage, reasoningStrip);
+    appendToChunk(lastChunk.id, newMessage, sanitizedContent);
     chunkId = lastChunk.id;
     vectorizationQueue.queueChunkVectorization(userId, chatId, lastChunk.id, 5);
   }
@@ -2387,12 +2402,19 @@ async function _rebuildChatChunksImpl(userId: string, chatId: string): Promise<v
   );
   const targetTokens = chatMemSettings.chunkTargetTokens;
   const reasoningStrip = getReasoningStripOptions(userId);
+  const anyMessageHasMacros = messages.some((m) => contentHasMacroHints(m.content));
+  const env = anyMessageHasMacros ? buildMacroEnvForChat(userId, chatId) : null;
+  const sanitizedByMsgId = new Map<string, string>();
+  for (const msg of messages) {
+    sanitizedByMsgId.set(msg.id, await resolveAndSanitizeForVectorization(msg.content, env, reasoningStrip));
+  }
 
   let currentChunk: Message[] = [];
+  let currentChunkSanitized: string[] = [];
   let currentTokens = 0;
 
   for (const msg of messages) {
-    const sanitizedContent = sanitizeForVectorization(msg.content, reasoningStrip);
+    const sanitizedContent = sanitizedByMsgId.get(msg.id) ?? "";
     const msgTokens = estimateTokens(`[${msg.is_user ? "USER" : "CHARACTER"} | ${msg.name}]: ${sanitizedContent}`);
     const wouldExceedTarget = currentTokens + msgTokens > targetTokens;
 
@@ -2433,18 +2455,20 @@ async function _rebuildChatChunksImpl(userId: string, chatId: string): Promise<v
     }
 
     if (forceNewChunk) {
-      const chunk = createChatChunk(chatId, currentChunk, reasoningStrip);
+      const chunk = createChatChunk(chatId, currentChunk, currentChunkSanitized);
       vectorizationQueue.queueChunkVectorization(userId, chatId, chunk.id, 3);
       currentChunk = [];
+      currentChunkSanitized = [];
       currentTokens = 0;
     }
 
     currentChunk.push(msg);
+    currentChunkSanitized.push(sanitizedContent);
     currentTokens += msgTokens;
   }
 
   if (currentChunk.length > 0) {
-    const chunk = createChatChunk(chatId, currentChunk, reasoningStrip);
+    const chunk = createChatChunk(chatId, currentChunk, currentChunkSanitized);
     vectorizationQueue.queueChunkVectorization(userId, chatId, chunk.id, 3);
   }
 

--- a/src/services/prompt-assembly.service.ts
+++ b/src/services/prompt-assembly.service.ts
@@ -51,7 +51,8 @@ import {
 } from "./world-info-activation.service";
 import { worldInfoInterceptorChain } from "../spindle/world-info-interceptor";
 import * as chatsSvc from "./chats.service";
-import { stripReasoningTags } from "./chats.service";
+import { stripReasoningTags, buildMacroEnvForChat } from "./chats.service";
+import { resolveAndSanitizeForVectorization } from "./vectorization-content.service";
 import {
   stripDetailsBlocks as _stripDetailsBlocks,
   stripLoomTags as _stripLoomTags,
@@ -972,9 +973,10 @@ export async function assemblePrompt(
           )
         : embeddingsSvc.DEFAULT_CHAT_MEMORY_SETTINGS;
 
-      const cortexQueryText = buildQueryText(
+      const cortexQueryText = await buildQueryText(
         messages,
         effective,
+        buildMacroEnvForChat(ctx.userId, ctx.chatId),
         getReasoningStripOptions(ctx.userId),
       );
       const recentContent = messages
@@ -1180,6 +1182,7 @@ export async function assemblePrompt(
   const vectorQueryPreview = await getWorldInfoVectorQueryPreview(
     ctx.userId,
     messages,
+    ctx.chatId,
   );
   let vectorActivated = ctx.precomputedVectorEntries ?? null;
   let vectorRetrievalDetails: VectorWorldInfoRetrievalResult | null = null;
@@ -3402,34 +3405,33 @@ function truncateToContextSize(text: string, maxTokens: number): string {
   return text.slice(-maxChars);
 }
 
-function buildWorldInfoVectorQueryPreview(
+async function buildWorldInfoVectorQueryPreview(
   messages: Message[],
   contextSize: number,
+  env: MacroEnv | null,
   reasoningStrip?: SanitizeOptions,
-): string {
+): Promise<string> {
   const queryMessages = messages
     .filter((m) => !m.extra?.hidden && m.content.trim().length > 0)
     .slice(-Math.max(1, contextSize));
-  return truncateToContextSize(
-    queryMessages
-      .map(
-        (m) =>
-          `[${m.is_user ? "USER" : "CHARACTER"} | ${m.name}]: ${sanitizeForVectorization(stripReasoningTags(m.content), reasoningStrip)}`,
-      )
-      .join("\n")
-      .trim(),
-    8000,
-  );
+  const parts = await Promise.all(queryMessages.map(async (m) => {
+    const sanitized = await resolveAndSanitizeForVectorization(stripReasoningTags(m.content), env, reasoningStrip);
+    return `[${m.is_user ? "USER" : "CHARACTER"} | ${m.name}]: ${sanitized}`;
+  }));
+  return truncateToContextSize(parts.join("\n").trim(), 8000);
 }
 
 export async function getWorldInfoVectorQueryPreview(
   userId: string,
   messages: Message[],
+  chatId?: string,
 ): Promise<string> {
   const cfg = await embeddingsSvc.getEmbeddingConfig(userId);
+  const env = chatId ? buildMacroEnvForChat(userId, chatId) : null;
   return buildWorldInfoVectorQueryPreview(
     messages,
     cfg.preferred_context_size || 3,
+    env,
     getReasoningStripOptions(userId),
   );
 }
@@ -3535,9 +3537,11 @@ export async function collectVectorActivatedWorldInfoDetailed(
   const blockerMessages: string[] = [];
   const topK = Math.max(1, worldBookVectorSettings.retrievalTopK || cfg.retrieval_top_k || 4);
   const queryBuildStartedAt = performance.now();
-  const queryText = buildWorldInfoVectorQueryPreview(
+  const env = buildMacroEnvForChat(userId, chatId);
+  const queryText = await buildWorldInfoVectorQueryPreview(
     messages,
     cfg.preferred_context_size || 3,
+    env,
     getReasoningStripOptions(userId),
   );
   const queryBuildMs = performance.now() - queryBuildStartedAt;
@@ -3872,11 +3876,12 @@ export interface MemoryRetrievalResult {
   chunksPending: number;
 }
 
-function buildQueryText(
+async function buildQueryText(
   messages: Message[],
   settings: import("./embeddings.service").ChatMemorySettings,
+  env: MacroEnv | null,
   reasoningStrip?: SanitizeOptions,
-): string {
+): Promise<string> {
   const visibleMessages = messages.filter(
     (m) => !m.extra?.hidden && m.content.trim().length > 0,
   );
@@ -3886,18 +3891,18 @@ function buildQueryText(
     case "last_user_message": {
       const lastUser = [...visibleMessages].reverse().find((m) => m.is_user);
       if (!lastUser) return "";
+      const sanitized = await resolveAndSanitizeForVectorization(lastUser.content, env, reasoningStrip);
       return truncateToContextSize(
-        `[USER | ${lastUser.name}]: ${sanitizeForVectorization(lastUser.content, reasoningStrip)}`,
+        `[USER | ${lastUser.name}]: ${sanitized}`,
         settings.queryMaxTokens,
       );
     }
     case "weighted_recent": {
       const queryMessages = visibleMessages.slice(-contextSize);
-      const parts = queryMessages.map(
-        (m) =>
-          `[${m.is_user ? "USER" : "CHARACTER"} | ${m.name}]: ${sanitizeForVectorization(m.content, reasoningStrip)}`,
-      );
-      // Repeat last message for recency bias
+      const parts = await Promise.all(queryMessages.map(async (m) => {
+        const sanitized = await resolveAndSanitizeForVectorization(m.content, env, reasoningStrip);
+        return `[${m.is_user ? "USER" : "CHARACTER"} | ${m.name}]: ${sanitized}`;
+      }));
       if (parts.length > 0) parts.push(parts[parts.length - 1]);
       return truncateToContextSize(
         parts.join("\n").trim(),
@@ -3907,14 +3912,12 @@ function buildQueryText(
     case "recent_messages":
     default: {
       const queryMessages = visibleMessages.slice(-contextSize);
+      const parts = await Promise.all(queryMessages.map(async (m) => {
+        const sanitized = await resolveAndSanitizeForVectorization(m.content, env, reasoningStrip);
+        return `[${m.is_user ? "USER" : "CHARACTER"} | ${m.name}]: ${sanitized}`;
+      }));
       return truncateToContextSize(
-        queryMessages
-          .map(
-            (m) =>
-              `[${m.is_user ? "USER" : "CHARACTER"} | ${m.name}]: ${sanitizeForVectorization(m.content, reasoningStrip)}`,
-          )
-          .join("\n")
-          .trim(),
+        parts.join("\n").trim(),
         settings.queryMaxTokens,
       );
     }

--- a/src/services/vectorization-content.service.ts
+++ b/src/services/vectorization-content.service.ts
@@ -1,0 +1,26 @@
+import { evaluate, registry, type MacroEnv } from "../macros";
+import { sanitizeForVectorization, type SanitizeOptions } from "../utils/content-sanitizer";
+
+const HAS_MACRO_HINT_RE = /\{\{|<(?:user|char|bot)>/i;
+
+export function contentHasMacroHints(content: string): boolean {
+  return HAS_MACRO_HINT_RE.test(content);
+}
+
+export async function resolveAndSanitizeForVectorization(
+  content: string,
+  env: MacroEnv | null,
+  options?: SanitizeOptions,
+): Promise<string> {
+  if (!content) return "";
+  let resolved = content;
+  if (env && HAS_MACRO_HINT_RE.test(content)) {
+    try {
+      const result = await evaluate(content, env, registry);
+      resolved = result.text;
+    } catch {
+      resolved = content;
+    }
+  }
+  return sanitizeForVectorization(resolved, options);
+}


### PR DESCRIPTION
A chat message with {{user}}, {{char}}, and any future macros that you or future extensions would reasonably implement in chat-content (the spindle API wiring is there to support this possibility now) would have the unresolved macro appear in the cortex itself. 

Admittedly this is a bit of a wishlist item for me as I am making one of those extensions, but chats without macros in them will have 0 performance hit with this change.

---

Notes:
- No performance hit to messages without macros.
- Only macro eval runs here (plus your existing html stripper), NO display regex.
- This WOULD be a 5 line change but I decided to properly wire up the async evaluator.
