### PR TITLE
Remove SSRF host validation from LumiHub endpoints

### DIFF
--- a/src/routes/lumihub.routes.ts
+++ b/src/routes/lumihub.routes.ts
@@ -2,7 +2,6 @@ import { Hono } from "hono";
 import { requireOwner } from "../auth/middleware";
 import * as linkSvc from "../services/lumihub-link.service";
 import { getLumiHubClient } from "../lumihub/client";
-import { validateHost, SSRFError } from "../utils/safe-fetch";
 
 // --- PKCE state storage (in-memory, same pattern as spindle/oauth-state.ts) ---
 
@@ -96,11 +95,7 @@ lumihubCallbackRoute.get("/callback", async (c) => {
       if (wsParsed.protocol !== "ws:" && wsParsed.protocol !== "wss:") {
         return c.html(errorHtml("Invalid WebSocket URL", "LumiHub returned an unsupported WebSocket protocol."), 400);
       }
-      await validateHost(wsParsed.hostname);
     } catch (err: any) {
-      if (err instanceof SSRFError) {
-        return c.html(errorHtml("Blocked WebSocket URL", err.message), 400);
-      }
       return c.html(errorHtml("Invalid WebSocket URL", "LumiHub returned an unparseable WebSocket URL."), 400);
     }
 
@@ -166,15 +161,6 @@ lumihubRoutes.post("/link", requireOwner, async (c) => {
   if (parsedHub.protocol !== "https:" && parsedHub.protocol !== "http:") {
     return c.json({ error: "lumihub_url must use http or https" }, 400);
   }
-  try {
-    await validateHost(parsedHub.hostname);
-  } catch (err: any) {
-    if (err instanceof SSRFError) {
-      return c.json({ error: err.message }, 400);
-    }
-    throw err;
-  }
-
   // Generate PKCE
   const { codeVerifier, codeChallenge } = await linkSvc.generatePKCE();
 


### PR DESCRIPTION
## Summary
- Removes `validateHost` SSRF checks from the LumiHub `/link` and `/callback` endpoints
- Failsafe for environments where the system DNS resolver cannot resolve custom TLDs (e.g. `.spot`) even though the browser can — this affects Termux on Android where the browser uses DNS-over-HTTPS but Node/Bun uses the system resolver
- The `/link` endpoint only builds a redirect URL for the browser (no server-side fetch), so SSRF validation provided no actual protection there. The callback's WS URL still gets protocol validation. URL format and protocol checks remain on both endpoints

## Context
On certain mobile environments (Termux/Android), the DNS resolver used by Node/Bun cannot resolve custom TLDs like `.spot`, causing `validateHost` to attempt `resolve4`, `resolve6`, and `lookup` — all of which time out sequentially, adding ~5 minutes of delay before ultimately failing. The browser on the same device resolves the same hostname fine via DoH.

## Test plan
- [x] Tested LumiHub OAuth pairing on Android/Termux — flow completes instantly
- [x] Verified desktop flow still works as before
- [x] Confirmed URL format and protocol validation still enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)