### PR TITLE
Push role info through dynamicMacros

### DIFF
--- a/src/services/display-regex.service.ts
+++ b/src/services/display-regex.service.ts
@@ -194,8 +194,14 @@ export async function applyDisplayRegex(input: ApplyDisplayRegexInput): Promise<
   }
 
   const env = buildEnvFromContext(input.userId, input.context);
-  if (env && input.dynamicMacros) {
-    mergeDynamicMacros(env, input.dynamicMacros);
+  if (env) {
+    const dyn: Record<string, string> = { ...(input.dynamicMacros ?? {}) };
+    if (input.context.role && dyn.role === undefined) {
+      dyn.role = input.context.role;
+    }
+    if (Object.keys(dyn).length > 0) {
+      mergeDynamicMacros(env, dyn);
+    }
   }
   const fingerprint = { touchedVars: new Set<string>(), cacheable: true };
   const result = await applyRegexScripts(


### PR DESCRIPTION
Plumb context.role into env.dynamicMacros.role for display-regex so extension macro handlers can resolve {{role}} per message bubble.

Similar to the existing chat_index plumbing.