### PR TITLE
feat(image-gen): add SD API provider for image gen

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  description = "Lumiverse development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {
+          inherit system;
+          config.allowUnfree = true;
+        };
+      in
+        {
+          devShells.default = pkgs.mkShell {
+            packages = with pkgs;
+              [
+                bun
+                git
+                nodejs_22
+                glib
+              ];
+            shellHook = ''
+              export LD_LIBRARY_PATH="${pkgs.gcc.cc.lib}/lib:${pkgs.glib}/lib"
+            '';
+        };
+        }
+    );
+}

--- a/src/image-gen/index.ts
+++ b/src/image-gen/index.ts
@@ -5,6 +5,7 @@ import { NovelAIImageProvider } from "./providers/novelai";
 import { PollinationsImageProvider } from "./providers/pollinations";
 import { ComfyUIImageProvider } from "./providers/comfyui";
 import { SwarmUIImageProvider } from "./providers/swarmui";
+import { SdApiImageProvider } from "./providers/sdapi";
 
 registerImageProvider(new GoogleGeminiImageProvider());
 registerImageProvider(new NanoGPTImageProvider());
@@ -12,3 +13,4 @@ registerImageProvider(new NovelAIImageProvider());
 registerImageProvider(new PollinationsImageProvider());
 registerImageProvider(new ComfyUIImageProvider());
 registerImageProvider(new SwarmUIImageProvider());
+registerImageProvider(new SdApiImageProvider());

--- a/src/image-gen/providers/sdapi.ts
+++ b/src/image-gen/providers/sdapi.ts
@@ -1,0 +1,476 @@
+import type { ImageProvider } from "../provider";
+import type { ImageProviderCapabilities, ImageParameterSchemaMap } from "../param-schema";
+import type { ImageGenRequest, ImageGenResponse } from "../types";
+import { applyRawOverride, PROTECTED_RAW_OVERRIDE_KEYS } from "../types";
+import { fetchProviderJson, ProviderRequestError, throwProviderResponseError } from "../../utils/provider-errors";
+
+const PARAMETERS: ImageParameterSchemaMap = {
+  prompt: {
+    type: "string",
+    description: "Text prompt for the image",
+  },
+  negativePrompt: {
+    type: "string",
+    description: "Negative prompt — things to exclude from the image",
+  },
+  width: {
+    type: "integer",
+    min: 64,
+    max: 4096,
+    default: 1024,
+    step: 64,
+    description: "Image width in pixels",
+  },
+  height: {
+    type: "integer",
+    min: 64,
+    max: 4096,
+    default: 1024,
+    step: 64,
+    description: "Image height in pixels",
+  },
+  steps: {
+    type: "integer",
+    min: 1,
+    max: 150,
+    default: 20,
+    description: "Number of sampling steps",
+  },
+  cfg: {
+    type: "number",
+    min: 1,
+    max: 30,
+    default: 7,
+    step: 0.5,
+    description: "Classifier-free guidance scale",
+  },
+  sampler_name: {
+    type: "string",
+    description: "Sampler name (e.g. euler, euler_ancestral, dpmpp_2m, ddim)",
+    group: "advanced",
+    modelSubtype: "samplers",
+  },
+  scheduler: {
+    type: "string",
+    description: "Scheduler name (e.g. normal, karras, sgm_uniform)",
+    group: "advanced",
+    modelSubtype: "schedulers",
+  },
+  seed: {
+    type: "integer",
+    default: -1,
+    description: "Random seed (-1 for random)",
+    group: "advanced",
+  },
+  batch_size: {
+    type: "integer",
+    min: 1,
+    max: 16,
+    default: 1,
+    description: "Number of images to generate",
+    group: "advanced",
+  },
+  clip_skip: {
+    type: "integer",
+    min: 1,
+    max: 12,
+    default: 1,
+    description: "CLIP skip — layers to ignore from the text encoder (higher = more abstract)",
+    group: "advanced",
+  },
+  mode: {
+    type: "select",
+    default: "txt2img",
+    description: "Generation mode",
+    group: "mode",
+    options: [
+      { id: "txt2img", label: "Text to Image" },
+      { id: "img2img", label: "Image to Image" },
+    ],
+  },
+  denoising_strength: {
+    type: "number",
+    min: 0,
+    max: 1,
+    default: 0.75,
+    description: "Denoising strength for img2img (0 = keep original, 1 = fully regenerated)",
+    group: "mode",
+  },
+  init_images: {
+    type: "string",
+    description: "Base64 or data URL of the init image for img2img mode",
+    group: "mode",
+  },
+  enable_hr: {
+    type: "boolean",
+    default: false,
+    description: "Enable high-resolution fix (upscaling pass after initial generation)",
+    group: "advanced",
+  },
+  hr_upscaler: {
+    type: "string",
+    description: "Upscaler model for highres fix (e.g. Lanczos, Nearest)",
+    group: "advanced",
+  },
+  hr_scale: {
+    type: "number",
+    min: 1,
+    max: 8,
+    default: 2,
+    description: "Scale factor for highres fix",
+    group: "advanced",
+  },
+  hr_resize_x: {
+    type: "integer",
+    min: 0,
+    description: "Target width for highres fix (0 = use hr_scale)",
+    group: "advanced",
+  },
+  hr_resize_y: {
+    type: "integer",
+    min: 0,
+    description: "Target height for highres fix (0 = use hr_scale)",
+    group: "advanced",
+  },
+  hr_steps: {
+    type: "integer",
+    min: 0,
+    description: "Steps for highres second pass (0 = reuse main steps)",
+    group: "advanced",
+  },
+  lora: {
+    type: "string",
+    description: 'JSON array of LoRA entries: [{ "path": "model.safetensors", "multiplier": 0.8 }]',
+    group: "models",
+    modelSubtype: "loras",
+  },
+  rawRequestOverride: {
+    type: "string",
+    description: "Raw JSON merged into the request body for advanced usage",
+    group: "advanced",
+  },
+};
+
+/** Protected keys for SD API raw request overrides — prevents smuggling auth/model fields. */
+const SDAPI_PROTECTED_KEYS = new Set<string>([
+  ...PROTECTED_RAW_OVERRIDE_KEYS,
+  "lora",
+  "loras",
+  "init_images",
+  "extra_images",
+]);
+
+/**
+ * SD API provider for stable-diffusion.cpp and AUTOMATIC1111 WebUI compatibility.
+ *
+ * Targets the `/sdapi/v1/` endpoint family:
+ * - `POST /sdapi/v1/txt2img` — text-to-image generation
+ * - `POST /sdapi/v1/img2img` — image-to-image generation
+ * - `GET  /sdapi/v1/sd-models` — checkpoint listing
+ * - `GET  /sdapi/v1/loras` — LoRA listing
+ * - `GET  /sdapi/v1/samplers` — sampler listing
+ * - `GET  /sdapi/v1/schedulers` — scheduler listing
+ */
+export class SdApiImageProvider implements ImageProvider {
+  readonly name = "sdapi";
+  readonly displayName = "SD API (stable-diffusion.cpp / A1111)";
+
+  readonly capabilities: ImageProviderCapabilities = {
+    parameters: PARAMETERS,
+    apiKeyRequired: false,
+    modelListStyle: "dynamic",
+    defaultUrl: "http://localhost:7860",
+  };
+
+  // ── Helpers ───────────────────────────────────────────────────────────
+
+  private baseUrl(apiUrl: string): string {
+    return (apiUrl || this.capabilities.defaultUrl).replace(/\/+$/, "");
+  }
+
+  private apiPath(apiUrl: string, path: string): string {
+    return `${this.baseUrl(apiUrl).replace(/\/+$/, "")}${path}`;
+  }
+
+  /** Parse the `/sdapi/v1/sd-models` response into a model list. */
+  private parseSdModels(data: unknown): Array<{ id: string; label: string }> {
+    const models = Array.isArray(data) ? data : [];
+    return models
+      .map((m: any) => ({
+        id: String(m?.model_name || m?.title || m?.filename || "").trim(),
+        label: String(m?.title || m?.model_name || m?.filename || "").trim(),
+      }))
+      .filter((m: { id: string; label: string }) => !!m.id)
+      .map((m: { id: string; label: string }) => ({ id: m.id, label: m.label || m.id }));
+  }
+
+  /** Parse the `/sdapi/v1/loras` response into a model list. */
+  private parseLoras(data: unknown): Array<{ id: string; label: string }> {
+    const items = Array.isArray(data) ? data : [];
+    return items
+      .map((l: any) => ({
+        id: String(l?.name || l?.path || "").trim(),
+        label: String(l?.name || l?.path || "").trim(),
+      }))
+      .filter((m: { id: string; label: string }) => !!m.id)
+      .map((m: { id: string; label: string }) => ({ id: m.id, label: m.label || m.id }));
+  }
+
+  /** Parse the `/sdapi/v1/samplers` response into a model list. */
+  private parseSamplers(data: unknown): Array<{ id: string; label: string }> {
+    const items = Array.isArray(data) ? data : [];
+    return items
+      .map((s: any) => ({
+        id: String(s?.name || s?.alias || "").trim(),
+        label: String(s?.name || s?.alias || "").trim(),
+      }))
+      .filter((m: { id: string; label: string }) => !!m.id)
+      .map((m: { id: string; label: string }) => ({ id: m.id, label: m.label || m.id }));
+  }
+
+  /** Parse the `/sdapi/v1/schedulers` response into a model list. */
+  private parseSchedulers(data: unknown): Array<{ id: string; label: string }> {
+    const items = Array.isArray(data) ? data : [];
+    return items
+      .map((s: any) => ({
+        id: String(s?.name || s?.label || "").trim(),
+        label: String(s?.label || s?.name || "").trim(),
+      }))
+      .filter((m: { id: string; label: string }) => !!m.id)
+      .map((m: { id: string; label: string }) => ({ id: m.id, label: m.label || m.id }));
+  }
+
+  /** Parse txt2img/img2img response — extract first image as data URL. */
+  private parseResponse(data: Record<string, any>, mimeType = "image/png"): string {
+    const images = Array.isArray(data?.images) ? data.images : [];
+    if (images.length === 0) {
+      throw new Error("SD API returned no images");
+    }
+    const b64 = images[0];
+    if (typeof b64 !== "string") {
+      throw new Error("SD API returned non-string image data");
+    }
+    return `data:${mimeType};base64,${b64}`;
+  }
+
+  // ── Build request body ────────────────────────────────────────────────
+
+  /** Build the txt2img request body from the ImageGenRequest. */
+  private buildTxt2ImgBody(request: ImageGenRequest): Record<string, any> {
+    const p = request.parameters ?? {};
+
+    const body: Record<string, any> = {
+      prompt: request.prompt,
+      negative_prompt: request.negativePrompt || p.negativePrompt || "",
+      model: request.model || "",
+      width: Number(p.width) || 1024,
+      height: Number(p.height) || 1024,
+      steps: Number(p.steps) || 20,
+      cfg_scale: Number(p.cfg) || 7,
+      seed: typeof p.seed === "number" && Number.isFinite(p.seed) ? Number(p.seed) : -1,
+      batch_size: Number(p.batch_size) || 1,
+    };
+
+    if (p.sampler_name) body.sampler_name = String(p.sampler_name);
+    if (p.scheduler) body.scheduler = String(p.scheduler);
+    if (p.clip_skip != null && Number.isFinite(Number(p.clip_skip))) body.clip_skip = Number(p.clip_skip);
+
+    // Highres fix
+    if (p.enable_hr) {
+      body.enable_hr = !!p.enable_hr;
+      body.hr_upscaler = p.hr_upscaler ? String(p.hr_upscaler) : undefined;
+      body.hr_scale = Number(p.hr_scale) || 2;
+      body.hr_resize_x = p.hr_resize_x != null ? Number(p.hr_resize_x) : 0;
+      body.hr_resize_y = p.hr_resize_y != null ? Number(p.hr_resize_y) : 0;
+      body.hr_steps = p.hr_steps != null ? Number(p.hr_steps) : 0;
+      body.denoising_strength = p.denoising_strength != null ? Number(p.denoising_strength) : 0.7;
+    }
+
+    // LoRA — parse JSON string into structured array
+    if (p.lora) {
+      try {
+        const loraParsed = JSON.parse(String(p.lora));
+        if (Array.isArray(loraParsed)) {
+          body.lora = loraParsed;
+        }
+      } catch {
+        // Invalid JSON — skip silently
+      }
+    }
+
+    return applyRawOverride(body, p.rawRequestOverride, SDAPI_PROTECTED_KEYS);
+  }
+
+  /** Build the img2img request body from the ImageGenRequest. */
+  private buildImg2ImgBody(request: ImageGenRequest): Record<string, any> {
+    const p = request.parameters ?? {};
+
+    const body: Record<string, any> = {
+      prompt: request.prompt,
+      negative_prompt: request.negativePrompt || p.negativePrompt || "",
+      model: request.model || "",
+      width: Number(p.width) || 1024,
+      height: Number(p.height) || 1024,
+      steps: Number(p.steps) || 20,
+      cfg_scale: Number(p.cfg) || 7,
+      seed: typeof p.seed === "number" && Number.isFinite(p.seed) ? Number(p.seed) : -1,
+      batch_size: Number(p.batch_size) || 1,
+      denoising_strength: Number(p.denoising_strength) || 0.75,
+    };
+
+    // Init images — parse JSON string or use as single data URL
+    if (p.init_images) {
+      try {
+        const initParsed = JSON.parse(String(p.init_images));
+        body.init_images = Array.isArray(initParsed) ? initParsed : [String(p.init_images)];
+      } catch {
+        body.init_images = [String(p.init_images)];
+      }
+    }
+
+    if (p.sampler_name) body.sampler_name = String(p.sampler_name);
+    if (p.scheduler) body.scheduler = String(p.scheduler);
+    if (p.clip_skip != null && Number.isFinite(Number(p.clip_skip))) body.clip_skip = Number(p.clip_skip);
+
+    // LoRA
+    if (p.lora) {
+      try {
+        const loraParsed = JSON.parse(String(p.lora));
+        if (Array.isArray(loraParsed)) {
+          body.lora = loraParsed;
+        }
+      } catch {
+        // Invalid JSON — skip silently
+      }
+    }
+
+    return applyRawOverride(body, p.rawRequestOverride, SDAPI_PROTECTED_KEYS);
+  }
+
+  // ── ImageProvider interface ───────────────────────────────────────────
+
+  async generate(
+    apiKey: string,
+    apiUrl: string,
+    request: ImageGenRequest,
+  ): Promise<ImageGenResponse> {
+    const mode = request.parameters?.mode || "txt2img";
+
+    let endpoint: string;
+    let body: Record<string, any>;
+
+    if (mode === "img2img") {
+      endpoint = this.apiPath(apiUrl, "/sdapi/v1/img2img");
+      body = this.buildImg2ImgBody(request);
+    } else {
+      endpoint = this.apiPath(apiUrl, "/sdapi/v1/txt2img");
+      body = this.buildTxt2ImgBody(request);
+    }
+
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (apiKey) {
+      headers["Authorization"] = `Bearer ${apiKey}`;
+    }
+
+    const res = await fetch(endpoint, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: request.signal,
+    });
+
+    if (!res.ok) {
+      await throwProviderResponseError(this.displayName, `${mode} generation`, res);
+    }
+
+    const data = (await res.json()) as Record<string, any>;
+    const imageDataUrl = this.parseResponse(data);
+
+    return {
+      imageDataUrl,
+      model: request.model || "sdapi-model",
+      provider: this.name,
+    };
+  }
+
+  async validateKey(apiKey: string, apiUrl: string): Promise<boolean> {
+    try {
+      const url = this.apiPath(apiUrl, "/sdapi/v1/options");
+      const headers: Record<string, string> = {};
+      if (apiKey) {
+        headers["Authorization"] = `Bearer ${apiKey}`;
+      }
+      const res = await fetch(url, {
+        signal: AbortSignal.timeout(5000),
+        headers,
+      });
+      if (!res.ok) {
+        await throwProviderResponseError(this.displayName, "connection check", res);
+      }
+      return res.ok;
+    } catch (err) {
+      if (err instanceof ProviderRequestError) throw err;
+      throw new ProviderRequestError({
+        provider: this.displayName,
+        operation: "connection check",
+        detail: err instanceof Error ? err.message : "network request failed",
+        retryable: true,
+      });
+    }
+  }
+
+  async listModels(apiKey: string, apiUrl: string): Promise<Array<{ id: string; label: string }>> {
+    const url = this.apiPath(apiUrl, "/sdapi/v1/sd-models");
+    const headers: Record<string, string> = {};
+    if (apiKey) {
+      headers["Authorization"] = `Bearer ${apiKey}`;
+    }
+    const data = await fetchProviderJson<any>(this.displayName, "model listing", url, {
+      signal: AbortSignal.timeout(10000),
+      headers,
+    });
+    return this.parseSdModels(data);
+  }
+
+  async listModelsBySubtype(
+    apiKey: string,
+    apiUrl: string,
+    subtype: string,
+  ): Promise<Array<{ id: string; label: string }>> {
+    const headers: Record<string, string> = {};
+    if (apiKey) {
+      headers["Authorization"] = `Bearer ${apiKey}`;
+    }
+    switch (subtype) {
+      case "loras":
+      case "lora": {
+        const url = this.apiPath(apiUrl, "/sdapi/v1/loras");
+        const data = await fetchProviderJson<any>(this.displayName, "LoRA listing", url, {
+          signal: AbortSignal.timeout(10000),
+          headers,
+        });
+        return this.parseLoras(data);
+      }
+      case "samplers":
+      case "sampler_name": {
+        const url = this.apiPath(apiUrl, "/sdapi/v1/samplers");
+        const data = await fetchProviderJson<any>(this.displayName, "sampler listing", url, {
+          signal: AbortSignal.timeout(10000),
+          headers,
+        });
+        return this.parseSamplers(data);
+      }
+      case "schedulers":
+      case "scheduler": {
+        const url = this.apiPath(apiUrl, "/sdapi/v1/schedulers");
+        const data = await fetchProviderJson<any>(this.displayName, "scheduler listing", url, {
+          signal: AbortSignal.timeout(10000),
+          headers,
+        });
+        return this.parseSchedulers(data);
+      }
+      default:
+        return [];
+    }
+  }
+}

--- a/src/services/dream-weaver/visual-studio/provider-registry.ts
+++ b/src/services/dream-weaver/visual-studio/provider-registry.ts
@@ -8,6 +8,7 @@ const adapters = new Map<DreamWeaverVisualProvider, VisualProviderAdapter>([
   ["novelai", createSimpleProviderAdapter("novelai")],
   ["nanogpt", createSimpleProviderAdapter("nanogpt")],
   ["google_gemini", createSimpleProviderAdapter("google_gemini")],
+  ["sdapi", createSimpleProviderAdapter("sdapi")],
   ["swarmui", swarmUIProviderAdapter],
   ["comfyui", comfyUIProviderAdapter],
 ]);

--- a/src/services/dream-weaver/visual-studio/providers/simple-provider-adapter.ts
+++ b/src/services/dream-weaver/visual-studio/providers/simple-provider-adapter.ts
@@ -9,7 +9,7 @@ import type { VisualProviderAdapter } from "../provider-adapter";
 
 type SimpleVisualProvider = Extract<
   DreamWeaverVisualProvider,
-  "novelai" | "nanogpt" | "google_gemini" | "swarmui"
+  "novelai" | "nanogpt" | "google_gemini" | "sdapi" | "swarmui"
 >;
 
 function filterSupportedParameters(

--- a/src/types/dream-weaver.ts
+++ b/src/types/dream-weaver.ts
@@ -96,7 +96,7 @@ export type DreamWeaverVisualProvider =
   | "novelai"
   | "nanogpt"
   | "google_gemini"
-  | "a1111"
+  | "sdapi"
   | "swarmui";
 
 export interface DreamWeaverVisualReference {


### PR DESCRIPTION
## Problem

I use stable-diffusion.cpp via llama-swap for image gen, which exposes SDAPI: the same API as Automatic1111. However, there is no way to connect this to Lumiverse.

## Solution

I added SDAPI / Automatic1111 as an image generation provider, tested it with my setup.

## Architecture

Straightforward addition of the new provider, plus adding it to DreamWeaver. Note that I saw DreamWeaver already had an entry for Automatic1111, but there was no provider for it to be able to connect it, so I renamed it to SDAPI in the codebase.

SDAPI does not support streaming.

## Known Issues

Like in my other PR #160 I added `flake.nix` for developing Lumiverse using Nix. If you prefer this separated out in another PR or removed, let me know.

## Screenshots of testing

<img width="1037" height="887" alt="Screenshot_20260527_185218" src="https://github.com/user-attachments/assets/6e0ff481-3804-4d1b-9416-9583bea6ec0f" />
<img width="609" height="553" alt="Screenshot_20260527_184511" src="https://github.com/user-attachments/assets/c05c101e-34b4-458c-9707-93e09bceacea" />
