### PR TITLE
Extension-owned display resolution decided per character

### DIFF
--- a/developer-docs/docs/frontend-api/display-resolver.md
+++ b/developer-docs/docs/frontend-api/display-resolver.md
@@ -9,7 +9,6 @@ export function setup(ctx: SpindleFrontendContext) {
   if (!ctx.display) return // host build without the display hook
 
   const unregister = ctx.display.registerResolver(myResolver)
-  ctx.display.setOwnedCharacters(['char-id-1', 'char-id-2'])
 
   return () => unregister()
 }
@@ -17,13 +16,18 @@ export function setup(ctx: SpindleFrontendContext) {
 
 ## Ownership
 
-The host consults your resolver only for chats it owns, and uses its own backend resolution for everything else. You declare ownership by publishing the character IDs you handle:
+The host consults your resolver only for chats it owns, and uses its own backend resolution for everything else. You own a chat by setting `display_owner: true` in your own namespaced character data, alongside whatever else you store there:
 
 ```ts
-ctx.display.setOwnedCharacters(myCharacterIds)
+// backend, when you write per-character state
+await characters.update(characterId, {
+  extensions: { my_extension: { ...myData, display_owner: true } },
+}, userId)
 ```
 
-A chat is owned when its active character is in that set. Call this whenever your owned set changes (on startup, after your card list loads). The host re-reads it synchronously at render time, so vanilla chats and chats from other extensions are never affected.
+A chat is owned when its character's `extensions["my_extension"].display_owner` is `true` and your extension is enabled. Storing data under your namespace without the flag does not claim display, so set it only on characters you actually render. To stop owning a character, set it `false`.
+
+Vanilla chats, and chats whose character only carries other extensions' data, are never routed to you.
 
 ## `ctx.display.registerResolver(resolver)`
 
@@ -48,7 +52,9 @@ const myResolver: SpindleDisplayResolver = {
 | `applyScripts` | Run the chat's display regex scripts over the content |
 | `ready(chatId)` | Return whether your resolver can handle this chat right now |
 
-Return `null` from any resolve method to let the host resolve that one with its own path.
+Return `null` from any resolve method to let the host resolve that one with its own path (only for chats you do not own; for owned chats a `null` return shows raw, never a backend fallback).
+
+For a chat you own, the host calls a resolve method only once `ready(chatId)` returns `true`. While it is `false` (your bundle still loading, snapshot not yet arrived) the host shows raw content and does not fall back to backend resolution. Return `true` as soon as you can resolve the chat, and call `invalidate` when your readiness or state changes so the host re-renders.
 
 ### Context
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "i18next": "^26.2.0",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^0.468.0",
-    "lumiverse-spindle-types": "0.5.21",
+    "lumiverse-spindle-types": "0.5.22",
     "marked": "^15.0.4",
     "motion": "^12.0.0",
     "react": "^19.2.6",

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -391,6 +391,7 @@ export default function ChatView() {
         if (cancelled) return
 
         setActiveChat(chatId, chat.character_id)
+        useStore.getState().setActiveChatDisplayOwner(chat.character_display_owner ?? null)
         setMessages(msgPage.data, msgPage.total)
 
         // If there's a pending council tools failure for this chat, show the retry modal now

--- a/frontend/src/hooks/useDisplayRegex.ts
+++ b/frontend/src/hooks/useDisplayRegex.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import { useStore } from '@/store'
 import { applyDisplayRegex, applyDisplayRegexAsync } from '@/lib/regex/compiler'
 import { resolveMacrosBatch } from '@/api/macros'
-import { getActiveDisplayResolver, isDisplayChatOwned } from '@/lib/spindle/display-resolver-registry'
+import { isDisplayChatOwned, getDisplayResolverForChat } from '@/lib/spindle/display-resolver-registry'
 import { regexApi } from '@/api/regex'
 import { toast } from '@/lib/toast'
 import i18n from '@/i18n'
@@ -121,29 +121,31 @@ async function resolveTemplatesWithResolver(
   templates: Record<string, string>,
   ctx: { chatId?: string; characterId?: string; personaId?: string },
 ): Promise<{ resolved: Record<string, string>; touched_vars?: Record<string, string[]>; cacheable?: Record<string, boolean> }> {
-  const resolver = getActiveDisplayResolver()
-  if (resolver && ctx.chatId && isDisplayChatOwned(ctx.chatId)) {
-    try {
-      const local = await resolver.resolveTemplates({
-        templates,
-        context: {
-          chatId: ctx.chatId,
-          characterId: ctx.characterId,
-          personaId: ctx.personaId,
-          isUser: false,
-          depth: 0,
-        },
-      })
-      if (local) {
-        return {
-          resolved: local.resolved,
-          ...(local.touchedVars ? { touched_vars: local.touchedVars } : {}),
-          ...(local.cacheable ? { cacheable: local.cacheable } : {}),
+  if (ctx.chatId && isDisplayChatOwned(ctx.chatId)) {
+    const resolver = getDisplayResolverForChat(ctx.chatId)
+    if (resolver) {
+      try {
+        const local = await resolver.resolveTemplates({
+          templates,
+          context: {
+            chatId: ctx.chatId,
+            characterId: ctx.characterId,
+            personaId: ctx.personaId,
+            isUser: false,
+            depth: 0,
+          },
+        })
+        if (local) {
+          return {
+            resolved: local.resolved,
+            ...(local.touchedVars ? { touched_vars: local.touchedVars } : {}),
+            ...(local.cacheable ? { cacheable: local.cacheable } : {}),
+          }
         }
+        console.error(`[display] resolver.resolveTemplates returned null for owned chat=${ctx.chatId}; showing raw (no backend fallback)`)
+      } catch (err) {
+        console.error(`[display] resolver.resolveTemplates threw for owned chat=${ctx.chatId}; showing raw (no backend fallback)`, err)
       }
-      console.error(`[display] resolver.resolveTemplates returned null for owned chat=${ctx.chatId}; showing raw (no backend fallback)`)
-    } catch (err) {
-      console.error(`[display] resolver.resolveTemplates threw for owned chat=${ctx.chatId}; showing raw (no backend fallback)`, err)
     }
     return { resolved: { ...templates } }
   }
@@ -206,28 +208,31 @@ function enqueueDisplayPreprocess(chatId: string, body: DisplayPreprocessBody): 
 }
 
 function fetchDisplayPreprocess(chatId: string, body: DisplayPreprocessBody): Promise<string> {
-  const resolver = getActiveDisplayResolver()
-  if (resolver && isDisplayChatOwned(chatId)) {
-    return resolver
-      .resolveBody({
-        content: body.rawContent,
-        context: {
-          chatId,
-          isUser: body.role === 'user',
-          depth: 0,
-          messageId: body.messageId,
-          role: body.role,
-        },
-      })
-      .then((local) => {
-        if (local) return local.content
-        console.error(`[display] resolver.resolveBody returned null for owned chat=${chatId}; showing raw (no backend fallback)`)
-        return body.rawContent
-      })
-      .catch((err: unknown) => {
-        console.error(`[display] resolver.resolveBody threw for owned chat=${chatId}; showing raw (no backend fallback)`, err)
-        return body.rawContent
-      })
+  if (isDisplayChatOwned(chatId)) {
+    const resolver = getDisplayResolverForChat(chatId)
+    if (resolver) {
+      return resolver
+        .resolveBody({
+          content: body.rawContent,
+          context: {
+            chatId,
+            isUser: body.role === 'user',
+            depth: 0,
+            messageId: body.messageId,
+            role: body.role,
+          },
+        })
+        .then((local) => {
+          if (local) return local.content
+          console.error(`[display] resolver.resolveBody returned null for owned chat=${chatId}; showing raw (no backend fallback)`)
+          return body.rawContent
+        })
+        .catch((err: unknown) => {
+          console.error(`[display] resolver.resolveBody threw for owned chat=${chatId}; showing raw (no backend fallback)`, err)
+          return body.rawContent
+        })
+    }
+    return Promise.resolve(body.rawContent)
   }
   return enqueueDisplayPreprocess(chatId, body)
 }

--- a/frontend/src/lib/regex/compiler.ts
+++ b/frontend/src/lib/regex/compiler.ts
@@ -1,6 +1,6 @@
 import type { RegexScript, RegexPlacement, RegexMacroMode, RegexPerformanceMetadata } from '@/types/regex'
 import type { DisplayMacroContext } from '@/lib/resolveDisplayMacros'
-import { getActiveDisplayResolver, isDisplayChatOwned } from '@/lib/spindle/display-resolver-registry'
+import { isDisplayChatOwned, getDisplayResolverForChat } from '@/lib/spindle/display-resolver-registry'
 import type { SpindleDisplayContext } from 'lumiverse-spindle-types'
 
 interface DisplayRegexMatch {
@@ -329,26 +329,28 @@ export async function applyDisplayRegexAsync(
   context: ApplyDisplayRegexContext,
   resolveRawTemplates: (templates: Record<string, string>) => Promise<Record<string, string>>,
 ): Promise<DisplayRegexBackendResult> {
-  const resolver = getActiveDisplayResolver()
-  if (resolver && context.chatId && isDisplayChatOwned(context.chatId)) {
-    try {
-      const local = await resolver.applyScripts({
-        content,
-        scripts,
-        context: toSpindleDisplayContext(context),
-        ...(context.resolvedFindPatterns ? { resolvedFindPatterns: mapToRecord(context.resolvedFindPatterns) } : {}),
-        ...(context.resolvedReplacements ? { resolvedReplacements: mapToRecord(context.resolvedReplacements) } : {}),
-      })
-      if (local) {
-        return {
-          result: local.content,
-          ...(local.touchedVars ? { touchedVars: new Set(local.touchedVars) } : {}),
-          ...(typeof local.cacheable === 'boolean' ? { cacheable: local.cacheable } : {}),
+  if (context.chatId && isDisplayChatOwned(context.chatId)) {
+    const resolver = getDisplayResolverForChat(context.chatId)
+    if (resolver) {
+      try {
+        const local = await resolver.applyScripts({
+          content,
+          scripts,
+          context: toSpindleDisplayContext(context),
+          ...(context.resolvedFindPatterns ? { resolvedFindPatterns: mapToRecord(context.resolvedFindPatterns) } : {}),
+          ...(context.resolvedReplacements ? { resolvedReplacements: mapToRecord(context.resolvedReplacements) } : {}),
+        })
+        if (local) {
+          return {
+            result: local.content,
+            ...(local.touchedVars ? { touchedVars: new Set(local.touchedVars) } : {}),
+            ...(typeof local.cacheable === 'boolean' ? { cacheable: local.cacheable } : {}),
+          }
         }
+        console.error(`[display] resolver.applyScripts returned null for owned chat=${context.chatId}; showing raw (no backend fallback)`)
+      } catch (err) {
+        console.error(`[display] resolver.applyScripts threw for owned chat=${context.chatId}; showing raw (no backend fallback)`, err)
       }
-      console.error(`[display] resolver.applyScripts returned null for owned chat=${context.chatId}; showing raw (no backend fallback)`)
-    } catch (err) {
-      console.error(`[display] resolver.applyScripts threw for owned chat=${context.chatId}; showing raw (no backend fallback)`, err)
     }
     return { result: content, cacheable: false }
   }

--- a/frontend/src/lib/spindle/display-resolver-registry.ts
+++ b/frontend/src/lib/spindle/display-resolver-registry.ts
@@ -2,45 +2,41 @@ import type { SpindleDisplayResolver } from 'lumiverse-spindle-types'
 import { useStore } from '@/store'
 
 interface RegisteredDisplayResolver {
-  extensionId: string
+  identifier: string
   resolver: SpindleDisplayResolver
-  ownedCharacterIds: Set<string>
 }
 
 let active: RegisteredDisplayResolver | null = null
 
-export function setOwnedDisplayCharacters(extensionId: string, characterIds: string[]): void {
-  if (active && active.extensionId === extensionId) {
-    active.ownedCharacterIds = new Set(characterIds)
-  }
+export function getDisplayOwnerIdentifier(chatId: string): string | null {
+  const st = useStore.getState()
+  if (chatId !== st.activeChatId) return null
+  const owner = st.activeChatDisplayOwner
+  return typeof owner === 'string' && owner.length > 0 ? owner : null
 }
 
 export function isDisplayChatOwned(chatId: string): boolean {
-  if (!active) return false
-  const st = useStore.getState()
-  if (chatId !== st.activeChatId) return false
-  return st.activeCharacterId != null && active.ownedCharacterIds.has(st.activeCharacterId)
+  return getDisplayOwnerIdentifier(chatId) !== null
+}
+
+export function getDisplayResolverForChat(chatId: string): SpindleDisplayResolver | null {
+  const owner = getDisplayOwnerIdentifier(chatId)
+  if (!owner || !active || active.identifier !== owner) return null
+  if (!active.resolver.ready(chatId)) return null
+  return active.resolver
 }
 
 export function registerDisplayResolver(
-  extensionId: string,
+  identifier: string,
   resolver: SpindleDisplayResolver,
 ): () => void {
-  const entry: RegisteredDisplayResolver = {
-    extensionId,
-    resolver,
-    ownedCharacterIds: active?.extensionId === extensionId ? active.ownedCharacterIds : new Set(),
-  }
+  const entry: RegisteredDisplayResolver = { identifier, resolver }
   active = entry
   return () => {
     if (active === entry) active = null
   }
 }
 
-export function unregisterDisplayResolver(extensionId: string): void {
-  if (active && active.extensionId === extensionId) active = null
-}
-
-export function getActiveDisplayResolver(): SpindleDisplayResolver | null {
-  return active ? active.resolver : null
+export function unregisterDisplayResolver(identifier: string): void {
+  if (active && active.identifier === identifier) active = null
 }

--- a/frontend/src/lib/spindle/loader.ts
+++ b/frontend/src/lib/spindle/loader.ts
@@ -1,7 +1,7 @@
 import type { SpindleManifest, SpindleFrontendContext, SpindleFrontendModule, PermissionRequestOptions } from 'lumiverse-spindle-types'
 import { createDOMHelper } from './dom-helper'
 import { registerTagInterceptor, unregisterTagInterceptorsByExtension } from './message-interceptors'
-import { registerDisplayResolver, unregisterDisplayResolver, setOwnedDisplayCharacters } from './display-resolver-registry'
+import { registerDisplayResolver, unregisterDisplayResolver } from './display-resolver-registry'
 import { invalidateDisplayRegexCacheForVars, invalidateDisplayRegexCache } from '@/hooks/useDisplayRegex'
 import { removeMessageWidgetsByExtension, upsertMessageWidget, removeMessageWidget } from './message-widgets'
 import {
@@ -658,14 +658,11 @@ async function doLoadFrontendExtension(
       },
       display: {
         registerResolver(resolver) {
-          return registerDisplayResolver(extensionId, resolver)
+          return registerDisplayResolver(manifest.identifier, resolver)
         },
         invalidate(touchedVars: string[]) {
           if (touchedVars.includes('*')) invalidateDisplayRegexCache()
           else invalidateDisplayRegexCacheForVars(new Set(touchedVars))
-        },
-        setOwnedCharacters(characterIds: string[]) {
-          setOwnedDisplayCharacters(extensionId, characterIds)
         },
       },
       manifest,
@@ -799,7 +796,7 @@ export async function unloadFrontendExtension(extensionId: string): Promise<void
   loaded.backendHandlers.clear()
   loaded.processHandlers.clear()
   unregisterTagInterceptorsByExtension(extensionId)
-  unregisterDisplayResolver(extensionId)
+  unregisterDisplayResolver(loaded.identifier)
   removeMessageWidgetsByExtension(extensionId)
   destroyAllComponentsForExtension(extensionId)
   destroyAllPlacementsForExtension(extensionId)

--- a/frontend/src/store/slices/chat.ts
+++ b/frontend/src/store/slices/chat.ts
@@ -95,6 +95,7 @@ export const createChatSlice: StateCreator<ChatSlice> = (set, get) => {
   return {
     activeChatId: null,
     activeCharacterId: null,
+    activeChatDisplayOwner: null,
     activeChatWallpaper: null,
     activeChatAvatarId: null,
     activeChatMetadata: null,
@@ -118,6 +119,7 @@ export const createChatSlice: StateCreator<ChatSlice> = (set, get) => {
       set({
         activeChatId: chatId,
         activeCharacterId: characterId,
+        activeChatDisplayOwner: null,
         activeChatWallpaper: null,
         activeChatAvatarId: null,
         activeChatMetadata: null,
@@ -148,6 +150,8 @@ export const createChatSlice: StateCreator<ChatSlice> = (set, get) => {
     setActiveChatAvatarId: (imageId) => set({ activeChatAvatarId: imageId }),
 
     setActiveChatMetadata: (metadata) => set({ activeChatMetadata: metadata }),
+
+    setActiveChatDisplayOwner: (owner) => set({ activeChatDisplayOwner: owner }),
 
     setMessages: (messages, total?) =>
       set({ messages: sortMessagesByPosition(messages), totalChatLength: total ?? messages.length }),

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -64,6 +64,7 @@ export interface Chat {
   metadata: Record<string, any>;
   created_at: number;
   updated_at: number;
+  character_display_owner?: string | null;
 }
 
 export interface CreateChatInput {

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -14,6 +14,7 @@ export interface ChatSlice {
    * write).
    */
   activeChatMetadata: Record<string, any> | null
+  activeChatDisplayOwner: string | null
   messages: Message[]
   isStreaming: boolean
   streamingContent: string
@@ -34,6 +35,7 @@ export interface ChatSlice {
   setActiveChatWallpaper: (wallpaper: WallpaperRef | null) => void
   setActiveChatAvatarId: (imageId: string | null) => void
   setActiveChatMetadata: (metadata: Record<string, any> | null) => void
+  setActiveChatDisplayOwner: (owner: string | null) => void
   setMessages: (messages: Message[], total?: number) => void
   prependMessages: (messages: Message[]) => void
   addMessage: (message: Message) => void

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "hono": "^4.7.0",
     "js-tiktoken": "^1.0.16",
     "jsdom": "^29.0.1",
-    "lumiverse-spindle-types": "0.5.21",
+    "lumiverse-spindle-types": "0.5.22",
     "mute-stream": "^3.0.0",
     "sharp": "^0.34.5",
     "ssh2-sftp-client": "^12.1.1"

--- a/src/routes/chats.routes.ts
+++ b/src/routes/chats.routes.ts
@@ -5,6 +5,7 @@ import * as charactersSvc from "../services/characters.service";
 import * as settingsSvc from "../services/settings.service";
 import * as worldBooksSvc from "../services/world-books.service";
 import * as regexScriptsSvc from "../services/regex-scripts.service";
+import * as managerSvc from "../spindle/manager.service";
 import { getCharacterWorldBookIds } from "../utils/character-world-books";
 import { parsePagination } from "../services/pagination";
 import { RECENT_CHATS_DEFAULT_LIMIT } from "../types/pagination";
@@ -251,9 +252,13 @@ app.get("/:id", (c) => {
   const userId = c.get("userId");
   const chat = svc.getChat(userId, c.req.param("id"));
   if (!chat) return c.json({ error: "Not found" }, 404);
-  if (c.req.query("messages") === "false") return c.json(chat);
+  const ownerCandidates = managerSvc.getEnabledExtensionIdentifiers();
+  const character_display_owner = chat.character_id
+    ? charactersSvc.getCharacterDisplayOwner(userId, chat.character_id, ownerCandidates)
+    : null;
+  if (c.req.query("messages") === "false") return c.json({ ...chat, character_display_owner });
   const messages = svc.getMessages(userId, chat.id);
-  return c.json({ ...chat, messages });
+  return c.json({ ...chat, character_display_owner, messages });
 });
 
 app.put("/:id", async (c) => {

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -27,6 +27,24 @@ function rowToSummary(row: any): CharacterSummary {
   };
 }
 
+export function getCharacterDisplayOwner(
+  userId: string,
+  characterId: string,
+  providerIds: string[],
+): string | null {
+  if (providerIds.length === 0) return null;
+  const db = getDb();
+  const whens = providerIds
+    .map(() => `WHEN json_extract(extensions, '$.' || ? || '.display_owner') = 1 THEN ?`)
+    .join(" ");
+  const params: string[] = [];
+  for (const id of providerIds) params.push(id, id);
+  const row = db
+    .query(`SELECT (CASE ${whens} ELSE NULL END) AS owner FROM characters WHERE id = ? AND user_id = ?`)
+    .get(...params, characterId, userId) as { owner: string | null } | null;
+  return row?.owner ?? null;
+}
+
 /**
  * Build an FTS5 MATCH query for the trigram tokenizer. Each whitespace-delimited
  * token is wrapped in a quoted phrase (substring needle); tokens are AND-ed

--- a/src/spindle/manager.service.ts
+++ b/src/spindle/manager.service.ts
@@ -1559,6 +1559,14 @@ export async function getEnabledExtensions(): Promise<ExtensionInfo[]> {
   return Promise.all(rows.map(rowToExtensionInfo));
 }
 
+export function getEnabledExtensionIdentifiers(): string[] {
+  const db = getDb();
+  const rows = db
+    .query("SELECT identifier FROM extensions WHERE enabled = 1")
+    .all() as { identifier: string }[];
+  return rows.map((r) => r.identifier);
+}
+
 export async function getFrontendBundlePath(identifier: string): Promise<string | null> {
   const manifest = await readManifest(identifier);
   const entry = manifest.entry_frontend || "dist/frontend.js";


### PR DESCRIPTION
Display-resolver extensions can now own a chat's rendering per character: the host derives ownership from the character's extensions[<extension-id>].display_owner flag and returns it as character_display_owner on the chat fetch, so the owner is known at first render before the extension's frontend loads. This replaces the old setOwnedCharacters runtime registration, which raced the frontend bundle and left owned chats briefly falling back to backend rendering, stampeding the worker, until the resolver registered.

This was particularly disastrous because the current regex timeout and skip conflates waiting for IPC and the worker queue with the actual regex time to run, thereby, it ended up timing out all regexes on cold restart due to the boundary cost being overloaded with requests.

Spindle: https://github.com/prolix-oc/lumiverse-spindle-types/pull/24