### PR TITLE
Expose message index and id on interceptor

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "i18next": "^26.2.0",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^0.468.0",
-    "lumiverse-spindle-types": "0.5.20",
+    "lumiverse-spindle-types": "0.5.21",
     "marked": "^15.0.4",
     "motion": "^12.0.0",
     "react": "^19.2.6",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "hono": "^4.7.0",
     "js-tiktoken": "^1.0.16",
     "jsdom": "^29.0.1",
-    "lumiverse-spindle-types": "0.5.20",
+    "lumiverse-spindle-types": "0.5.21",
     "mute-stream": "^3.0.0",
     "sharp": "^0.34.5",
     "ssh2-sftp-client": "^12.1.1"

--- a/src/services/prompt-assembly.service.ts
+++ b/src/services/prompt-assembly.service.ts
@@ -128,14 +128,33 @@ export type {
 // outbound requests, so the tag never leaks to the LLM.
 
 const CHAT_HISTORY_KEY = "__chatHistorySource";
+const SOURCE_ID_KEY = "__sourceMessageId";
+const SOURCE_INDEX_KEY = "__sourceIndexInChat";
 
-function markAsChatHistory(msg: LlmMessage): LlmMessage {
+function markAsChatHistory(
+  msg: LlmMessage,
+  source?: { id: string; index_in_chat: number },
+): LlmMessage {
   (msg as any)[CHAT_HISTORY_KEY] = true;
+  if (source) {
+    (msg as any)[SOURCE_ID_KEY] = source.id;
+    (msg as any)[SOURCE_INDEX_KEY] = source.index_in_chat;
+  }
   return msg;
 }
 
 export function isChatHistoryMessage(msg: LlmMessage): boolean {
   return (msg as any)[CHAT_HISTORY_KEY] === true;
+}
+
+export function getSourceMessageId(msg: LlmMessage): string | undefined {
+  const v = (msg as any)[SOURCE_ID_KEY];
+  return typeof v === "string" ? v : undefined;
+}
+
+export function getSourceIndexInChat(msg: LlmMessage): number | undefined {
+  const v = (msg as any)[SOURCE_INDEX_KEY];
+  return typeof v === "number" ? v : undefined;
 }
 
 export function resolveChatHistoryInsertionIndex(
@@ -2100,13 +2119,19 @@ export async function assemblePrompt(
               });
             }
           }
+          const source = { id: msg.id, index_in_chat: msg.index_in_chat };
           if (parts.length > 0) {
-            result.push(markAsChatHistory({ role, content: parts }));
+            result.push(markAsChatHistory({ role, content: parts }, source));
           } else {
-            result.push(markAsChatHistory({ role, content: resolvedContent }));
+            result.push(markAsChatHistory({ role, content: resolvedContent }, source));
           }
         } else {
-          result.push(markAsChatHistory({ role, content: resolvedContent }));
+          result.push(
+            markAsChatHistory(
+              { role, content: resolvedContent },
+              { id: msg.id, index_in_chat: msg.index_in_chat },
+            ),
+          );
         }
         historyCount++;
       }
@@ -4616,6 +4641,10 @@ function mergeConsecutiveUserMessages(
       // — both are typically chat-history user turns being merged.
       const wasChatHistory =
         isChatHistoryMessage(result[i]) || isChatHistoryMessage(result[i + 1]);
+      const mergedSourceId =
+        getSourceMessageId(result[i]) ?? getSourceMessageId(result[i + 1]);
+      const mergedSourceIndex =
+        getSourceIndexInChat(result[i]) ?? getSourceIndexInChat(result[i + 1]);
       if (allParts.length > 0) {
         result[i] = {
           role: "user",
@@ -4624,7 +4653,14 @@ function mergeConsecutiveUserMessages(
       } else {
         result[i] = { role: "user", content: mergedText };
       }
-      if (wasChatHistory) markAsChatHistory(result[i]);
+      if (wasChatHistory) {
+        markAsChatHistory(
+          result[i],
+          typeof mergedSourceId === "string" && typeof mergedSourceIndex === "number"
+            ? { id: mergedSourceId, index_in_chat: mergedSourceIndex }
+            : undefined,
+        );
+      }
       result.splice(i + 1, 1);
       remaining--;
       // Don't increment — next element slid into i+1, check again

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -3311,11 +3311,18 @@ export class WorkerHost {
         // (depth gating is chat-history-only; injected non-history blocks are
         // ungated and must not shift real-turn numbering). Shallow-copy so the
         // synthetic flag never leaks onto the outbound LLM payload.
-        const messagesWithHistoryFlag = messages.map((m) =>
-          promptAssemblySvc.isChatHistoryMessage(m as unknown as LlmMessage)
-            ? { ...m, __isChatHistory: true }
-            : m,
-        );
+        const messagesWithHistoryFlag = messages.map((m) => {
+          const llm = m as unknown as LlmMessage;
+          if (!promptAssemblySvc.isChatHistoryMessage(llm)) return m;
+          const sourceMessageId = promptAssemblySvc.getSourceMessageId(llm);
+          const sourceIndexInChat = promptAssemblySvc.getSourceIndexInChat(llm);
+          return {
+            ...m,
+            __isChatHistory: true,
+            ...(sourceMessageId !== undefined ? { sourceMessageId } : {}),
+            ...(sourceIndexInChat !== undefined ? { sourceIndexInChat } : {}),
+          };
+        });
 
         this.postToWorker({
           type: "intercept_request",


### PR DESCRIPTION
Chat-history turns in the assembled prompt now carry `sourceMessageId` and `sourceIndexInChat` on the interceptor DTO. This lets interceptors map an assembled message back to its originating chat message deterministically instead of matching on content or counting, which is unreliable because macros ({{roll}}, {{random}}), stateful regex mutate message text, and other sources may insert entries arbitrarily before it reaches the interceptor.

Spindle: https://github.com/prolix-oc/lumiverse-spindle-types/pull/23