### PR TITLE
fix udvy flag wrapping on regex UI panel

### DIFF
--- a/frontend/src/components/panels/RegexPanel.module.css
+++ b/frontend/src/components/panels/RegexPanel.module.css
@@ -258,8 +258,9 @@
 }
 
 .flagsRow {
-  display: flex;
-  gap: 8px;
+  display: grid;
+  grid-template-columns: repeat(4, max-content);
+  gap: 4px 8px;
   align-items: center;
 }
 


### PR DESCRIPTION
fix the wrapping
Before:
<img width="412" height="129" alt="image" src="https://github.com/user-attachments/assets/415e15df-6505-4e19-801f-054b6f5979ab" />
After:
<img width="422" height="140" alt="image" src="https://github.com/user-attachments/assets/52c14d98-3a82-4537-8d52-b45035778753" />
(this was kinda my fault)
