### PR TITLE
Extension controlled display regex resolution

### DIFF
--- a/developer-docs/docs/frontend-api/display-resolver.md
+++ b/developer-docs/docs/frontend-api/display-resolver.md
@@ -1,0 +1,99 @@
+# Display Resolver
+
+Display resolution turns stored message content into what the user sees: macro expansion, format transforms, and regex display scripts. By default the host runs this on the backend and the frontend fetches the result. An extension can register a frontend resolver to do that work in the browser instead, for chats it owns. This removes a backend round trip per render and lets you run your own resolution engine client side.
+
+`ctx.display` is optional. Feature-detect it before use.
+
+```ts
+export function setup(ctx: SpindleFrontendContext) {
+  if (!ctx.display) return // host build without the display hook
+
+  const unregister = ctx.display.registerResolver(myResolver)
+  ctx.display.setOwnedCharacters(['char-id-1', 'char-id-2'])
+
+  return () => unregister()
+}
+```
+
+## Ownership
+
+The host consults your resolver only for chats it owns, and uses its own backend resolution for everything else. You declare ownership by publishing the character IDs you handle:
+
+```ts
+ctx.display.setOwnedCharacters(myCharacterIds)
+```
+
+A chat is owned when its active character is in that set. Call this whenever your owned set changes (on startup, after your card list loads). The host re-reads it synchronously at render time, so vanilla chats and chats from other extensions are never affected.
+
+## `ctx.display.registerResolver(resolver)`
+
+Register your resolver. Returns an unregister function. The resolver implements four methods the host calls while rendering messages.
+
+```ts
+const myResolver: SpindleDisplayResolver = {
+  ready: (chatId) => true,
+  resolveBody: async ({ content, context }) => ({
+    content: transform(content),
+    touchedVars: ['chat:mood'],
+  }),
+  resolveTemplates: async ({ templates, context }) => ({ resolved: { /* key: value */ } }),
+  applyScripts: async ({ content, scripts, context }) => ({ content: applied }),
+}
+```
+
+| Method | Purpose |
+|---|---|
+| `resolveBody` | Transform a full message body (macro expansion, format passes) |
+| `resolveTemplates` | Pre-resolve a batch of named templates, such as regex find/replace strings |
+| `applyScripts` | Run the chat's display regex scripts over the content |
+| `ready(chatId)` | Return whether your resolver can handle this chat right now |
+
+Return `null` from any resolve method to let the host resolve that one with its own path.
+
+### Context
+
+Each resolve method receives a `context`:
+
+| Field | Type | Description |
+|---|---|---|
+| `chatId` | `string?` | Chat being rendered |
+| `characterId` | `string?` | Active character |
+| `personaId` | `string?` | Active persona |
+| `messageId` | `string?` | Message being rendered |
+| `messageIndex` | `number?` | Position of the message in the chat |
+| `role` | `string?` | Message role |
+| `isUser` | `boolean` | Whether the message is from the user |
+| `depth` | `number` | Message depth |
+| `dynamicMacros` | `Record<string, string>?` | Per-call macro values supplied by the host |
+
+The method-specific arguments alongside `context` are: `content` for `resolveBody`, `templates` (a `Record<key, string>`) for `resolveTemplates`, and `content` plus `scripts` for `applyScripts`.
+
+### Result
+
+`resolveBody` and `applyScripts` return:
+
+| Field | Type | Description |
+|---|---|---|
+| `content` | `string` | The resolved output |
+| `touchedVars` | `string[]?` | Variables this result depends on, as `scope:name` (e.g. `chat:mood`, `global:lang`) |
+| `cacheable` | `boolean?` | Set `false` to never cache this result. Defaults to cacheable |
+
+`resolveTemplates` returns the same information keyed per template: `resolved` (`Record<key, string>`), and optional `touchedVars` (`Record<key, string[]>`) and `cacheable` (`Record<key, boolean>`).
+
+## Caching and invalidation
+
+The host caches your results so it does not call you on every render, using `touchedVars` as the dependency key. When a variable changes, only cached entries that listed it are dropped. Mark a result `cacheable: false` if it depends on something that is not a variable (time, randomness).
+
+When your own state changes, tell the host which entries to drop:
+
+```ts
+// Drop cached resolutions that depend on these variables
+ctx.display.invalidate(['chat:mood', 'global:lang'])
+
+// Drop all cached display resolutions for the active chat
+ctx.display.invalidate(['*'])
+```
+
+`invalidate` takes a list of `scope:name` strings, or `['*']` to clear everything. Use the wholesale form after a change you cannot express as a small set of variables, such as switching the chat your extension owns.
+
+The hook is frontend only and requires no permission.

--- a/developer-docs/docs/frontend-api/index.md
+++ b/developer-docs/docs/frontend-api/index.md
@@ -45,4 +45,5 @@ Frontend UI can follow two supported rendering paths:
 | [Backend Communication](backend-communication.md) | Free | Send/receive messages to/from backend worker |
 | [Frontend Process Lifecycle](processes.md) | Free | Register backend-spawned frontend process handlers |
 | [Message Tags](message-tags.md) | Free | Intercept custom XML tags in chat messages |
+| [Display Resolver](display-resolver.md) | Free | Resolve message display (macros, format, regex) in the browser for chats your extension owns |
 | [File Uploads](file-uploads.md) | Free | Open file picker and read selected files |

--- a/frontend/src/hooks/useDisplayRegex.ts
+++ b/frontend/src/hooks/useDisplayRegex.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import { useStore } from '@/store'
 import { applyDisplayRegex, applyDisplayRegexAsync } from '@/lib/regex/compiler'
 import { resolveMacrosBatch } from '@/api/macros'
+import { getActiveDisplayResolver, isDisplayChatOwned } from '@/lib/spindle/display-resolver-registry'
 import { regexApi } from '@/api/regex'
 import { toast } from '@/lib/toast'
 import i18n from '@/i18n'
@@ -16,6 +17,7 @@ interface ResolvedDisplayRegexTemplates {
 interface DisplayRegexCacheEntry {
   value?: ResolvedDisplayRegexTemplates
   promise?: Promise<ResolvedDisplayRegexTemplates>
+  touchedVars?: ReadonlySet<string>
 }
 
 interface DisplayRegexContentCacheEntry {
@@ -115,6 +117,44 @@ function fnv1a(s: string): string {
   return h.toString(16)
 }
 
+async function resolveTemplatesWithResolver(
+  templates: Record<string, string>,
+  ctx: { chatId?: string; characterId?: string; personaId?: string },
+): Promise<{ resolved: Record<string, string>; touched_vars?: Record<string, string[]>; cacheable?: Record<string, boolean> }> {
+  const resolver = getActiveDisplayResolver()
+  if (resolver && ctx.chatId && isDisplayChatOwned(ctx.chatId)) {
+    try {
+      const local = await resolver.resolveTemplates({
+        templates,
+        context: {
+          chatId: ctx.chatId,
+          characterId: ctx.characterId,
+          personaId: ctx.personaId,
+          isUser: false,
+          depth: 0,
+        },
+      })
+      if (local) {
+        return {
+          resolved: local.resolved,
+          ...(local.touchedVars ? { touched_vars: local.touchedVars } : {}),
+          ...(local.cacheable ? { cacheable: local.cacheable } : {}),
+        }
+      }
+      console.error(`[display] resolver.resolveTemplates returned null for owned chat=${ctx.chatId}; showing raw (no backend fallback)`)
+    } catch (err) {
+      console.error(`[display] resolver.resolveTemplates threw for owned chat=${ctx.chatId}; showing raw (no backend fallback)`, err)
+    }
+    return { resolved: { ...templates } }
+  }
+  return resolveMacrosBatch({
+    templates,
+    chat_id: ctx.chatId,
+    character_id: ctx.characterId,
+    persona_id: ctx.personaId,
+  })
+}
+
 async function fetchDisplayPreprocessBatch(
   chatId: string,
   bodies: DisplayPreprocessBody[],
@@ -153,7 +193,7 @@ function flushDisplayPreprocessQueue(): void {
   }
 }
 
-function fetchDisplayPreprocess(chatId: string, body: DisplayPreprocessBody): Promise<string> {
+function enqueueDisplayPreprocess(chatId: string, body: DisplayPreprocessBody): Promise<string> {
   return new Promise((resolve) => {
     const queue = displayPreprocessQueues.get(chatId)
     if (queue) queue.push({ body, resolve })
@@ -163,6 +203,33 @@ function fetchDisplayPreprocess(chatId: string, body: DisplayPreprocessBody): Pr
       displayPreprocessFlushTimer = window.setTimeout(flushDisplayPreprocessQueue, DISPLAY_PREPROCESS_BATCH_DELAY_MS)
     }
   })
+}
+
+function fetchDisplayPreprocess(chatId: string, body: DisplayPreprocessBody): Promise<string> {
+  const resolver = getActiveDisplayResolver()
+  if (resolver && isDisplayChatOwned(chatId)) {
+    return resolver
+      .resolveBody({
+        content: body.rawContent,
+        context: {
+          chatId,
+          isUser: body.role === 'user',
+          depth: 0,
+          messageId: body.messageId,
+          role: body.role,
+        },
+      })
+      .then((local) => {
+        if (local) return local.content
+        console.error(`[display] resolver.resolveBody returned null for owned chat=${chatId}; showing raw (no backend fallback)`)
+        return body.rawContent
+      })
+      .catch((err: unknown) => {
+        console.error(`[display] resolver.resolveBody threw for owned chat=${chatId}; showing raw (no backend fallback)`, err)
+        return body.rawContent
+      })
+  }
+  return enqueueDisplayPreprocess(chatId, body)
 }
 
 export function useDisplayPreprocessed(
@@ -328,7 +395,14 @@ export function invalidateDisplayRegexCacheForVars(changedVars: ReadonlySet<stri
       }
     }
   }
-  displayRegexResolutionCache.clear()
+  // Selective clear by touchedVars
+  for (const [key, entry] of displayRegexResolutionCache) {
+    const fp = entry.touchedVars
+    if (!fp) { displayRegexResolutionCache.delete(key); continue }
+    for (const v of fp) {
+      if (changedVars.has(v)) { displayRegexResolutionCache.delete(key); break }
+    }
+  }
   for (const messageId of affectedMessages) bumpPerMessageCv(messageId)
   bumpGlobalCv()
 }
@@ -491,11 +565,10 @@ export function useDisplayRegex(
 
     if (!cached?.promise) {
       let assignedPromise: Promise<ResolvedDisplayRegexTemplates>
-      const promise = resolveMacrosBatch({
-        templates,
-        chat_id: activeChatId ?? undefined,
-        character_id: activeCharacterId ?? undefined,
-        persona_id: activePersonaId ?? undefined,
+      const promise = resolveTemplatesWithResolver(templates, {
+        chatId: activeChatId ?? undefined,
+        characterId: activeCharacterId ?? undefined,
+        personaId: activePersonaId ?? undefined,
       })
         .then((res) => {
           const next = createEmptyResolvedTemplates()
@@ -506,8 +579,13 @@ export function useDisplayRegex(
               next.resolvedReplacements.set(key.slice(8), value)
             }
           }
+          let agg: Set<string> | null = res.touched_vars ? new Set<string>() : null
+          if (agg && res.touched_vars) {
+            for (const arr of Object.values(res.touched_vars)) for (const v of arr) agg.add(v)
+          }
+          if (res.cacheable && Object.values(res.cacheable).some((c) => c === false)) agg = null
           if (displayRegexResolutionCache.get(templateCacheKey)?.promise === assignedPromise) {
-            displayRegexResolutionCache.set(templateCacheKey, { value: next })
+            displayRegexResolutionCache.set(templateCacheKey, agg ? { value: next, touchedVars: agg } : { value: next })
           }
           return next
         })

--- a/frontend/src/lib/regex/compiler.ts
+++ b/frontend/src/lib/regex/compiler.ts
@@ -1,5 +1,7 @@
 import type { RegexScript, RegexPlacement, RegexMacroMode, RegexPerformanceMetadata } from '@/types/regex'
 import type { DisplayMacroContext } from '@/lib/resolveDisplayMacros'
+import { getActiveDisplayResolver, isDisplayChatOwned } from '@/lib/spindle/display-resolver-registry'
+import type { SpindleDisplayContext } from 'lumiverse-spindle-types'
 
 interface DisplayRegexMatch {
   fullMatch: string
@@ -307,12 +309,50 @@ export function applyDisplayRegex(
   return result
 }
 
+function toSpindleDisplayContext(context: ApplyDisplayRegexContext): SpindleDisplayContext {
+  return {
+    isUser: context.isUser,
+    depth: context.depth,
+    ...(context.chatId ? { chatId: context.chatId } : {}),
+    ...(context.characterId ? { characterId: context.characterId } : {}),
+    ...(context.personaId ? { personaId: context.personaId } : {}),
+    ...(context.messageId ? { messageId: context.messageId } : {}),
+    ...(typeof context.messageIndex === 'number' ? { messageIndex: context.messageIndex } : {}),
+    ...(context.role ? { role: context.role } : {}),
+    ...(context.dynamicMacros ? { dynamicMacros: context.dynamicMacros } : {}),
+  }
+}
+
 export async function applyDisplayRegexAsync(
   content: string,
   scripts: RegexScript[],
   context: ApplyDisplayRegexContext,
   resolveRawTemplates: (templates: Record<string, string>) => Promise<Record<string, string>>,
 ): Promise<DisplayRegexBackendResult> {
+  const resolver = getActiveDisplayResolver()
+  if (resolver && context.chatId && isDisplayChatOwned(context.chatId)) {
+    try {
+      const local = await resolver.applyScripts({
+        content,
+        scripts,
+        context: toSpindleDisplayContext(context),
+        ...(context.resolvedFindPatterns ? { resolvedFindPatterns: mapToRecord(context.resolvedFindPatterns) } : {}),
+        ...(context.resolvedReplacements ? { resolvedReplacements: mapToRecord(context.resolvedReplacements) } : {}),
+      })
+      if (local) {
+        return {
+          result: local.content,
+          ...(local.touchedVars ? { touchedVars: new Set(local.touchedVars) } : {}),
+          ...(typeof local.cacheable === 'boolean' ? { cacheable: local.cacheable } : {}),
+        }
+      }
+      console.error(`[display] resolver.applyScripts returned null for owned chat=${context.chatId}; showing raw (no backend fallback)`)
+    } catch (err) {
+      console.error(`[display] resolver.applyScripts threw for owned chat=${context.chatId}; showing raw (no backend fallback)`, err)
+    }
+    return { result: content, cacheable: false }
+  }
+
   const backendResult = await applyDisplayRegexOnBackend(content, scripts, context)
   if (backendResult !== null) return backendResult
 

--- a/frontend/src/lib/spindle/display-resolver-registry.ts
+++ b/frontend/src/lib/spindle/display-resolver-registry.ts
@@ -1,0 +1,46 @@
+import type { SpindleDisplayResolver } from 'lumiverse-spindle-types'
+import { useStore } from '@/store'
+
+interface RegisteredDisplayResolver {
+  extensionId: string
+  resolver: SpindleDisplayResolver
+  ownedCharacterIds: Set<string>
+}
+
+let active: RegisteredDisplayResolver | null = null
+
+export function setOwnedDisplayCharacters(extensionId: string, characterIds: string[]): void {
+  if (active && active.extensionId === extensionId) {
+    active.ownedCharacterIds = new Set(characterIds)
+  }
+}
+
+export function isDisplayChatOwned(chatId: string): boolean {
+  if (!active) return false
+  const st = useStore.getState()
+  if (chatId !== st.activeChatId) return false
+  return st.activeCharacterId != null && active.ownedCharacterIds.has(st.activeCharacterId)
+}
+
+export function registerDisplayResolver(
+  extensionId: string,
+  resolver: SpindleDisplayResolver,
+): () => void {
+  const entry: RegisteredDisplayResolver = {
+    extensionId,
+    resolver,
+    ownedCharacterIds: active?.extensionId === extensionId ? active.ownedCharacterIds : new Set(),
+  }
+  active = entry
+  return () => {
+    if (active === entry) active = null
+  }
+}
+
+export function unregisterDisplayResolver(extensionId: string): void {
+  if (active && active.extensionId === extensionId) active = null
+}
+
+export function getActiveDisplayResolver(): SpindleDisplayResolver | null {
+  return active ? active.resolver : null
+}

--- a/frontend/src/lib/spindle/loader.ts
+++ b/frontend/src/lib/spindle/loader.ts
@@ -1,6 +1,8 @@
 import type { SpindleManifest, SpindleFrontendContext, SpindleFrontendModule, PermissionRequestOptions } from 'lumiverse-spindle-types'
 import { createDOMHelper } from './dom-helper'
 import { registerTagInterceptor, unregisterTagInterceptorsByExtension } from './message-interceptors'
+import { registerDisplayResolver, unregisterDisplayResolver, setOwnedDisplayCharacters } from './display-resolver-registry'
+import { invalidateDisplayRegexCacheForVars, invalidateDisplayRegexCache } from '@/hooks/useDisplayRegex'
 import { removeMessageWidgetsByExtension, upsertMessageWidget, removeMessageWidget } from './message-widgets'
 import {
   createDrawerTabHandle,
@@ -654,6 +656,18 @@ async function doLoadFrontendExtension(
           return updated
         },
       },
+      display: {
+        registerResolver(resolver) {
+          return registerDisplayResolver(extensionId, resolver)
+        },
+        invalidate(touchedVars: string[]) {
+          if (touchedVars.includes('*')) invalidateDisplayRegexCache()
+          else invalidateDisplayRegexCacheForVars(new Set(touchedVars))
+        },
+        setOwnedCharacters(characterIds: string[]) {
+          setOwnedDisplayCharacters(extensionId, characterIds)
+        },
+      },
       manifest,
     }
 
@@ -785,6 +799,7 @@ export async function unloadFrontendExtension(extensionId: string): Promise<void
   loaded.backendHandlers.clear()
   loaded.processHandlers.clear()
   unregisterTagInterceptorsByExtension(extensionId)
+  unregisterDisplayResolver(extensionId)
   removeMessageWidgetsByExtension(extensionId)
   destroyAllComponentsForExtension(extensionId)
   destroyAllPlacementsForExtension(extensionId)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "hono": "^4.7.0",
     "js-tiktoken": "^1.0.16",
     "jsdom": "^29.0.1",
-    "lumiverse-spindle-types": "0.5.18",
+    "lumiverse-spindle-types": "0.5.19",
     "mute-stream": "^3.0.0",
     "sharp": "^0.34.5",
     "ssh2-sftp-client": "^12.1.1"


### PR DESCRIPTION
Adds a frontend display-resolver hook that lets an extension register a resolver and declare which characters it owns, so display-time macro/regex resolution can run client-side in the extension instead of round-tripping to the backend. If an extension chooses to run regex inline in the frontend in order to skip the regex, macro, and sandbox boundaries, it can provide a 10000x+ reduction in resolution times. This often is the difference between a regex timeout on a backed up worker, and instant evaluation.

<img width="1031" height="206" alt="image" src="https://github.com/user-attachments/assets/f8c21ae4-155d-47be-8131-214c03498b5a" />

For chats the extension owns, useDisplayRegex and the regex compiler consult the registered resolver first (resolveBody/resolveTemplates/applyScripts) and fall back to the normal backend path for everything else, keeping vanilla chats untouched. 

The loader also exposes ctx.display.invalidate(touchedVars) so the extension can drive the host's display caches when its own state changes.

Lumiverse core would also benefit from moving its native display regex resolution to the frontend entirely (but that would be a larger architectural change).

Spindle PR: https://github.com/prolix-oc/Lumiverse/pull/175