### PR TITLE
roundtrip reasoning_content for DeepSeek thinking-mode tool loops

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "hono": "^4.7.0",
     "js-tiktoken": "^1.0.16",
     "jsdom": "^29.0.1",
-    "lumiverse-spindle-types": "0.4.71",
+    "lumiverse-spindle-types": "0.4.72",
     "mute-stream": "^3.0.0",
     "sharp": "^0.34.5",
     "ssh2-sftp-client": "^12.1.1"

--- a/src/llm/providers/openai-compatible.test.ts
+++ b/src/llm/providers/openai-compatible.test.ts
@@ -189,3 +189,127 @@ describe("OpenAICompatibleProvider tool calling wire shape", () => {
     ]);
   });
 });
+
+// DeepSeek thinking-mode (deepseek-reasoner, deepseek-chat with thinking
+// enabled) requires the previous turn's reasoning_content to be echoed back
+// on the assistant message when continuing a conversation that involved a
+// tool call. Without this, the API rejects the request with:
+//   "The `reasoning_content` in the thinking mode must be passed back to
+//   the API." (deepseek 400 invalid_request_error)
+// Per DeepSeek's docs (api-docs.deepseek.com/guides/thinking_mode), the
+// requirement applies ONLY to tool-call continuations — plain-text
+// continuations don't need the field. Tests pin that scope deliberately.
+describe("OpenAICompatibleProvider reasoning_content roundtrip", () => {
+  const provider = new TestOpenAICompatibleProvider();
+
+  test("assistant + tool_use parts + reasoning_content → field on assistant body", () => {
+    const body = (provider as any).buildBody(
+      {
+        model: "deepseek-reasoner",
+        messages: [
+          { role: "user", content: "weather?" },
+          {
+            role: "assistant",
+            content: [
+              { type: "tool_use", id: "call_x", name: "lookup", input: { q: "SF" } },
+            ],
+            reasoning_content: "I should look up SF weather.",
+          },
+          {
+            role: "user",
+            content: [
+              { type: "tool_result", tool_use_id: "call_x", content: "72F" },
+            ],
+          },
+        ],
+        parameters: {},
+      },
+      false,
+    );
+
+    expect(body.messages[1]).toEqual({
+      role: "assistant",
+      content: null,
+      tool_calls: [
+        { id: "call_x", type: "function", function: { name: "lookup", arguments: '{"q":"SF"}' } },
+      ],
+      reasoning_content: "I should look up SF weather.",
+    });
+  });
+
+  test("assistant + tool_use without reasoning_content → field absent (no undefined / null pollution)", () => {
+    const body = (provider as any).buildBody(
+      {
+        model: "gpt-4o",
+        messages: [
+          { role: "user", content: "x" },
+          {
+            role: "assistant",
+            content: [
+              { type: "tool_use", id: "call_1", name: "ping", input: {} },
+            ],
+          },
+        ],
+        parameters: {},
+      },
+      false,
+    );
+
+    expect(body.messages[1]).toEqual({
+      role: "assistant",
+      content: null,
+      tool_calls: [
+        { id: "call_1", type: "function", function: { name: "ping", arguments: "{}" } },
+      ],
+    });
+    expect("reasoning_content" in body.messages[1]).toBe(false);
+  });
+
+  test("assistant + text-only parts (no tool_use) + reasoning_content → field NOT propagated", () => {
+    // DeepSeek's docs are explicit: reasoning_content is required only on
+    // tool-call continuations, NOT on plain-text continuations. We honour
+    // that scope and deliberately do not propagate the field for non-tool
+    // assistant turns, even when the script supplies it. If a future
+    // provider requires broader propagation, expand this then — but pinning
+    // the current narrow scope prevents accidental over-propagation.
+    const body = (provider as any).buildBody(
+      {
+        model: "deepseek-reasoner",
+        messages: [
+          { role: "user", content: "what's 2+2?" },
+          {
+            role: "assistant",
+            content: [
+              { type: "text", text: "The answer is 4." },
+            ],
+            reasoning_content: "2+2 is basic arithmetic; the answer is 4.",
+          },
+          { role: "user", content: "thanks" },
+        ],
+        parameters: {},
+      },
+      false,
+    );
+
+    expect("reasoning_content" in body.messages[1]).toBe(false);
+  });
+
+  test("user-role message with reasoning_content → field ignored (only assistant tool-call turns carry reasoning)", () => {
+    // Defensive: reasoning_content on a non-assistant message is meaningless
+    // and shouldn't leak into the request body — DeepSeek's API doesn't
+    // accept reasoning_content on user/system messages.
+    const body = (provider as any).buildBody(
+      {
+        model: "deepseek-reasoner",
+        messages: [
+          { role: "user", content: "hello", reasoning_content: "WRONG SHOULD NOT APPEAR" },
+        ],
+        parameters: {},
+      },
+      false,
+    );
+
+    expect(body.messages[0]).toEqual({ role: "user", content: "hello" });
+    expect("reasoning_content" in body.messages[0]).toBe(false);
+  });
+});

--- a/src/llm/providers/openai-compatible.ts
+++ b/src/llm/providers/openai-compatible.ts
@@ -309,6 +309,18 @@ export abstract class OpenAICompatibleProvider implements LlmProvider {
         .filter((p): p is Extract<LlmMessagePart, { type: "text" }> => p.type === "text")
         .map((p) => p.text)
         .join("");
+      // DeepSeek thinking-mode (`deepseek-reasoner`, `deepseek-chat` with
+      // thinking enabled) requires the previous turn's `reasoning_content` to
+      // be echoed back on the assistant message **when the turn invoked a
+      // tool call** and the conversation continues. Without it, the API
+      // rejects the continuation request with:
+      //   "The `reasoning_content` in the thinking mode must be passed back
+      //   to the API." (deepseek 400 invalid_request_error)
+      // Per DeepSeek's docs, this is required ONLY on tool-call turns —
+      // plain-text continuations do not need the field. We scope propagation
+      // accordingly. Other openai-compatible providers that route DeepSeek
+      // (NanoGPT, OpenRouter, etc.) inherit this behaviour; providers
+      // without thinking mode never receive the field anyway.
       out.push({
         role: "assistant",
         content: text.length > 0 ? text : null,
@@ -317,6 +329,7 @@ export abstract class OpenAICompatibleProvider implements LlmProvider {
           type: "function",
           function: { name: tc.name, arguments: JSON.stringify(tc.input ?? {}) },
         })),
+        ...(m.reasoning_content ? { reasoning_content: m.reasoning_content } : {}),
       });
     } else if (nonTool.length > 0) {
       out.push({ role: m.role, content: this.formatContent({ ...m, content: nonTool }) });


### PR DESCRIPTION
`OpenAICompatibleProvider.flattenForChat` now propagates an assistant message's `reasoning_content` field into the request body when the turn invoked a tool call, satisfying DeepSeek's thinking-mode roundtrip requirement on continuations.

Pins `lumiverse-spindle-types` to `0.4.72`, which adds the `LlmMessageDTO.reasoning_content?` slot used by this code path.

## Why

Reproduces against `api.deepseek.com` with any thinking-enabled DeepSeek model. Minimal repro:

1. Make a tool-calling generation request — model returns `tool_calls` and `reasoning_content`.
2. Execute the tools, build a continuation request with the assistant turn echoed back (as you must, to make tool results meaningful to the model).
3. Submit the continuation.

DeepSeek's API rejects step 3 with:

```
HTTP 400: The `reasoning_content` in the thinking mode must be passed back to the API.
```

The error makes any agentic tool loop against a thinking-mode DeepSeek model unusable. Per the
[DeepSeek docs](https://api-docs.deepseek.com/guides/thinking_mode), the requirement applies only to tool-call continuations — plain-text continuations don't need the field.

## Root cause

Response side was fine — `generate()` already reads `choice?.message?.reasoning || choice?.message?.reasoning_content` into `GenerationResponse.reasoning`. The break was on the request side: `flattenForChat` emitted assistant tool-call messages without copying `reasoning_content` from the input `LlmMessage`. Spindle-types 0.4.71 didn't expose a slot for it on `LlmMessageDTO`, so callers couldn't supply it even if `flattenForChat` had asked.

## Fix

Two coupled pieces:

- **spindle-types** ([`feat/llm-reasoning-roundtrip` in `lumiverse-spindle-types`](TBD), publishing as `0.4.72`) adds `reasoning_content?: string` to `LlmMessageDTO`.
- **This PR** updates `flattenForChat` to propagate the field onto the emitted assistant body **on the tool-call branch only**. Inline conditional spread; minimal diff. Per DeepSeek's docs the roundtrip is required only on tool-call continuations, and we scope accordingly to avoid over-propagating into cases that don't need it.

Coverage: all openai-compatible providers that route DeepSeek thinking models — DeepSeek's official endpoint (via `DeepSeekProvider`) plus third-party proxies that subclass `OpenAICompatibleProvider` (NanoGPT, OpenRouter, etc.). Non-DeepSeek providers don't see the field on their responses and so don't need to roundtrip it; their behaviour is unchanged.

## Tests

`openai-compatible.test.ts` gains a new `reasoning_content roundtrip` describe block (4 cases):

- Assistant + tool_use + `reasoning_content` → field present on body
- Assistant + tool_use without `reasoning_content` → field absent (no `undefined` / `null` pollution)
- Assistant + text-only parts + `reasoning_content` → field **NOT** propagated (pins the deliberate narrow scope)
- User-role message with `reasoning_content` → field stripped (defensive: meaningless on non-assistant turns)

## Verification

Reproduced the failure against `api.deepseek.com` via the LumiScript extension's `generateWithTools` agentic loop. Confirmed the fix end-to-end. Re-verified non-thinking-mode generation still works against several openai-compatible connections to rule out regression.

## Depends on

https://github.com/prolix-oc/lumiverse-spindle-types/pull/14