### PR TITLE
Fix cacheable resolved content + invalidation

### DIFF
--- a/src/services/display-regex.service.ts
+++ b/src/services/display-regex.service.ts
@@ -10,6 +10,8 @@ import * as connectionsSvc from "./connections.service";
 import * as personasSvc from "./personas.service";
 import { populateLumiaLoomContext } from "./prompt-assembly.service";
 import { applyRegexScripts } from "./regex-scripts.service";
+import { eventBus } from "../ws/bus";
+import { EventType } from "../ws/events";
 
 initMacros();
 
@@ -161,6 +163,75 @@ export interface ApplyDisplayRegexResult {
   cacheable: boolean;
 }
 
+type DisplayVarEnv = { variables: { local: Map<string, unknown>; chat: Map<string, unknown>; global: Map<string, unknown> } } | null | undefined;
+
+const DISPLAY_REGEX_CACHE = new Map<string, { result: string; touched: ReadonlyArray<readonly [string, string]> }>();
+const DISPLAY_REGEX_CACHE_MAX = 1000;
+
+function varStateForKey(env: DisplayVarEnv, name: string): string {
+  if (!env) return "";
+  const v = env.variables;
+  const sep = name.indexOf(":");
+  if (sep > 0) {
+    const scope = name.slice(0, sep);
+    const bare = name.slice(sep + 1);
+    const map = scope === "local" ? v.local : scope === "chat" ? v.chat : scope === "global" ? v.global : null;
+    if (map) return String(map.get(bare) ?? "");
+  }
+  return `${v.local.get(name) ?? ""}${v.chat.get(name) ?? ""}${v.global.get(name) ?? ""}`;
+}
+
+function displayRegexCacheKey(
+  chatId: string | undefined,
+  content: string,
+  placement: RegexPlacement,
+  depth: number | undefined,
+  scripts: ReadonlyArray<{ id: string; updated_at: number }>,
+  dynamicMacros: Record<string, string> | undefined,
+  resolvedFind?: ReadonlyMap<string, string>,
+  resolvedReplace?: ReadonlyMap<string, string>,
+): string {
+  const SEP = "\x00";
+  let k = (chatId ?? "") + SEP + content + SEP + placement + SEP + (depth ?? "") + SEP;
+  for (const s of scripts) k += s.id + ":" + s.updated_at + ";";
+  if (dynamicMacros) { k += SEP + "D"; for (const a of Object.keys(dynamicMacros).sort()) k += a + "=" + dynamicMacros[a] + ";"; }
+  if (resolvedFind) { k += SEP + "F"; for (const [a, b] of resolvedFind) k += a + "=" + b + ";"; }
+  if (resolvedReplace) { k += SEP + "R"; for (const [a, b] of resolvedReplace) k += a + "=" + b + ";"; }
+  return k;
+}
+
+export function resetDisplayRegexCache(): void {
+  DISPLAY_REGEX_CACHE.clear();
+}
+
+export function invalidateDisplayRegexCacheForChat(chatId: string): void {
+  if (!chatId) { DISPLAY_REGEX_CACHE.clear(); return; }
+  const prefix = chatId + "\x00";
+  for (const key of DISPLAY_REGEX_CACHE.keys()) {
+    if (key.startsWith(prefix)) DISPLAY_REGEX_CACHE.delete(key);
+  }
+}
+
+for (const __ev of [
+  EventType.CHAT_CHANGED, EventType.CHAT_SWITCHED, EventType.CHAT_DELETED,
+  EventType.MESSAGE_SENT, EventType.MESSAGE_EDITED, EventType.MESSAGE_DELETED, EventType.MESSAGE_SWIPED,
+  EventType.GENERATION_ENDED, EventType.GENERATION_STOPPED,
+]) {
+  eventBus.on(__ev, (msg) => {
+    const p = (msg as { payload?: { chatId?: string; chat_id?: string; chat?: { id?: string } } }).payload;
+    const cid = p?.chatId ?? p?.chat_id ?? p?.chat?.id;
+    if (cid) invalidateDisplayRegexCacheForChat(cid);
+    else DISPLAY_REGEX_CACHE.clear();
+  });
+}
+
+for (const __ev of [
+  EventType.CHARACTER_EDITED, EventType.PERSONA_CHANGED,
+  EventType.REGEX_SCRIPT_CHANGED, EventType.REGEX_SCRIPT_DELETED,
+]) {
+  eventBus.on(__ev, () => { DISPLAY_REGEX_CACHE.clear(); });
+}
+
 export async function applyDisplayRegex(input: ApplyDisplayRegexInput): Promise<ApplyDisplayRegexResult> {
   const placement: RegexPlacement = input.context.is_user ? "user_input" : "ai_output";
 
@@ -197,15 +268,28 @@ export async function applyDisplayRegex(input: ApplyDisplayRegexInput): Promise<
   }
 
   const env = buildEnvFromContext(input.userId, input.context);
+  const dyn: Record<string, string> = { ...(input.dynamicMacros ?? {}) };
   if (env) {
-    const dyn: Record<string, string> = { ...(input.dynamicMacros ?? {}) };
     if (input.context.role && dyn.role === undefined) {
       dyn.role = input.context.role;
+    }
+    const lastMsgId = (env.chat as { lastMessageId?: number } | undefined)?.lastMessageId;
+    if (typeof lastMsgId === "number" && typeof input.context.depth === "number") {
+      dyn.chat_index = String(lastMsgId - input.context.depth);
     }
     if (Object.keys(dyn).length > 0) {
       mergeDynamicMacros(env, dyn);
     }
   }
+  const noCache = (globalThis as { Bun?: { env?: Record<string, string | undefined> } }).Bun?.env?.LUMIVERSE_DISPLAY_REGEX_NO_CACHE === "1";
+  const cacheKey = displayRegexCacheKey(input.context.chat_id, content, placement, input.context.depth, input.scripts, dyn, input.resolvedFindPatterns, input.resolvedReplacements);
+  if (!noCache) {
+    const cached = DISPLAY_REGEX_CACHE.get(cacheKey);
+    if (cached && (env ? cached.touched.every(([n, val]) => varStateForKey(env, n) === val) : cached.touched.length === 0)) {
+      return { result: cached.result, touchedVars: new Set(cached.touched.map(([n]) => n)), cacheable: true };
+    }
+  }
+
   const fingerprint = { touchedVars: new Set<string>(), cacheable: true };
   const result = await applyRegexScripts(
     content,
@@ -219,6 +303,16 @@ export async function applyDisplayRegex(input: ApplyDisplayRegexInput): Promise<
     },
     { source: "display_backend", outFingerprint: fingerprint },
   );
+  if (!noCache && fingerprint.cacheable) {
+    DISPLAY_REGEX_CACHE.set(cacheKey, {
+      result,
+      touched: [...fingerprint.touchedVars].map((n) => [n, varStateForKey(env, n)] as const),
+    });
+    if (DISPLAY_REGEX_CACHE.size > DISPLAY_REGEX_CACHE_MAX) {
+      const first = DISPLAY_REGEX_CACHE.keys().next().value;
+      if (first !== undefined) DISPLAY_REGEX_CACHE.delete(first);
+    }
+  }
   return {
     result,
     touchedVars: fingerprint.touchedVars,

--- a/src/services/regex-scripts.service.ts
+++ b/src/services/regex-scripts.service.ts
@@ -1127,6 +1127,7 @@ export async function applyRegexScripts(
         });
       }
     } catch (e) {
+      if (options?.outFingerprint) options.outFingerprint.cacheable = false;
       if (e instanceof RegexTimeoutError) {
         const elapsedMs = Date.now() - startedAt;
         const flagged = reportRegexScriptPerformance(script.user_id, script.id, {

--- a/src/utils/regex-sandbox.ts
+++ b/src/utils/regex-sandbox.ts
@@ -136,6 +136,7 @@ class RegexWorkerPool {
       flight.reject(new RegexSandboxError(`Regex worker crashed: ${event.message || "unknown"}`));
     }
     this.discard(worker);
+    this.drainQueue();
   }
 
   private onTimeout(worker: Worker): void {


### PR DESCRIPTION
Adds a resolved-content cache to the display-regex pipeline, keyed on the resolution's dependencies, so repeated renders of unchanged messages skip re-running the regex/macro pipeline. Includes invalidation on variable and message changes, eliminating the redundant per-render recomputation without serving stale panel content.