### PR TITLE
Allow extensions to mount overlays beneath the sidebar

### DIFF
--- a/developer-docs/docs/frontend-api/ui-placement.md
+++ b/developer-docs/docs/frontend-api/ui-placement.md
@@ -170,7 +170,7 @@ Mount an unrestricted portal into `document.body` that persists across route cha
 ```ts
 const mount = ctx.ui.mountApp({
   className: 'my-ext-overlay',
-  position: 'end',     // 'start' or 'end' of body
+  position: 'end',     // 'start' | 'end' (body) | 'app-overlay'
 })
 
 // Full control over the mount
@@ -181,6 +181,8 @@ mount.setVisible(false)
 
 mount.destroy()
 ```
+
+`'app-overlay'` mounts inside the app shell, layered below the sidebar drawer and modals. `position: fixed` children still anchor to the viewport, but app chrome covers the overlay through normal stacking instead of you hiding it manually.
 
 ## Input Bar Actions (free — no permission needed)
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -151,6 +151,7 @@ export default function App() {
         <MotionConfig reducedMotion="user">
           <div
             className={styles.app}
+            data-app-root=""
             style={{
               '--spindle-dock-left': `${dockInsets.left}px`,
               '--spindle-dock-right': `${dockInsets.right}px`,

--- a/frontend/src/components/spindle/SpindleAppMount.tsx
+++ b/frontend/src/components/spindle/SpindleAppMount.tsx
@@ -25,9 +25,24 @@ export default function SpindleAppMount({ mount }: Props) {
       container.replaceChildren(mount.root)
     }
 
-    if (mount.position === 'start') {
+    if (mount.position === 'app-overlay') {
+      const appRoot = document.querySelector('[data-app-root]')
+      if (appRoot) {
+        container.style.position = 'relative'
+        container.style.zIndex = '9990'
+        appRoot.appendChild(container)
+      } else {
+        container.style.position = ''
+        container.style.zIndex = ''
+        document.body.appendChild(container)
+      }
+    } else if (mount.position === 'start') {
+      container.style.position = ''
+      container.style.zIndex = ''
       document.body.insertBefore(container, document.body.firstChild)
     } else {
+      container.style.position = ''
+      container.style.zIndex = ''
       document.body.appendChild(container)
     }
 

--- a/frontend/src/lib/spindle/placement-helper.ts
+++ b/frontend/src/lib/spindle/placement-helper.ts
@@ -304,7 +304,7 @@ export function createAppMountHandle(
     extensionId,
     root,
     className: options?.className,
-    position: options?.position ?? 'end',
+    position: (options?.position ?? 'end') as 'start' | 'end' | 'app-overlay',
     visible: true,
   })
 

--- a/frontend/src/store/slices/spindle-placement.ts
+++ b/frontend/src/store/slices/spindle-placement.ts
@@ -72,7 +72,7 @@ export interface AppMountState {
   extensionId: string
   root: HTMLElement
   className?: string
-  position: 'start' | 'end'
+  position: 'start' | 'end' | 'app-overlay'
   visible: boolean
 }
 


### PR DESCRIPTION
Extension overlays used to be mounted outside the app shell, where CSS made it impossible to slide them behind the sidebar without hiding them entirely with JavaScript. This adds an app-overlay mount option that places them inside the shell but layered beneath the sidebar, so the sidebar simply covers them like any other panel while overlay elements elsewhere on screen stay visible, and they still stick to the screen correctly.