### PR TITLE
Fix failed post recursion stack overflow

### DIFF
--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -1776,10 +1776,13 @@ export class WorkerHost {
   }
 
   private handleRuntimeTransportFailure(error: unknown): void {
+    // Already torn down by an earlier failure on this stack, bail before recursing.
+    if (!this.runtime) return;
     const message = error instanceof Error ? error.message : String(error);
     console.warn(
       `[Spindle:${this.manifest.identifier}] Runtime transport failed, cleaning up: ${message}`
     );
+    this.runtime = null;
     this.cleanup();
   }
 


### PR DESCRIPTION
The bug:
1. Something posts to an extension worker via postToWorker. The worker's Bun subprocess IPC channel is closed, so runtime.postMessage throws..
2. The catch calls cleanup().
3. cleanup() calls stopAllBackendProcesses, which for each backend process calls transitionBackendProcess -> emitBackendProcessLifecycle -> postToWorker again.
4. this.runtime is only nulled at the very end of cleanup(). So during cleanup it's still set, the post throws again and so forth. Until crash.