### PR TITLE
fix(display-regex): refetch pre-resolved templates when vars change

### DIFF
--- a/frontend/src/hooks/useDisplayRegex.ts
+++ b/frontend/src/hooks/useDisplayRegex.ts
@@ -281,8 +281,10 @@ export function invalidateDisplayRegexCacheForVars(changedVars: ReadonlySet<stri
       }
     }
   }
+  const resolutionWasNonEmpty = displayRegexResolutionCache.size > 0
   displayRegexResolutionCache.clear()
   for (const messageId of affectedMessages) bumpPerMessageCv(messageId)
+  if (resolutionWasNonEmpty) bumpGlobalCv()
 }
 
 async function resolveMacrosBatchChunked(
@@ -477,7 +479,7 @@ export function useDisplayRegex(
     displayRegexResolutionCache.get(templateCacheKey)?.promise?.then(applyResolvedTemplates)
 
     return () => { cancelled = true }
-  }, [scriptsNeedingResolution, templateCacheKey, activeChatId, activeCharacterId, activePersonaId])
+  }, [scriptsNeedingResolution, templateCacheKey, activeChatId, activeCharacterId, activePersonaId, cvSnapshot])
 
   const fallbackContent = useMemo(
     () => {


### PR DESCRIPTION
Two fixes that surfaced in escaped and after regex modes (raw mode skips the pre-resolve cache entirely):

1. invalidateDisplayRegexCacheForVars bumps globalCv when it actually cleared the resolution cache.

2. Add cvSnapshot to the templateCacheKey useEffect's deps. Now when globalCv bumps, the useEffect's deps actually change, so the effect runs again. 

The problem with #112 was that clearing the cache alone doesn't make the component refetch.