### PR TITLE
Extension controlled prompt regex resolution

### DIFF
--- a/developer-docs/docs/backend-api/index.md
+++ b/developer-docs/docs/backend-api/index.md
@@ -15,6 +15,7 @@ declare const spindle: import('lumiverse-spindle-types').SpindleAPI
 | [Events](events.md) | Free | Subscribe to Lumiverse lifecycle events |
 | [Macros](macros.md) | Free | Register custom `{{macros}}` for prompts |
 | [Interceptors](interceptors.md) | `interceptor` | Modify the prompt before it reaches the LLM |
+| [Prompt Regex Ownership](prompt-regex.md) | Free | Apply `target:prompt` regex yourself for chats you own |
 | [Context Handlers](context-handlers.md) | `context_handler` | Enrich the generation context before assembly |
 | [Macro Interceptor](macro-interceptor.md) | `macro_interceptor` | Transform raw templates before macro parsing/dispatch |
 | [World Info Interceptor](world-info-interceptor.md) | `generation` | Disable world info entries or override their content before activation |

--- a/developer-docs/docs/backend-api/prompt-regex.md
+++ b/developer-docs/docs/backend-api/prompt-regex.md
@@ -1,0 +1,65 @@
+# Prompt Regex Ownership
+
+Regex scripts with `target: "prompt"` rewrite chat history before it reaches the LLM. By default the host runs this pass itself during prompt assembly. An extension can take it over for chats it owns, so it applies those rules in its own interceptor instead.
+
+Use this when you already transform the prompt in a [`registerInterceptor`](interceptors.md) handler and want a single, consistent pass instead of the host's pass plus yours.
+
+`spindle.promptRegex` is optional. Feature-detect it before use. No permission is required.
+
+```ts
+if (typeof spindle.promptRegex?.setOwnedChats === 'function') {
+  spindle.promptRegex.setOwnedChats(['chat-id-1', 'chat-id-2'])
+}
+```
+
+## Ownership
+
+You declare ownership by publishing the chat IDs you handle. For an owned chat the host skips its own `target: "prompt"` regex pass; for every other chat it runs that pass as usual.
+
+```ts
+spindle.promptRegex.setOwnedChats(myOwnedChatIds)
+```
+
+- Pass the **full** owned set each call. It replaces the previous set.
+- Pass an empty array to release ownership. The host resumes its own pass.
+- Ownership is dropped automatically when your extension unloads.
+
+Call this whenever your owned set changes, such as when the user opens a chat you handle. The host reads the latest set at generation time.
+
+## Applying the regex yourself
+
+When you own a chat, the host does not apply its `target: "prompt"` scripts, so you must apply them. Do this in a [`registerInterceptor`](interceptors.md) handler, which runs after assembly on the final message array.
+
+```ts
+spindle.registerInterceptor(async (messages, context) => {
+  if (!iOwn(context.chatId)) return messages
+
+  // Apply your target:prompt regex over `messages` here.
+  return messages
+})
+```
+
+The invariant is **apply if you own**. If you declare ownership but cannot apply (your runtime is unavailable, a fetch fails), the prompt ships with no prompt regex at all, because the host already skipped its pass. Release ownership in that case so the host runs its own pass, and log loudly when an owned chat would otherwise ship un-transformed.
+
+### Chat history flag
+
+Messages passed to your interceptor carry `__isChatHistory` when they are genuine chat-history turns, as opposed to depth-injected world info, preset, or author's note blocks spliced into the history range. The host gates `min_depth` / `max_depth` on chat-history messages only, so use this flag to rebuild the same depth frame and to number turns. Injected non-history blocks must not shift the index of real turns.
+
+```ts
+interface LlmMessageDTO {
+  role: 'system' | 'user' | 'assistant'
+  content: string | LlmMessagePartDTO[]
+  name?: string
+  __isChatHistory?: boolean // host-set, present only on interceptor input
+}
+```
+
+The flag is set by the host on interceptor input only. It is never sent to the LLM.
+
+## `spindle.promptRegex.setOwnedChats(chatIds)`
+
+| Param | Type | Description |
+|---|---|---|
+| `chatIds` | `string[]` | The full set of chats whose `target: "prompt"` regex you apply yourself. Replaces the previous set. Empty array releases ownership. |
+
+Returns `void`. The call is a hint and takes effect on the next generation for those chats.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "i18next": "^26.2.0",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^0.468.0",
-    "lumiverse-spindle-types": "0.5.18",
+    "lumiverse-spindle-types": "0.5.20",
     "marked": "^15.0.4",
     "motion": "^12.0.0",
     "react": "^19.2.6",

--- a/frontend/src/components/chat/BubbleMessage.module.css
+++ b/frontend/src/components/chat/BubbleMessage.module.css
@@ -208,6 +208,13 @@
   contain: style;
 }
 
+/* Allow card authored extension-relaxed content to render at arbitrary z levels,
+  as long as they stay below the sidebars. */
+:global([data-style-mode='extension-relaxed']) .bubble,
+:global([data-style-mode='extension-relaxed']) .content {
+  z-index: auto;
+}
+
 /* ── Bubble inner content ── */
 .bubble {
   flex: 1;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "hono": "^4.7.0",
     "js-tiktoken": "^1.0.16",
     "jsdom": "^29.0.1",
-    "lumiverse-spindle-types": "0.5.19",
+    "lumiverse-spindle-types": "0.5.20",
     "mute-stream": "^3.0.0",
     "sharp": "^0.34.5",
     "ssh2-sftp-client": "^12.1.1"

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -206,6 +206,9 @@ export interface AssemblyContext {
   regenFeedback?: string;
   /** Where to inject regen feedback: 'system' (last system msg) or 'user' (last user msg). */
   regenFeedbackPosition?: "system" | "user";
+  /** When true, an extension owns this chat's `target:prompt` regex and the
+   *  host skips its own per-message prompt-regex pass. */
+  skipPromptRegex?: boolean;
   /** Pre-fetched data to avoid redundant DB calls during assembly.
    *  When provided, assembly reads from this instead of querying DB. */
   prefetched?: PrefetchedData;

--- a/src/macros/MacroEvaluator.ts
+++ b/src/macros/MacroEvaluator.ts
@@ -67,8 +67,7 @@ export async function evaluate(
     if (env.signal?.aborted) throw env.signal.reason ?? new DOMException("Aborted", "AbortError");
 
     if (runInterceptors) {
-      const beforeInterceptor = text;
-      text = await macroInterceptorChain.run({
+      const interceptorResult = await macroInterceptorChain.run({
         template: text,
         env: snapshotEnvForInterceptor(env),
         commit: env.commit !== false,
@@ -76,7 +75,11 @@ export async function evaluate(
         ...(sourceHint ? { sourceHint } : {}),
         ...(userId !== undefined ? { userId } : {}),
       });
-      if (text !== beforeInterceptor) fingerprint.cacheable = false;
+      text = interceptorResult.text;
+      for (const v of interceptorResult.touchedVars) fingerprint.touched.add(v);
+      if (interceptorResult.volatile || interceptorResult.opaque) {
+        fingerprint.cacheable = false;
+      }
       if (!text.includes("{{")) break;
     }
 

--- a/src/services/generate.service.ts
+++ b/src/services/generate.service.ts
@@ -131,6 +131,8 @@ import {
   assemblePromptInWorker,
   canUsePromptAssemblyWorker,
 } from "./prompt-assembly-worker-client";
+import { isPromptRegexChatOwned } from "../spindle/prompt-regex-ownership";
+import { isRunning as isExtensionRunning } from "../spindle/lifecycle";
 import { clampErrorMessage, describeProviderError, ProviderRequestError } from "../utils/provider-errors";
 
 interface GenerateInput {
@@ -1121,6 +1123,7 @@ async function runPromptPipeline(opts: {
       precomputedVectorEntries: opts.precomputedVectorEntries,
       regenFeedback: opts.regenFeedback,
       regenFeedbackPosition: opts.regenFeedbackPosition,
+      skipPromptRegex: isPromptRegexChatOwned(opts.chatId, isExtensionRunning),
       signal: opts.signal,
     };
 
@@ -1210,7 +1213,11 @@ async function runPromptPipeline(opts: {
 
   // Normal assembly applies prompt-target regexes before context clipping.
   // Keep this fallback for raw/explicit message callers that bypass assembly.
-  if (opts.inputMessages) {
+  // When an extension owns this chat's prompt-regex it has already applied the
+  // rules inline via the interceptor pipeline above; running this fallback too
+  // would double-apply (non-idempotent rules compound). Mirror the assembly
+  // pass's skip in prompt-assembly.service.ts (applyPromptRegexScriptsBeforeClipping).
+  if (opts.inputMessages && !isPromptRegexChatOwned(opts.chatId, isExtensionRunning)) {
     const chatForRegex = chatsSvc.getChat(opts.userId, opts.chatId);
     const characterId = opts.targetCharacterId || chatForRegex?.character_id;
     const promptScripts = regexScriptsSvc.getActiveScripts(opts.userId, {

--- a/src/services/prompt-assembly.service.ts
+++ b/src/services/prompt-assembly.service.ts
@@ -284,6 +284,8 @@ async function applyPromptRegexScriptsBeforeClipping(
   characterId: string,
   macroEnv: MacroEnv,
 ): Promise<void> {
+  if (ctx.skipPromptRegex) return;
+
   const scripts = regexScriptsSvc.getActiveScripts(ctx.userId, {
     characterId,
     chatId: ctx.chatId,

--- a/src/spindle/macro-interceptor.ts
+++ b/src/spindle/macro-interceptor.ts
@@ -30,7 +30,20 @@ export interface MacroInterceptorCtx {
   readonly userId?: string;
 }
 
-export type MacroInterceptorResult = string | void;
+export interface MacroInterceptorRichResult {
+  text: string;
+  touchedVars?: readonly string[];
+  volatile?: boolean;
+}
+
+export type MacroInterceptorResult = string | MacroInterceptorRichResult | void;
+
+export interface MacroInterceptorRunResult {
+  text: string;
+  touchedVars: readonly string[];
+  volatile: boolean;
+  opaque: boolean;
+}
 
 export interface MacroInterceptor {
   extensionId: string;
@@ -58,8 +71,11 @@ class MacroInterceptorChain {
     this.handlers = this.handlers.filter((h) => h.extensionId !== extensionId);
   }
 
-  async run(ctx: MacroInterceptorCtx): Promise<string> {
+  async run(ctx: MacroInterceptorCtx): Promise<MacroInterceptorRunResult> {
     let template = ctx.template;
+    const touchedVars = new Set<string>();
+    let volatile = false;
+    let opaque = false;
 
     for (const handler of this.handlers) {
       if (handler.userId && handler.userId !== ctx.userId) continue;
@@ -78,7 +94,22 @@ class MacroInterceptorChain {
             )
           ),
         ]);
-        if (typeof next === "string") template = next;
+        if (typeof next === "string") {
+          if (next !== template) {
+            template = next;
+            opaque = true;
+          }
+        } else if (
+          next &&
+          typeof next === "object" &&
+          typeof next.text === "string"
+        ) {
+          if (next.text !== template) template = next.text;
+          if (next.touchedVars) {
+            for (const v of next.touchedVars) touchedVars.add(v);
+          }
+          if (next.volatile) volatile = true;
+        }
       } catch (err) {
         console.error(
           `[Spindle] Macro interceptor error from ${handler.extensionId}:`,
@@ -87,7 +118,7 @@ class MacroInterceptorChain {
       }
     }
 
-    return template;
+    return { text: template, touchedVars: [...touchedVars], volatile, opaque };
   }
 
   get count(): number {

--- a/src/spindle/prompt-regex-ownership.ts
+++ b/src/spindle/prompt-regex-ownership.ts
@@ -1,0 +1,29 @@
+// Backend prompt-target regex ownership registry.
+//
+// An extension declares the chat IDs for which it applies `target:prompt` 
+// regex itself, and the host then skips its own per-message prompt-regex 
+// pass for those chats.
+
+const ownedByExtension = new Map<string, Set<string>>();
+
+export function setPromptRegexOwnedChats(extensionId: string, chatIds: string[]): void {
+  if (chatIds.length === 0) {
+    ownedByExtension.delete(extensionId);
+    return;
+  }
+  ownedByExtension.set(extensionId, new Set(chatIds));
+}
+
+export function isPromptRegexChatOwned(
+  chatId: string,
+  isExtAlive: (extId: string) => boolean,
+): boolean {
+  for (const [extId, chatIds] of ownedByExtension) {
+    if (chatIds.has(chatId) && isExtAlive(extId)) return true;
+  }
+  return false;
+}
+
+export function clearPromptRegexOwner(extensionId: string): void {
+  ownedByExtension.delete(extensionId);
+}

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -57,6 +57,10 @@ import {
   type WorldInfoInterceptorResultDTO,
 } from "./world-info-interceptor";
 import { toolRegistry } from "./tool-registry";
+import {
+  setPromptRegexOwnedChats,
+  clearPromptRegexOwner,
+} from "./prompt-regex-ownership";
 import * as managerSvc from "./manager.service";
 import {
   BUILT_IN_DRAWER_TABS,
@@ -329,6 +333,7 @@ type RuntimeWorkerToHost =
       rpcPermissionScopeId?: string;
     }
   | { type: "toast_show"; toastType: "success" | "warning" | "error" | "info"; message: string; title?: string; duration?: number; userId?: string }
+  | { type: "prompt_regex_set_owned"; chatIds: string[] }
   | { type: "user_storage_read_binary"; requestId: string; path: string; userId?: string }
   | { type: "user_get_role"; requestId: string; userId?: string }
   | {
@@ -1721,6 +1726,9 @@ export class WorkerHost {
     // Unregister all tools for this extension
     toolRegistry.unregisterByExtension(this.extensionId);
 
+    // Drop any prompt-regex ownership claims so the host resumes its own pass
+    clearPromptRegexOwner(this.extensionId);
+
     // Unregister all macros registered by this extension
     for (const macroName of this.registeredMacroNames) {
       macroRegistry.unregisterMacro(macroName);
@@ -2873,6 +2881,9 @@ export class WorkerHost {
       case "log":
         this.handleLog(msg.level, msg.message);
         break;
+      case "prompt_regex_set_owned":
+        setPromptRegexOwnedChats(this.extensionId, msg.chatIds);
+        break;
       // ─── Commands (free tier) ─────────────────────────────────────────
       case "commands_register":
         this.handleCommandsRegister(msg.commands);
@@ -3295,10 +3306,21 @@ export class WorkerHost {
         const requestId = crypto.randomUUID();
         const timeoutMs = resolveTimeoutMs();
 
+        // Expose chat-history membership explicitly on the DTO so an extension
+        // applying prompt-target regex inline can rebuild the host's depth frame
+        // (depth gating is chat-history-only; injected non-history blocks are
+        // ungated and must not shift real-turn numbering). Shallow-copy so the
+        // synthetic flag never leaks onto the outbound LLM payload.
+        const messagesWithHistoryFlag = messages.map((m) =>
+          promptAssemblySvc.isChatHistoryMessage(m as unknown as LlmMessage)
+            ? { ...m, __isChatHistory: true }
+            : m,
+        );
+
         this.postToWorker({
           type: "intercept_request",
           requestId,
-          messages,
+          messages: messagesWithHistoryFlag,
           context,
         });
 

--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -252,6 +252,7 @@ type RuntimeWorkerToHost =
       rpcPermissionScopeId?: string;
     }
   | { type: "toast_show"; toastType: "success" | "warning" | "error" | "info"; message: string; title?: string; duration?: number; userId?: string }
+  | { type: "prompt_regex_set_owned"; chatIds: string[] }
   | { type: "user_storage_read_binary"; requestId: string; path: string; userId?: string }
   | {
       type: "user_storage_write_binary";
@@ -3270,6 +3271,12 @@ const spindleApi: RuntimeSpindleAPI = {
     },
     error(msg: string) {
       post({ type: "log", level: "error", message: msg });
+    },
+  },
+
+  promptRegex: {
+    setOwnedChats(chatIds: string[]) {
+      post({ type: "prompt_regex_set_owned", chatIds: chatIds.map(String) });
     },
   },
 


### PR DESCRIPTION
Performance counterpart to https://github.com/prolix-oc/Lumiverse/pull/175. 

Adds a backend prompt-regex ownership hook that lets an extension declare which chats it owns, so the host skips its own target:prompt regex pass for those chats and the extension applies those rules inline in its interceptor instead of the host running them per message through the regex sandbox worker pool. Running it inline in-process skips the regex, macro, and sandbox boundaries, often the difference between a regex timeout on a backed up worker and instant evaluation.

For chats the extension owns, prompt assembly sets skipPromptRegex and the prompt-regex pass returns early, falling back to the normal host pass for everything else, keeping vanilla chats untouched.

The host also stamps __isChatHistory on interceptor messages so the extension can rebuild the host's depth frame for min_depth/max_depth gating.

Ownership is declared with spindle.promptRegex.setOwnedChats(chatIds) and cleared automatically when the extension unloads.

Two extra fixes I included:
1. Macro interceptor handlers can now return ({ text, touchedVars, volatile }) so the host caches by the reported variable dependencies instead of marking the result non-cacheable whenever it changes the template.
2. A BubbleMessage.module.css rule that lets extension-relaxed card content render at arbitrary z levels, as long as it stays below the sidebars.

Spindle types PR: https://github.com/prolix-oc/lumiverse-spindle-types/pull/22