### PR TITLE
fix: resolve Chrome Android PWA installability

### DIFF
--- a/frontend/dist/manifest.json
+++ b/frontend/dist/manifest.json
@@ -1,8 +1,10 @@
 {
+  "id": "/",
   "name": "Lumiverse",
   "short_name": "Lumiverse",
   "description": "Lumiverse chat companion app",
   "start_url": "/",
+  "scope": "/",
   "display": "standalone",
   "background_color": "#1C1826",
   "theme_color": "#9370DB",
@@ -16,12 +18,14 @@
     {
       "src": "/icon-192.png",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any"
     },
     {
       "src": "/icon-512.png",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any"
     }
   ]
 }

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,8 +1,10 @@
 {
+  "id": "/",
   "name": "Lumiverse",
   "short_name": "Lumiverse",
   "description": "Lumiverse chat companion app",
   "start_url": "/",
+  "scope": "/",
   "display": "standalone",
   "background_color": "#1C1826",
   "theme_color": "#9370DB",
@@ -16,12 +18,14 @@
     {
       "src": "/icon-192.png",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any"
     },
     {
       "src": "/icon-512.png",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any"
     }
   ]
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -297,6 +297,12 @@ if (env.frontendDir) {
     } else if (!path.startsWith("/api/")) {
       c.res.headers.set("Cache-Control", "no-cache");
     }
+    if (path === "/manifest.json") {
+      c.res.headers.set("Content-Type", "application/manifest+json");
+    }
+    if (path === "/sw.js") {
+      c.res.headers.set("Service-Worker-Allowed", "/");
+    }
   });
 
   app.use(


### PR DESCRIPTION
## Summary
- **Set `Content-Type: application/manifest+json`** for manifest.json responses — Bun/Hono defaults to `application/json`, which Chrome on Android rejects for PWA installability checks
- **Add `Service-Worker-Allowed: /`** header for sw.js
- **Add `id` and `scope` fields** to manifest.json (Chrome 111+ uses these for PWA identity)
- **Add explicit `purpose: "any"`** to PNG icon entries

Builds on the prior SW NavigationRoute denylist fix (4f300d6) which prevented the SW from hijacking manifest fetches with index.html. That fix stopped the SW from serving HTML for the manifest, but Chrome still rejected the manifest because the server was sending it with the wrong MIME type.

## Test plan
- [x] Clear Chrome site data for localhost on Android
- [x] Visit Lumiverse, wait for SW to register
- [x] Tap three-dot menu > Add to home screen > **Install option now appears** (previously only showed Create shortcut)
- Tested on Samsung S25 Ultra, Android 16, One UI 8.0, Chrome

🤖 Generated and tested with [Claude Code](https://claude.com/claude-code)
