### PR TITLE
fix: unable to override MinimalMessage

### DIFF
--- a/frontend/src/components/chat/BubbleMessage.tsx
+++ b/frontend/src/components/chat/BubbleMessage.tsx
@@ -42,6 +42,7 @@ export default function BubbleMessage({ message, chatId, depth = 0, isSelectMode
       isUser,
       displayName,
       avatarUrl,
+      fullAvatarUrl,
       isHidden,
       isStreaming: isActivelyStreaming,
       isLastMessage,

--- a/frontend/src/components/chat/MinimalMessage.tsx
+++ b/frontend/src/components/chat/MinimalMessage.tsx
@@ -1,134 +1,12 @@
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import { useTranslation } from 'react-i18next'
-import { createPortal } from 'react-dom'
-import { Copy, Pencil, Trash2, EyeOff, Eye, BarChart3, Volume2, Square } from 'lucide-react'
-import { IconGitFork } from '@tabler/icons-react'
-import { useStore } from '@/store'
+import { useCallback, useMemo } from 'react'
 import { useMessageCard } from '@/hooks/useMessageCard'
-import { useMessagePlayback } from '@/hooks/useMessagePlayback'
-import { useLongPress } from '@/hooks/useLongPress'
-import useSwipeAction from '@/hooks/useSwipeAction'
-import useSwipeGesture from '@/hooks/useSwipeGesture'
-import { copyTextToClipboard, getSelectionTextWithin } from '@/lib/clipboard'
-import { replay as replaySpindleInjections } from '@/lib/spindle/dom-injection-registry'
-import MessageContent from './MessageContent'
-import MessageEditArea from './MessageEditArea'
-import MessageAttachments from './MessageAttachments'
-import MessageAudioSlot from './MessageAudioSlot'
-import MessageActions from './MessageActions'
-import SwipeControls from './SwipeControls'
-import GreetingNav from './GreetingNav'
-import ReasoningBlock from './ReasoningBlock'
-import StreamingIndicator from './StreamingIndicator'
-import LazyImage from '@/components/shared/LazyImage'
-import ContextMenu, { type ContextMenuEntry, type ContextMenuPos } from '@/components/shared/ContextMenu'
-import ConfirmationModal from '@/components/shared/ConfirmationModal'
+import { useComponentOverride } from '@/hooks/useComponentOverride'
+import MinimalMessageDefault, { type MinimalMessageDefaultProps } from './MinimalMessageDefault'
+import { useStore } from '@/store'
+import { copyTextToClipboard } from '@/lib/clipboard'
 import type { Message } from '@/types/api'
-import type { GenerationMetrics } from '@/types/ws-events'
+import type { MessageOverrideProps } from '@/lib/componentOverrides'
 import styles from './MinimalMessage.module.css'
-import clsx from 'clsx'
-
-function formatMetaDate(timestamp: number) {
-  const d = new Date(timestamp * 1000)
-  const month = d.toLocaleString('en-US', { month: 'short' })
-  const day = d.getDate()
-  const time = d.toLocaleString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
-  return `${month} ${day}, ${time}`
-}
-
-function formatMs(ms: number): string {
-  if (ms < 1000) return `${Math.round(ms)}ms`
-  return `${(ms / 1000).toFixed(2)}s`
-}
-
-function MetaPill({ index, timestamp, tokenCount, isHidden, isUser, generationMetrics, showTokenCount }: {
-  index: number
-  timestamp: number
-  tokenCount: number | undefined
-  isHidden: boolean
-  isUser: boolean
-  generationMetrics: GenerationMetrics | undefined
-  showTokenCount: boolean
-}) {
-  const { t } = useTranslation('chat')
-  const pillRef = useRef<HTMLSpanElement>(null)
-  const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number } | null>(null)
-  const hasGenerationDetails = !isUser && !!generationMetrics && (
-    generationMetrics.ttft != null
-    || generationMetrics.tps != null
-    || !!generationMetrics.model
-    || !!generationMetrics.provider
-  )
-
-  const handleMouseEnter = useCallback(() => {
-    if (!hasGenerationDetails || !pillRef.current) return
-    const rect = pillRef.current.getBoundingClientRect()
-    setTooltipPos({ x: rect.left, y: rect.top })
-  }, [hasGenerationDetails])
-
-  const handleMouseLeave = useCallback(() => {
-    setTooltipPos(null)
-  }, [])
-
-  return (
-    <span
-      ref={pillRef}
-      className={styles.metaPill}
-      onMouseEnter={hasGenerationDetails ? handleMouseEnter : undefined}
-      onMouseLeave={hasGenerationDetails ? handleMouseLeave : undefined}
-    >
-      <span className={styles.metaSegment}>#{index}</span>
-      <span className={styles.metaSegment}>
-        <span className={styles.metaDot}>&middot;</span>
-        {formatMetaDate(timestamp)}
-      </span>
-      {showTokenCount && tokenCount != null && (
-        <span className={styles.metaSegment}>
-          <span className={styles.metaDot}>&middot;</span>
-          {tokenCount}t
-        </span>
-      )}
-      {isHidden && (
-        <span className={styles.metaSegment}>
-          <span className={styles.metaDot}>&middot;</span>
-          <span className={styles.hiddenBadge}>{t('messageMeta.hidden')}</span>
-        </span>
-      )}
-      {tooltipPos && hasGenerationDetails && createPortal(
-        <span
-          className={styles.metaPillTooltip}
-          style={{ position: 'fixed', left: tooltipPos.x, top: tooltipPos.y - 6, transform: 'translateY(-100%)' }}
-        >
-          {generationMetrics!.model && (
-            <span className={styles.tooltipRow}>
-              <span className={styles.tooltipLabel}>{t('messageMeta.model')}</span>
-              <span className={styles.tooltipValue}>{generationMetrics!.model}</span>
-            </span>
-          )}
-          {generationMetrics!.provider && (
-            <span className={styles.tooltipRow}>
-              <span className={styles.tooltipLabel}>{t('messageMeta.provider')}</span>
-              <span className={styles.tooltipValue}>{generationMetrics!.provider}</span>
-            </span>
-          )}
-          {generationMetrics!.ttft != null && (
-            <span className={styles.tooltipRow}>
-              <span className={styles.tooltipLabel}>{t('messageMeta.firstToken')}</span>
-              <span className={styles.tooltipValue}>{formatMs(generationMetrics!.ttft)}</span>
-            </span>
-          )}
-          {generationMetrics!.tps != null && (
-            <span className={styles.tooltipRow}>
-              <span className={styles.tooltipLabel}>{t('messageMeta.speed')}</span>
-              <span className={styles.tooltipValue}>{t('messageMeta.tokPerSec', { count: generationMetrics!.tps })}</span>
-            </span>
-          )}
-        </span>,
-        document.body
-      )}
-    </span>
-  )
-}
 
 interface MinimalMessageProps {
   message: Message
@@ -140,343 +18,89 @@ interface MinimalMessageProps {
 }
 
 export default function MinimalMessage({ message, chatId, depth = 0, isSelectMode = false, isSelected = false, onToggleSelect }: MinimalMessageProps) {
-  const { t } = useTranslation('chat')
-  const { t: tc } = useTranslation('common')
   const {
-    isEditing,
-    editContent,
-    setEditContent,
-    editReasoning,
-    setEditReasoning,
-    showReasoningEditor,
-    isUser,
-    isActivelyStreaming,
-    displayContent,
-    reasoning,
-    reasoningDuration,
-    reasoningStartedAt,
-    tokenCount,
-    generationMetrics,
-    avatarUrl,
-    fullAvatarUrl,
-    displayName,
-    macroUserName,
-    isHidden,
-    handleEdit,
-    handleSaveEdit,
-    handleCancelEdit,
-    handleDelete,
-    handleToggleHidden,
-    handleFork,
+    isEditing, editContent, setEditContent, editReasoning, setEditReasoning, showReasoningEditor,
+    isUser, isLastMessage, isActivelyStreaming, displayContent, reasoning, reasoningDuration, reasoningStartedAt,
+    tokenCount, generationMetrics, avatarUrl, fullAvatarUrl, displayName, macroUserName, isHidden,
+    handleEdit, handleSaveEdit, handleCancelEdit, handleDelete, handleToggleHidden, handleFork,
   } = useMessageCard(message, chatId)
 
   const openModal = useStore((s) => s.openModal)
-  const openFloatingAvatar = useStore((s) => s.openFloatingAvatar)
-  const swipeGesturesEnabled = useStore((s) => s.swipeGesturesEnabled)
-  const showMessageTokenCount = useStore((s) => s.showMessageTokenCount ?? true)
-  const messageContextMenuEnabled = useStore((s) => s.messageContextMenuEnabled ?? true)
-  // Keep a MessageAudioSlot wrapper mounted on every assistant bubble
-  // when TTS is enabled, OR whenever an audio attachment already exists.
-  // See BubbleMessageDefault for the full rationale.
-  const ttsEnabled = useStore((s) => s.voiceSettings.ttsEnabled)
-  // Audio is per-swipe: see BubbleMessageDefault for the full rationale.
-  const audioAttachment = useMemo(() => {
-    const attachments = message.extra?.attachments ?? []
-    return attachments.find((a: any) =>
-      a && a.type === 'audio' && (a.swipe_id === undefined || a.swipe_id === message.swipe_id),
-    ) ?? null
-  }, [message.extra?.attachments, message.swipe_id])
-  const renderAudioSlot = !isEditing && (ttsEnabled || !!audioAttachment) && !message.is_user
-  const isHighlighted = useStore((s) => s.highlightedMessageId === message.id)
   const handlePromptBreakdown = useCallback(() => {
     openModal('promptItemizer', { messageId: message.id })
   }, [openModal, message.id])
 
-  const cardRef = useRef<HTMLDivElement>(null)
-
-  // Replay any Spindle extension DOM that was registered against this
-  // message id but lost when the chat virtualizer unmounted the row. See
-  // dom-injection-registry.ts for the full mechanism. useLayoutEffect so
-  // the injection lands in the same paint as the bubble's mount.
-  useLayoutEffect(() => {
-    if (!cardRef.current) return
-    replaySpindleInjections(message.id, cardRef.current)
-  }, [message.id])
-
-  const [contextMenuPos, setContextMenuPos] = useState<ContextMenuPos | null>(null)
-  const { handleSwipe } = useSwipeAction(message, chatId)
-  const onSwipeLeft = useCallback(() => handleSwipe('left'), [handleSwipe])
-  const onSwipeRight = useCallback(() => handleSwipe('right'), [handleSwipe])
-  const {
-    canPlay,
-    isPlaying,
-    hasSavedAudio,
-    isGenerating,
-    toggle: togglePlayback,
-    regenModalOpen,
-    confirmRegen,
-    cancelRegen,
-    requestDelete,
-    deleteModalOpen,
-    confirmDelete,
-    cancelDelete,
-  } = useMessagePlayback(message.id, message.content, message.name, message.is_user)
-  const canOpenContextMenu = !isEditing && !isSelectMode && messageContextMenuEnabled
-
-  const closeContextMenu = useCallback(() => setContextMenuPos(null), [])
-
-  const contextAction = useCallback((action: () => void) => {
-    closeContextMenu()
-    action()
-  }, [closeContextMenu])
-
-  const handleCopy = useCallback(() => {
-    const selected = getSelectionTextWithin(cardRef.current)
-    copyTextToClipboard(selected || message.content).catch(console.error)
-  }, [message.content])
-
-  const longPress = useLongPress({
-    onLongPress: (pos) => {
-      if (canOpenContextMenu) setContextMenuPos(pos)
+  // ── Build the flattened override props contract ──
+  const overrideProps: MessageOverrideProps = useMemo(() => ({
+    message: {
+      id: message.id,
+      index: message.index_in_chat,
+      sendDate: message.swipe_dates?.[message.swipe_id] ?? message.send_date,
+      isUser,
+      displayName,
+      avatarUrl,
+      fullAvatarUrl,
+      isHidden,
+      isStreaming: isActivelyStreaming,
+      isLastMessage,
+      tokenCount: tokenCount ?? null,
     },
-  })
-
-  const handleContextMenu = useCallback((e: React.MouseEvent) => {
-    if (!canOpenContextMenu) return
-    longPress.onContextMenu(e)
-  }, [canOpenContextMenu, longPress])
-
-  const contextMenuItems: ContextMenuEntry[] = useMemo(() => [
-    {
-      key: 'copy',
-      label: tc('actions.copy'),
-      icon: <Copy size={14} />,
-      onClick: () => contextAction(handleCopy),
+    content: {
+      raw: displayContent,
+      html: '', // Will be populated by the override user via dangerouslySetInnerHTML if needed
     },
-    {
-      key: 'edit',
-      label: tc('actions.edit'),
-      icon: <Pencil size={14} />,
-      onClick: () => contextAction(handleEdit),
+    reasoning: reasoning ? {
+      raw: reasoning,
+      duration: reasoningDuration ?? null,
+      isStreaming: isActivelyStreaming,
+    } : null,
+    swipes: {
+      current: message.swipe_id + 1,
+      total: message.swipes.length,
     },
-    ...(canPlay ? [{
-      key: 'play',
-      label: isGenerating
-        ? t('messageActions.cancelTtsGeneration')
-        : isPlaying
-          ? t('messageActions.stopPlayback')
-          : hasSavedAudio
-            ? t('messageActions.regenerateTtsAudio')
-            : t('messageActions.playTts'),
-      icon: (isGenerating || isPlaying) ? <Square size={14} /> : <Volume2 size={14} />,
-      onClick: () => contextAction(togglePlayback),
-    }] satisfies ContextMenuEntry[] : []),
-    {
-      key: 'toggle-hidden',
-      label: isHidden ? t('messageActions.unhideFromAi') : t('messageActions.hideFromAi'),
-      icon: isHidden ? <Eye size={14} /> : <EyeOff size={14} />,
-      active: isHidden,
-      onClick: () => contextAction(handleToggleHidden),
-    },
-    {
-      key: 'fork',
-      label: t('messageActions.fork'),
-      icon: <IconGitFork size={14} />,
-      onClick: () => contextAction(handleFork),
-    },
-    ...(!isUser ? [{
-      key: 'prompt-breakdown',
-      label: t('messageActions.promptBreakdown'),
-      icon: <BarChart3 size={14} />,
-      onClick: () => contextAction(handlePromptBreakdown),
-    }] satisfies ContextMenuEntry[] : []),
-    { key: 'delete-divider', type: 'divider' },
-    {
-      key: 'delete',
-      label: tc('actions.delete'),
-      icon: <Trash2 size={14} />,
-      danger: true,
-      onClick: () => contextAction(handleDelete),
-    },
-  ], [
-    canPlay, contextAction, handleCopy, handleDelete, handleEdit, handleFork,
-    handlePromptBreakdown, handleToggleHidden, hasSavedAudio, isGenerating, isHidden, isPlaying, isUser,
-    togglePlayback, t, tc,
+    attachments: (message.extra?.attachments || []).map((a: any) => ({
+      type: a.type,
+      imageId: a.image_id,
+      mimeType: a.mime_type,
+      filename: a.original_filename,
+    })),
+    editing: Object.freeze({
+      active: isEditing,
+      content: editContent,
+      reasoning: editReasoning,
+      setContent: setEditContent,
+      setReasoning: setEditReasoning,
+      save: handleSaveEdit,
+      cancel: handleCancelEdit,
+    }),
+    actions: Object.freeze({
+      copy: () => copyTextToClipboard(message.content).catch(console.error),
+      edit: handleEdit,
+      delete: handleDelete,
+      toggleHidden: handleToggleHidden,
+      fork: handleFork,
+      promptBreakdown: handlePromptBreakdown,
+      swipeLeft: () => {},
+      swipeRight: () => {},
+    }),
+    styles,
+  }), [
+    message, isUser, displayName, avatarUrl, fullAvatarUrl, isHidden, isActivelyStreaming,
+    isLastMessage, tokenCount, displayContent, reasoning, reasoningDuration,
+    isEditing, editContent, editReasoning, setEditContent, setEditReasoning,
+    handleSaveEdit, handleCancelEdit, handleEdit, handleDelete, handleToggleHidden,
+    handleFork, handlePromptBreakdown,
   ])
 
-  useSwipeGesture(cardRef, {
-    enabled: swipeGesturesEnabled && !isUser && !isEditing && !isSelectMode,
-    onSwipeLeft,
-    onSwipeRight,
-  })
+  // ── Default props for the built-in renderer ──
+  const defaultProps: MinimalMessageDefaultProps = {
+    message, chatId, depth, isSelectMode, isSelected, onToggleSelect,
+    isEditing, editContent, setEditContent, editReasoning, setEditReasoning, showReasoningEditor,
+    isUser, isActivelyStreaming, displayContent, reasoning, reasoningDuration, reasoningStartedAt,
+    tokenCount, generationMetrics, avatarUrl, fullAvatarUrl, displayName, macroUserName, isHidden,
+    handleEdit, handleSaveEdit, handleCancelEdit, handleDelete, handleToggleHidden,
+    handleFork, handlePromptBreakdown,
+  }
 
-  return (
-    <div
-      ref={cardRef}
-      data-component="MinimalMessage"
-      data-part={isUser ? 'user' : 'character'}
-      className={clsx(
-        styles.card,
-        isUser ? styles.user : styles.character,
-        isActivelyStreaming && styles.streaming,
-        isHidden && styles.hidden,
-        isSelectMode && isSelected && styles.selected,
-        isSelectMode && styles.selectMode,
-        isHighlighted && styles.highlight,
-      )}
-      data-message-id={message.id}
-      onClick={isSelectMode ? onToggleSelect : undefined}
-      onContextMenu={handleContextMenu}
-      onTouchStart={canOpenContextMenu ? longPress.onTouchStart : undefined}
-      onTouchMove={canOpenContextMenu ? longPress.onTouchMove : undefined}
-      onTouchEnd={canOpenContextMenu ? longPress.onTouchEnd : undefined}
-    >
-      {/* Avatar */}
-      <div
-        className={styles.avatar}
-        style={fullAvatarUrl ? { cursor: 'pointer' } : undefined}
-        onClick={fullAvatarUrl ? (e) => { e.stopPropagation(); openFloatingAvatar(fullAvatarUrl, displayName) } : undefined}
-      >
-        <LazyImage
-          src={avatarUrl}
-          alt={displayName}
-          fallback={
-            <div className={styles.avatarFallback}>
-              {displayName?.[0]?.toUpperCase() || '?'}
-            </div>
-          }
-        />
-      </div>
-
-      <div className={styles.bubble}>
-        {/* Name + meta pill */}
-        <div className={styles.header}>
-          <span className={clsx(styles.name, isUser ? styles.nameUser : styles.nameChar)}>
-            {displayName}
-          </span>
-          <MetaPill
-            index={message.index_in_chat}
-            timestamp={message.swipe_dates?.[message.swipe_id] ?? message.send_date}
-            tokenCount={tokenCount}
-            isHidden={isHidden}
-            isUser={isUser}
-            generationMetrics={generationMetrics}
-            showTokenCount={showMessageTokenCount}
-          />
-        </div>
-
-        {/* Reasoning block — hidden during editing since the edit area shows it inline */}
-        {reasoning && !isEditing && (
-          <ReasoningBlock
-            reasoning={reasoning}
-            reasoningDuration={reasoningDuration}
-            reasoningStartedAt={reasoningStartedAt}
-            isStreaming={isActivelyStreaming}
-          />
-        )}
-
-        {/* Inline image attachments — before content for assistant. */}
-        {!isUser && message.extra?.attachments && message.extra.attachments.length > 0 && !isEditing && (
-          <MessageAttachments attachments={message.extra.attachments} isUser={false} chatId={chatId} messageId={message.id} />
-        )}
-
-        {/* Content */}
-        {isEditing ? (
-          <MessageEditArea
-            editContent={editContent}
-            onChangeContent={setEditContent}
-            onSave={handleSaveEdit}
-            onCancel={handleCancelEdit}
-            editReasoning={showReasoningEditor ? editReasoning : undefined}
-            onChangeReasoning={showReasoningEditor ? setEditReasoning : undefined}
-          />
-        ) : displayContent ? (
-          <MessageContent
-            content={displayContent}
-            isUser={isUser}
-            userName={macroUserName}
-            isStreaming={isActivelyStreaming}
-            messageId={message.id}
-            chatId={chatId}
-            depth={depth}
-          />
-        ) : isActivelyStreaming ? (
-          <StreamingIndicator />
-        ) : null}
-
-        {/* User attachments render after content */}
-        {isUser && message.extra?.attachments && message.extra.attachments.length > 0 && !isEditing && (
-          <MessageAttachments attachments={message.extra.attachments} isUser={true} chatId={chatId} messageId={message.id} />
-        )}
-
-        {/* Audio slot — always-mounted when TTS is on (or audio exists)
-            so its grid-template-rows: 0fr ↔ 1fr transition has somewhere
-            to animate from. Renders zero-height when no audio, transitions
-            smoothly when audio attaches/detaches. */}
-        {renderAudioSlot && (
-          <MessageAudioSlot
-            audio={audioAttachment}
-            messageId={message.id}
-            isUser={isUser}
-            onDelete={hasSavedAudio ? requestDelete : undefined}
-          />
-        )}
-
-        {/* Swipe controls — assistant messages only, except the greeting (index 0),
-            which uses the GreetingNav picker below instead. */}
-        {!isUser && !isEditing && message.index_in_chat !== 0 && (
-          <SwipeControls message={message} chatId={chatId} />
-        )}
-
-        {/* Greeting navigator for first message */}
-        {message.index_in_chat === 0 && !isUser && !isEditing && (
-          <GreetingNav message={message} chatId={chatId} />
-        )}
-      </div>
-
-      {/* Actions (hidden in select mode) */}
-      {!isEditing && !isSelectMode && (
-        <div className={styles.actionsWrap}>
-          <MessageActions
-            onEdit={handleEdit}
-            onDelete={handleDelete}
-            onToggleHidden={handleToggleHidden}
-            onFork={handleFork}
-            onPromptBreakdown={!isUser ? handlePromptBreakdown : undefined}
-            onPlay={canPlay ? togglePlayback : undefined}
-            isPlaying={isPlaying}
-            isGenerating={isGenerating}
-            hasSavedAudio={hasSavedAudio}
-            isUser={isUser}
-            isHidden={isHidden}
-            content={message.content}
-          />
-        </div>
-      )}
-
-      <ContextMenu position={contextMenuPos} items={contextMenuItems} onClose={closeContextMenu} />
-
-      <ConfirmationModal
-        isOpen={regenModalOpen}
-        onCancel={cancelRegen}
-        onConfirm={confirmRegen}
-        title="Regenerate TTS audio?"
-        message="This will replace the saved audio attached to this message with a new TTS synthesis. The current recording will be deleted."
-        confirmText="Regenerate"
-        cancelText="Keep current"
-        variant="warning"
-      />
-
-      <ConfirmationModal
-        isOpen={deleteModalOpen}
-        onCancel={cancelDelete}
-        onConfirm={confirmDelete}
-        title="Delete saved audio?"
-        message="This removes the TTS recording attached to this message swipe. Other swipes' recordings are unaffected. You can always regenerate it later."
-        confirmText="Delete"
-        cancelText="Keep"
-        variant="danger"
-      />
-    </div>
-  )
+  return useComponentOverride('MinimalMessage', MinimalMessageDefault, overrideProps, defaultProps)
 }

--- a/frontend/src/components/chat/MinimalMessageDefault.tsx
+++ b/frontend/src/components/chat/MinimalMessageDefault.tsx
@@ -1,0 +1,487 @@
+/**
+ * Default MinimalMessage renderer — the original implementation extracted
+ * so it can be used as a fallback when a user override crashes or is disabled.
+ */
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { createPortal } from 'react-dom'
+import { Copy, Pencil, Trash2, EyeOff, Eye, BarChart3, Volume2, Square } from 'lucide-react'
+import { IconGitFork } from '@tabler/icons-react'
+import { useStore } from '@/store'
+import { useLongPress } from '@/hooks/useLongPress'
+import { useMessagePlayback } from '@/hooks/useMessagePlayback'
+import useSwipeAction from '@/hooks/useSwipeAction'
+import useSwipeGesture from '@/hooks/useSwipeGesture'
+import { copyTextToClipboard, getSelectionTextWithin } from '@/lib/clipboard'
+import { replay as replaySpindleInjections } from '@/lib/spindle/dom-injection-registry'
+import MessageContent from './MessageContent'
+import MessageEditArea from './MessageEditArea'
+import MessageAttachments from './MessageAttachments'
+import MessageAudioSlot from './MessageAudioSlot'
+import MessageActions from './MessageActions'
+import SwipeControls from './SwipeControls'
+import GreetingNav from './GreetingNav'
+import ReasoningBlock from './ReasoningBlock'
+import StreamingIndicator from './StreamingIndicator'
+import LazyImage from '@/components/shared/LazyImage'
+import ContextMenu, { type ContextMenuEntry, type ContextMenuPos } from '@/components/shared/ContextMenu'
+import ConfirmationModal from '@/components/shared/ConfirmationModal'
+import type { Message } from '@/types/api'
+import type { GenerationMetrics } from '@/types/ws-events'
+import styles from './MinimalMessage.module.css'
+import clsx from 'clsx'
+
+export interface MinimalMessageDefaultProps {
+  message: Message
+  chatId: string
+  depth: number
+  isSelectMode: boolean
+  isSelected: boolean
+  onToggleSelect?: (e: React.MouseEvent) => void
+  // Pre-computed from useMessageCard
+  isEditing: boolean
+  editContent: string
+  setEditContent: (s: string) => void
+  editReasoning: string
+  setEditReasoning: (s: string) => void
+  showReasoningEditor: boolean
+  isUser: boolean
+  isActivelyStreaming: boolean
+  displayContent: string
+  reasoning: string | undefined
+  reasoningDuration: number | undefined
+  reasoningStartedAt: number | undefined
+  tokenCount: number | undefined
+  generationMetrics: GenerationMetrics | undefined
+  avatarUrl: string | null
+  fullAvatarUrl: string | null
+  displayName: string
+  macroUserName: string
+  isHidden: boolean
+  handleEdit: () => void
+  handleSaveEdit: () => void
+  handleCancelEdit: () => void
+  handleDelete: () => void
+  handleToggleHidden: () => void
+  handleFork: () => void
+  handlePromptBreakdown: () => void
+}
+
+function formatMetaDate(timestamp: number) {
+  const d = new Date(timestamp * 1000)
+  const month = d.toLocaleString('en-US', { month: 'short' })
+  const day = d.getDate()
+  const time = d.toLocaleString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
+  return `${month} ${day}, ${time}`
+}
+
+function formatMs(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  return `${(ms / 1000).toFixed(2)}s`
+}
+
+function MetaPill({ index, timestamp, tokenCount, isHidden, isUser, generationMetrics, showTokenCount }: {
+  index: number
+  timestamp: number
+  tokenCount: number | undefined
+  isHidden: boolean
+  isUser: boolean
+  generationMetrics: GenerationMetrics | undefined
+  showTokenCount: boolean
+}) {
+  const { t } = useTranslation('chat')
+  const pillRef = useRef<HTMLSpanElement>(null)
+  const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number } | null>(null)
+  const hasGenerationDetails = !isUser && !!generationMetrics && (
+    generationMetrics.ttft != null
+    || generationMetrics.tps != null
+    || !!generationMetrics.model
+    || !!generationMetrics.provider
+  )
+
+  const handleMouseEnter = useCallback(() => {
+    if (!hasGenerationDetails || !pillRef.current) return
+    const rect = pillRef.current.getBoundingClientRect()
+    setTooltipPos({ x: rect.left, y: rect.top })
+  }, [hasGenerationDetails])
+
+  const handleMouseLeave = useCallback(() => {
+    setTooltipPos(null)
+  }, [])
+
+  return (
+    <span
+      ref={pillRef}
+      className={styles.metaPill}
+      onMouseEnter={hasGenerationDetails ? handleMouseEnter : undefined}
+      onMouseLeave={hasGenerationDetails ? handleMouseLeave : undefined}
+    >
+      <span className={styles.metaSegment}>#{index}</span>
+      <span className={styles.metaSegment}>
+        <span className={styles.metaDot}>&middot;</span>
+        {formatMetaDate(timestamp)}
+      </span>
+      {showTokenCount && tokenCount != null && (
+        <span className={styles.metaSegment}>
+          <span className={styles.metaDot}>&middot;</span>
+          {tokenCount}t
+        </span>
+      )}
+      {isHidden && (
+        <span className={styles.metaSegment}>
+          <span className={styles.metaDot}>&middot;</span>
+          <span className={styles.hiddenBadge}>{t('messageMeta.hidden')}</span>
+        </span>
+      )}
+      {tooltipPos && hasGenerationDetails && createPortal(
+        <span
+          className={styles.metaPillTooltip}
+          style={{ position: 'fixed', left: tooltipPos.x, top: tooltipPos.y - 6, transform: 'translateY(-100%)' }}
+        >
+          {generationMetrics!.model && (
+            <span className={styles.tooltipRow}>
+              <span className={styles.tooltipLabel}>{t('messageMeta.model')}</span>
+              <span className={styles.tooltipValue}>{generationMetrics!.model}</span>
+            </span>
+          )}
+          {generationMetrics!.provider && (
+            <span className={styles.tooltipRow}>
+              <span className={styles.tooltipLabel}>{t('messageMeta.provider')}</span>
+              <span className={styles.tooltipValue}>{generationMetrics!.provider}</span>
+            </span>
+          )}
+          {generationMetrics!.ttft != null && (
+            <span className={styles.tooltipRow}>
+              <span className={styles.tooltipLabel}>{t('messageMeta.firstToken')}</span>
+              <span className={styles.tooltipValue}>{formatMs(generationMetrics!.ttft)}</span>
+            </span>
+          )}
+          {generationMetrics!.tps != null && (
+            <span className={styles.tooltipRow}>
+              <span className={styles.tooltipLabel}>{t('messageMeta.speed')}</span>
+              <span className={styles.tooltipValue}>{t('messageMeta.tokPerSec', { count: generationMetrics!.tps })}</span>
+            </span>
+          )}
+        </span>,
+        document.body
+      )}
+    </span>
+  )
+}
+
+export default function MinimalMessageDefault({
+  message, chatId, depth, isSelectMode, isSelected, onToggleSelect,
+  isEditing, editContent, setEditContent, editReasoning, setEditReasoning, showReasoningEditor,
+  isUser, isActivelyStreaming, displayContent, reasoning, reasoningDuration, reasoningStartedAt,
+  tokenCount, generationMetrics, avatarUrl, fullAvatarUrl, displayName, macroUserName, isHidden,
+  handleEdit, handleSaveEdit, handleCancelEdit, handleDelete, handleToggleHidden,
+  handleFork, handlePromptBreakdown,
+}: MinimalMessageDefaultProps) {
+  const { t } = useTranslation('chat')
+  const { t: tc } = useTranslation('common')
+  const openFloatingAvatar = useStore((s) => s.openFloatingAvatar)
+  const swipeGesturesEnabled = useStore((s) => s.swipeGesturesEnabled)
+  const showMessageTokenCount = useStore((s) => s.showMessageTokenCount ?? true)
+  const messageContextMenuEnabled = useStore((s) => s.messageContextMenuEnabled ?? true)
+  // Keep a MessageAudioSlot wrapper mounted on every assistant bubble
+  // when TTS is enabled, OR whenever an audio attachment already exists.
+  // See BubbleMessageDefault for the full rationale.
+  const ttsEnabled = useStore((s) => s.voiceSettings.ttsEnabled)
+  // Audio is per-swipe: see BubbleMessageDefault for the full rationale.
+  const audioAttachment = useMemo(() => {
+    const attachments = message.extra?.attachments ?? []
+    return attachments.find((a: any) =>
+      a && a.type === 'audio' && (a.swipe_id === undefined || a.swipe_id === message.swipe_id),
+    ) ?? null
+  }, [message.extra?.attachments, message.swipe_id])
+  const renderAudioSlot = !isEditing && (ttsEnabled || !!audioAttachment) && !message.is_user
+  const isHighlighted = useStore((s) => s.highlightedMessageId === message.id)
+
+  const cardRef = useRef<HTMLDivElement>(null)
+
+  // Replay any Spindle extension DOM that was registered against this
+  // message id but lost when the chat virtualizer unmounted the row. See
+  // dom-injection-registry.ts for the full mechanism. useLayoutEffect so
+  // the injection lands in the same paint as the bubble's mount.
+  useLayoutEffect(() => {
+    if (!cardRef.current) return
+    replaySpindleInjections(message.id, cardRef.current)
+  }, [message.id])
+
+  const [contextMenuPos, setContextMenuPos] = useState<ContextMenuPos | null>(null)
+  const { handleSwipe } = useSwipeAction(message, chatId)
+  const onSwipeLeft = useCallback(() => handleSwipe('left'), [handleSwipe])
+  const onSwipeRight = useCallback(() => handleSwipe('right'), [handleSwipe])
+  const {
+    canPlay,
+    isPlaying,
+    hasSavedAudio,
+    isGenerating,
+    toggle: togglePlayback,
+    regenModalOpen,
+    confirmRegen,
+    cancelRegen,
+    requestDelete,
+    deleteModalOpen,
+    confirmDelete,
+    cancelDelete,
+  } = useMessagePlayback(message.id, message.content, message.name, message.is_user)
+  const canOpenContextMenu = !isEditing && !isSelectMode && messageContextMenuEnabled
+
+  const closeContextMenu = useCallback(() => setContextMenuPos(null), [])
+
+  const contextAction = useCallback((action: () => void) => {
+    closeContextMenu()
+    action()
+  }, [closeContextMenu])
+
+  const handleCopy = useCallback(() => {
+    const selected = getSelectionTextWithin(cardRef.current)
+    copyTextToClipboard(selected || message.content).catch(console.error)
+  }, [message.content])
+
+  const longPress = useLongPress({
+    onLongPress: (pos) => {
+      if (canOpenContextMenu) setContextMenuPos(pos)
+    },
+  })
+
+  const handleContextMenu = useCallback((e: React.MouseEvent) => {
+    if (!canOpenContextMenu) return
+    longPress.onContextMenu(e)
+  }, [canOpenContextMenu, longPress])
+
+  const contextMenuItems: ContextMenuEntry[] = useMemo(() => [
+    {
+      key: 'copy',
+      label: tc('actions.copy'),
+      icon: <Copy size={14} />,
+      onClick: () => contextAction(handleCopy),
+    },
+    {
+      key: 'edit',
+      label: tc('actions.edit'),
+      icon: <Pencil size={14} />,
+      onClick: () => contextAction(handleEdit),
+    },
+    ...(canPlay ? [{
+      key: 'play',
+      label: isGenerating
+        ? t('messageActions.cancelTtsGeneration')
+        : isPlaying
+          ? t('messageActions.stopPlayback')
+          : hasSavedAudio
+            ? t('messageActions.regenerateTtsAudio')
+            : t('messageActions.playTts'),
+      icon: (isGenerating || isPlaying) ? <Square size={14} /> : <Volume2 size={14} />,
+      onClick: () => contextAction(togglePlayback),
+    }] satisfies ContextMenuEntry[] : []),
+    {
+      key: 'toggle-hidden',
+      label: isHidden ? t('messageActions.unhideFromAi') : t('messageActions.hideFromAi'),
+      icon: isHidden ? <Eye size={14} /> : <EyeOff size={14} />,
+      active: isHidden,
+      onClick: () => contextAction(handleToggleHidden),
+    },
+    {
+      key: 'fork',
+      label: t('messageActions.fork'),
+      icon: <IconGitFork size={14} />,
+      onClick: () => contextAction(handleFork),
+    },
+    ...(!isUser ? [{
+      key: 'prompt-breakdown',
+      label: t('messageActions.promptBreakdown'),
+      icon: <BarChart3 size={14} />,
+      onClick: () => contextAction(handlePromptBreakdown),
+    }] satisfies ContextMenuEntry[] : []),
+    { key: 'delete-divider', type: 'divider' },
+    {
+      key: 'delete',
+      label: tc('actions.delete'),
+      icon: <Trash2 size={14} />,
+      danger: true,
+      onClick: () => contextAction(handleDelete),
+    },
+  ], [
+    canPlay, contextAction, handleCopy, handleDelete, handleEdit, handleFork,
+    handlePromptBreakdown, handleToggleHidden, hasSavedAudio, isGenerating, isHidden, isPlaying, isUser,
+    togglePlayback, t, tc,
+  ])
+
+  useSwipeGesture(cardRef, {
+    enabled: swipeGesturesEnabled && !isUser && !isEditing && !isSelectMode,
+    onSwipeLeft,
+    onSwipeRight,
+  })
+
+  return (
+    <div
+      ref={cardRef}
+      data-component="MinimalMessage"
+      data-part={isUser ? 'user' : 'character'}
+      className={clsx(
+        styles.card,
+        isUser ? styles.user : styles.character,
+        isActivelyStreaming && styles.streaming,
+        isHidden && styles.hidden,
+        isSelectMode && isSelected && styles.selected,
+        isSelectMode && styles.selectMode,
+        isHighlighted && styles.highlight,
+      )}
+      data-message-id={message.id}
+      onClick={isSelectMode ? onToggleSelect : undefined}
+      onContextMenu={handleContextMenu}
+      onTouchStart={canOpenContextMenu ? longPress.onTouchStart : undefined}
+      onTouchMove={canOpenContextMenu ? longPress.onTouchMove : undefined}
+      onTouchEnd={canOpenContextMenu ? longPress.onTouchEnd : undefined}
+    >
+      {/* Avatar */}
+      <div
+        className={styles.avatar}
+        style={fullAvatarUrl ? { cursor: 'pointer' } : undefined}
+        onClick={fullAvatarUrl ? (e) => { e.stopPropagation(); openFloatingAvatar(fullAvatarUrl, displayName) } : undefined}
+      >
+        <LazyImage
+          src={avatarUrl}
+          alt={displayName}
+          fallback={
+            <div className={styles.avatarFallback}>
+              {displayName?.[0]?.toUpperCase() || '?'}
+            </div>
+          }
+        />
+      </div>
+
+      <div className={styles.bubble}>
+        {/* Name + meta pill */}
+        <div className={styles.header}>
+          <span className={clsx(styles.name, isUser ? styles.nameUser : styles.nameChar)}>
+            {displayName}
+          </span>
+          <MetaPill
+            index={message.index_in_chat}
+            timestamp={message.swipe_dates?.[message.swipe_id] ?? message.send_date}
+            tokenCount={tokenCount}
+            isHidden={isHidden}
+            isUser={isUser}
+            generationMetrics={generationMetrics}
+            showTokenCount={showMessageTokenCount}
+          />
+        </div>
+
+        {/* Reasoning block — hidden during editing since the edit area shows it inline */}
+        {reasoning && !isEditing && (
+          <ReasoningBlock
+            reasoning={reasoning}
+            reasoningDuration={reasoningDuration}
+            reasoningStartedAt={reasoningStartedAt}
+            isStreaming={isActivelyStreaming}
+          />
+        )}
+
+        {/* Inline image attachments — before content for assistant. */}
+        {!isUser && message.extra?.attachments && message.extra.attachments.length > 0 && !isEditing && (
+          <MessageAttachments attachments={message.extra.attachments} isUser={false} chatId={chatId} messageId={message.id} />
+        )}
+
+        {/* Content */}
+        {isEditing ? (
+          <MessageEditArea
+            editContent={editContent}
+            onChangeContent={setEditContent}
+            onSave={handleSaveEdit}
+            onCancel={handleCancelEdit}
+            editReasoning={showReasoningEditor ? editReasoning : undefined}
+            onChangeReasoning={showReasoningEditor ? setEditReasoning : undefined}
+          />
+        ) : displayContent ? (
+          <MessageContent
+            content={displayContent}
+            isUser={isUser}
+            userName={macroUserName}
+            isStreaming={isActivelyStreaming}
+            messageId={message.id}
+            chatId={chatId}
+            depth={depth}
+          />
+        ) : isActivelyStreaming ? (
+          <StreamingIndicator />
+        ) : null}
+
+        {/* User attachments render after content */}
+        {isUser && message.extra?.attachments && message.extra.attachments.length > 0 && !isEditing && (
+          <MessageAttachments attachments={message.extra.attachments} isUser={true} chatId={chatId} messageId={message.id} />
+        )}
+
+        {/* Audio slot — always-mounted when TTS is on (or audio exists)
+            so its grid-template-rows: 0fr ↔ 1fr transition has somewhere
+            to animate from. Renders zero-height when no audio, transitions
+            smoothly when audio attaches/detaches. */}
+        {renderAudioSlot && (
+          <MessageAudioSlot
+            audio={audioAttachment}
+            messageId={message.id}
+            isUser={isUser}
+            onDelete={hasSavedAudio ? requestDelete : undefined}
+          />
+        )}
+
+        {/* Swipe controls — assistant messages only, except the greeting (index 0),
+            which uses the GreetingNav picker below instead. */}
+        {!isUser && !isEditing && message.index_in_chat !== 0 && (
+          <SwipeControls message={message} chatId={chatId} />
+        )}
+
+        {/* Greeting navigator for first message */}
+        {message.index_in_chat === 0 && !isUser && !isEditing && (
+          <GreetingNav message={message} chatId={chatId} />
+        )}
+      </div>
+
+      {/* Actions (hidden in select mode) */}
+      {!isEditing && !isSelectMode && (
+        <div className={styles.actionsWrap}>
+          <MessageActions
+            onEdit={handleEdit}
+            onDelete={handleDelete}
+            onToggleHidden={handleToggleHidden}
+            onFork={handleFork}
+            onPromptBreakdown={!isUser ? handlePromptBreakdown : undefined}
+            onPlay={canPlay ? togglePlayback : undefined}
+            isPlaying={isPlaying}
+            isGenerating={isGenerating}
+            hasSavedAudio={hasSavedAudio}
+            isUser={isUser}
+            isHidden={isHidden}
+            content={message.content}
+          />
+        </div>
+      )}
+
+      <ContextMenu position={contextMenuPos} items={contextMenuItems} onClose={closeContextMenu} />
+
+      <ConfirmationModal
+        isOpen={regenModalOpen}
+        onCancel={cancelRegen}
+        onConfirm={confirmRegen}
+        title="Regenerate TTS audio?"
+        message="This will replace the saved audio attached to this message with a new TTS synthesis. The current recording will be deleted."
+        confirmText="Regenerate"
+        cancelText="Keep current"
+        variant="warning"
+      />
+
+      <ConfirmationModal
+        isOpen={deleteModalOpen}
+        onCancel={cancelDelete}
+        onConfirm={confirmDelete}
+        title="Delete saved audio?"
+        message="This removes the TTS recording attached to this message swipe. Other swipes' recordings are unaffected. You can always regenerate it later."
+        confirmText="Delete"
+        cancelText="Keep"
+        variant="danger"
+      />
+    </div>
+  )
+}

--- a/frontend/src/lib/componentOverrides.ts
+++ b/frontend/src/lib/componentOverrides.ts
@@ -22,6 +22,7 @@ export interface OverrideMessageInfo {
   isUser: boolean
   displayName: string
   avatarUrl: string | null
+  fullAvatarUrl: string | null
   isHidden: boolean
   isStreaming: boolean
   isLastMessage: boolean

--- a/frontend/src/lib/componentTemplates.ts
+++ b/frontend/src/lib/componentTemplates.ts
@@ -24,61 +24,62 @@ export interface ComponentTemplate {
 const BUBBLE_MESSAGE: ComponentTemplate = {
   template: `export default function BubbleMessage({ message, content, reasoning, swipes, attachments, editing, actions, styles }) {
   return (
-    <div className={styles.message || ''} style={{ padding: 12 }}>
-      {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-        {message.avatarUrl && (
-          <img src={message.avatarUrl} alt="" width={32} height={32} style={{ borderRadius: '50%' }} />
+    <div className={styles.card || ''} data-part={message.isUser ? 'user' : 'character'}>
+      {/* Avatar */}
+      <div className={styles.avatar || ''}>
+        {message.avatarUrl ? (
+          <img src={message.avatarUrl} alt={message.displayName} style={{ width: '100%', height: '100%', objectFit: 'cover', borderRadius: '50%' }} />
+        ) : (
+          <div className={styles.avatarFallback || ''}>
+            {message.displayName?.[0]?.toUpperCase() || '?'}
+          </div>
         )}
-        <strong style={{ color: message.isUser ? '#a78bfa' : '#60a5fa' }}>
-          {message.displayName}
-        </strong>
-        <span style={{ fontSize: 11, opacity: 0.5 }}>#{message.index}</span>
       </div>
 
-      {/* Reasoning */}
-      {reasoning && (
-        <details style={{ marginBottom: 8, fontSize: 12, opacity: 0.7 }}>
-          <summary>Thinking{reasoning.duration ? \` (\${reasoning.duration}ms)\` : ''}</summary>
-          <pre style={{ whiteSpace: 'pre-wrap' }}>{reasoning.raw}</pre>
-        </details>
-      )}
-
-      {/* Content */}
-      <div style={{ whiteSpace: 'pre-wrap', lineHeight: 1.5 }}>{content.raw}</div>
-
-      {/* Attachments */}
-      {attachments.length > 0 && (
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 8 }}>
-          {attachments.map(attachment => (
-            <img
-              key={attachment.imageId}
-              src={\`/api/v1/images/\${attachment.imageId}?size=sm\`}
-              alt={attachment.filename}
-              width={96}
-              height={96}
-              style={{ objectFit: 'cover', borderRadius: 8 }}
-            />
-          ))}
+      {/* Bubble */}
+      <div className={styles.bubble || ''}>
+        {/* Header */}
+        <div className={styles.header || ''}>
+          <span className={styles.name || ''} style={{ color: message.isUser ? 'rgba(255,165,0,0.85)' : 'var(--lumiverse-primary-text)' }}>
+            {message.displayName}
+          </span>
         </div>
-      )}
 
-      {/* Swipes */}
-      {swipes.total > 1 && (
-        <div style={{ display: 'flex', gap: 6, marginTop: 8, fontSize: 12 }}>
-          <button onClick={actions.swipeLeft}>←</button>
-          <span>{swipes.current} / {swipes.total}</span>
-          <button onClick={actions.swipeRight}>→</button>
-        </div>
-      )}
+        {/* Reasoning */}
+        {reasoning && (
+          <details style={{ marginBottom: 8, fontSize: 12, opacity: 0.7 }}>
+            <summary>Thinking{reasoning.duration ? \` (\${reasoning.duration}ms)\` : ''}</summary>
+            <pre style={{ whiteSpace: 'pre-wrap' }}>{reasoning.raw}</pre>
+          </details>
+        )}
 
-      {/* Actions */}
-      <div style={{ display: 'flex', gap: 4, marginTop: 8, opacity: 0.6, fontSize: 11 }}>
-        <button onClick={actions.copy}>Copy</button>
-        <button onClick={actions.edit}>Edit</button>
-        <button onClick={actions.fork}>Fork</button>
-        <button onClick={actions.toggleHidden}>{message.isHidden ? 'Show' : 'Hide'}</button>
-        <button onClick={actions.delete}>Delete</button>
+        {/* Content */}
+        <div style={{ whiteSpace: 'pre-wrap', lineHeight: 1.5 }}>{content.raw}</div>
+
+        {/* Attachments */}
+        {attachments.length > 0 && (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 8 }}>
+            {attachments.map(attachment => (
+              <img
+                key={attachment.imageId}
+                src={\`/api/v1/images/\${attachment.imageId}?size=sm\`}
+                alt={attachment.filename}
+                width={96}
+                height={96}
+                style={{ objectFit: 'cover', borderRadius: 8 }}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Swipes */}
+        {swipes.total > 1 && (
+          <div style={{ display: 'flex', gap: 6, marginTop: 8, fontSize: 12 }}>
+            <button onClick={actions.swipeLeft}>←</button>
+            <span>{swipes.current} / {swipes.total}</span>
+            <button onClick={actions.swipeRight}>→</button>
+          </div>
+        )}
       </div>
     </div>
   )
@@ -90,7 +91,8 @@ const BUBBLE_MESSAGE: ComponentTemplate = {
       { name: 'sendDate', type: 'number', description: 'Unix timestamp' },
       { name: 'isUser', type: 'boolean', description: 'True if sent by user' },
       { name: 'displayName', type: 'string', description: 'Resolved display name' },
-      { name: 'avatarUrl', type: 'string | null', description: 'Avatar image URL' },
+      { name: 'avatarUrl', type: 'string | null', description: 'Avatar image URL (thumbnail)' },
+      { name: 'fullAvatarUrl', type: 'string | null', description: 'Full-size avatar image URL (original aspect ratio)' },
       { name: 'isHidden', type: 'boolean', description: 'Hidden from AI context' },
       { name: 'isStreaming', type: 'boolean', description: 'Currently streaming tokens' },
       { name: 'isLastMessage', type: 'boolean', description: 'Last message in chat' },


### PR DESCRIPTION
This fixes an issue where overriding MinimalMessage in CSS settings does nothing, and some other issues with overridden components and their ability to access data.

- Extract original MinimalMessage rendering into MinimalMessageDefault
- Make MinimalMessage a thin orchestrator using useComponentOverride
- Add fullAvatarUrl to message override props and BubbleMessage
- Update default template with proper CSS classes and avatar fallback

Note that some stuff is still broken: overridden Message components cannot render HTML content.