### PR TITLE
Add unsafe_eval permission for per-frame CSP opt-in

### DIFF
--- a/frontend/src/lib/spindle/dom-helper.ts
+++ b/frontend/src/lib/spindle/dom-helper.ts
@@ -20,7 +20,8 @@ const FORBIDDEN_CREATE_TAGS = new Set(['iframe', 'frame', 'object', 'embed'])
 
 export function createDOMHelper(
   extensionId: string,
-  corsProxy?: (url: string, options?: any) => Promise<any>
+  corsProxy?: (url: string, options?: any) => Promise<any>,
+  canEval?: () => boolean
 ): SpindleDOMHelper {
   const trackedElements = new Set<Element>()
   const trackedStyles: (() => void)[] = []
@@ -122,7 +123,13 @@ export function createDOMHelper(
     },
 
     createSandboxFrame(options) {
-      const handle = createSandboxFrame(extensionId, options, corsProxy)
+      // Honor allowEval only if the extension holds the unsafe_eval grant
+      // (fail-closed).
+      const gatedOptions = {
+        ...options,
+        allowEval: options.allowEval === true && canEval?.() === true,
+      }
+      const handle = createSandboxFrame(extensionId, gatedOptions, corsProxy)
       trackedElements.add(handle.element)
       const originalDestroy = handle.destroy.bind(handle)
 

--- a/frontend/src/lib/spindle/loader.ts
+++ b/frontend/src/lib/spindle/loader.ts
@@ -226,7 +226,11 @@ async function doLoadFrontendExtension(
       })
     }
 
-    const dom = createDOMHelper(extensionId, corsProxy)
+    const dom = createDOMHelper(
+      extensionId,
+      corsProxy,
+      () => cachedGrantedPermissions.includes('unsafe_eval'),
+    )
     const uiEvents = createUIEventsHelper(extensionId)
 
     // Cache granted permissions for synchronous permission checks in ui methods

--- a/frontend/src/lib/spindle/sandbox-frame.ts
+++ b/frontend/src/lib/spindle/sandbox-frame.ts
@@ -8,6 +8,7 @@ interface SandboxFrameRecord {
   maxHeight: number
   destroyed: boolean
   corsProxy?: (url: string, options?: any) => Promise<any>
+  allowEval: boolean
 }
 
 const SANDBOX_MESSAGE_KEY = '__lumiverseSpindleSandbox'
@@ -133,6 +134,7 @@ export function createSandboxFrame(
     maxHeight,
     destroyed: false,
     corsProxy,
+    allowEval: options.allowEval === true,
   }
   sandboxFrames.set(token, record)
 
@@ -155,6 +157,7 @@ export function createSandboxFrame(
         minHeight,
         maxHeight,
         corsProxy: !!record.corsProxy,
+        allowEval: record.allowEval,
       })
     },
     postMessage(payload: unknown) {
@@ -189,6 +192,7 @@ function buildSandboxDocument(options: {
   minHeight: number
   maxHeight: number
   corsProxy?: boolean
+  allowEval?: boolean
 }): string {
   const injection = buildHeadInjection(options)
   const html = options.html || ''
@@ -207,9 +211,11 @@ function buildHeadInjection(options: {
   minHeight: number
   maxHeight: number
   corsProxy?: boolean
+  allowEval?: boolean
 }): string {
   const tokenLit = JSON.stringify(options.token)
   const autoResizeLit = options.autoResize ? 'true' : 'false'
+  const scriptSrc = options.allowEval ? "'unsafe-inline' 'unsafe-eval'" : "'unsafe-inline'"
   const minHeightLit = String(options.minHeight)
   const maxHeightLit = String(options.maxHeight)
 
@@ -231,7 +237,7 @@ function buildHeadInjection(options: {
   return [
     '<meta charset="utf-8">',
     '<meta name="viewport" content="width=device-width,initial-scale=1">',
-    `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; font-src data: blob:; connect-src 'none'; media-src data: blob:; object-src 'none'; frame-src 'none'; child-src 'none'; worker-src 'none'; form-action 'none'; base-uri 'none'; frame-ancestors 'none'; navigate-to 'none'; upgrade-insecure-requests;">`,
+    `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src ${scriptSrc}; style-src 'unsafe-inline'; img-src data: blob:; font-src data: blob:; connect-src 'none'; media-src data: blob:; object-src 'none'; frame-src 'none'; child-src 'none'; worker-src 'none'; form-action 'none'; base-uri 'none'; frame-ancestors 'none'; navigate-to 'none'; upgrade-insecure-requests;">`,
     '<meta name="color-scheme" content="dark light">',
     '<style>html,body{margin:0;padding:0;background:transparent!important}body{box-sizing:border-box;overflow-x:hidden}:root{color-scheme:dark light}</style>',
     '<script>(function(){',

--- a/src/spindle/manager.service.ts
+++ b/src/spindle/manager.service.ts
@@ -749,6 +749,7 @@ export const PRIVILEGED_PERMISSIONS = new Set([
   "image_gen",
   "images",
   "web_search",
+  "unsafe_eval",
 ]);
 
 function grantRequestedPermissionsByDefault(


### PR DESCRIPTION
Per-frame CSP `unsafe-eval` opt-in for sandboxed widget frames, gated by a new privileged `unsafe_eval` permission.
`createSandboxFrame` threads `allowEval` through to `buildHeadInjection`, which conditionally appends `'unsafe-eval'` to `script-src`. Default-off emits a byte-identical CSP. The dom-helper wrapper fail-closes: `allowEval` is honored only when the grant exists, read lazily from `cachedGrantedPermissions`.
Validity for the new permission comes from the paired spindle-types PR: https://github.com/prolix-oc/lumiverse-spindle-types/pull/20