### PR TITLE
Fix ordering race by adding mcp before regex apply

### DIFF
--- a/developer-docs/docs/backend-api/message-content-processor.md
+++ b/developer-docs/docs/backend-api/message-content-processor.md
@@ -46,7 +46,7 @@ interface MessageContentProcessorCtx {
 | `"update"` | `PUT /api/v1/chats/:chatId/messages/:id` | Edits an existing message's content or extra. |
 | `"swipe_add"` | `POST /api/v1/chats/:chatId/messages/:id/swipe` (with `content`) | Appends a new swipe. |
 | `"swipe_update"` | `PUT /api/v1/chats/:chatId/messages/:id/swipe/:idx` | Rewrites the swipe at `swipeIndex`. |
-| `"render"` | `POST /api/v1/chats/:chatId/display-preprocess` | Per-render transform for display only. Output feeds the display-regex pass and final paint. Does not write to the message row. |
+| `"render"` | `POST /api/v1/chats/:chatId/display-preprocess` AND `POST /api/v1/regex-scripts/apply` | Per-render transform for display only. Output feeds the display-regex pass and final paint. Does not write to the message row. |
 
 Returned `extra` is ignored on swipe origins: swipes share the parent message's `extra`, which `addSwipe` and `updateSwipe` cannot patch. Only `content` is honored.
 
@@ -74,6 +74,9 @@ The render context populates `extra` with hints from the calling frontend:
 | `extra.is_user` | `boolean` | Mirror of `role === "user"`. |
 
 `messageId` is set on the context when the rendered message has one. The route accepts an optional `messageIndex` body field that lands on `extra.messageIndex` if supplied by the caller.
+
+!!! note "The render origin fires twice per visible message"
+    Both `/display-preprocess` and `/regex-scripts/apply` invoke the chain so the body the regex pipeline sees matches the body destined for the frontend. Both calls pass identical `(chatId, messageId, content)`. Handlers doing non-trivial work should dedupe with a small content-hash cache keyed by `(chatId, messageId, fnv1a(content))` so the second invocation is a Map lookup. Invalidate the cache on `CHAT_CHANGED` (var change), `MESSAGE_EDITED`, `MESSAGE_SWIPED`, and `MESSAGE_DELETED`.
 
 ## Return Value
 

--- a/frontend/src/hooks/useDisplayRegex.ts
+++ b/frontend/src/hooks/useDisplayRegex.ts
@@ -652,6 +652,8 @@ export function useDisplayRegex(
           resolvedFindPatterns: resolvedTemplates.resolvedFindPatterns,
           resolvedReplacements: resolvedTemplates.resolvedReplacements,
           dynamicMacros,
+          ...(preprocessOpts?.messageId ? { messageId: preprocessOpts.messageId } : {}),
+          ...(preprocessOpts?.role ? { role: preprocessOpts.role } : {}),
         },
         (templates) => resolveMacrosBatchChunked(templates, {
           chat_id: activeChatId ?? undefined,

--- a/frontend/src/lib/regex/compiler.ts
+++ b/frontend/src/lib/regex/compiler.ts
@@ -139,6 +139,9 @@ interface ApplyDisplayRegexContext {
   resolvedFindPatterns?: Map<string, string>
   resolvedReplacements?: Map<string, string>
   dynamicMacros?: Record<string, string>
+  messageId?: string
+  messageIndex?: number
+  role?: 'user' | 'assistant' | 'system'
 }
 
 interface SlowRegexReport {
@@ -196,6 +199,9 @@ async function applyDisplayRegexOnBackend(
           persona_id: context.personaId,
           is_user: context.isUser,
           depth: context.depth,
+          ...(context.messageId ? { message_id: context.messageId } : {}),
+          ...(typeof context.messageIndex === 'number' ? { message_index: context.messageIndex } : {}),
+          ...(context.role ? { role: context.role } : {}),
         },
       }),
     })

--- a/src/routes/regex-scripts.routes.ts
+++ b/src/routes/regex-scripts.routes.ts
@@ -170,6 +170,11 @@ app.post("/apply", async (c) => {
     ? Object.fromEntries(Object.entries(body.dynamic_macros).filter(([, v]) => typeof v === "string")) as Record<string, string>
     : undefined;
 
+  const ctxRole = typeof context.role === "string"
+    && (context.role === "user" || context.role === "assistant" || context.role === "system")
+    ? (context.role as "user" | "assistant" | "system")
+    : undefined;
+
   const applied = await applyDisplayRegex({
     content,
     scripts: scripts.filter((script) => !script.disabled),
@@ -179,11 +184,15 @@ app.post("/apply", async (c) => {
       persona_id: typeof context.persona_id === "string" ? context.persona_id : undefined,
       is_user: !!context.is_user,
       depth: typeof context.depth === "number" ? context.depth : 0,
+      ...(typeof context.message_id === "string" ? { message_id: context.message_id } : {}),
+      ...(typeof context.message_index === "number" ? { message_index: context.message_index } : {}),
+      ...(ctxRole ? { role: ctxRole } : {}),
     },
     userId,
     resolvedFindPatterns: normalizeResolvedMap(body.resolved_find_patterns),
     resolvedReplacements: normalizeResolvedMap(body.resolved_replacements),
     dynamicMacros,
+    signal: c.req.raw.signal,
   });
 
   return c.json({

--- a/src/services/display-regex.service.ts
+++ b/src/services/display-regex.service.ts
@@ -1,5 +1,6 @@
 import { buildEnv, initMacros, mergeDynamicMacros, resolveGroupCharacterNames } from "../macros";
 import type { MacroEnv } from "../macros";
+import { messageContentProcessorChain } from "../spindle/message-content-processor";
 import { getEffectiveCharacterName } from "../types/character";
 import type { Chat } from "../types/chat";
 import type { RegexPlacement, RegexScript } from "../types/regex-script";
@@ -18,6 +19,9 @@ export interface DisplayRegexContext {
   persona_id?: string;
   is_user: boolean;
   depth: number;
+  message_id?: string;
+  message_index?: number;
+  role?: "user" | "assistant" | "system";
 }
 
 export interface ApplyDisplayRegexInput {
@@ -28,6 +32,7 @@ export interface ApplyDisplayRegexInput {
   resolvedFindPatterns?: Map<string, string>;
   resolvedReplacements?: Map<string, string>;
   dynamicMacros?: Record<string, string>;
+  signal?: AbortSignal;
 }
 
 function buildEnvFromContext(userId: string, ctx: DisplayRegexContext): MacroEnv | undefined {
@@ -155,13 +160,46 @@ export interface ApplyDisplayRegexResult {
 
 export async function applyDisplayRegex(input: ApplyDisplayRegexInput): Promise<ApplyDisplayRegexResult> {
   const placement: RegexPlacement = input.context.is_user ? "user_input" : "ai_output";
+
+  let content = input.content;
+  if (
+    messageContentProcessorChain.count > 0
+    && input.context.chat_id
+    && content.length > 0
+  ) {
+    try {
+      const pre = await messageContentProcessorChain.run(
+        {
+          chatId: input.context.chat_id,
+          content,
+          origin: "render",
+          userId: input.userId,
+          ...(input.context.message_id ? { messageId: input.context.message_id } : {}),
+          extra: {
+            ...(typeof input.context.message_index === "number"
+              ? { messageIndex: input.context.message_index }
+              : {}),
+            ...(input.context.role
+              ? { role: input.context.role, is_user: input.context.role === "user" }
+              : {}),
+          },
+        },
+        input.userId,
+        input.signal,
+      );
+      if (typeof pre.content === "string") content = pre.content;
+    } catch {
+      // Render-MCP failure should not block regex application; fall through with the raw content.
+    }
+  }
+
   const env = buildEnvFromContext(input.userId, input.context);
   if (env && input.dynamicMacros) {
     mergeDynamicMacros(env, input.dynamicMacros);
   }
   const fingerprint = { touchedVars: new Set<string>(), cacheable: true };
   const result = await applyRegexScripts(
-    input.content,
+    content,
     input.scripts,
     placement,
     input.context.depth,


### PR DESCRIPTION
This PR fixes a performance destroying ordering race in the display pipeline. /regex-scripts/apply and /display-preprocess operate on the same message body but fire in parallel from the frontend, so /apply consistently runs on the raw, un-preprocessed body. This is fine for most cards but catastrophic for cards whose regex rules use 'after' or 'raw' mode with state-dependent replace strings.

Display-preprocess and display-regex-apply both operate on the body about to be rendered. Without this PR, the raw body contains every conditional branch the card defines, native string-replace substitutes the heavy replace string at every branch's body, and the body balloons before macro eval can collapse it. Metrics below.

<img width="893" height="230" alt="image" src="https://github.com/user-attachments/assets/72e419c5-f2b1-4310-a23f-808bcb6ed9cb" />

Note:
- Render-MCP chain now runs once per /display-preprocess AND once per /apply. Extensions doing work in the render hook should dedupe via a content-hash cache or they pay the cost twice.
- Existing clients work unchanged.
