### PR TITLE
feat(spindle): add built-in drawer tab mobility

### DIFF
--- a/developer-docs/docs/frontend-api/ui-placement.md
+++ b/developer-docs/docs/frontend-api/ui-placement.md
@@ -130,6 +130,70 @@ widget.destroy()
 | `tooltip` | `string` | — | Hover tooltip text |
 | `chromeless` | `boolean` | `false` | Strip the default container chrome (border, background, shadow, border-radius). The extension fully owns the visual presentation. |
 
+## Tab Mobility (requires `app_manipulation` or `ui_panels`)
+
+Move any built-in or extension drawer tab between the main drawer and any registered container. Built-in tabs (like `'profile'`, `'connections'`, etc.) are addressable by their stable id. Extension tabs are addressable by the id assigned at registration time.
+
+```ts
+// Move a tab to a registered container (by container id)
+ctx.ui.requestTabLocation('connections', { kind: 'container', containerId: 'canvas-secondary' })
+
+// Move it back to the main drawer
+ctx.ui.requestTabLocation('connections', { kind: 'main-drawer' })
+
+// Query current location
+const loc = ctx.ui.getTabLocation('profile')
+// { kind: 'main-drawer' } | { kind: 'container', containerId: string }
+```
+
+### TabLocation
+
+| Value | Description |
+|---|---|
+| `{ kind: 'main-drawer' }` | Default location — the tab lives in the main left sidebar drawer |
+| `{ kind: 'container', containerId }` | Moved to a registered container. The `containerId` is the id passed to `registerContainer`. If no container with that id is registered, the tab resets to `main-drawer`. |
+
+### Method: `requestTabLocation`
+
+```ts
+ctx.ui.requestTabLocation(tabId, location): void
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `tabId` | `string` | yes | The tab to move (built-in id or extension-assigned id) |
+| `location` | `TabLocation` | yes | Target location (see `TabLocation` above) |
+
+### Notes
+
+- Built-in tabs are addressable by their id (`'profile'`, `'connections'`, `'presets'`, etc.). Extension tabs use the id assigned at registration time.
+- When a tab is routed to a container id that has no matching registered entry, `ContainerTabContent` automatically resets the tab to `{ kind: 'main-drawer' }` so it remains visible.
+- `requestTabLocation` requires the `app_manipulation` permission; `getBuiltInTabRoot` requires the `ui_panels` permission; `getTabLocation` is a read-only query and is free.
+
+### Method: `getBuiltInTabRoot`
+
+```ts
+ctx.ui.getBuiltInTabRoot(tabId): HTMLElement | undefined
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `tabId` | `string` | yes | The built-in tab id |
+
+Returns the lazy-mounted DOM root of a built-in tab, so extensions can mount it into their own UI. Requires `ui_panels`.
+
+### Method: `getBuiltInTabTitle`
+
+```ts
+ctx.ui.getBuiltInTabTitle(tabId): string | undefined
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `tabId` | `string` | yes | The built-in tab id |
+
+Returns the header title for the built-in tab. Read-only.
+
 ## Dock Panels (requires `ui_panels`)
 
 Create an always-visible panel fixed to a screen edge. Max 1 per edge per extension, 2 per edge global.

--- a/frontend/bun-test-setup.ts
+++ b/frontend/bun-test-setup.ts
@@ -1,0 +1,50 @@
+// Test-environment shims loaded via bunfig.toml [test] preload.
+//
+// Newer tests (placement-helper, containers, spindle-placement) import
+// modules that transitively touch `window`, `document`, and `localStorage`
+// at module-load time. Bun's test runtime does not provide DOM globals
+// by default, so we shim them here. The shims are no-ops if the globals
+// are already defined (e.g. when run under a DOM test env).
+
+if (typeof (globalThis as any).window === 'undefined') {
+  const noop = () => {}
+  ;(globalThis as any).window = {
+    location: { protocol: 'http:' },
+    addEventListener: noop,
+    removeEventListener: noop,
+    dispatchEvent: () => false,
+    CustomEvent: class { constructor(_t: string, init?: any) { this.detail = init?.detail } },
+  }
+}
+
+if (typeof (globalThis as any).document === 'undefined') {
+  ;(globalThis as any).document = {
+    createElement(_tag: string) {
+      return {
+        setAttribute() {},
+        style: {} as Record<string, string>,
+        appendChild() {},
+        removeChild() {},
+        replaceChildren() {},
+        addEventListener() {},
+        removeEventListener() {},
+        contains() { return false },
+        get firstChild() { return null },
+        get parentElement() { return null },
+      }
+    },
+  }
+}
+
+if (typeof (globalThis as any).localStorage === 'undefined') {
+  const store = new Map<string, string>()
+  const shim = {
+    getItem(k: string) { return store.has(k) ? store.get(k)! : null },
+    setItem(k: string, v: string) { store.set(k, v) },
+    removeItem(k: string) { store.delete(k) },
+    clear() { store.clear() },
+    key(i: number) { return Array.from(store.keys())[i] ?? null },
+    get length() { return store.size },
+  }
+  ;(globalThis as any).localStorage = shim
+}

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -29,7 +29,7 @@
         "i18next": "^26.2.0",
         "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "^0.468.0",
-        "lumiverse-spindle-types": "0.5.23",
+        "lumiverse-spindle-types": "^0.5.23",
         "marked": "^15.0.4",
         "motion": "^12.0.0",
         "react": "^19.2.6",

--- a/frontend/bunfig.toml
+++ b/frontend/bunfig.toml
@@ -1,2 +1,5 @@
 [install]
 peer = false
+
+[test]
+preload = ["./bun-test-setup.ts"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "i18next": "^26.2.0",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^0.468.0",
-    "lumiverse-spindle-types": "0.5.23",
+    "lumiverse-spindle-types": "^0.5.23",
     "marked": "^15.0.4",
     "motion": "^12.0.0",
     "react": "^19.2.6",

--- a/frontend/src/components/panels/TabPanelContent.tsx
+++ b/frontend/src/components/panels/TabPanelContent.tsx
@@ -1,0 +1,70 @@
+import { useRef, useEffect } from 'react'
+import { useStore } from '@/store'
+import { ensureRegistryRoot } from '@/lib/drawer-tab-registry'
+import ErrorBoundary from '@/components/shared/ErrorBoundary'
+import type { TabLocation } from '@/lib/spindle/tab-mobility-types'
+
+interface Props {
+  tabId: string
+  location: TabLocation
+}
+
+/**
+ * Unified tab host — looks up a tab's persistent root (built-in via
+ * `ensureRegistryRoot`, extension via `drawerTabs.find(...).root`) and
+ * mounts it into a stable container via `replaceChildren`.
+ *
+ * The `<ErrorBoundary>` is keyed on `tabId+location` so React does not
+ * reset the boundary when the location changes.
+ */
+export default function TabPanelContent({ tabId, location }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const drawerTabs = useStore((s) => s.drawerTabs)
+  const tabLocations = useStore((s) => s.tabLocations)
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+
+    // If the tab belongs to a different location, do NOT mount it here —
+    // let the container that owns it handle the root.
+    const currentLocation = tabLocations[tabId] ?? { kind: 'main-drawer' } as const
+    const isMatch =
+      currentLocation.kind === location.kind &&
+      (currentLocation.kind === 'main-drawer' || (location.kind === 'container' && currentLocation.kind === 'container' && currentLocation.containerId === location.containerId))
+    if (!isMatch) {
+      el.replaceChildren()
+      return
+    }
+
+    // Built-in tabs have a persistent root lazily mounted on first view
+    const registryRoot = ensureRegistryRoot(tabId)
+    // Extension tabs store their root in the drawerTabs slice
+    const extTab = drawerTabs.find((t) => t.id === tabId)
+    const root = registryRoot ?? extTab?.root
+
+    if (root) {
+      // Avoid replaceChildren when root is already mounted — it clears
+      // then re-appends, causing a 1-frame empty/black flash.
+      if (el.firstChild !== root) {
+        el.replaceChildren(root)
+      }
+    } else {
+      // No root yet — clear any stale content so the previous tab's
+      // panel doesn't linger visually.
+      el.replaceChildren()
+    }
+  }, [tabId, location, drawerTabs, tabLocations])
+
+  // Determine a display label for the error boundary
+  const label = tabId
+
+  return (
+    <ErrorBoundary key={`${tabId}:${location.kind}${location.kind === 'container' ? `:${location.containerId}` : ''}`} label={label}>
+      <div
+        ref={containerRef}
+        style={{ width: '100%', height: '100%' }}
+      />
+    </ErrorBoundary>
+  )
+}

--- a/frontend/src/components/panels/ViewportDrawer.tsx
+++ b/frontend/src/components/panels/ViewportDrawer.tsx
@@ -10,6 +10,7 @@ import { useLongPress } from '@/hooks/useLongPress'
 import { DRAWER_TABS, adaptExtensionTabs, applyDrawerTabOrder, sanitizeDrawerTabOrder, sanitizeHiddenDrawerTabIds } from '@/lib/drawer-tab-registry'
 import { translateDrawerField } from '@/lib/i18n/resolveLabel'
 import { useTranslation } from 'react-i18next'
+import TabPanelContent from './TabPanelContent'
 import styles from './ViewportDrawer.module.css'
 import DOMPurify from 'dompurify'
 import clsx from 'clsx'
@@ -47,6 +48,7 @@ export default function ViewportDrawer() {
   const isMobile = useIsMobile()
   const sidebarRef = useRef<HTMLDivElement>(null)
   const tabListRef = useRef<HTMLDivElement>(null)
+  const panelContentRef = useRef<HTMLDivElement>(null)
   const [tabListScroll, setTabListScroll] = useState({ up: false, down: false })
   const [contextMenu, setContextMenu] = useState<ContextMenuPos | null>(null)
 
@@ -105,6 +107,17 @@ export default function ViewportDrawer() {
       setDrawerTab(activeTab)
     }
   }, [drawerTab, activeTab, setDrawerTab])
+
+  // Reset active tab when the current tab is moved out of main-drawer
+  const pendingActiveTabReset = useStore((s) => s.pendingActiveTabReset)
+  const clearPendingReset = useStore((s) => s.clearPendingActiveTabReset)
+  useEffect(() => {
+    if (!pendingActiveTabReset) return
+    // Find the first available built-in tab that isn't the one being moved away
+    const fallback = allTabs.find((t) => t.id !== pendingActiveTabReset)
+    setDrawerTab(fallback?.id ?? 'profile')
+    clearPendingReset()
+  }, [pendingActiveTabReset, allTabs, setDrawerTab, clearPendingReset])
 
   const handleTabClick = useCallback(
     (tabId: string) => {
@@ -210,6 +223,7 @@ export default function ViewportDrawer() {
                       key={tab.id}
                       type="button"
                       className={clsx(styles.tabBtn, showTabLabels && styles.tabBtnLabeled, activeTab === tab.id && styles.tabBtnActive)}
+                      data-tab-id={tab.id}
                       onClick={() => handleTabClick(tab.id)}
                       onContextMenu={handleTabContextMenu}
                       onTouchStart={tabQuickMenu.onTouchStart}
@@ -289,10 +303,8 @@ export default function ViewportDrawer() {
               </h2>
               <CloseButton onClick={closeDrawer} />
             </div>
-            <div className={clsx(styles.panelContent, (activeTab === 'loom' || activeTab === 'lumi' || activeTab === 'browser') && styles.panelContentFull)}>
-              <ErrorBoundary key={activeTab} label={activeTabConfig?.tabName}>
-                {activeTabConfig?.component()}
-              </ErrorBoundary>
+            <div className={clsx(styles.panelContent, (activeTab === 'loom' || activeTab === 'lumi' || activeTab === 'browser') && styles.panelContentFull)} ref={panelContentRef}>
+              <TabPanelContent tabId={activeTab} location={{ kind: 'main-drawer' }} />
             </div>
           </div>
         </div>

--- a/frontend/src/components/spindle/ContainerTabContent.tsx
+++ b/frontend/src/components/spindle/ContainerTabContent.tsx
@@ -1,0 +1,72 @@
+import { useEffect } from 'react'
+import { useStore } from '@/store'
+import { ensureRegistryRoot } from '@/lib/drawer-tab-registry'
+
+/**
+ * React renderer that re-parents tab persistent roots into registered
+ * DOM containers (e.g. Canvas's secondary drawer, or any custom
+ * container an extension registers via `registerContainer`).
+ *
+ * Subscribes to both `containers` (ContainerEntry[]) and `tabLocations`
+ * (Record<string, TabLocation>). For each tab whose location is
+ * `{ kind: 'container', containerId }`, it finds the matching
+ * container element and calls `appendChild(root)` to mount the tab's
+ * content there. Tabs whose target container is missing are reset to
+ * `{ kind: 'main-drawer' }`.
+ *
+ * Renders nothing — all work is side-effect driven.
+ */
+export default function ContainerTabContent() {
+  const containers = useStore((s) => s.containers)
+  const tabLocations = useStore((s) => s.tabLocations)
+  const drawerTabs = useStore((s) => s.drawerTabs)
+
+  useEffect(() => {
+    // Pass 1: mount tabs into their matching registered container
+    for (const container of containers) {
+      if (!container.element) continue
+
+      for (const [tabId, location] of Object.entries(tabLocations)) {
+        if (location.kind !== 'container') continue
+        if (location.containerId !== container.id) continue
+
+        const registryRoot = ensureRegistryRoot(tabId)
+        const extTab = drawerTabs.find((t) => t.id === tabId)
+        const root = registryRoot ?? extTab?.root
+        if (!root) continue
+
+        if (!container.element.contains(root)) {
+          container.element.appendChild(root)
+        }
+      }
+    }
+
+    // Pass 2: remove stale roots from containers that no longer own the tab
+    for (const container of containers) {
+      if (!container.element) continue
+
+      for (const [tabId, location] of Object.entries(tabLocations)) {
+        const registryRoot = ensureRegistryRoot(tabId)
+        const extTab = drawerTabs.find((t) => t.id === tabId)
+        const root = registryRoot ?? extTab?.root
+        if (!root) continue
+
+        const belongsHere =
+          location.kind === 'container' && location.containerId === container.id
+        if (!belongsHere && container.element.contains(root)) {
+          container.element.removeChild(root)
+        }
+      }
+    }
+
+    // Pass 3: fallback — tabs pointing to a missing container reset to main-drawer
+    const { moveTabTo } = useStore.getState()
+    for (const [tabId, location] of Object.entries(tabLocations)) {
+      if (location.kind !== 'container') continue
+      if (containers.some((c) => c.id === location.containerId)) continue
+      moveTabTo(tabId, { kind: 'main-drawer' })
+    }
+  }, [containers, tabLocations, drawerTabs])
+
+  return null
+}

--- a/frontend/src/components/spindle/SpindleUIManager.tsx
+++ b/frontend/src/components/spindle/SpindleUIManager.tsx
@@ -6,6 +6,7 @@ import { useStore } from '@/store'
 import SpindleFloatWidget from './SpindleFloatWidget'
 import SpindleDockPanel from './SpindleDockPanel'
 import SpindleAppMount from './SpindleAppMount'
+import ContainerTabContent from './ContainerTabContent'
 import ExpandedTextEditor from '@/components/shared/ExpandedTextEditor'
 import ConfirmationModal from '@/components/shared/ConfirmationModal'
 import { InputPromptModal } from '@/components/shared/InputPromptModal'
@@ -78,6 +79,9 @@ export default function SpindleUIManager() {
         .map((m) => (
           <SpindleAppMount key={m.id} mount={m} />
         ))}
+
+      {/* Re-parents tab roots into registered containers (e.g. Canvas secondary drawer) */}
+      <ContainerTabContent />
 
       <SpindleTextEditor />
       <SpindleModal />

--- a/frontend/src/lib/core-drawer-tab-ids.ts
+++ b/frontend/src/lib/core-drawer-tab-ids.ts
@@ -1,0 +1,18 @@
+/**
+ * Built-in drawer tabs that extensions can relocate via
+ * `requestTabLocation`. Of the 24 entries in DRAWER_TABS, only these 9
+ * are dispatchable to extensions — the remaining 15 (e.g. weaver) are
+ * movable only via `core.store.requestTabLocation`. See
+ * `ui-placement.md` Permissions for the full breakdown.
+ */
+export const CORE_DRAWER_TAB_IDS = new Set([
+  'profile',
+  'presets',
+  'loom',
+  'characters',
+  'personas',
+  'branches',
+  'spindle',
+  'theme',
+  'lorebook',
+])

--- a/frontend/src/lib/drawer-tab-registry.tsx
+++ b/frontend/src/lib/drawer-tab-registry.tsx
@@ -1,4 +1,5 @@
 import type { ComponentType, ReactNode } from 'react'
+import { createRoot } from 'react-dom/client'
 import {
   User, Wand2, GitFork, Link2, Package, Zap,
   Users, Drama, PenTool, MessageCircle, FileText, Brain, ScrollText,
@@ -11,6 +12,8 @@ import { wsClient } from '@/ws/client'
 import i18n from '@/i18n'
 import type { Command, CommandScope } from '@/lib/commands'
 import type { DrawerTabState, ExtensionCommandState } from '@/store/slices/spindle-placement'
+import { CORE_DRAWER_TAB_IDS } from './core-drawer-tab-ids'
+import ErrorBoundary from '@/components/shared/ErrorBoundary'
 import CharacterProfile from '@/components/panels/CharacterProfile'
 import CharacterBrowser from '@/components/panels/CharacterBrowser'
 import PersonaManager from '@/components/panels/PersonaManager'
@@ -55,21 +58,15 @@ export interface DrawerTabEntry {
   keywords: string[]
   /** Optional scope restriction for command palette filtering */
   scope?: CommandScope
-  /** React component factory to render the panel content */
-  component: () => ReactNode
+  /**
+   * Mount the tab content into a persistent root element.
+   * Returns a cleanup function. Called once by ensureRegistryRoot on
+   * first request, then cached.
+   */
+  mount: (root: HTMLElement) => () => void
 }
 
-export const CORE_DRAWER_TAB_IDS = new Set([
-  'profile',
-  'presets',
-  'loom',
-  'characters',
-  'personas',
-  'branches',
-  'spindle',
-  'theme',
-  'lorebook',
-])
+export { CORE_DRAWER_TAB_IDS } from './core-drawer-tab-ids'
 
 export function isDrawerTabCore(tabId: string): boolean {
   return CORE_DRAWER_TAB_IDS.has(tabId)
@@ -103,6 +100,12 @@ export function applyDrawerTabOrder<T extends { id: string }>(items: T[], order:
   return indexed.map((entry) => entry.item)
 }
 
+function mountReactComponent(root: HTMLElement, element: ReactNode, tabId?: string): () => void {
+  const reactRoot = createRoot(root)
+  reactRoot.render(<ErrorBoundary label={tabId}>{element}</ErrorBoundary>)
+  return () => { reactRoot.unmount() }
+}
+
 export const DRAWER_TABS: DrawerTabEntry[] = [
   {
     id: 'profile',
@@ -111,7 +114,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabDescription: 'View and edit the active character',
     tabIcon: User,
     keywords: ['character', 'avatar', 'info', 'edit', 'card', 'description', 'bio', 'greeting', 'first message'],
-    component: () => <CharacterProfile />,
+    mount: (root) => mountReactComponent(root, <CharacterProfile />),
   },
   {
     id: 'presets',
@@ -121,7 +124,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabIcon: Wand2,
     tabHeaderTitle: 'Reasoning',
     keywords: ['reasoning', 'cot', 'chain of thought', 'thinking', 'reasoning effort', 'api reasoning', 'prompt bias', 'start reply with', 'prefix', 'suffix'],
-    component: () => <PresetManager />,
+    mount: (root) => mountReactComponent(root, <PresetManager />),
   },
   {
     id: 'loom',
@@ -130,7 +133,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabDescription: 'Configure narrative structure and story beats',
     tabIcon: GitFork,
     keywords: ['narrative', 'story', 'lore', 'structure', 'beats', 'loom', 'pacing', 'plot', 'sovereign hand', 'director'],
-    component: () => <LoomBuilder compact />,
+    mount: (root) => mountReactComponent(root, <LoomBuilder compact />),
   },
   {
     id: 'weaver',
@@ -139,7 +142,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabDescription: 'Craft a character from your idea',
     tabIcon: Feather,
     keywords: ['weaver', 'dream', 'character', 'create', 'ai'],
-    component: () => <WeaverPanel />,
+    mount: (root) => mountReactComponent(root, <WeaverPanel />),
   },
   {
     id: 'connections',
@@ -149,8 +152,8 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabIcon: Link2,
     tabHeaderTitle: 'Connections',
     keywords: ['api', 'provider', 'key', 'openai', 'anthropic', 'model', 'endpoint', 'google', 'vertex', 'claude', 'gemini', 'openrouter', 'deepseek', 'url', 'secret'],
-    component: () => (
-      <>
+    mount: (root) => mountReactComponent(root, (
+      <div className="connections-stack">
         <ConnectionManager />
         <div style={{ marginTop: 24, paddingTop: 16, borderTop: '1px solid var(--lumiverse-border)' }}>
           <h3 style={{ fontSize: 13, fontWeight: 600, marginBottom: 12, color: 'var(--lumiverse-text-secondary)' }}>{i18n.t('connections.imageGeneration', { ns: 'panels' })}</h3>
@@ -164,8 +167,8 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
           <h3 style={{ fontSize: 13, fontWeight: 600, marginBottom: 12, color: 'var(--lumiverse-text-secondary)' }}>{i18n.t('connections.textToSpeech', { ns: 'panels' })}</h3>
           <TTSConnectionManager />
         </div>
-      </>
-    ),
+      </div>
+    )),
   },
   {
     id: 'browser',
@@ -175,7 +178,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabIcon: Package,
     tabHeaderTitle: 'Browser',
     keywords: ['packs', 'content', 'download', 'browse', 'browser', 'install', 'marketplace', 'library', 'search'],
-    component: () => <PackBrowser />,
+    mount: (root) => mountReactComponent(root, <PackBrowser />),
   },
   {
     id: 'characters',
@@ -185,7 +188,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabIcon: Users,
     tabHeaderTitle: 'Characters',
     keywords: ['character', 'list', 'import', 'card', 'browse', 'export', 'png', 'charx', 'gallery', 'switch', 'select'],
-    component: () => <CharacterBrowser />,
+    mount: (root) => mountReactComponent(root, <CharacterBrowser />),
   },
   {
     id: 'personas',
@@ -194,7 +197,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabDescription: 'Manage your user personas',
     tabIcon: Drama,
     keywords: ['persona', 'identity', 'user', 'avatar', 'name', 'sender', 'you', 'addons'],
-    component: () => <PersonaManager />,
+    mount: (root) => mountReactComponent(root, <PersonaManager />),
   },
   {
     id: 'lorebook',
@@ -204,7 +207,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabIcon: Library,
     tabHeaderTitle: 'Lorebook',
     keywords: ['lorebook', 'world', 'lore', 'book', 'entries', 'worldbook', 'world info', 'wi', 'keywords', 'triggers', 'knowledge'],
-    component: () => <WorldBookPanel />,
+    mount: (root) => mountReactComponent(root, <WorldBookPanel />),
   },
   {
     id: 'cortex',
@@ -214,7 +217,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabIcon: Brain,
     tabHeaderTitle: 'Memory',
     keywords: ['memory', 'cortex', 'embeddings', 'recall', 'brain', 'entities', 'relationships', 'salience', 'vector', 'long term', 'ltcm', 'facts'],
-    component: () => <MemoryCortexPanel />,
+    mount: (root) => mountReactComponent(root, <MemoryCortexPanel />),
   },
   {
     id: 'databank',
@@ -224,7 +227,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabIcon: Database,
     tabHeaderTitle: 'Databank',
     keywords: ['databank', 'knowledge', 'documents', 'upload', 'files', 'bank', 'reference', 'data', 'rag'],
-    component: () => <DatabankPanel />,
+    mount: (root) => mountReactComponent(root, <DatabankPanel />),
   },
   {
     id: 'create',
@@ -234,7 +237,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabIcon: PenTool,
     tabHeaderTitle: 'Create',
     keywords: ['create', 'workshop', 'editor', 'build', 'new', 'lumia', 'loom', 'author', 'write', 'draft', 'custom'],
-    component: () => <ContentWorkshop />,
+    mount: (root) => mountReactComponent(root, <ContentWorkshop />),
   },
   {
     id: 'ooc',
@@ -243,7 +246,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabDescription: 'Out-of-character comment display settings',
     tabIcon: MessageCircle,
     keywords: ['ooc', 'out of character', 'comments', 'irc', 'social', 'chat', 'meta', 'parentheses', 'brackets'],
-    component: () => <OOCPanel />,
+    mount: (root) => mountReactComponent(root, <OOCPanel />),
   },
   {
     id: 'prompt',
@@ -253,7 +256,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabIcon: FileText,
     tabHeaderTitle: 'Composition',
     keywords: ['composition', 'compose', 'lumia', 'loom', 'sovereign hand', 'context filters', 'narrative', 'selection', 'modes'],
-    component: () => <PromptPanel />,
+    mount: (root) => mountReactComponent(root, <PromptPanel />),
   },
   {
     id: 'council',
@@ -262,7 +265,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabDescription: 'Configure the Lumia Council and tool functions',
     tabIcon: IconUsersGroup,
     keywords: ['council', 'tools', 'agents', 'lumia', 'functions', 'tool use', 'sidecar', 'function calling'],
-    component: () => <CouncilManager />,
+    mount: (root) => mountReactComponent(root, <CouncilManager />),
   },
   {
     id: 'summary',
@@ -271,7 +274,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabDescription: 'Configure context summarization and truncation',
     tabIcon: ScrollText,
     keywords: ['summary', 'context', 'truncation', 'compress', 'summarize', 'shorten', 'overflow', 'window', 'limit'],
-    component: () => <SummaryEditor />,
+    mount: (root) => mountReactComponent(root, <SummaryEditor />),
   },
   {
     id: 'feedback',
@@ -281,7 +284,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabIcon: MessageSquareReply,
     tabHeaderTitle: 'Feedback',
     keywords: ['feedback', 'council', 'results', 'tools', 'output', 'debug', 'log', 'response', 'execution', 'trace'],
-    component: () => <CouncilFeedback />,
+    mount: (root) => mountReactComponent(root, <CouncilFeedback />),
   },
   {
     id: 'worldinfo',
@@ -291,7 +294,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabIcon: Globe,
     tabHeaderTitle: 'World Info',
     keywords: ['world info', 'activation', 'lorebook', 'active', 'entries', 'triggered', 'wi', 'matched', 'fired'],
-    component: () => <WorldInfoFeedback />,
+    mount: (root) => mountReactComponent(root, <WorldInfoFeedback />),
   },
   {
     id: 'imagegen',
@@ -301,7 +304,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabIcon: Image,
     tabHeaderTitle: 'Image Gen',
     keywords: ['image', 'generation', 'scene', 'art', 'picture', 'ai', 'background', 'novelai', 'nai', 'dalle', 'illustration'],
-    component: () => <ImageGenPanel />,
+    mount: (root) => mountReactComponent(root, <ImageGenPanel />),
   },
   {
     id: 'wallpaper',
@@ -310,7 +313,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabDescription: 'Set global or per-chat background wallpapers',
     tabIcon: Wallpaper,
     keywords: ['wallpaper', 'background', 'backdrop', 'image', 'video', 'animated', 'mp4', 'webm', 'gif', 'scenery', 'chat background'],
-    component: () => <WallpaperPanel />,
+    mount: (root) => mountReactComponent(root, <WallpaperPanel />),
   },
   {
     id: 'regex',
@@ -320,7 +323,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabIcon: Replace,
     tabHeaderTitle: 'Regex',
     keywords: ['regex', 'find', 'replace', 'script', 'transform', 'filter', 'pattern', 'substitution', 'text', 'output', 'display', 'rewrite', 'format'],
-    component: () => <RegexPanel />,
+    mount: (root) => mountReactComponent(root, <RegexPanel />),
   },
   {
     id: 'branches',
@@ -330,7 +333,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabIcon: GitBranch,
     tabHeaderTitle: 'Branches',
     keywords: ['branch', 'fork', 'history', 'tree', 'navigate', 'alternate', 'swipe', 'undo', 'timeline', 'rewind', 'path'],
-    component: () => <BranchTreePanel />,
+    mount: (root) => mountReactComponent(root, <BranchTreePanel />),
   },
   {
     id: 'theme',
@@ -339,7 +342,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabDescription: 'Customize colors, accent, and visual style',
     tabIcon: Palette,
     keywords: ['theme', 'colors', 'accent', 'appearance', 'dark', 'light', 'glass', 'radius', 'font', 'css', 'style', 'customize', 'ui', 'mode'],
-    component: () => <ThemePanel />,
+    mount: (root) => mountReactComponent(root, <ThemePanel />),
   },
   {
     id: 'spindle',
@@ -349,7 +352,7 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabIcon: Puzzle,
     tabHeaderTitle: 'Extensions',
     keywords: ['extensions', 'spindle', 'plugins', 'addons', 'install', 'manage', 'enable', 'disable', 'uninstall', 'github'],
-    component: () => <SpindlePanel />,
+    mount: (root) => mountReactComponent(root, <SpindlePanel />),
   },
 ]
 
@@ -363,8 +366,48 @@ export function adaptExtensionTabs(tabs: DrawerTabState[]): DrawerTabEntry[] {
     tabIcon: Puzzle,
     tabHeaderTitle: dt.headerTitle,
     keywords: ['extension', 'spindle', dt.extensionId, ...(dt.keywords ?? [])],
-    component: () => null,
+    mount: () => () => {},
   }))
+}
+
+// ── Persistent tab roots (built-in tabs) ──
+//
+// Roots are mounted lazily on first request via `ensureRegistryRoot`.
+// Once mounted, a tab's root is cached and reused — matching the
+// original "persistent root" design (state survives tab switches).
+
+const _registryRoots = new Map<string, HTMLElement>()
+const _registryCleanups = new Map<string, () => void>()
+
+/**
+ * Mount a single built-in tab's persistent root on first request, then
+ * cache. Subsequent calls are O(1) lookups. Returns undefined if the
+ * tabId is not in DRAWER_TABS or if the mount throws.
+ *
+ * Roots are kept detached until reparented into a TabPanelContent /
+ * ContainerTabContent via replaceChildren.
+ */
+export function ensureRegistryRoot(tabId: string): HTMLElement | undefined {
+  const existing = _registryRoots.get(tabId)
+  if (existing) return existing
+
+  const tab = DRAWER_TABS.find((t) => t.id === tabId)
+  if (!tab) return undefined
+
+  const root = document.createElement('div')
+  root.setAttribute('data-spindle-drawer-tab', tabId)
+  root.style.width = '100%'
+  root.style.height = '100%'
+  _registryRoots.set(tabId, root)
+  try {
+    const cleanup = tab.mount(root)
+    _registryCleanups.set(tabId, cleanup)
+    return root
+  } catch (err) {
+    console.error(`[Spindle mount] ${tabId}`, err)
+    _registryRoots.delete(tabId)
+    return undefined
+  }
 }
 
 /** Generate Panel commands from the registry for the command palette. */

--- a/frontend/src/lib/spindle/loader.ts
+++ b/frontend/src/lib/spindle/loader.ts
@@ -1,4 +1,5 @@
 import type { SpindleManifest, SpindleFrontendContext, SpindleFrontendModule, PermissionRequestOptions } from 'lumiverse-spindle-types'
+import type { SpindleTabMobilityUI, TabLocation } from './tab-mobility-types'
 import { createDOMHelper } from './dom-helper'
 import { registerTagInterceptor, unregisterTagInterceptorsByExtension } from './message-interceptors'
 import { registerDisplayResolver, unregisterDisplayResolver } from './display-resolver-registry'
@@ -10,11 +11,14 @@ import {
   createDockPanelHandle,
   createAppMountHandle,
   createInputBarActionHandle,
+  createTabMobilityHandle,
+  clearTabMobilityHandle,
   destroyAllPlacementsForExtension,
 } from './placement-helper'
 import { createComponentsHelper, destroyAllComponentsForExtension } from './components-helper'
 import { generateUUID } from '@/lib/uuid'
 import { installSpindleNavigationGuards } from './navigation-guards'
+import { DRAWER_TABS, ensureRegistryRoot } from '@/lib/drawer-tab-registry'
 import { createUIEventsHelper, type FrontendUIEventsHelper } from './ui-events-helper'
 import { wsClient } from '@/ws/client'
 import { spindleApi } from '@/api/spindle'
@@ -70,7 +74,7 @@ interface ActiveFrontendProcess {
 }
 
 type FrontendExtensionContext = Omit<SpindleFrontendContext, 'ui' | 'messages'> & {
-  ui: SpindleFrontendContext['ui'] & {
+  ui: SpindleTabMobilityUI & {
     events: FrontendUIEventsHelper
   }
   processes: {
@@ -328,6 +332,27 @@ async function doLoadFrontendExtension(
             throw new Error('PERMISSION_DENIED:ui_panels — requestDockPanel requires the ui_panels permission')
           }
           return createDockPanelHandle(extensionId, options)
+        },
+        requestTabLocation(tabId: string, location: TabLocation) {
+          const granted = cachedGrantedPermissions
+          if (!granted.includes('app_manipulation')) {
+            throw new Error('PERMISSION_DENIED:app_manipulation — requestTabLocation requires the app_manipulation permission')
+          }
+          createTabMobilityHandle(extensionId).requestTabLocation(tabId, location)
+        },
+        getBuiltInTabTitle(tabId: string): string | undefined {
+          const tab = DRAWER_TABS.find((t) => t.id === tabId)
+          return tab ? (tab.tabHeaderTitle ?? tab.tabName) : undefined
+        },
+        getTabLocation(tabId: string): TabLocation {
+          return (useStore.getState().tabLocations[tabId] ?? { kind: 'main-drawer' }) as TabLocation
+        },
+        getBuiltInTabRoot(tabId: string): HTMLElement | undefined {
+          const granted = cachedGrantedPermissions
+          if (!granted.includes('ui_panels')) {
+            throw new Error('PERMISSION_DENIED:ui_panels — getBuiltInTabRoot requires the ui_panels permission')
+          }
+          return ensureRegistryRoot(tabId)
         },
         mountApp(options) {
           const granted = cachedGrantedPermissions
@@ -665,6 +690,12 @@ async function doLoadFrontendExtension(
           else invalidateDisplayRegexCacheForVars(new Set(touchedVars))
         },
       },
+      containers: {
+        registerContainer: (opts: { id: string; side: 'left' | 'right' | 'top' | 'bottom'; element: HTMLElement }) =>
+          useStore.getState().registerContainer(opts),
+        unregisterContainer: (id: string) =>
+          useStore.getState().unregisterContainer(id),
+      },
       manifest,
     }
 
@@ -704,7 +735,7 @@ async function doLoadFrontendExtension(
       stopMountSync: cleanupMountInfra,
     })
 
-    console.log(`[Spindle] Loaded frontend: ${manifest.identifier}`)
+    console.debug(`[Spindle] Loaded frontend: ${manifest.identifier}`)
   } catch (err) {
     console.error(`[Spindle] Failed to load frontend for ${manifest.identifier}:`, err)
   }
@@ -800,9 +831,10 @@ export async function unloadFrontendExtension(extensionId: string): Promise<void
   removeMessageWidgetsByExtension(extensionId)
   destroyAllComponentsForExtension(extensionId)
   destroyAllPlacementsForExtension(extensionId)
+  clearTabMobilityHandle(extensionId)
   loadedExtensions.delete(extensionId)
 
-  console.log(`[Spindle] Unloaded frontend: ${loaded.identifier}`)
+  console.debug(`[Spindle] Unloaded frontend: ${loaded.identifier}`)
 }
 
 export function routeBackendMessage(extensionId: string, payload: unknown): void {
@@ -987,4 +1019,70 @@ export async function unloadAllFrontendExtensions(): Promise<void> {
   for (const [id] of loadedExtensions) {
     await unloadFrontendExtension(id)
   }
+}
+
+// ── window.spindle global bridge ──
+// Provides a runtime API surface for extensions (e.g. Canvas) that cannot
+// import from lumiverse-spindle-types directly. Defined lazily via getter
+// so the store is fully initialised by the time any extension reads the bridge.
+//
+// This bridge is a system-level API — it does NOT enforce extension
+// permissions. Use `ctx.ui.*` from the extension context for permission-
+// gated access.
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'spindle', {
+    configurable: true,
+    get() {
+      const api = {
+        ui: {
+          getBuiltInTabTitle(tabId: string): string | undefined {
+            const tab = DRAWER_TABS.find((t) => t.id === tabId)
+            return tab ? (tab.tabHeaderTitle ?? tab.tabName) : undefined
+          },
+          getBuiltInTabRoot(tabId: string): HTMLElement | undefined {
+            return ensureRegistryRoot(tabId)
+          },
+          requestTabLocation(tabId: string, location: TabLocation) {
+            useStore.getState().moveTabTo(tabId, location)
+          },
+          getTabLocation(tabId: string): TabLocation {
+            return (useStore.getState().tabLocations[tabId] ?? { kind: 'main-drawer' }) as TabLocation
+          },
+          /**
+           * Get the backend message bus for a loaded extension. Used by
+           * Canvas's secondary-drawer re-executor: when an extension bundle
+           * is re-executed in the secondary drawer, its `setup(ctx)` calls
+           * `ctx.sendToBackend(...)` and `ctx.onBackendMessage(...)`. If
+           * those were bound to canvas_ext's own context, the messages
+           * would be routed to canvas_ext's worker (wrong worker) and
+           * responses from the target extension's worker would never be
+           * received. This helper returns the target extension's actual
+           * bus so the re-executed setup() can talk to the right worker.
+           *
+           * Returns null if the extension is not loaded.
+           */
+          getExtensionBackend(extensionId: string): {
+            sendToBackend: (payload: unknown) => void
+            onBackendMessage: (handler: (payload: unknown) => void) => () => void
+          } | null {
+            const loaded = loadedExtensions.get(extensionId)
+            if (!loaded) return null
+            return {
+              sendToBackend: loaded.context.sendToBackend.bind(loaded.context),
+              onBackendMessage: loaded.context.onBackendMessage.bind(loaded.context),
+            }
+          },
+        },
+        containers: {
+          registerContainer: (opts: { id: string; side: string; element: HTMLElement }) =>
+            useStore.getState().registerContainer(opts as any),
+          unregisterContainer: (id: string) =>
+            useStore.getState().unregisterContainer(id),
+        },
+      }
+      // Cache so subsequent reads don't re-invoke the getter
+      Object.defineProperty(window, 'spindle', { value: api, configurable: true })
+      return api
+    },
+  })
 }

--- a/frontend/src/lib/spindle/placement-helper.ts
+++ b/frontend/src/lib/spindle/placement-helper.ts
@@ -11,11 +11,18 @@ import type {
   SpindleInputBarActionHandle,
 } from 'lumiverse-spindle-types'
 import { useStore } from '@/store'
+import type { TabLocation } from './tab-mobility-types'
+import { isTabDispatchable } from './tab-dispatch'
 
 let placementCounter = 0
 function nextId(extensionId: string, kind: string): string {
   return `spindle:${extensionId}:${kind}:${++placementCounter}`
 }
+
+// ── Tab Mobility Handle Cache ──
+// Each call to createTabMobilityHandle subscribes to useStore.
+// Cache one handle per extensionId to avoid subscription leaks.
+const _tabMobilityCache = new Map<string, ReturnType<typeof createTabMobilityHandle>>
 
 function getStore() {
   return useStore.getState()
@@ -361,6 +368,39 @@ export function createInputBarActionHandle(
     destroy() {
       getStore().unregisterInputBarAction(actionId)
       clickHandlers.clear()
+    },
+  }
+}
+
+// ── Tab Mobility ──
+
+/**
+ * Create a tab mobility handle for an extension. Filters to (a) own
+ * extension's tabs, (b) CORE_DRAWER_TAB_IDS.
+ */
+export function createTabMobilityHandle(extensionId: string): {
+  requestTabLocation(tabId: string, location: TabLocation): void
+} {
+  const cached = _tabMobilityCache.get(extensionId)
+  if (cached) return cached
+
+  const handle = createTabMobilityHandleUncached(extensionId)
+  _tabMobilityCache.set(extensionId, handle)
+  return handle
+}
+
+/** Clear the cached tab mobility handle for an extension (call on unload). */
+export function clearTabMobilityHandle(extensionId: string): void {
+  _tabMobilityCache.delete(extensionId)
+}
+
+function createTabMobilityHandleUncached(extensionId: string): {
+  requestTabLocation(tabId: string, location: TabLocation): void
+} {
+  return {
+    requestTabLocation(tabId: string, location: TabLocation): void {
+      if (!isTabDispatchable(tabId, extensionId, getStore().drawerTabs)) return
+      getStore().moveTabTo(tabId, location)
     },
   }
 }

--- a/frontend/src/lib/spindle/tab-dispatch.test.ts
+++ b/frontend/src/lib/spindle/tab-dispatch.test.ts
@@ -1,0 +1,54 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { isTabDispatchable } from './tab-dispatch'
+
+// `isTabDispatchable` is the pure dispatch-authorization check that
+// gates `requestTabLocation` in placement-helper. The CORE ids are
+// hard-coded here (rather than imported from drawer-tab-registry)
+// because the registry transitively imports the store graph, which
+// references Vite-only `import.meta.glob` that bun:test cannot
+// resolve. Keeping the test self-contained avoids the import chain
+// while still exercising the same authorization rule.
+
+const CORE_IDS = ['profile', 'presets', 'loom', 'characters', 'personas', 'branches', 'spindle', 'theme', 'lorebook'] as const
+
+const ownTabs = [
+  { id: 'ext-tab-1', extensionId: 'ext-A' },
+  { id: 'ext-tab-2', extensionId: 'ext-B' },
+]
+
+describe('isTabDispatchable', () => {
+  test('returns true for any CORE_DRAWER_TAB_ID', () => {
+    for (const core of CORE_IDS) {
+      expect(isTabDispatchable(core, 'ext-A', ownTabs)).toBe(true)
+    }
+  })
+
+  test('returns true for a drawer tab owned by the calling extension', () => {
+    expect(isTabDispatchable('ext-tab-1', 'ext-A', ownTabs)).toBe(true)
+  })
+
+  test('returns false for a drawer tab owned by a different extension', () => {
+    expect(isTabDispatchable('ext-tab-2', 'ext-A', ownTabs)).toBe(false)
+  })
+
+  test('returns false for an unknown tab id', () => {
+    expect(isTabDispatchable('not-a-real-tab', 'ext-A', ownTabs)).toBe(false)
+  })
+
+  test('returns false for an empty string that is not in the CORE set', () => {
+    expect(isTabDispatchable('', 'ext-A', ownTabs)).toBe(false)
+  })
+
+  test('returns false when ownDrawerTabs is empty and the tab is not CORE', () => {
+    expect(isTabDispatchable('ext-tab-1', 'ext-A', [])).toBe(false)
+  })
+
+  test('the same tab id in two extensions is dispatchable only for the owner', () => {
+    const shared = { id: 'shared-id', extensionId: 'ext-A' }
+    const ownTabsWithShared = [...ownTabs, shared]
+    expect(isTabDispatchable('shared-id', 'ext-A', ownTabsWithShared)).toBe(true)
+    expect(isTabDispatchable('shared-id', 'ext-B', ownTabsWithShared)).toBe(false)
+  })
+})

--- a/frontend/src/lib/spindle/tab-dispatch.ts
+++ b/frontend/src/lib/spindle/tab-dispatch.ts
@@ -1,0 +1,20 @@
+import { CORE_DRAWER_TAB_IDS } from '@/lib/core-drawer-tab-ids'
+
+/**
+ * Pure dispatch-authorization check for `requestTabLocation`. Exported
+ * for testability — the runtime call site reads the live store, but
+ * the rule is a pure function of (tabId, extensionId, the slice of
+ * extension-owned drawer tabs).
+ *
+ * Returns true iff `tabId` is either a CORE_DRAWER_TAB_IDS entry or a
+ * drawer tab owned by `extensionId`. Other-extension tabs and unknown
+ * tab ids are denied.
+ */
+export function isTabDispatchable(
+  tabId: string,
+  extensionId: string,
+  ownDrawerTabs: ReadonlyArray<{ id: string; extensionId: string }>,
+): boolean {
+  if (CORE_DRAWER_TAB_IDS.has(tabId)) return true
+  return ownDrawerTabs.some((t) => t.id === tabId && t.extensionId === extensionId)
+}

--- a/frontend/src/lib/spindle/tab-mobility-types.ts
+++ b/frontend/src/lib/spindle/tab-mobility-types.ts
@@ -1,0 +1,38 @@
+/**
+ * Local type definitions for tab mobility (v0.5.24 placeholder).
+ *
+ * TODO(remove-when-bumped): Delete this file once `lumiverse-spindle-types`
+ * is bumped to `^0.5.24` in `frontend/package.json` (currently `^0.5.23`).
+ * The v0.5.24 precursor PR (j-dandelion/lumiverse-spindle-types
+ * feat/tab-mobility-v0.5.24) ships a discriminated `SpindleTabLocation`
+ * shape and the `containers` property in the package proper. Until then,
+ * this file's module augmentation merges the types into the package's
+ * `SpindleFrontendContext` interface, and the local declarations here
+ * are load-bearing.
+ */
+
+/** Where a built-in drawer tab currently lives. */
+export type TabLocation =
+  | { kind: 'main-drawer' }
+  | { kind: 'container'; containerId: string }
+
+import type { SpindleFrontendContext } from 'lumiverse-spindle-types'
+
+export type SpindleTabMobilityUI = SpindleFrontendContext['ui'] & {
+  requestTabLocation(tabId: string, location: TabLocation): void
+  getTabLocation(tabId: string): TabLocation
+  getBuiltInTabTitle(tabId: string): string | undefined
+  getBuiltInTabRoot(tabId: string): HTMLElement | undefined
+}
+
+declare module 'lumiverse-spindle-types' {
+  interface SpindleFrontendContext {
+    /** Register or unregister passive DOM containers that can receive tab roots. */
+    containers: {
+      /** Register a container element with a stable id. Tabs routed to this id via `requestTabLocation` will be reparented into `element`. Idempotent on id collision. */
+      registerContainer(entry: { id: string; side: 'left' | 'right' | 'top' | 'bottom'; element: HTMLElement }): void
+      /** Remove a previously registered container. Tabs still pointing to this id will fall back to the main drawer. */
+      unregisterContainer(id: string): void
+    }
+  }
+}

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -32,6 +32,7 @@ import { createChatHeadsSlice } from './slices/chat-heads'
 import { createDatabankSlice } from './slices/databank'
 import { createConnectionSlice } from './slices/connection'
 import { createWeaverSlice } from './slices/weaver'
+import { createContainersSlice } from './slices/containers'
 import { registerUserScopedResetStore } from './user-scoped-reset'
 
 export const useStore = create<AppStore>()((...a) => ({
@@ -67,6 +68,7 @@ export const useStore = create<AppStore>()((...a) => ({
   ...createDatabankSlice(...a),
   ...createConnectionSlice(...a),
   ...createWeaverSlice(...a),
+  ...createContainersSlice(...a),
 }))
 
 registerUserScopedResetStore(useStore, useStore.getState())

--- a/frontend/src/store/slices/container-dispatch.test.ts
+++ b/frontend/src/store/slices/container-dispatch.test.ts
@@ -1,0 +1,155 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test, beforeEach } from 'bun:test'
+import { createSpindlePlacementSlice } from './spindle-placement'
+import { createContainersSlice } from './containers'
+import type { SpindlePlacementSlice } from '@/types/store'
+import type { ContainersSlice } from './containers'
+
+// Test the container dispatch logic that ContainerTabContent runs
+// on every effect cycle. We test the pure store logic rather than
+// rendering the component because no @testing-library/react is installed.
+// HTMLElement is not available in bun's default test env, so container
+// entries use plain placeholder objects — the test only exercises the
+// routing and fallback logic, not actual DOM manipulation.
+
+function makeStore() {
+  let placementState = {} as SpindlePlacementSlice
+  const placementSet = (partial: any) => {
+    const next = typeof partial === 'function' ? partial(placementState) : partial
+    placementState = { ...placementState, ...next }
+  }
+  const placementGet = () => placementState
+  Object.assign(placementState, createSpindlePlacementSlice(placementSet as any, placementGet as any, {} as any))
+
+  let containerState = {} as ContainersSlice
+  const containerSet = (partial: any) => {
+    const next = typeof partial === 'function' ? partial(containerState) : containerState
+    containerState = { ...containerState, ...next }
+  }
+  const containerGet = () => containerState
+  Object.assign(containerState, createContainersSlice(containerSet as any, containerGet as any, {} as any))
+
+  return {
+    get tabLocations() { return placementState.tabLocations },
+    get containers() { return containerState.containers },
+    moveTabTo: placementState.moveTabTo,
+    registerContainer: containerState.registerContainer,
+    unregisterContainer: containerState.unregisterContainer,
+  }
+}
+
+function makeContainer(id: string, side: 'left' | 'right' = 'right') {
+  // Cast to avoid HTMLElement requirement — tests only check routing, not DOM
+  return { id, side, element: {} as any }
+}
+
+describe('container dispatch logic (mirrors ContainerTabContent)', () => {
+  let store: ReturnType<typeof makeStore>
+
+  beforeEach(() => {
+    if (typeof localStorage !== 'undefined') {
+      try { localStorage.clear() } catch { /* no-op */ }
+    }
+    store = makeStore()
+  })
+
+  test('tabs with a registered container are not reset', () => {
+    const c1 = makeContainer('my-panel')
+    store.registerContainer(c1)
+    store.moveTabTo('profile', { kind: 'container', containerId: 'my-panel' })
+
+    // Simulate ContainerTabContent pass 3: fallback scan
+    for (const [tabId, location] of Object.entries(store.tabLocations)) {
+      if (location.kind !== 'container') continue
+      if (store.containers.some((c) => c.id === location.containerId)) continue
+      store.moveTabTo(tabId, { kind: 'main-drawer' })
+    }
+
+    expect(store.tabLocations.profile).toEqual({ kind: 'container', containerId: 'my-panel' })
+  })
+
+  test('tabs pointing to a missing container are reset to main-drawer', () => {
+    store.moveTabTo('profile', { kind: 'container', containerId: 'nonexistent' })
+    store.moveTabTo('connections', { kind: 'container', containerId: 'also-missing' })
+
+    // Simulate ContainerTabContent pass 3: fallback scan
+    for (const [tabId, location] of Object.entries(store.tabLocations)) {
+      if (location.kind !== 'container') continue
+      if (store.containers.some((c) => c.id === location.containerId)) continue
+      store.moveTabTo(tabId, { kind: 'main-drawer' })
+    }
+
+    expect(store.tabLocations.profile).toEqual({ kind: 'main-drawer' })
+    expect(store.tabLocations.connections).toEqual({ kind: 'main-drawer' })
+  })
+
+  test('container unregister triggers fallback reset', () => {
+    const c1 = makeContainer('temp')
+    store.registerContainer(c1)
+    store.moveTabTo('profile', { kind: 'container', containerId: 'temp' })
+
+    // Unregister the container
+    store.unregisterContainer('temp')
+
+    // Simulate the fallback scan
+    for (const [tabId, location] of Object.entries(store.tabLocations)) {
+      if (location.kind !== 'container') continue
+      if (store.containers.some((c) => c.id === location.containerId)) continue
+      store.moveTabTo(tabId, { kind: 'main-drawer' })
+    }
+
+    expect(store.tabLocations.profile).toEqual({ kind: 'main-drawer' })
+  })
+
+  test('tab with main-drawer kind is never touched by fallback', () => {
+    store.moveTabTo('profile', { kind: 'main-drawer' })
+
+    for (const [tabId, location] of Object.entries(store.tabLocations)) {
+      if (location.kind !== 'container') continue
+      if (store.containers.some((c) => c.id === location.containerId)) continue
+      store.moveTabTo(tabId, { kind: 'main-drawer' })
+    }
+
+    expect(store.tabLocations.profile).toEqual({ kind: 'main-drawer' })
+  })
+
+  test('mixed locations: some main-drawer, some container, some missing', () => {
+    const c1 = makeContainer('right-panel')
+    store.registerContainer(c1)
+
+    store.moveTabTo('profile', { kind: 'main-drawer' })
+    store.moveTabTo('connections', { kind: 'container', containerId: 'right-panel' })
+    store.moveTabTo('lorebook', { kind: 'container', containerId: 'nowhere' })
+
+    // Fallback scan
+    for (const [tabId, location] of Object.entries(store.tabLocations)) {
+      if (location.kind !== 'container') continue
+      if (store.containers.some((c) => c.id === location.containerId)) continue
+      store.moveTabTo(tabId, { kind: 'main-drawer' })
+    }
+
+    expect(store.tabLocations.profile).toEqual({ kind: 'main-drawer' })
+    expect(store.tabLocations.connections).toEqual({ kind: 'container', containerId: 'right-panel' })
+    expect(store.tabLocations.lorebook).toEqual({ kind: 'main-drawer' })
+  })
+
+  test('container id matching finds the right container among many', () => {
+    const c1 = makeContainer('a')
+    const c2 = makeContainer('b')
+    const c3 = makeContainer('c')
+    store.registerContainer(c1)
+    store.registerContainer(c2)
+    store.registerContainer(c3)
+
+    store.moveTabTo('tab-x', { kind: 'container', containerId: 'b' })
+
+    // Find matching container
+    const matched = store.containers.find((c) => {
+      const loc = store.tabLocations['tab-x']
+      return loc.kind === 'container' && loc.containerId === c.id
+    })
+
+    expect(matched?.id).toBe('b')
+  })
+})

--- a/frontend/src/store/slices/containers.test.ts
+++ b/frontend/src/store/slices/containers.test.ts
@@ -1,0 +1,83 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { createContainersSlice } from './containers'
+import type { ContainersSlice } from './containers'
+
+// ContainersSlice is a Zustand slice creator. Calling it directly with
+// a mock set/get pair exercises the slice logic without spinning up a
+// real store (and avoids pulling the rest of the app's store graph
+// into the test process).
+
+function makeSlice(): {
+  state: ContainersSlice
+  set: (partial: Partial<ContainersSlice> | ((s: ContainersSlice) => Partial<ContainersSlice>)) => void
+  get: () => ContainersSlice
+} {
+  let state = {} as ContainersSlice
+  const set = (partial: Partial<ContainersSlice> | ((s: ContainersSlice) => Partial<ContainersSlice>)) => {
+    const next = typeof partial === 'function' ? (partial as (s: ContainersSlice) => Partial<ContainersSlice>)(state) : partial
+    state = { ...state, ...next }
+  }
+  const get = () => state
+  Object.assign(state, createContainersSlice(set as any, get as any, {} as any))
+  // `state` is reassigned inside `set`, so the returned object must
+  // expose a live getter rather than a snapshot of the value.
+  return {
+    get state() { return state },
+    set,
+    get,
+  }
+}
+
+function makeEntry(id: string, side: ContainersSlice['containers'][number]['side'] = 'right') {
+  // The slice's container operations don't touch the DOM element, so
+  // a plain object cast to HTMLElement is enough for the test.
+  return { id, side, element: {} as unknown as HTMLElement }
+}
+
+describe('ContainersSlice', () => {
+  test('registerContainer adds a container', () => {
+    const s = makeSlice()
+    s.state.registerContainer(makeEntry('c1'))
+    expect(s.state.containers).toHaveLength(1)
+    expect(s.state.containers[0].id).toBe('c1')
+  })
+
+  test('registerContainer replaces on id collision (idempotent)', () => {
+    const s = makeSlice()
+    s.state.registerContainer(makeEntry('c1', 'right'))
+    s.state.registerContainer(makeEntry('c1', 'left'))
+    expect(s.state.containers).toHaveLength(1)
+    expect(s.state.containers[0].side).toBe('left')
+  })
+
+  test('unregisterContainer removes by id', () => {
+    const s = makeSlice()
+    s.state.registerContainer(makeEntry('c1'))
+    s.state.registerContainer(makeEntry('c2'))
+    s.state.unregisterContainer('c1')
+    expect(s.state.containers).toHaveLength(1)
+    expect(s.state.containers[0].id).toBe('c2')
+  })
+
+  test('unregisterContainer is a no-op for an unknown id', () => {
+    const s = makeSlice()
+    s.state.registerContainer(makeEntry('c1'))
+    s.state.unregisterContainer('nope')
+    expect(s.state.containers).toHaveLength(1)
+  })
+
+  test('getContainer returns the matching entry', () => {
+    const s = makeSlice()
+    const e1 = makeEntry('c1')
+    s.state.registerContainer(e1)
+    expect(s.state.getContainer('c1')).toBe(e1)
+    expect(s.state.getContainer('nope')).toBeUndefined()
+  })
+
+  test('containers is initialized as an empty array', () => {
+    const s = makeSlice()
+    expect(s.state.containers).toEqual([])
+  })
+})

--- a/frontend/src/store/slices/containers.ts
+++ b/frontend/src/store/slices/containers.ts
@@ -1,0 +1,46 @@
+import type { StateCreator } from 'zustand'
+
+/**
+ * Container registration slice — tracks passive DOM containers that can
+ * receive tab roots via `requestTabLocation(tabId, { kind: 'container', containerId })`.
+ *
+ * Any extension or core code can register a container with a stable id
+ * and tabs routed to that id will be reparented into its element.
+ * Tabs whose target id has no registered entry are reset to
+ * `{ kind: 'main-drawer' }` by ContainerTabContent.
+ */
+
+export interface ContainerEntry {
+  id: string
+  side: 'left' | 'right' | 'top' | 'bottom'
+  element: HTMLElement
+}
+
+export interface ContainersSlice {
+  containers: ContainerEntry[]
+  registerContainer(entry: ContainerEntry): void
+  unregisterContainer(id: string): void
+  getContainer(id: string): ContainerEntry | undefined
+}
+
+export const createContainersSlice: StateCreator<ContainersSlice> = (set, get) => ({
+  containers: [],
+
+  registerContainer(entry: ContainerEntry) {
+    set((state) => {
+      // Idempotent: replace on id collision
+      const filtered = state.containers.filter((c) => c.id !== entry.id)
+      return { containers: [...filtered, entry] }
+    })
+  },
+
+  unregisterContainer(id: string) {
+    set((state) => ({
+      containers: state.containers.filter((c) => c.id !== id),
+    }))
+  },
+
+  getContainer(id: string) {
+    return get().containers.find((c) => c.id === id)
+  },
+})

--- a/frontend/src/store/slices/spindle-placement.test.ts
+++ b/frontend/src/store/slices/spindle-placement.test.ts
@@ -1,0 +1,101 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test, beforeEach } from 'bun:test'
+import { createSpindlePlacementSlice } from './spindle-placement'
+import type { SpindlePlacementSlice } from '@/types/store'
+
+// SpindlePlacementSlice is a Zustand slice creator. Calling it with a
+// mock set/get pair exercises the slice logic without spinning up a
+// real store. The slice's module-level loadHiddenPlacements() reads
+// localStorage at import time; if it's missing in the test runtime
+// the try/catch returns []. If present, we clear it in beforeEach
+// for isolation.
+
+function makeSlice(): {
+  state: SpindlePlacementSlice
+  set: (partial: SpindlePlacementSlice | ((s: SpindlePlacementSlice) => SpindlePlacementSlice | Partial<SpindlePlacementSlice>)) => void
+  get: () => SpindlePlacementSlice
+} {
+  let state = {} as SpindlePlacementSlice
+  const set = (partial: any) => {
+    const next = typeof partial === 'function' ? partial(state) : partial
+    state = { ...state, ...next }
+  }
+  const get = () => state
+  Object.assign(state, createSpindlePlacementSlice(set as any, get as any, {} as any))
+  // `state` is reassigned inside `set`, so the returned object must
+  // expose a live getter rather than a snapshot of the value.
+  return {
+    get state() { return state },
+    set,
+    get,
+  }
+}
+
+describe('moveTabTo / clearPendingActiveTabReset', () => {
+  let slice: ReturnType<typeof makeSlice>
+  beforeEach(() => {
+    if (typeof localStorage !== 'undefined') {
+      try { localStorage.clear() } catch { /* no-op */ }
+    }
+    slice = makeSlice()
+  })
+
+  test('moveTabTo updates tabLocations', () => {
+    slice.state.moveTabTo('profile', { kind: 'container', containerId: 'secondary-drawer' })
+    expect(slice.state.tabLocations.profile).toEqual({ kind: 'container', containerId: 'secondary-drawer' })
+  })
+
+  test('moveTabTo sets pendingActiveTabReset when target is not main-drawer', () => {
+    slice.state.moveTabTo('profile', { kind: 'container', containerId: 'secondary-drawer' })
+    expect(slice.state.pendingActiveTabReset).toBe('profile')
+  })
+
+  test('moveTabTo does NOT set pendingActiveTabReset when target is main-drawer', () => {
+    slice.state.moveTabTo('profile', { kind: 'main-drawer' })
+    expect(slice.state.pendingActiveTabReset).toBeNull()
+  })
+
+  test('pendingActiveTabReset is preserved when moving another tab back to main-drawer', () => {
+    slice.state.moveTabTo('profile', { kind: 'container', containerId: 'secondary-drawer' })
+    slice.state.moveTabTo('connections', { kind: 'main-drawer' })
+    // The "main-drawer" branch intentionally does not clear the
+    // existing pending reset — that's the caller's job via
+    // clearPendingActiveTabReset, which ViewportDrawer invokes after
+    // picking the fallback tab.
+    expect(slice.state.pendingActiveTabReset).toBe('profile')
+  })
+
+  test('clearPendingActiveTabReset clears the field', () => {
+    slice.state.moveTabTo('profile', { kind: 'container', containerId: 'secondary-drawer' })
+    expect(slice.state.pendingActiveTabReset).toBe('profile')
+    slice.state.clearPendingActiveTabReset()
+    expect(slice.state.pendingActiveTabReset).toBeNull()
+  })
+
+  test('tabLocations accumulates across multiple moves', () => {
+    slice.state.moveTabTo('profile', { kind: 'container', containerId: 'secondary-drawer' })
+    slice.state.moveTabTo('connections', { kind: 'container', containerId: 'secondary-drawer' })
+    expect(slice.state.tabLocations).toEqual({
+      profile: { kind: 'container', containerId: 'secondary-drawer' },
+      connections: { kind: 'container', containerId: 'secondary-drawer' },
+    })
+  })
+
+  test('moveTabTo overwrites a previous location for the same tab', () => {
+    slice.state.moveTabTo('profile', { kind: 'container', containerId: 'secondary-drawer' })
+    slice.state.moveTabTo('profile', { kind: 'main-drawer' })
+    expect(slice.state.tabLocations.profile).toEqual({ kind: 'main-drawer' })
+  })
+
+  test('initial state has empty tabLocations and null pendingActiveTabReset', () => {
+    expect(slice.state.tabLocations).toEqual({})
+    expect(slice.state.pendingActiveTabReset).toBeNull()
+  })
+
+  test('moveTabTo with container kind sets pendingActiveTabReset and the value object', () => {
+    slice.state.moveTabTo('profile', { kind: 'container', containerId: 'x' })
+    expect(slice.state.tabLocations.profile).toEqual({ kind: 'container', containerId: 'x' })
+    expect(slice.state.pendingActiveTabReset).toBe('profile')
+  })
+})

--- a/frontend/src/store/slices/spindle-placement.ts
+++ b/frontend/src/store/slices/spindle-placement.ts
@@ -1,6 +1,7 @@
 import type { StateCreator } from 'zustand'
 import type { SpindlePlacementSlice } from '@/types/store'
 import type { SpindleDockEdge } from 'lumiverse-spindle-types'
+import type { TabLocation } from '@/lib/spindle/tab-mobility-types'
 
 // ── Capacity limits ──
 
@@ -127,6 +128,10 @@ export const createSpindlePlacementSlice: StateCreator<SpindlePlacementSlice> = 
   inputBarActions: [],
   extensionCommands: [],
   hiddenPlacements: loadHiddenPlacements(),
+
+  // ── Tab Mobility ──
+  tabLocations: {},
+  pendingActiveTabReset: null,
 
   // ── Drawer Tabs ──
 
@@ -339,4 +344,22 @@ export const createSpindlePlacementSlice: StateCreator<SpindlePlacementSlice> = 
     saveHiddenPlacements(allIds)
     set({ hiddenPlacements: allIds })
   },
+
+  // ── Tab Mobility Actions ──
+
+  moveTabTo: (tabId: string, location: TabLocation) => {
+    set((state) => {
+      const next = { ...state.tabLocations, [tabId]: location }
+
+      // Signal ViewportDrawer to reset active tab when the moved tab leaves main-drawer
+      let pendingActiveTabReset = state.pendingActiveTabReset
+      if (location.kind !== 'main-drawer') {
+        pendingActiveTabReset = tabId
+      }
+
+      return { tabLocations: next, pendingActiveTabReset }
+    })
+  },
+
+  clearPendingActiveTabReset: () => set({ pendingActiveTabReset: null }),
 })

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -1051,6 +1051,7 @@ import type {
   InputBarActionState,
   ExtensionCommandState,
 } from '@/store/slices/spindle-placement'
+import type { TabLocation } from '@/lib/spindle/tab-mobility-types'
 
 export interface SpindlePlacementSlice {
   drawerTabs: DrawerTabState[]
@@ -1060,6 +1061,11 @@ export interface SpindlePlacementSlice {
   inputBarActions: InputBarActionState[]
   extensionCommands: ExtensionCommandState[]
   hiddenPlacements: string[]
+
+  // ── Tab Mobility ──
+  tabLocations: Record<string, TabLocation>
+  /** When set, ViewportDrawer resets main-drawer activeTab to this value then nulls it. */
+  pendingActiveTabReset: string | null
 
   registerDrawerTab: (tab: DrawerTabState) => void
   unregisterDrawerTab: (tabId: string) => void
@@ -1089,6 +1095,10 @@ export interface SpindlePlacementSlice {
   setPlacementHidden: (placementId: string, hidden: boolean) => void
   showAllPlacements: () => void
   hideAllPlacements: () => void
+
+  // ── Tab Mobility Actions ──
+  moveTabTo: (tabId: string, location: TabLocation) => void
+  clearPendingActiveTabReset: () => void
 }
 
 // ---- Prompt Breakdown Slice ----
@@ -1391,6 +1401,8 @@ export interface DatabankSlice {
 }
 
 // ---- Combined Store ----
+import type { ContainerEntry, ContainersSlice } from '@/store/slices/containers'
+
 export interface WeaverSlice {
   weaverSessions: WeaverSession[]
   activeWeaverSessionId: string | null
@@ -1500,4 +1512,5 @@ export type AppStore = ChatSlice &
   FloatingAvatarSlice &
   ChatHeadsSlice &
   DatabankSlice &
-  ConnectionSlice
+  ConnectionSlice &
+  ContainersSlice


### PR DESCRIPTION
Companion PR: [lumiverse-spindle-types: feat - tab mobility + containers API](https://github.com/prolix-oc/lumiverse-spindle-types/pull/25)

Adds built-in drawer tab mobility — extensions can move any built-in or
extension-contributed drawer tab (Profile, Connections, etc.) into a registered DOM container and back, with automatic fallback if the container disappears.

### Register a container

Any extension or core code can register a DOM element as a tab target:

```ts
ctx.containers.registerContainer({
  id: "canvas-secondary",
  side: "right",
  element: drawerElement,
})
```

### Move tabs into it

```ts
ctx.ui.requestTabLocation("connections", {
  kind: "container",
  containerId: "canvas-secondary",
})
```

The tab's DOM root is reparented from the main sidebar drawer into the
registered container element. The main sidebar automatically hides the tab's slot.

### Move tabs back

```ts
ctx.ui.requestTabLocation("connections", { kind: "main-drawer" })
```

### Query current location

```ts
const loc = ctx.ui.getTabLocation("connections")
// { kind: "main-drawer" } | { kind: "container", containerId: "..." }
```

### Automatic fallback

If a tab is routed to a container that isn't registered (or gets unregistered),
the system automatically resets it to the main drawer so it stays visible.

### Authorization

`requestTabLocation` requires the `app_manipulation` permission. Extensions can
move their own tabs or any of the 9 core drawer tabs (`profile`, `presets`,
`loom`, `characters`, `personas`, `branches`, `spindle`, `theme`, `lorebook`).
Other-extension tabs are denied.

### Architecture

| Component               | Role                                                                                       |
| ----------------------- | ------------------------------------------------------------------------------------------ |
| `containers` slice      | Tracks registered `{ id, side, element }` entries in the Zustand store                      |
| `ContainerTabContent`   | Effect-driven React component that reparents tab roots and resets orphaned tabs             |
| `TabPanelContent`       | Renders the main-drawer tab panel; clears itself when the tab's location changes away       |
| `tab-dispatch.ts`       | Pure authorization check — gates `requestTabLocation` by tab ownership and core id allowlist |
| `tab-mobility-types.ts` | Local type bridge (module augmentation) until `lumiverse-spindle-types` ^0.5.24 is published |
| `getExtensionBackend`   | `window.spindle.ui` bridge — returns a target extension's `sendToBackend`/`onBackendMessage` for canvas's secondary-drawer re-executor |

### `getExtensionBackend` (canvas re-executor support)

When canvas moves an extension tab into the secondary drawer, it re-executes the extension bundle with a wrapper context. The bundle's `setup(ctx)` calls `ctx.sendToBackend(...)` and `ctx.onBackendMessage(...)` — and Lumiverse's `sendToBackend` closure captures the `extensionId` of the context it was created for. 

Without a way to obtain the *target* extension's bus, those methods would inherit canvas_ext's own, and the re-executed extension's `ready`/`get_state` messages would be tagged with canvas_ext's `extensionId`, routed to canvas_ext's worker (which doesn't know the target's protocol), and the target's worker would never respond. Result: the secondary tab's content area stayed stuck on "Loading..." or empty.

`getExtensionBackend(extensionId)` closes that gap:

```ts
const backend = window.spindle.ui.getExtensionBackend(extensionId)
if (backend) {
  buildCanvasSecondaryCtx(primaryCtx, extensionId, backend, onActivate)
}
```

It returns the target's `sendToBackend` (which closes over the target's
`extensionId`) and `onBackendMessage` (which registers on the target's
`backendHandlers` Set), or `null` if the extension isn't loaded. This is a
system-level bridge API — no permission gating — intended for canvas_ext and other host-level re-execution paths.

### Tests

| File                        | Tests | Coverage                                        |
| --------------------------- | ----- | ----------------------------------------------- |
| `spindle-placement.test.ts` | 9     | `moveTabTo`, `pendingActiveTabReset`, shape     |
| `container-dispatch.test.ts`| 6     | Per-container routing, fallback, unregister      |
| `tab-dispatch.test.ts`      | 8     | Dispatch authorization (core, own, deny)         |
| `containers.test.ts`        | 6     | Container CRUD, idempotent register              |

29 tests in this repo, all passing. `getExtensionBackend` is a thin lookup
against `loadedExtensions` — its correctness is exercised end-to-end by
canvas_ext's `secondary-ctx.test.ts` (T18–T20 cover target bus routing,
handler registration, and primary fallback), which fail loudly if the bridge returns a wrong bus.

### Dependency

Requires `lumiverse-spindle-types` ^0.5.24 for the discriminated
`SpindleTabLocation` type and the `containers` context property. Until
published, `tab-mobility-types.ts` provides the types via module augmentation.

`getExtensionBackend` does not require a types-package change — callers use the returned functions through the same `(payload: unknown) => void` shape they already accept.
