### PR TITLE
Thread userId through spindle.theme.apply IPC envelope

### DIFF
--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -1687,10 +1687,10 @@ const spindleApi: RuntimeSpindleAPI = {
   },
 
   theme: {
-    async apply(overrides: { variables?: Record<string, string>; variablesByMode?: { dark?: Record<string, string>; light?: Record<string, string> } }): Promise<void> {
+    async apply(overrides: { variables?: Record<string, string>; variablesByMode?: { dark?: Record<string, string>; light?: Record<string, string> } }, userId?: string): Promise<void> {
       assertMutationAllowed("spindle.theme.apply()");
       const requestId = crypto.randomUUID();
-      await request({ type: "theme_apply", requestId, overrides });
+      await request({ type: "theme_apply", requestId, overrides, userId });
     },
     async applyPalette(palette, userId?: string): Promise<void> {
       assertMutationAllowed("spindle.theme.applyPalette()");


### PR DESCRIPTION
`handleThemeApply` in worker-host.ts already reads `msg.userId` and runs `resolveEffectiveUserId(userId)` — but the worker-runtime's `spindle.theme.apply` wrapper neither accepts a userId parameter nor includes it in the IPC envelope. Operator-scoped extensions therefore can't satisfy `resolveEffectiveUserId` and every `spindle.theme.apply()` call fails with "userId is required for operator-scoped extensions".

Aligns the signature + IPC payload with `applyPalette`/`clear`/`getCurrent`, all of which already thread userId through.