### PR TITLE
fix(display-regex): bump globalCv unconditionally on var-change

### DIFF
--- a/frontend/src/hooks/useDisplayRegex.ts
+++ b/frontend/src/hooks/useDisplayRegex.ts
@@ -281,10 +281,9 @@ export function invalidateDisplayRegexCacheForVars(changedVars: ReadonlySet<stri
       }
     }
   }
-  const resolutionWasNonEmpty = displayRegexResolutionCache.size > 0
   displayRegexResolutionCache.clear()
   for (const messageId of affectedMessages) bumpPerMessageCv(messageId)
-  if (resolutionWasNonEmpty) bumpGlobalCv()
+  bumpGlobalCv()
 }
 
 async function resolveMacrosBatchChunked(


### PR DESCRIPTION
Remove the overconstrained check as CHAT_CHANGED events were skipping the cache-version bump unless something happened to be in the pre-resolved-templates cache, so cards whose display-regex rules don't use macro pre-resolution silently rendered stale content after a variable changed. Shouldn't actually change vanilla behaviour as ST cards don't really do this, but it is a correctness bug for extensions that register things. This is a fix to the cv rework that I did in https://github.com/prolix-oc/Lumiverse/pull/112