### PR TITLE
feat(tts): add Cartesia provider

### DIFF
--- a/frontend/src/api/tts.ts
+++ b/frontend/src/api/tts.ts
@@ -32,18 +32,20 @@ export const ttsApi = {
   async synthesizeStream(
     connectionId: string,
     text: string,
-    options?: { voice?: string; model?: string; speed?: number }
+    options?: { voice?: string; model?: string; speed?: number; outputFormat?: string; signal?: AbortSignal }
   ): Promise<Response> {
     return fetch(`${BASE_URL}/tts/synthesize/stream`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
+      signal: options?.signal,
       body: JSON.stringify({
         connectionId,
         text,
         voice: options?.voice,
         model: options?.model,
         parameters: options?.speed != null ? { speed: options.speed } : undefined,
+        outputFormat: options?.outputFormat,
       }),
     })
   },

--- a/frontend/src/components/shared/providerVisuals.ts
+++ b/frontend/src/components/shared/providerVisuals.ts
@@ -17,6 +17,7 @@ export const PROVIDER_COLORS: Record<string, string> = {
   openai_tts: '#10a37f',
   elevenlabs: '#8b5cf6',
   kokoro: '#f59e0b',
+  cartesia: '#5046e5',
   // fallback
   custom: 'var(--lumiverse-text-dim)',
 }

--- a/src/routes/tts.routes.ts
+++ b/src/routes/tts.routes.ts
@@ -5,6 +5,7 @@ import * as audioSvc from "../services/audio.service";
 import * as muxSvc from "../services/audio-mux.service";
 import * as chatsSvc from "../services/chats.service";
 import { clampErrorMessage, describeProviderError } from "../utils/provider-errors";
+import { contentTypeForFormat } from "../utils/audio-content-type";
 
 const app = new Hono();
 
@@ -84,9 +85,10 @@ app.post("/synthesize/stream", async (c) => {
       },
     });
 
+    // Derive from request so non-MP3 streams (Cartesia wav/raw, OpenRouter pcm) play in browsers.
     return new Response(stream, {
       headers: {
-        "Content-Type": "audio/mpeg",
+        "Content-Type": contentTypeForFormat(body.outputFormat),
         "Transfer-Encoding": "chunked",
         "Content-Disposition": "inline",
       },

--- a/src/tts/index.ts
+++ b/src/tts/index.ts
@@ -3,7 +3,9 @@ import { OpenAITtsProvider } from "./providers/openai-tts";
 import { ElevenLabsTtsProvider } from "./providers/elevenlabs";
 import { KokoroTtsProvider } from "./providers/kokoro";
 import { OpenRouterTtsProvider } from "./providers/openrouter-tts";
+import { CartesiaTtsProvider } from "./providers/cartesia";
 
+registerTtsProvider(new CartesiaTtsProvider());
 registerTtsProvider(new OpenAITtsProvider());
 registerTtsProvider(new ElevenLabsTtsProvider());
 registerTtsProvider(new KokoroTtsProvider());

--- a/src/tts/providers/cartesia.ts
+++ b/src/tts/providers/cartesia.ts
@@ -1,0 +1,244 @@
+import type { TtsProvider } from "../provider";
+import type { TtsProviderCapabilities } from "../param-schema";
+import type { TtsRequest, TtsResponse, TtsStreamChunk, TtsVoice } from "../types";
+import { fetchProviderJson, ProviderRequestError, throwProviderResponseError } from "../../utils/provider-errors";
+
+const CARTESIA_API_VERSION = "2026-03-01";
+const CARTESIA_DEFAULT_SAMPLE_RATE = 22050;
+const CARTESIA_DEFAULT_MP3_BITRATE = 128000;
+const VOICES_PAGE_SIZE = 100;
+const MAX_VOICE_PAGES = 50;
+
+type OutputFormatContainer = "mp3" | "wav" | "raw";
+
+export class CartesiaTtsProvider implements TtsProvider {
+  readonly name = "cartesia";
+  readonly displayName = "Cartesia";
+
+  readonly capabilities: TtsProviderCapabilities = {
+    parameters: {
+      output_format: {
+        type: "select",
+        default: "mp3",
+        description: "Audio container for streamed output (MP3 is browser-friendly; WAV/PCM for downstream processing)",
+        options: [
+          { id: "mp3", label: "MP3 (browser-friendly)" },
+          { id: "wav", label: "WAV (PCM s16le, 22.05 kHz)" },
+          { id: "raw", label: "Raw PCM s16le, 22.05 kHz" },
+        ],
+      },
+      language: {
+        type: "string",
+        description: "ISO 639-1 language code (e.g. en, fr, ja, zh) — forces a specific accent",
+        group: "advanced",
+      },
+      volume: {
+        type: "number",
+        default: 1.0,
+        min: 0.5,
+        max: 2.0,
+        step: 0.05,
+        description: "Playback volume multiplier",
+        group: "advanced",
+      },
+      speed: {
+        type: "number",
+        default: 1.0,
+        min: 0.6,
+        max: 1.5,
+        step: 0.05,
+        description: "Playback speed multiplier",
+        group: "advanced",
+      },
+      emotion: {
+        // string, not select — Cartesia supports 50+ emotions. A dropdown would be
+        // unusable; a curated hint in the description preserves the full surface area
+        // for users who edit default_parameters metadata directly.
+        type: "string",
+        description: "Emotion guide (e.g. neutral, happy, sad, calm, angry, scared). sonic-3+ only — see Cartesia docs for the full list of 50+ emotions.",
+        group: "advanced",
+      },
+    },
+    apiKeyRequired: true,
+    voiceListStyle: "dynamic",
+    modelListStyle: "static",
+    staticModels: [
+      { id: "sonic-3.5", label: "Sonic 3.5 (Recommended)" },
+      { id: "sonic-3", label: "Sonic 3 (Stable)" },
+      { id: "sonic-latest", label: "Sonic Latest (Beta — may change without notice)" },
+    ],
+    supportsStreaming: true,
+    supportedFormats: ["mp3", "wav", "raw"],
+    defaultUrl: "https://api.cartesia.ai",
+    defaultFormat: "mp3",
+  };
+
+  private baseUrl(apiUrl: string): string {
+    return (apiUrl || this.capabilities.defaultUrl).replace(/\/+$/, "");
+  }
+
+  // use a switch with no default — TS exhaustiveness check enforces every
+  // container is handled and rejects drift when OutputFormatContainer grows.
+  private buildOutputFormat(container: OutputFormatContainer): Record<string, any> {
+    switch (container) {
+      case "mp3":
+        return { container: "mp3", sample_rate: CARTESIA_DEFAULT_SAMPLE_RATE, bit_rate: CARTESIA_DEFAULT_MP3_BITRATE };
+      case "wav":
+        return { container: "wav", encoding: "pcm_s16le", sample_rate: CARTESIA_DEFAULT_SAMPLE_RATE };
+      case "raw":
+        return { container: "raw", encoding: "pcm_s16le", sample_rate: CARTESIA_DEFAULT_SAMPLE_RATE };
+    }
+  }
+
+  private headers(apiKey: string): Record<string, string> {
+    // Cartesia-Version is required by the Cartesia API. It's a dated snapshot
+    // pin — bump via code change when adopting a newer version.
+    return {
+      Authorization: `Bearer ${apiKey}`,
+      "Cartesia-Version": CARTESIA_API_VERSION,
+      "Content-Type": "application/json",
+    };
+  }
+
+  private buildBody(request: TtsRequest): Record<string, any> {
+    const p = request.parameters;
+    const container: OutputFormatContainer = p.output_format || "mp3";
+    const body: Record<string, any> = {
+      model_id: request.model,
+      transcript: request.text,
+      voice: { mode: "id", id: request.voice },
+      output_format: this.buildOutputFormat(container),
+    };
+    if (p.language) body.language = p.language;
+
+    // generation_config is only supported on sonic-3+. Omit when all values
+    // are defaults so we don't trigger model-version errors on older snapshots,
+    // and so non-generation_config requests stay minimal.
+    const hasGenConfig =
+      (p.volume != null && p.volume !== 1.0) ||
+      (p.speed != null && p.speed !== 1.0) ||
+      !!p.emotion;
+    if (hasGenConfig) {
+      body.generation_config = {
+        ...(p.volume != null && p.volume !== 1.0 ? { volume: p.volume } : {}),
+        ...(p.speed != null && p.speed !== 1.0 ? { speed: p.speed } : {}),
+        ...(p.emotion ? { emotion: p.emotion } : {}),
+      };
+    }
+    return body;
+  }
+
+  async synthesize(apiKey: string, apiUrl: string, request: TtsRequest): Promise<TtsResponse> {
+    const base = this.baseUrl(apiUrl);
+    const body = this.buildBody(request);
+
+    const res = await fetch(`${base}/tts/bytes`, {
+      method: "POST",
+      headers: this.headers(apiKey),
+      body: JSON.stringify(body),
+      signal: request.signal,
+    });
+
+    if (!res.ok) await throwProviderResponseError(this.displayName, "tts synthesize", res);
+
+    const audioData = await res.arrayBuffer();
+    const contentType = res.headers.get("content-type") || "audio/mpeg";
+
+    return {
+      audioData,
+      contentType,
+      model: request.model,
+      provider: this.name,
+    };
+  }
+
+  async *synthesizeStream(
+    apiKey: string,
+    apiUrl: string,
+    request: TtsRequest
+  ): AsyncGenerator<TtsStreamChunk, void, unknown> {
+    const base = this.baseUrl(apiUrl);
+    const body = this.buildBody(request);
+
+    const res = await fetch(`${base}/tts/bytes`, {
+      method: "POST",
+      headers: this.headers(apiKey),
+      body: JSON.stringify(body),
+      signal: request.signal,
+    });
+
+    if (!res.ok) await throwProviderResponseError(this.displayName, "tts stream", res);
+
+    if (!res.body) {
+      throw new Error("Cartesia: no response body for streaming");
+    }
+
+    const reader = res.body.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          yield { data: new Uint8Array(0), done: true };
+          break;
+        }
+        yield { data: value, done: false };
+      }
+    } finally {
+      reader.cancel().catch(() => {});
+    }
+  }
+
+  async validateKey(apiKey: string, apiUrl: string): Promise<boolean> {
+    // Cartesia has no dedicated auth probe; /voices is the cheapest auth-required
+    // endpoint. limit=1 minimizes the response size.
+    try {
+      const res = await fetch(`${this.baseUrl(apiUrl)}/voices?limit=1`, { headers: this.headers(apiKey) });
+      if (!res.ok) await throwProviderResponseError(this.displayName, "authentication", res);
+      return true;
+    } catch (err) {
+      if (err instanceof ProviderRequestError) throw err;
+      throw new ProviderRequestError({
+        provider: this.displayName,
+        operation: "authentication",
+        detail: err instanceof Error ? err.message : "network request failed",
+        retryable: true,
+      });
+    }
+  }
+
+  async listModels(_apiKey: string, _apiUrl: string): Promise<Array<{ id: string; label: string }>> {
+    return this.capabilities.staticModels || [];
+  }
+
+  async listVoices(apiKey: string, apiUrl: string): Promise<TtsVoice[]> {
+    // Cursor pagination — first paginated voice fetch in this codebase.
+    // Cartesia returns { data: Voice[], has_more: boolean, next_page: string | null }.
+    const collected: TtsVoice[] = [];
+    let starting_after: string | undefined;
+    let pages = 0;
+    while (pages++ < MAX_VOICE_PAGES) {
+      const qs = new URLSearchParams({ limit: String(VOICES_PAGE_SIZE) });
+      if (starting_after) qs.set("starting_after", starting_after);
+      const data = await fetchProviderJson<any>(this.displayName, "voice listing", `${this.baseUrl(apiUrl)}/voices?${qs}`, {
+        headers: this.headers(apiKey),
+      });
+      for (const v of data.data || []) {
+        collected.push({
+          id: v.id,
+          name: v.name,
+          language: v.language,
+          // Map Cartesia's masculine|feminine|gender_neutral to Lumiverse's
+          // male|female|neutral convention (matches Kokoro's storage).
+          gender:
+            v.gender === "masculine" ? "male"
+            : v.gender === "feminine" ? "female"
+            : v.gender === "gender_neutral" ? "neutral"
+            : undefined,
+        });
+      }
+      if (!data.has_more || !data.next_page) break;
+      starting_after = data.next_page;
+    }
+    return collected;
+  }
+}

--- a/src/utils/audio-content-type.ts
+++ b/src/utils/audio-content-type.ts
@@ -1,0 +1,17 @@
+/**
+ * Derive the HTTP Content-Type for a TTS audio stream from the client's
+ * requested output format. Falls back to audio/mpeg for mp3 and any
+ * unrecognised value.
+ */
+export function contentTypeForFormat(format?: string | null): string {
+  switch (format) {
+    case "wav":
+      return "audio/wav";
+    case "raw":
+    case "pcm":
+      return "audio/pcm";
+    case "mp3":
+    default:
+      return "audio/mpeg";
+  }
+}


### PR DESCRIPTION
## What's in this PR

Adds Cartesia as a fifth TTS provider alongside OpenAI, ElevenLabs, Kokoro, and OpenRouter. Uses the `/tts/bytes` endpoint for raw chunked audio, matching the existing 4-provider streaming pattern (no SSE parser or base64 decode needed). Supports Sonic 3.5, Sonic 3, and Sonic Latest models with cursor-paginated voice listing, `generation_config` for volume/speed/emotion on sonic-3+, and exhaustively-typed output format mapping (MP3/WAV/PCM).

Also fixes a pre-existing latent bug where the streaming route hardcoded `Content-Type: audio/mpeg`, which would have broken WAV/raw PCM playback for any provider that supports those formats. The fix is shipped as a separate commit in this PR.

## Files changed

Source-only (6 files, +268/−2, no `dist/` or `bun.lock`):

- `src/tts/providers/cartesia.ts` — new Cartesia provider (~240 LOC)
- `src/utils/audio-content-type.ts` — new `contentTypeForFormat()` helper (~15 LOC)
- `src/tts/index.ts` — register Cartesia (+2 lines)
- `src/routes/tts.routes.ts` — use `contentTypeForFormat` instead of hardcoded `audio/mpeg` (1 line)
- `frontend/src/api/tts.ts` — add `outputFormat` and `signal` to `synthesizeStream` options (~3 lines)
- `frontend/src/components/shared/providerVisuals.ts` — add `cartesia: '#5046e5'` (+1 line)

## Conventions

- Two commits: `fix(tts): derive stream Content-Type from output format` + `feat(tts): add Cartesia provider`
- No `Co-Authored-By` trailer
- No tests added (no TTS test precedent in `tests/`; provider follows established patterns from ElevenLabs/Kokoro)
- Source-only commit; `dist/` rebuilt by CI
- Zero new dependencies
- Backend TypeScript typecheck passes (`tsc --noEmit` clean)
- Frontend build has a pre-existing CodeMirror type mismatch in `CSSEditor.tsx` (unrelated to this PR)

## Deferred

- `/tts/sse` with word/phoneme timestamps — defer until word-level alignment is a concrete UX requirement
- Per-connection `Cartesia-Version` override — defer until pinning becomes a real use case
- TTS unit tests — no precedent in `tests/`, out of scope for a single-provider addition
- README/docs updates — TTS providers aren't enumerated in `README.md`; nothing to update
- Adding `openrouter_tts` to `providerVisuals.ts` — pre-existing gap (registered provider with no color entry); trivial follow-up