### PR TITLE
Fix Gemini Tooling

### DIFF
--- a/src/llm/providers/google-vertex.test.ts
+++ b/src/llm/providers/google-vertex.test.ts
@@ -27,8 +27,31 @@ describe("GoogleVertexProvider tool calling wire shape", () => {
       role: "model",
       parts: [
         { text: "Looking it up." },
-        { functionCall: { name: "get_weather", args: { city: "SF" } } },
+        { functionCall: { name: "get_weather", args: { city: "SF" } }, thoughtSignature: "context_engineering_is_the_way_to_go" },
       ],
+    });
+  });
+
+  test("captured thought_signature is echoed verbatim on the functionCall", () => {
+    const provider = new GoogleVertexProvider();
+    const body = (provider as any).buildBody({
+      model: "gemini-3-flash",
+      messages: [
+        { role: "user", content: "hi" },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "fc_1", name: "get_weather", input: { city: "SF" }, thought_signature: "REAL_SIG_A" },
+          ],
+        },
+      ],
+      parameters: {},
+      tools: [{ name: "get_weather", description: "weather", parameters: {} }],
+    });
+
+    expect(body.contents[1].parts[0]).toEqual({
+      functionCall: { name: "get_weather", args: { city: "SF" } },
+      thoughtSignature: "REAL_SIG_A",
     });
   });
 

--- a/src/llm/providers/google-vertex.ts
+++ b/src/llm/providers/google-vertex.ts
@@ -288,7 +288,7 @@ export class GoogleVertexProvider implements LlmProvider {
       if (p.thought) {
         reasoning += p.text || "";
       } else if (p.functionCall) {
-        fnCalls.push({ name: p.functionCall.name, args: p.functionCall.args ?? {}, call_id: crypto.randomUUID() });
+        fnCalls.push({ name: p.functionCall.name, args: p.functionCall.args ?? {}, call_id: crypto.randomUUID(), thought_signature: p.thoughtSignature });
       } else {
         content += p.text || "";
       }
@@ -369,7 +369,7 @@ export class GoogleVertexProvider implements LlmProvider {
               if (p.thought) {
                 reasoning += p.text || "";
               } else if (p.functionCall) {
-                fnCalls.push({ name: p.functionCall.name, args: p.functionCall.args ?? {}, call_id: crypto.randomUUID() });
+                fnCalls.push({ name: p.functionCall.name, args: p.functionCall.args ?? {}, call_id: crypto.randomUUID(), thought_signature: p.thoughtSignature });
               } else {
                 text += p.text || "";
               }
@@ -468,7 +468,9 @@ export class GoogleVertexProvider implements LlmProvider {
         case "audio":
           return { inlineData: { mimeType: part.mime_type, data: part.data } };
         case "tool_use":
-          return { functionCall: { name: part.name, args: part.input } };
+          return part.thought_signature
+            ? { functionCall: { name: part.name, args: part.input }, thoughtSignature: part.thought_signature }
+            : { functionCall: { name: part.name, args: part.input } };
         case "tool_result": {
           let payload: unknown = part.content;
           try { payload = JSON.parse(part.content); } catch { /* keep as string */ }

--- a/src/llm/providers/google-vertex.ts
+++ b/src/llm/providers/google-vertex.ts
@@ -468,9 +468,7 @@ export class GoogleVertexProvider implements LlmProvider {
         case "audio":
           return { inlineData: { mimeType: part.mime_type, data: part.data } };
         case "tool_use":
-          return part.thought_signature
-            ? { functionCall: { name: part.name, args: part.input }, thoughtSignature: part.thought_signature }
-            : { functionCall: { name: part.name, args: part.input } };
+          return { functionCall: { name: part.name, args: part.input }, thoughtSignature: part.thought_signature || "context_engineering_is_the_way_to_go" };
         case "tool_result": {
           let payload: unknown = part.content;
           try { payload = JSON.parse(part.content); } catch { /* keep as string */ }

--- a/src/llm/providers/google-vertex.ts
+++ b/src/llm/providers/google-vertex.ts
@@ -3,6 +3,7 @@ import { COMMON_PARAMS, type ProviderCapabilities } from "../param-schema";
 import { createCooperativeYielder, fetchWithPreflightAbort, readWithAbort } from "../stream-utils";
 import { getTextContent, type GenerationRequest, type GenerationResponse, type StreamChunk, type ToolCallResult, type LlmMessage, type LlmMessagePart } from "../types";
 import { fetchProviderJson, throwProviderResponseError } from "../../utils/provider-errors";
+import { sanitizeGeminiSchema } from "./google";
 
 // ── Service account JWT → OAuth2 access token ──────────────────────────────
 
@@ -568,7 +569,7 @@ export class GoogleVertexProvider implements LlmProvider {
         functionDeclarations: request.tools.map((t) => ({
           name: t.name,
           description: t.description,
-          parameters: t.parameters,
+          parameters: sanitizeGeminiSchema(t.parameters),
         })),
       }];
     }

--- a/src/llm/providers/google.test.ts
+++ b/src/llm/providers/google.test.ts
@@ -28,8 +28,31 @@ describe("GoogleProvider tool calling wire shape", () => {
       role: "model",
       parts: [
         { text: "Looking it up." },
-        { functionCall: { name: "get_weather", args: { city: "SF" } } },
+        { functionCall: { name: "get_weather", args: { city: "SF" } }, thoughtSignature: "context_engineering_is_the_way_to_go" },
       ],
+    });
+  });
+
+  test("captured thought_signature is echoed verbatim on the functionCall", () => {
+    const provider = new GoogleProvider();
+    const body = (provider as any).buildBody({
+      model: "gemini-3-flash",
+      messages: [
+        { role: "user", content: "hi" },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "fc_1", name: "get_weather", input: { city: "SF" }, thought_signature: "REAL_SIG_A" },
+          ],
+        },
+      ],
+      parameters: {},
+      tools: [{ name: "get_weather", description: "weather", parameters: {} }],
+    });
+
+    expect(body.contents[1].parts[0]).toEqual({
+      functionCall: { name: "get_weather", args: { city: "SF" } },
+      thoughtSignature: "REAL_SIG_A",
     });
   });
 

--- a/src/llm/providers/google.ts
+++ b/src/llm/providers/google.ts
@@ -4,13 +4,20 @@ import { createCooperativeYielder, fetchWithPreflightAbort, readWithAbort } from
 import { getTextContent, type GenerationRequest, type GenerationResponse, type StreamChunk, type ToolCallResult, type LlmMessage, type LlmMessagePart } from "../types";
 import { fetchProviderJson, ProviderRequestError, throwProviderResponseError } from "../../utils/provider-errors";
 
+const GEMINI_SCHEMA_FIELDS = new Set(["type","format","title","description","nullable","enum","maxItems","minItems","properties","required","minProperties","maxProperties","minLength","maxLength","pattern","example","anyOf","propertyOrdering","default","items","minimum","maximum"]);
+
 export function sanitizeGeminiSchema(schema: unknown): unknown {
-  if (Array.isArray(schema)) return schema.map(sanitizeGeminiSchema);
-  if (!schema || typeof schema !== "object") return schema;
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) return schema;
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(schema as Record<string, unknown>)) {
-    if (k === "additionalProperties" || k === "$schema") continue;
-    out[k] = sanitizeGeminiSchema(v);
+    if (!GEMINI_SCHEMA_FIELDS.has(k)) continue;
+    if (k === "items") out[k] = sanitizeGeminiSchema(v);
+    else if (k === "anyOf" && Array.isArray(v)) out[k] = v.map(sanitizeGeminiSchema);
+    else if (k === "properties" && v && typeof v === "object" && !Array.isArray(v)) {
+      const p: Record<string, unknown> = {};
+      for (const [pn, ps] of Object.entries(v as Record<string, unknown>)) p[pn] = sanitizeGeminiSchema(ps);
+      out[k] = p;
+    } else out[k] = v;
   }
   return out;
 }

--- a/src/llm/providers/google.ts
+++ b/src/llm/providers/google.ts
@@ -71,7 +71,7 @@ export class GoogleProvider implements LlmProvider {
       if (p.thought) {
         reasoning += p.text || "";
       } else if (p.functionCall) {
-        fnCalls.push({ name: p.functionCall.name, args: p.functionCall.args ?? {}, call_id: crypto.randomUUID() });
+        fnCalls.push({ name: p.functionCall.name, args: p.functionCall.args ?? {}, call_id: crypto.randomUUID(), thought_signature: p.thoughtSignature });
       } else {
         content += p.text || "";
       }
@@ -146,7 +146,7 @@ export class GoogleProvider implements LlmProvider {
             if (p.thought) {
               reasoning += p.text || "";
             } else if (p.functionCall) {
-              fnCalls.push({ name: p.functionCall.name, args: p.functionCall.args ?? {}, call_id: crypto.randomUUID() });
+              fnCalls.push({ name: p.functionCall.name, args: p.functionCall.args ?? {}, call_id: crypto.randomUUID(), thought_signature: p.thoughtSignature });
             } else {
               text += p.text || "";
             }
@@ -221,7 +221,9 @@ export class GoogleProvider implements LlmProvider {
         case "audio":
           return { inlineData: { mimeType: part.mime_type, data: part.data } };
         case "tool_use":
-          return { functionCall: { name: part.name, args: part.input } };
+          return part.thought_signature
+            ? { functionCall: { name: part.name, args: part.input }, thoughtSignature: part.thought_signature }
+            : { functionCall: { name: part.name, args: part.input } };
         case "tool_result": {
           let payload: unknown = part.content;
           try { payload = JSON.parse(part.content); } catch { /* keep as string */ }

--- a/src/llm/providers/google.ts
+++ b/src/llm/providers/google.ts
@@ -4,6 +4,17 @@ import { createCooperativeYielder, fetchWithPreflightAbort, readWithAbort } from
 import { getTextContent, type GenerationRequest, type GenerationResponse, type StreamChunk, type ToolCallResult, type LlmMessage, type LlmMessagePart } from "../types";
 import { fetchProviderJson, ProviderRequestError, throwProviderResponseError } from "../../utils/provider-errors";
 
+export function sanitizeGeminiSchema(schema: unknown): unknown {
+  if (Array.isArray(schema)) return schema.map(sanitizeGeminiSchema);
+  if (!schema || typeof schema !== "object") return schema;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(schema as Record<string, unknown>)) {
+    if (k === "additionalProperties" || k === "$schema") continue;
+    out[k] = sanitizeGeminiSchema(v);
+  }
+  return out;
+}
+
 export class GoogleProvider implements LlmProvider {
   readonly name = "google";
   readonly displayName = "Google Gemini";
@@ -320,7 +331,7 @@ export class GoogleProvider implements LlmProvider {
         functionDeclarations: request.tools.map((t) => ({
           name: t.name,
           description: t.description,
-          parameters: t.parameters,
+          parameters: sanitizeGeminiSchema(t.parameters),
         })),
       }];
     } else {

--- a/src/llm/providers/google.ts
+++ b/src/llm/providers/google.ts
@@ -228,9 +228,7 @@ export class GoogleProvider implements LlmProvider {
         case "audio":
           return { inlineData: { mimeType: part.mime_type, data: part.data } };
         case "tool_use":
-          return part.thought_signature
-            ? { functionCall: { name: part.name, args: part.input }, thoughtSignature: part.thought_signature }
-            : { functionCall: { name: part.name, args: part.input } };
+          return { functionCall: { name: part.name, args: part.input }, thoughtSignature: part.thought_signature || "context_engineering_is_the_way_to_go" };
         case "tool_result": {
           let payload: unknown = part.content;
           try { payload = JSON.parse(part.content); } catch { /* keep as string */ }

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -28,6 +28,7 @@ export interface LlmToolUsePart {
   name: string;
   input: Record<string, unknown>;
   cache_control?: Record<string, unknown>;
+  thought_signature?: string;
 }
 
 export interface LlmToolResultPart {
@@ -104,6 +105,7 @@ export interface ToolCallResult {
   args: Record<string, unknown>;
   /** Provider call ID (e.g. Anthropic `id`, OpenAI `id`). Synthetic UUID for providers that don't supply one. */
   call_id: string;
+  thought_signature?: string;
 }
 
 export interface GenerationResponse {


### PR DESCRIPTION
I missed this in the first tooling implementation. The fix strips JSON-Schema fields outside the OpenAPI 3.0 subset and captures and echoes thoughtSignature on functionCall parts.