### PR TITLE
Disable indents making code blocks

### DIFF
--- a/frontend/src/lib/markedTokenizer.ts
+++ b/frontend/src/lib/markedTokenizer.ts
@@ -6,6 +6,10 @@ const STRICT_DOUBLE_TILDE_DEL_RE = /^~~(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]
 export function createStrictTildeTokenizer() {
   const tokenizer = new Tokenizer()
 
+  tokenizer.code = function (): Tokens.Code | undefined {
+    return undefined
+  }
+
   tokenizer.del = function (src: string): Tokens.Del | undefined {
     const cap = STRICT_DOUBLE_TILDE_DEL_RE.exec(src)
     if (!cap) return


### PR DESCRIPTION
Disable indented (4-space/tab) code blocks. Card-authored HTML/CSS panels are routinely indented and without this they render as escaped \<pre>\<code> instead of HTML. 

Fenced \`\`\` and inline \`code\` are untouched.