### PR TITLE
feat: add full-size avatar toggle in theme panel

### DIFF
--- a/frontend/src/components/chat/BubbleMessage.tsx
+++ b/frontend/src/components/chat/BubbleMessage.tsx
@@ -19,6 +19,7 @@ interface BubbleMessageProps {
 
 export default function BubbleMessage({ message, chatId, depth = 0, isSelectMode = false, isSelected = false, onToggleSelect }: BubbleMessageProps) {
   const bubbleUserAlign = useStore((s) => s.bubbleUserAlign)
+  const bubbleUseFullAvatar = useStore((s) => s.bubbleUseFullAvatar ?? false)
   const {
     isEditing, editContent, setEditContent, editReasoning, setEditReasoning, showReasoningEditor,
     isUser, isLastMessage, isActivelyStreaming, displayContent, reasoning, reasoningDuration, reasoningStartedAt,
@@ -33,6 +34,9 @@ export default function BubbleMessage({ message, chatId, depth = 0, isSelectMode
 
   const userLeft = isUser && bubbleUserAlign === 'left'
 
+  // ── Use full-size avatar when setting is enabled ──
+  const displayAvatarUrl = bubbleUseFullAvatar && fullAvatarUrl ? fullAvatarUrl : avatarUrl
+
   // ── Build the flattened override props contract ──
   const overrideProps: MessageOverrideProps = useMemo(() => ({
     message: {
@@ -41,7 +45,7 @@ export default function BubbleMessage({ message, chatId, depth = 0, isSelectMode
       sendDate: message.swipe_dates?.[message.swipe_id] ?? message.send_date,
       isUser,
       displayName,
-      avatarUrl,
+      avatarUrl: displayAvatarUrl,
       isHidden,
       isStreaming: isActivelyStreaming,
       isLastMessage,
@@ -87,7 +91,7 @@ export default function BubbleMessage({ message, chatId, depth = 0, isSelectMode
     }),
     styles,
   }), [
-    message, isUser, displayName, avatarUrl, isHidden, isActivelyStreaming,
+    message, isUser, displayName, avatarUrl, fullAvatarUrl, isHidden, isActivelyStreaming,
     isLastMessage, tokenCount, displayContent, reasoning, reasoningDuration,
     isEditing, editContent, editReasoning, setEditContent, setEditReasoning,
     handleSaveEdit, handleCancelEdit, handleEdit, handleDelete, handleToggleHidden,
@@ -99,7 +103,7 @@ export default function BubbleMessage({ message, chatId, depth = 0, isSelectMode
     message, chatId, depth, isSelectMode, isSelected, onToggleSelect,
     isEditing, editContent, setEditContent, editReasoning, setEditReasoning, showReasoningEditor,
     isUser, isActivelyStreaming, displayContent, reasoning, reasoningDuration, reasoningStartedAt,
-    tokenCount, generationMetrics, avatarUrl, fullAvatarUrl, displayName, macroUserName, isHidden, userLeft,
+    tokenCount, generationMetrics, avatarUrl, fullAvatarUrl, displayAvatarUrl, displayName, macroUserName, isHidden, userLeft,
     handleEdit, handleSaveEdit, handleCancelEdit, handleDelete, handleToggleHidden,
     handleFork, handlePromptBreakdown,
   }

--- a/frontend/src/components/chat/BubbleMessageDefault.tsx
+++ b/frontend/src/components/chat/BubbleMessageDefault.tsx
@@ -55,6 +55,7 @@ export interface BubbleMessageDefaultProps {
   generationMetrics: GenerationMetrics | undefined
   avatarUrl: string | null
   fullAvatarUrl: string | null
+  displayAvatarUrl: string | null
   displayName: string
   macroUserName: string
   isHidden: boolean
@@ -350,9 +351,9 @@ export default function BubbleMessageDefault({
       onTouchMove={canOpenContextMenu ? longPress.onTouchMove : undefined}
       onTouchEnd={canOpenContextMenu ? longPress.onTouchEnd : undefined}
     >
-      {avatarUrl && (
+      {displayAvatarUrl && (
         <div className={styles.avatarBg}>
-          <img className={styles.avatarBgImg} src={avatarUrl} alt="" />
+          <img className={styles.avatarBgImg} src={displayAvatarUrl} alt="" />
           <div className={styles.avatarBgScrim} />
         </div>
       )}
@@ -365,9 +366,9 @@ export default function BubbleMessageDefault({
               style={fullAvatarUrl ? { cursor: 'pointer' } : undefined}
               onClick={fullAvatarUrl ? (e) => { e.stopPropagation(); openFloatingAvatar(fullAvatarUrl, displayName) } : undefined}
             >
-              {avatarUrl ? (
+              {displayAvatarUrl ? (
                 <LazyImage
-                  src={avatarUrl}
+                  src={displayAvatarUrl}
                   alt={displayName}
                   fallback={
                     <div className={styles.avatarFallback}>

--- a/frontend/src/components/chat/MinimalMessage.tsx
+++ b/frontend/src/components/chat/MinimalMessage.tsx
@@ -171,6 +171,8 @@ export default function MinimalMessage({ message, chatId, depth = 0, isSelectMod
   } = useMessageCard(message, chatId)
 
   const openModal = useStore((s) => s.openModal)
+  const bubbleUseFullAvatar = useStore((s) => s.bubbleUseFullAvatar ?? false)
+  const displayAvatarUrl = bubbleUseFullAvatar && fullAvatarUrl ? fullAvatarUrl : avatarUrl
   const openFloatingAvatar = useStore((s) => s.openFloatingAvatar)
   const swipeGesturesEnabled = useStore((s) => s.swipeGesturesEnabled)
   const showMessageTokenCount = useStore((s) => s.showMessageTokenCount ?? true)
@@ -338,7 +340,7 @@ export default function MinimalMessage({ message, chatId, depth = 0, isSelectMod
         onClick={fullAvatarUrl ? (e) => { e.stopPropagation(); openFloatingAvatar(fullAvatarUrl, displayName) } : undefined}
       >
         <LazyImage
-          src={avatarUrl}
+          src={displayAvatarUrl}
           alt={displayName}
           fallback={
             <div className={styles.avatarFallback}>

--- a/frontend/src/components/panels/ThemePanel.tsx
+++ b/frontend/src/components/panels/ThemePanel.tsx
@@ -23,6 +23,8 @@ export default function ThemePanel() {
   )
 
   const openModal = useStore((s) => s.openModal)
+  const bubbleUseFullAvatar = useStore((s) => s.bubbleUseFullAvatar ?? false)
+  const setSetting = useStore((s) => s.setSetting)
   const current = theme ?? DEFAULT_THEME
 
   // Always read the latest theme from the store to avoid stale closures
@@ -185,10 +187,12 @@ export default function ThemePanel() {
         <DepthControls
           radiusScale={current.radiusScale}
           enableGlass={current.enableGlass}
+          useFullAvatar={bubbleUseFullAvatar}
           fontScale={current.fontScale}
           uiScale={current.uiScale ?? 1}
           onRadiusChange={handleRadiusChange}
           onGlassToggle={handleGlassToggle}
+          onFullAvatarToggle={(v) => setSetting('bubbleUseFullAvatar', v)}
           onFontScaleChange={handleFontScaleChange}
           onUiScaleChange={handleUiScaleChange}
         />

--- a/frontend/src/components/panels/theme-panel/DepthControls.tsx
+++ b/frontend/src/components/panels/theme-panel/DepthControls.tsx
@@ -6,10 +6,12 @@ import styles from './DepthControls.module.css'
 interface DepthControlsProps {
   radiusScale: number
   enableGlass: boolean
+  useFullAvatar: boolean
   fontScale: number
   uiScale: number
   onRadiusChange: (v: number) => void
   onGlassToggle: (v: boolean) => void
+  onFullAvatarToggle: (v: boolean) => void
   onFontScaleChange: (v: number) => void
   onUiScaleChange: (v: number) => void
 }
@@ -29,10 +31,12 @@ function commitFromInput(e: React.SyntheticEvent, commit: (v: number) => void) {
 export default function DepthControls({
   radiusScale,
   enableGlass,
+  useFullAvatar,
   fontScale,
   uiScale,
   onRadiusChange,
   onGlassToggle,
+  onFullAvatarToggle,
   onFontScaleChange,
   onUiScaleChange,
 }: DepthControlsProps) {
@@ -105,6 +109,13 @@ export default function DepthControls({
         checked={enableGlass}
         onChange={onGlassToggle}
         label={t('glassEffects')}
+      />
+
+      {/* Full-size avatar toggle */}
+      <Toggle.Checkbox
+        checked={useFullAvatar}
+        onChange={onFullAvatarToggle}
+        label={t('useFullAvatar')}
       />
     </div>
   )

--- a/frontend/src/i18n/locales/en/panels.json
+++ b/frontend/src/i18n/locales/en/panels.json
@@ -2323,6 +2323,7 @@
     "fontScale": "Font Scale",
     "uiScale": "UI Scale",
     "glassEffects": "Glass effects",
+    "useFullAvatar": "Use full-size avatars",
     "extensionThemesTitle": "Extension Themes",
     "overridesApplied_one": "{{count}} override applied",
     "overridesApplied_other": "{{count}} overrides applied",

--- a/frontend/src/store/slices/settings.ts
+++ b/frontend/src/store/slices/settings.ts
@@ -262,6 +262,7 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
   bubbleUserAlign: 'right',
   bubbleDisableHover: false,
   bubbleHideAvatarBg: false,
+  bubbleUseFullAvatar: false,
   bubbleOpacity: 1,
   chatSheldEnterToSend: true,
   saveDraftInput: false,

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -402,6 +402,7 @@ export interface SettingsSlice {
   bubbleUserAlign: 'left' | 'right'
   bubbleDisableHover: boolean
   bubbleHideAvatarBg: boolean
+  bubbleUseFullAvatar: boolean
   /** Bubble background opacity, 0–1. 1 = the theme's natural bubble fill (default). */
   bubbleOpacity: number
   chatSheldEnterToSend: boolean


### PR DESCRIPTION
- Add bubbleUseFullAvatar setting in store
- Add checkbox in theme panel next to Glass Effects toggle
- Use fullAvatarUrl for avatar rendering when enabled
- Applies to both BubbleMessage and MinimalMessage components

<img width="951" height="472" alt="image" src="https://github.com/user-attachments/assets/d7ccbe67-721a-4e32-bfcf-03b13b9508cc" />
<img width="622" height="238" alt="image" src="https://github.com/user-attachments/assets/232fc4ed-8334-4e85-ad6c-232f940fd5f3" />
