### PR TITLE
WS and Spindle Images Upload Speedup

### DIFF
--- a/developer-docs/docs/backend-api/images.md
+++ b/developer-docs/docs/backend-api/images.md
@@ -43,6 +43,13 @@ const uploaded = await spindle.images.upload({
   owner_chat_id: 'chat-id',
 })
 
+// Batch upload — one IPC + host-side concurrency pool replaces N round-trips
+const results = await spindle.images.uploadMany([
+  { data: bytes1, filename: 'a.png', mime_type: 'image/png' },
+  { data: bytes2, filename: 'b.png', mime_type: 'image/png' },
+])
+// Returns Array<{ id?: string; error?: string }> — per-item failures don't throw the batch
+
 // Upload a data URL with ownership tags
 const generated = await spindle.images.uploadFromDataUrl(dataUrl, {
   originalFilename: 'generated.png',
@@ -61,6 +68,7 @@ await spindle.images.delete(uploaded.id)
 | `list(options?)` | `Promise<{ data: ImageDTO[], total: number }>` | List images. Options: `{ limit?, offset?, specificity?, onlyOwned?, characterId?, chatId? }`. Defaults: limit 50, max 200. |
 | `get(imageId, options?)` | `Promise<ImageDTO \| null>` | Get a single image DTO. Options: `{ specificity?, onlyOwned?, characterId?, chatId? }`. Returns `null` when the image is missing or excluded by the ownership filters. |
 | `upload(input)` | `Promise<ImageDTO>` | Upload raw image bytes. The host automatically tags the image with the current extension identifier. |
+| `uploadMany(items, options?)` | `Promise<Array<{ id?: string; error?: string }>>` | Batch upload multiple images in a single IPC call. Per-item failures captured as `{error}` rather than throwing. Options: `{ userId?, concurrency? }` (concurrency capped at 32, default 16). |
 | `uploadFromDataUrl(dataUrl, options?)` | `Promise<ImageDTO>` | Upload a base64 image data URL. The host automatically tags the image with the current extension identifier. |
 | `delete(imageId)` | `Promise<boolean>` | Delete an image by ID. Returns `true` when deleted. |
 
@@ -134,7 +142,7 @@ Same ownership and `specificity` fields as `ImageListOptionsDTO`, minus paginati
 ## Notes
 
 - `spindle.images.get()` returns metadata plus a URL, not the binary image bytes themselves.
-- Thumbnail generation is supported automatically. `has_thumbnail` tells you whether thumbnails are available or can be lazily generated.
+- Thumbnail generation is supported automatically. `has_thumbnail` tells you whether thumbnails are available or can be lazily generated. `uploadMany` defers thumbnail (and width/height) generation to a background job for throughput; the underlying row populates these fields asynchronously after the call returns.
 - Generated images persisted through `spindle.imageGen.generate()` also participate in this ownership model when `owner_character_id` or `owner_chat_id` are supplied.
 
 !!! note

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "hono": "^4.7.0",
     "js-tiktoken": "^1.0.16",
     "jsdom": "^29.0.1",
-    "lumiverse-spindle-types": "0.4.68",
+    "lumiverse-spindle-types": "0.4.69",
     "mute-stream": "^3.0.0",
     "sharp": "^0.34.5",
     "ssh2-sftp-client": "^12.1.1"

--- a/src/services/images.service.ts
+++ b/src/services/images.service.ts
@@ -334,16 +334,14 @@ export async function uploadImages(
   type Prepared = {
     id: string;
     filename: string;
+    filepath: string;
     item: UploadImagesItem;
-    width: number | null;
-    height: number | null;
-    hasThumbnail: boolean;
+    isImage: boolean;
   };
   const prepared: Array<Prepared | null> = new Array(items.length).fill(null);
   const errors: Array<string | null> = new Array(items.length).fill(null);
 
   let next = 0;
-  const sizes = getThumbnailSettings(userId);
   const worker = async (): Promise<void> => {
     while (true) {
       const i = next++;
@@ -357,24 +355,14 @@ export async function uploadImages(
         const ext = extname(item.filename || "") || ".bin";
         const filename = `${id}${ext}`;
         const filepath = join(dir, filename);
-        const buffer = Buffer.from(item.data);
-        await Bun.write(filepath, buffer);
-
-        let width: number | null = null;
-        let height: number | null = null;
-        let hasThumbnail = false;
-        try {
-          const meta = await sharp(buffer).metadata();
-          width = meta.width ?? null;
-          height = meta.height ?? null;
-          const [smOk, lgOk] = await Promise.all([
-            generateThumbnail(buffer, join(dir, `${id}${thumbSuffix("sm")}`), sizes.smallSize),
-            generateThumbnail(buffer, join(dir, `${id}${thumbSuffix("lg")}`), sizes.largeSize),
-          ]);
-          hasThumbnail = smOk || lgOk;
-        } catch {}
-
-        prepared[i] = { id, filename, item, width, height, hasThumbnail };
+        await Bun.write(filepath, item.data);
+        prepared[i] = {
+          id,
+          filename,
+          filepath,
+          item,
+          isImage: (item.mime_type || "").startsWith("image/"),
+        };
       } catch (err: any) {
         errors[i] = err?.message ?? String(err);
       }
@@ -404,9 +392,9 @@ export async function uploadImages(
         p.filename,
         p.item.filename || "",
         p.item.mime_type || "",
-        p.width,
-        p.height,
-        p.hasThumbnail ? 1 : 0,
+        null,
+        null,
+        0,
         ownerExtensionIdentifier,
         normalizeOwnershipValue(p.item.owner_character_id),
         normalizeOwnershipValue(p.item.owner_chat_id),
@@ -427,9 +415,9 @@ export async function uploadImages(
       filename: p.filename,
       original_filename: p.item.filename || "",
       mime_type: p.item.mime_type || "",
-      width: p.width,
-      height: p.height,
-      has_thumbnail: p.hasThumbnail,
+      width: null,
+      height: null,
+      has_thumbnail: false,
       url: buildImageUrl(p.id, "full"),
       specificity: "full",
       owner_extension_identifier: ownerExtensionIdentifier,
@@ -438,8 +426,42 @@ export async function uploadImages(
       created_at: now,
     };
     results[i] = { id: p.id, image };
+    if (p.isImage) scheduleDeferredImageProcessing(userId, p.id, p.filepath);
   }
   return results;
+}
+
+function scheduleDeferredImageProcessing(
+  userId: string,
+  id: string,
+  filepath: string,
+): void {
+  void (async () => {
+    try {
+      const buffer = Buffer.from(await Bun.file(filepath).arrayBuffer());
+      let width: number | null = null;
+      let height: number | null = null;
+      try {
+        const meta = await sharp(buffer).metadata();
+        width = meta.width ?? null;
+        height = meta.height ?? null;
+      } catch {
+        return;
+      }
+      const dir = getImagesDir();
+      const sizes = getThumbnailSettings(userId);
+      const [smOk, lgOk] = await Promise.all([
+        ensureThumbnail(`${id}_sm`, buffer, join(dir, `${id}${thumbSuffix("sm")}`), sizes.smallSize),
+        ensureThumbnail(`${id}_lg`, buffer, join(dir, `${id}${thumbSuffix("lg")}`), sizes.largeSize),
+      ]);
+      const hasThumb = smOk || lgOk;
+      getDb()
+        .query("UPDATE images SET width = COALESCE(?, width), height = COALESCE(?, height), has_thumbnail = ? WHERE id = ?")
+        .run(width, height, hasThumb ? 1 : 0, id);
+    } catch (err) {
+      console.warn(`[images] deferred image processing failed for ${id}:`, err);
+    }
+  })();
 }
 
 export const IMAGE_GEN_FILENAME_PREFIX = "image-gen-";

--- a/src/services/images.service.ts
+++ b/src/services/images.service.ts
@@ -304,7 +304,144 @@ export async function saveImageFromDataUrl(
   return image;
 }
 
-/** Prefix used for image gen results — only images with this prefix are publicly accessible. */
+export interface UploadImagesItem {
+  data: Uint8Array;
+  filename: string;
+  mime_type: string;
+  owner_character_id?: string;
+  owner_chat_id?: string;
+}
+
+export interface UploadImagesResult {
+  id?: string;
+  error?: string;
+  image?: Image;
+}
+
+export async function uploadImages(
+  userId: string,
+  items: ReadonlyArray<UploadImagesItem>,
+  options?: {
+    owner_extension_identifier?: string;
+    concurrency?: number;
+  },
+): Promise<UploadImagesResult[]> {
+  if (items.length === 0) return [];
+  const concurrency = Math.min(Math.max(1, options?.concurrency ?? 16), 32);
+  const dir = getImagesDir();
+  const ownerExtensionIdentifier = normalizeOwnershipValue(options?.owner_extension_identifier);
+
+  type Prepared = {
+    id: string;
+    filename: string;
+    item: UploadImagesItem;
+    width: number | null;
+    height: number | null;
+    hasThumbnail: boolean;
+  };
+  const prepared: Array<Prepared | null> = new Array(items.length).fill(null);
+  const errors: Array<string | null> = new Array(items.length).fill(null);
+
+  let next = 0;
+  const sizes = getThumbnailSettings(userId);
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      const item = items[i]!;
+      try {
+        if (!(item.data instanceof Uint8Array) || item.data.byteLength === 0) {
+          throw new Error("Image data must be a non-empty Uint8Array");
+        }
+        const id = crypto.randomUUID();
+        const ext = extname(item.filename || "") || ".bin";
+        const filename = `${id}${ext}`;
+        const filepath = join(dir, filename);
+        const buffer = Buffer.from(item.data);
+        await Bun.write(filepath, buffer);
+
+        let width: number | null = null;
+        let height: number | null = null;
+        let hasThumbnail = false;
+        try {
+          const meta = await sharp(buffer).metadata();
+          width = meta.width ?? null;
+          height = meta.height ?? null;
+          const [smOk, lgOk] = await Promise.all([
+            generateThumbnail(buffer, join(dir, `${id}${thumbSuffix("sm")}`), sizes.smallSize),
+            generateThumbnail(buffer, join(dir, `${id}${thumbSuffix("lg")}`), sizes.largeSize),
+          ]);
+          hasThumbnail = smOk || lgOk;
+        } catch {}
+
+        prepared[i] = { id, filename, item, width, height, hasThumbnail };
+      } catch (err: any) {
+        errors[i] = err?.message ?? String(err);
+      }
+    }
+  };
+  const pool: Promise<void>[] = [];
+  for (let w = 0; w < Math.min(concurrency, items.length); w++) pool.push(worker());
+  await Promise.all(pool);
+
+  const now = Math.floor(Date.now() / 1000);
+  const db = getDb();
+  const insertStmt = db.query(
+    `INSERT INTO images (
+       id, user_id, filename, original_filename, mime_type,
+       width, height, has_thumbnail,
+       owner_extension_identifier, owner_character_id, owner_chat_id,
+       created_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+  db.transaction(() => {
+    for (let i = 0; i < prepared.length; i++) {
+      const p = prepared[i];
+      if (!p) continue;
+      insertStmt.run(
+        p.id,
+        userId,
+        p.filename,
+        p.item.filename || "",
+        p.item.mime_type || "",
+        p.width,
+        p.height,
+        p.hasThumbnail ? 1 : 0,
+        ownerExtensionIdentifier,
+        normalizeOwnershipValue(p.item.owner_character_id),
+        normalizeOwnershipValue(p.item.owner_chat_id),
+        now,
+      );
+    }
+  })();
+
+  const results: UploadImagesResult[] = new Array(items.length);
+  for (let i = 0; i < items.length; i++) {
+    const p = prepared[i];
+    if (!p) {
+      results[i] = { error: errors[i] ?? "unknown error" };
+      continue;
+    }
+    const image: Image = {
+      id: p.id,
+      filename: p.filename,
+      original_filename: p.item.filename || "",
+      mime_type: p.item.mime_type || "",
+      width: p.width,
+      height: p.height,
+      has_thumbnail: p.hasThumbnail,
+      url: buildImageUrl(p.id, "full"),
+      specificity: "full",
+      owner_extension_identifier: ownerExtensionIdentifier,
+      owner_character_id: normalizeOwnershipValue(p.item.owner_character_id),
+      owner_chat_id: normalizeOwnershipValue(p.item.owner_chat_id),
+      created_at: now,
+    };
+    results[i] = { id: p.id, image };
+  }
+  return results;
+}
+
 export const IMAGE_GEN_FILENAME_PREFIX = "image-gen-";
 
 /**

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -405,6 +405,13 @@ type RuntimeWorkerToHost =
     }
   | { type: "images_upload"; requestId: string; input: ImageUploadDTO; userId?: string }
   | {
+      type: "images_upload_many";
+      requestId: string;
+      items: ImageUploadDTO[];
+      userId?: string;
+      concurrency?: number;
+    }
+  | {
       type: "images_upload_from_data_url";
       requestId: string;
       dataUrl: string;
@@ -2505,6 +2512,9 @@ export class WorkerHost {
         break;
       case "images_upload":
         this.handleImagesUpload(msg.requestId, msg.input, msg.userId);
+        break;
+      case "images_upload_many":
+        this.handleImagesUploadMany(msg.requestId, msg.items, msg.userId, msg.concurrency);
         break;
       case "images_upload_from_data_url":
         this.handleImagesUploadFromDataUrl(
@@ -6109,6 +6119,73 @@ export class WorkerHost {
         });
 
         this.postToWorker({ type: "response", requestId, result: this.toImageDTO(img) });
+      } catch (err: any) {
+        this.postToWorker({ type: "response", requestId, error: err.message });
+      }
+    })();
+  }
+
+  private handleImagesUploadMany(
+    requestId: string,
+    items: any[],
+    userId?: string,
+    concurrency?: number,
+  ): void {
+    (async () => {
+      try {
+        if (!managerSvc.hasPermission(this.manifest.identifier, "images")) {
+          throw new Error(`${PERMISSION_DENIED_PREFIX} images — Images permission not granted`);
+        }
+        const resolvedUserId = this.resolveEffectiveUserId(userId);
+        if (!resolvedUserId) throw new Error("userId is required for operator-scoped extensions");
+        this.enforceScopedUser(resolvedUserId);
+
+        if (!Array.isArray(items)) {
+          throw new Error("items must be an array of ImageUploadDTO");
+        }
+        const total = items.length;
+        const workers = Math.min(Math.max(1, concurrency ?? 16), 32);
+
+        const results: Array<{ id?: string; error?: string }> = new Array(total);
+        let next = 0;
+        const ext = this.manifest.identifier;
+        const runWorker = async (): Promise<void> => {
+          while (true) {
+            const i = next++;
+            if (i >= total) return;
+            const input = items[i];
+            try {
+              if (!(input?.data instanceof Uint8Array) || input.data.byteLength === 0) {
+                throw new Error("Image data must be a non-empty Uint8Array");
+              }
+              const mimeType = typeof input?.mime_type === "string" && input.mime_type.trim()
+                ? input.mime_type.trim()
+                : "image/png";
+              const filename = typeof input?.filename === "string" && input.filename.trim()
+                ? input.filename.trim()
+                : "image.png";
+              const imageBytes = Uint8Array.from(input.data);
+              const file = new File([imageBytes.buffer], filename, { type: mimeType });
+              const img = await imagesSvc.uploadImage(resolvedUserId, file, {
+                owner_extension_identifier: ext,
+                owner_character_id: typeof input?.owner_character_id === "string" && input.owner_character_id.trim()
+                  ? input.owner_character_id.trim()
+                  : undefined,
+                owner_chat_id: typeof input?.owner_chat_id === "string" && input.owner_chat_id.trim()
+                  ? input.owner_chat_id.trim()
+                  : undefined,
+              });
+              results[i] = { id: img.id };
+            } catch (err: any) {
+              results[i] = { error: err?.message ?? String(err) };
+            }
+          }
+        };
+        const pool: Promise<void>[] = [];
+        for (let w = 0; w < Math.min(workers, total); w++) pool.push(runWorker());
+        await Promise.all(pool);
+
+        this.postToWorker({ type: "response", requestId, result: results });
       } catch (err: any) {
         this.postToWorker({ type: "response", requestId, error: err.message });
       }

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -6143,47 +6143,58 @@ export class WorkerHost {
         if (!Array.isArray(items)) {
           throw new Error("items must be an array of ImageUploadDTO");
         }
-        const total = items.length;
-        const workers = Math.min(Math.max(1, concurrency ?? 16), 32);
 
-        const results: Array<{ id?: string; error?: string }> = new Array(total);
-        let next = 0;
-        const ext = this.manifest.identifier;
-        const runWorker = async (): Promise<void> => {
-          while (true) {
-            const i = next++;
-            if (i >= total) return;
-            const input = items[i];
-            try {
-              if (!(input?.data instanceof Uint8Array) || input.data.byteLength === 0) {
-                throw new Error("Image data must be a non-empty Uint8Array");
-              }
-              const mimeType = typeof input?.mime_type === "string" && input.mime_type.trim()
-                ? input.mime_type.trim()
-                : "image/png";
-              const filename = typeof input?.filename === "string" && input.filename.trim()
-                ? input.filename.trim()
-                : "image.png";
-              const imageBytes = Uint8Array.from(input.data);
-              const file = new File([imageBytes.buffer], filename, { type: mimeType });
-              const img = await imagesSvc.uploadImage(resolvedUserId, file, {
-                owner_extension_identifier: ext,
-                owner_character_id: typeof input?.owner_character_id === "string" && input.owner_character_id.trim()
-                  ? input.owner_character_id.trim()
-                  : undefined,
-                owner_chat_id: typeof input?.owner_chat_id === "string" && input.owner_chat_id.trim()
-                  ? input.owner_chat_id.trim()
-                  : undefined,
-              });
-              results[i] = { id: img.id };
-            } catch (err: any) {
-              results[i] = { error: err?.message ?? String(err) };
-            }
+        const normalised: imagesSvc.UploadImagesItem[] = new Array(items.length);
+        const failures: Array<{ index: number; error: string }> = [];
+        for (let i = 0; i < items.length; i++) {
+          const input = items[i];
+          if (!input || typeof input !== "object") {
+            failures.push({ index: i, error: "item must be an object" });
+            continue;
           }
-        };
-        const pool: Promise<void>[] = [];
-        for (let w = 0; w < Math.min(workers, total); w++) pool.push(runWorker());
-        await Promise.all(pool);
+          if (!(input.data instanceof Uint8Array) || input.data.byteLength === 0) {
+            failures.push({ index: i, error: "Image data must be a non-empty Uint8Array" });
+            continue;
+          }
+          normalised[i] = {
+            data: input.data,
+            filename: typeof input.filename === "string" && input.filename.trim()
+              ? input.filename.trim()
+              : "image.png",
+            mime_type: typeof input.mime_type === "string" && input.mime_type.trim()
+              ? input.mime_type.trim()
+              : "image/png",
+            ...(typeof input.owner_character_id === "string" && input.owner_character_id.trim()
+              ? { owner_character_id: input.owner_character_id.trim() }
+              : {}),
+            ...(typeof input.owner_chat_id === "string" && input.owner_chat_id.trim()
+              ? { owner_chat_id: input.owner_chat_id.trim() }
+              : {}),
+          };
+        }
+
+        const validIndices: number[] = [];
+        const validItems: imagesSvc.UploadImagesItem[] = [];
+        for (let i = 0; i < normalised.length; i++) {
+          if (normalised[i] !== undefined) {
+            validIndices.push(i);
+            validItems.push(normalised[i]!);
+          }
+        }
+
+        const batchResults = await imagesSvc.uploadImages(resolvedUserId, validItems, {
+          owner_extension_identifier: this.manifest.identifier,
+          concurrency,
+        });
+
+        const results: Array<{ id?: string; error?: string }> = new Array(items.length);
+        for (const f of failures) results[f.index] = { error: f.error };
+        for (let k = 0; k < validIndices.length; k++) {
+          const out = batchResults[k]!;
+          results[validIndices[k]!] = out.id !== undefined
+            ? { id: out.id }
+            : { error: out.error ?? "unknown error" };
+        }
 
         this.postToWorker({ type: "response", requestId, result: results });
       } catch (err: any) {

--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -1737,6 +1737,21 @@ const spindleApi: RuntimeSpindleAPI = {
       const result = await request({ type: "images_upload", requestId, input, userId });
       return result as ImageDTO;
     },
+    async uploadMany(
+      items: ImageUploadDTO[],
+      options?: { userId?: string; concurrency?: number },
+    ): Promise<Array<{ id?: string; error?: string }>> {
+      assertMutationAllowed("spindle.images.uploadMany()");
+      const requestId = crypto.randomUUID();
+      const result = await request({
+        type: "images_upload_many",
+        requestId,
+        items,
+        userId: options?.userId,
+        concurrency: options?.concurrency,
+      });
+      return result as Array<{ id?: string; error?: string }>;
+    },
     async uploadFromDataUrl(
       dataUrl: string,
       originalFilenameOrOptions?: string | ImageUploadFromDataUrlOptionsDTO,

--- a/src/ws/handler.ts
+++ b/src/ws/handler.ts
@@ -8,7 +8,7 @@ import { getWorkerHost } from "../spindle/lifecycle";
 import * as managerSvc from "../spindle/manager.service";
 import { getFirstUserId } from "../auth/seed";
 
-const WS_MESSAGE_SIZE_LIMIT_DEFAULT = 65_536;
+const WS_MESSAGE_SIZE_LIMIT_DEFAULT = 1024 * 1024;
 const WS_MESSAGE_SIZE_LIMIT_SPINDLE_BACKEND_MSG = 4 * 1024 * 1024;
 
 export const wsHandler = upgradeWebSocket((c) => {


### PR DESCRIPTION
WS and Image Upload Speedup

- fa212a9ddd7018982806968ad5fa52330f93e0c9 Self explanatory. Different path to below commits.
- 28a568f35174a894ba4538bf2e19352b76fab448 Not much on its own. Adds batch uploading to the API.
- effdc9dd628b9ed72d2a236697fea1774f2b65a1 Allows batch inserting into the DB.
- 18a7e2fd6f334079c7cfb3760eec9e8f06681b3c This is a 10x speedup alone ontop of the previous steps. Defers sharp thumbnail generation in batch upload specifically. 

Spindle Types PR: https://github.com/prolix-oc/lumiverse-spindle-types/pull/12