### PR TITLE
fix: full size avatar toggle

### DIFF
--- a/frontend/src/components/chat/BubbleMessage.tsx
+++ b/frontend/src/components/chat/BubbleMessage.tsx
@@ -48,7 +48,7 @@ export default function BubbleMessage({ message, chatId, depth = 0, isSelectMode
       sendDate: message.swipe_dates?.[message.swipe_id] ?? message.send_date,
       isUser,
       displayName,
-      avatarUrl,
+      avatarUrl: displayAvatarUrl,
       fullAvatarUrl,
       avatar,
       isHidden,
@@ -95,7 +95,7 @@ export default function BubbleMessage({ message, chatId, depth = 0, isSelectMode
     }),
     styles,
   }), [
-    message, isUser, displayName, avatarUrl, fullAvatarUrl, avatar, isHidden, isActivelyStreaming,
+    message, isUser, displayName, avatarUrl, fullAvatarUrl, displayAvatarUrl, avatar, isHidden, isActivelyStreaming,
     isLastMessage, tokenCount, displayContent, reasoning, reasoningDuration,
     isEditing, editContent, editReasoning, setEditContent, setEditReasoning,
     handleSaveEdit, handleCancelEdit, handleEdit, handleDelete, handleToggleHidden,

--- a/frontend/src/components/chat/MinimalMessage.tsx
+++ b/frontend/src/components/chat/MinimalMessage.tsx
@@ -29,6 +29,8 @@ export default function MinimalMessage({ message, chatId, depth = 0, isSelectMod
   } = useMessageCard(message, chatId)
 
   const openModal = useStore((s) => s.openModal)
+  const bubbleUseFullAvatar = useStore((s) => s.bubbleUseFullAvatar ?? false)
+  const displayAvatarUrl = bubbleUseFullAvatar && fullAvatarUrl ? fullAvatarUrl : avatarUrl
   const handlePromptBreakdown = useCallback(() => {
     openModal('promptItemizer', { messageId: message.id })
   }, [openModal, message.id])
@@ -88,7 +90,7 @@ export default function MinimalMessage({ message, chatId, depth = 0, isSelectMod
     }),
     styles,
   }), [
-    message, isUser, displayName, avatarUrl, fullAvatarUrl, avatar, isHidden, isActivelyStreaming,
+    message, isUser, displayName, avatarUrl, fullAvatarUrl, displayAvatarUrl, avatar, isHidden, isActivelyStreaming,
     isLastMessage, tokenCount, displayContent, reasoning, reasoningDuration,
     isEditing, editContent, editReasoning, setEditContent, setEditReasoning,
     handleSaveEdit, handleCancelEdit, handleEdit, handleDelete, handleToggleHidden,
@@ -132,7 +134,7 @@ export default function MinimalMessage({ message, chatId, depth = 0, isSelectMod
     message, chatId, depth, isSelectMode, isSelected, onToggleSelect,
     isEditing, editContent, setEditContent, editReasoning, setEditReasoning, showReasoningEditor,
     isUser, isActivelyStreaming, displayContent, reasoning, reasoningDuration, reasoningStartedAt,
-    tokenCount, generationMetrics, avatarUrl, fullAvatarUrl, displayName, macroUserName, isHidden,
+    tokenCount, generationMetrics, avatarUrl, fullAvatarUrl, displayAvatarUrl, displayName, macroUserName, isHidden,
     handleEdit, handleSaveEdit, handleCancelEdit, handleDelete, handleToggleHidden,
     handleFork, handlePromptBreakdown,
   }

--- a/frontend/src/components/chat/MinimalMessageDefault.tsx
+++ b/frontend/src/components/chat/MinimalMessageDefault.tsx
@@ -55,6 +55,7 @@ export interface MinimalMessageDefaultProps {
   generationMetrics: GenerationMetrics | undefined
   avatarUrl: string | null
   fullAvatarUrl: string | null
+  displayAvatarUrl: string | null
   displayName: string
   macroUserName: string
   isHidden: boolean
@@ -173,7 +174,7 @@ export default function MinimalMessageDefault({
   message, chatId, depth, isSelectMode, isSelected, onToggleSelect,
   isEditing, editContent, setEditContent, editReasoning, setEditReasoning, showReasoningEditor,
   isUser, isActivelyStreaming, displayContent, reasoning, reasoningDuration, reasoningStartedAt,
-  tokenCount, generationMetrics, avatarUrl, fullAvatarUrl, displayName, macroUserName, isHidden,
+  tokenCount, generationMetrics, avatarUrl, fullAvatarUrl, displayAvatarUrl, displayName, macroUserName, isHidden,
   handleEdit, handleSaveEdit, handleCancelEdit, handleDelete, handleToggleHidden,
   handleFork, handlePromptBreakdown,
 }: MinimalMessageDefaultProps) {
@@ -343,7 +344,7 @@ export default function MinimalMessageDefault({
         onClick={fullAvatarUrl ? (e) => { e.stopPropagation(); openFloatingAvatar(fullAvatarUrl, displayName) } : undefined}
       >
         <LazyImage
-          src={avatarUrl}
+          src={displayAvatarUrl}
           alt={displayName}
           fallback={
             <div className={styles.avatarFallback}>

--- a/frontend/src/i18n/locales/it/panels.json
+++ b/frontend/src/i18n/locales/it/panels.json
@@ -2323,6 +2323,7 @@
     "fontScale": "Scala font",
     "uiScale": "Scala UI",
     "glassEffects": "Effetti vetro",
+    "useFullAvatar": "Usa avatar a dimensione piena",
     "extensionThemesTitle": "Temi estensioni",
     "overridesApplied_one": "{{count}} override applicato",
     "overridesApplied_other": "{{count}} override applicati",

--- a/frontend/src/store/slices/settings.ts
+++ b/frontend/src/store/slices/settings.ts
@@ -27,6 +27,7 @@ const DATA_KEYS: ReadonlySet<string> = new Set([
   'bubbleUserAlign',
   'bubbleDisableHover',
   'bubbleHideAvatarBg',
+  'bubbleUseFullAvatar',
   'bubbleOpacity',
   'chatSheldEnterToSend',
   'saveDraftInput',


### PR DESCRIPTION
The toggle was broken: wasn't working and wasn't saving

- MinimalMessage: the toggle logic was lost during the override system refactor (commit 557f3b53). Add bubbleUseFullAvatar → displayAvatarUrl resolution and pass it to MinimalMessageDefault.
- BubbleMessage: override props was passing raw avatarUrl instead of displayAvatarUrl, breaking theme overrides. Fix by mapping avatarUrl: displayAvatarUrl in override props.
- Fix saving the toggle to persistent settings
- Add Italian translation for 'useFullAvatar' in panels.json.

Tested working on both bubble and minimal