### PR TITLE
feat: add memory regex placement to strip content at memory ingestion

### DIFF
--- a/developer-docs/docs/backend-api/regex-scripts.md
+++ b/developer-docs/docs/backend-api/regex-scripts.md
@@ -124,7 +124,7 @@ Same fields as `RegexScriptCreateDTO`, all optional.
   find_regex: string
   replace_string: string
   flags: string                 // any subset of "dgimsuvy" (full JS regex flag set)
-  placement: ("user_input" | "ai_output" | "world_info" | "reasoning")[]
+  placement: ("user_input" | "ai_output" | "world_info" | "reasoning" | "memory")[]
   scope: "global" | "character" | "chat"
   scope_id: string | null       // character ID or chat ID when scoped
   target: "prompt" | "response" | "display"

--- a/frontend/src/components/modals/RegexEditorModal.tsx
+++ b/frontend/src/components/modals/RegexEditorModal.tsx
@@ -415,6 +415,7 @@ export default function RegexEditorModal() {
                       { p: 'ai_output' as const, label: tr('placementAi') },
                       { p: 'world_info' as const, label: tr('placementWi') },
                       { p: 'reasoning' as const, label: tr('placementReasoning') },
+                      { p: 'memory' as const, label: tr('placementMemory') },
                     ]).map(({ p, label }) => (
                       <button
                         key={p}

--- a/frontend/src/components/panels/RegexPanel.tsx
+++ b/frontend/src/components/panels/RegexPanel.tsx
@@ -964,6 +964,7 @@ function ScriptRow({
                   { p: 'ai_output' as const, label: t('regexPanel.targetAi') },
                   { p: 'world_info' as const, label: t('regexPanel.targetWi') },
                   { p: 'reasoning' as const, label: t('regexPanel.targetCot') },
+                  { p: 'memory' as const, label: t('regexPanel.targetMemory') },
                 ]).map(({ p, label }) => (
                   <label key={p} className={styles.flagCheck}>
                     <input

--- a/frontend/src/i18n/locales/en/modals.json
+++ b/frontend/src/i18n/locales/en/modals.json
@@ -649,6 +649,7 @@
     "placementAi": "AI",
     "placementReasoning": "CoT",
     "placementWi": "WI",
+    "placementMemory": "Memory",
     "macroNone": "None",
     "macroRaw": "Raw",
     "macroEscaped": "Escaped",

--- a/frontend/src/i18n/locales/en/panels.json
+++ b/frontend/src/i18n/locales/en/panels.json
@@ -768,6 +768,7 @@
     "targetAi": "AI",
     "targetWi": "WI",
     "targetCot": "CoT",
+    "targetMemory": "Memory",
     "allOptions": "All options..."
   },
   "personaEditor": {

--- a/frontend/src/types/regex.ts
+++ b/frontend/src/types/regex.ts
@@ -1,4 +1,4 @@
-export type RegexPlacement = 'user_input' | 'ai_output' | 'world_info' | 'reasoning'
+export type RegexPlacement = 'user_input' | 'ai_output' | 'world_info' | 'reasoning' | 'memory'
 export type RegexScope = 'global' | 'character' | 'chat'
 export type RegexTarget = 'prompt' | 'response' | 'display'
 export type RegexMacroMode = 'none' | 'raw' | 'escaped' | 'after'

--- a/src/services/chats.service.ts
+++ b/src/services/chats.service.ts
@@ -13,6 +13,7 @@ import { paginatedQuery } from "./pagination";
 import * as embeddingsSvc from "./embeddings.service";
 import * as audioSvc from "./audio.service";
 import * as memoryCortex from "./memory-cortex";
+import * as regexScriptsSvc from "./regex-scripts.service";
 import { removePoolEntriesForChat } from "./generation-pool.service";
 import { invalidateChatMemoryCache, scheduleChatMemoryRefresh } from "./chat-memory-cache.service";
 import { enqueueChatPipelineTask } from "./chat-pipeline-coordinator.service";
@@ -2848,9 +2849,20 @@ async function updateChatChunks(userId: string, chatId: string, newMessage: Mess
   const cfg = await embeddingsSvc.getEmbeddingConfig(userId);
   if (!cfg.enabled || !cfg.vectorize_chat_messages) return;
 
+  const chat = getChat(userId, chatId);
+  const characterId = chat?.character_id ?? null;
+
+  // Strip "memory"-placement scripts before vectorizing; only this copy is
+  // stripped, the stored message row stays intact for display.
+  const memStripped = await regexScriptsSvc.applyMemoryIngestionRegex(
+    userId,
+    newMessage.content,
+    { characterId, chatId },
+  );
+
   const reasoningStrip = getReasoningStripOptions(userId);
-  const env = contentHasMacroHints(newMessage.content) ? buildMacroEnvForChat(userId, chatId) : null;
-  const sanitizedContent = await resolveAndSanitizeForVectorization(newMessage.content, env, reasoningStrip);
+  const env = contentHasMacroHints(memStripped) ? buildMacroEnvForChat(userId, chatId) : null;
+  const sanitizedContent = await resolveAndSanitizeForVectorization(memStripped, env, reasoningStrip);
   const lastChunk = getLastChatChunk(chatId);
   let chunkId: string;
 
@@ -2874,7 +2886,6 @@ async function updateChatChunks(userId: string, chatId: string, newMessage: Mess
       const cortexConfig = memoryCortex.getCortexConfig(userId);
       if (!cortexConfig.enabled) return;
 
-      const chat = getChat(userId, chatId);
       const characterNames: string[] = [];
       const aliasMaps: Map<string, string>[] = [];
       if (chat) {
@@ -2948,6 +2959,7 @@ async function updateChatChunks(userId: string, chatId: string, newMessage: Mess
         chunkId: chunk.id,
         chatId,
         userId,
+        characterId,
         content: chunk.content,
         messageIds: JSON.parse(chunk.message_ids || "[]"),
         startMessageIndex: 0,
@@ -3268,11 +3280,18 @@ async function chunkAndPersistMessages(
 
   const targetTokens = chatMemSettings.chunkTargetTokens;
   const reasoningStrip = getReasoningStripOptions(userId);
+  // Memory strip on rebuild too, else re-chunking raw messages bypasses it.
+  // Scripts fetched once for the whole chat.
+  const characterId = getChat(userId, chatId)?.character_id;
+  const memoryScripts = regexScriptsSvc.getActiveMemoryScripts(userId, { characterId, chatId });
   const anyMessageHasMacros = messages.some((m) => contentHasMacroHints(m.content));
   const env = anyMessageHasMacros ? buildMacroEnvForChat(userId, chatId) : null;
   const sanitizedByMsgId = new Map<string, string>();
   for (const msg of messages) {
-    sanitizedByMsgId.set(msg.id, await resolveAndSanitizeForVectorization(msg.content, env, reasoningStrip));
+    const memStripped = memoryScripts.length > 0
+      ? await regexScriptsSvc.applyRegexScripts(msg.content, memoryScripts, "memory", undefined, undefined, undefined, { source: "prompt_backend" })
+      : msg.content;
+    sanitizedByMsgId.set(msg.id, await resolveAndSanitizeForVectorization(memStripped, env, reasoningStrip));
   }
 
   let currentChunk: Message[] = [];

--- a/src/services/memory-cortex/index.ts
+++ b/src/services/memory-cortex/index.ts
@@ -43,6 +43,7 @@ import { processChunkFontColors, formatColorMapForPrompt, deleteColorMapForChat,
 import { extractRelationshipsHeuristic } from "./relationship-extractor";
 import { extractNPsFromChunk } from "./np-chunker";
 import { stripNonProseTags } from "../../utils/content-sanitizer";
+import * as regexScriptsSvc from "../regex-scripts.service";
 import { getLinkedCortexData, reindexVault, getVaultRow } from "./vault";
 import { eventBus } from "../../ws/bus";
 import { EventType } from "../../ws/events";
@@ -1090,7 +1091,14 @@ export async function processChunk(
     let sidecarDiscoveredAliases: Array<{ canonicalName: string; alias: string; evidence?: string }> = [];
     let sidecarGrading: import("./types").SidecarGradedHeuristics | undefined;
 
-    const rawChunkContent = hydrateChunkContentFromMessages(data.messageIds, data.content);
+    const hydratedChunkContent = hydrateChunkContentFromMessages(data.messageIds, data.content);
+    // Cortex re-hydrates raw messages rather than reusing the sanitized vector
+    // chunk, so the memory strip must run on this path too.
+    const rawChunkContent = await regexScriptsSvc.applyMemoryIngestionRegex(
+      data.userId,
+      hydratedChunkContent,
+      { characterId: data.characterId, chatId: data.chatId },
+    );
     // Strip non-prose markup (HTML, <details>, <lumia_ooc>, scaffold blocks,
     // user-defined HUD tags, etc.) before any evaluator sees the chunk —
     // keeps font tags so attribution still works.
@@ -1868,6 +1876,10 @@ export async function rebuildCortex(
     throw signal.reason ?? new DOMException("Cortex rebuild aborted", "AbortError");
   }
   const db = getDb();
+  // Character scope for memory-strip scripts; matches the live ingestion path.
+  const characterId = (db
+    .query("SELECT character_id FROM chats WHERE id = ?")
+    .get(chatId) as { character_id: string | null } | undefined)?.character_id ?? null;
 
   console.info(
     `[memory-cortex] ${resumable ? "Warming" : "Rebuilding"} cortex for chat ${chatId} (sidecar: ${sidecarAvailable ? "yes" : "heuristic only"})`,
@@ -1935,6 +1947,7 @@ export async function rebuildCortex(
           chunks[i],
           chatId,
           userId,
+          characterId,
           characterNames,
           sidecarAvailable ? generateRawFn : undefined,
           sidecarAvailable ? sidecarConnectionId : undefined,
@@ -2127,15 +2140,15 @@ export async function rebuildCortex(
               const sidecarResult = sidecarResults[i];
               if (sidecarResult) {
                 await processChunkWithPrecomputedSidecar(
-                  chunk, chatId, userId, characterNames, sidecarResult, descriptionAliases,
+                  chunk, chatId, userId, characterId, characterNames, sidecarResult, descriptionAliases,
                   perChunkHeuristic[i] ?? undefined,
                 );
               } else {
-                await processChunkFromRaw(chunk, chatId, userId, characterNames, undefined, undefined, descriptionAliases);
+                await processChunkFromRaw(chunk, chatId, userId, characterId, characterNames, undefined, undefined, descriptionAliases);
               }
             } catch {
               // fall back to heuristic on ingest failure
-              await processChunkFromRaw(chunk, chatId, userId, characterNames, undefined, undefined, descriptionAliases);
+              await processChunkFromRaw(chunk, chatId, userId, characterId, characterNames, undefined, undefined, descriptionAliases);
             }
             tickProgress();
           }
@@ -2188,6 +2201,7 @@ async function processChunkFromRaw(
   chunk: any,
   chatId: string,
   userId: string,
+  characterId: string | null,
   characterNames: string[],
   generateRawFn?: any,
   sidecarConnectionId?: string,
@@ -2198,6 +2212,7 @@ async function processChunkFromRaw(
       chunkId: chunk.id,
       chatId: chunk.chat_id || chatId,
       userId,
+      characterId,
       content: chunk.content,
       messageIds: safeJsonArray(chunk.message_ids),
       startMessageIndex: 0,
@@ -2220,6 +2235,7 @@ async function processChunkWithPrecomputedSidecar(
   chunk: any,
   chatId: string,
   userId: string,
+  characterId: string | null,
   characterNames: string[],
   sidecarResult: import("./types").SidecarExtractionResult,
   descriptionAliases?: Map<string, string>,
@@ -2296,6 +2312,7 @@ async function processChunkWithPrecomputedSidecar(
       chunkId: chunk.id,
       chatId: chunk.chat_id || chatId,
       userId,
+      characterId,
       content: chunk.content,
       messageIds: safeJsonArray(chunk.message_ids),
       startMessageIndex: 0,

--- a/src/services/memory-cortex/types.ts
+++ b/src/services/memory-cortex/types.ts
@@ -497,6 +497,7 @@ export interface ChunkIngestionData {
   chunkId: string;
   chatId: string;
   userId: string;
+  characterId: string | null;
   content: string;
   messageIds: string[];
   startMessageIndex: number;

--- a/src/services/regex-scripts.service.ts
+++ b/src/services/regex-scripts.service.ts
@@ -61,7 +61,7 @@ interface ApplyRegexScriptOptions {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-const VALID_PLACEMENTS = new Set(["user_input", "ai_output", "world_info", "reasoning"]);
+const VALID_PLACEMENTS = new Set(["user_input", "ai_output", "world_info", "reasoning", "memory"]);
 const VALID_SCOPES = new Set(["global", "character", "chat"]);
 const VALID_TARGETS = new Set(["prompt", "response", "display"]);
 const VALID_FLAGS = new Set(["d", "g", "i", "m", "s", "u", "v", "y"]);
@@ -879,25 +879,19 @@ export function getRegexScriptByScriptId(
 // ── Pipeline ─────────────────────────────────────────────────────────────────
 
 /**
- * Get active (enabled) scripts matching the given context, properly ordered by
- * scope resolution: global → character → chat, within each tier by sort_order ASC, created_at ASC.
+ * Active scripts for a chat context, ordered global → character → chat then
+ * sort_order, created_at. matchConditions/matchParams are the caller's column
+ * filter; bind order is userId, matchParams, scope ids.
  */
-export function getActiveScripts(
+function getScopedScripts(
   userId: string,
-  opts: { characterId?: string; chatId?: string; target: RegexTarget }
+  opts: { characterId?: string | null; chatId?: string | null },
+  matchConditions: string[],
+  matchParams: any[],
 ): RegexScript[] {
-  const db = getDb();
+  const conditions = ["user_id = ?", "disabled = 0", ...matchConditions];
+  const params: any[] = [userId, ...matchParams];
 
-  // target is stored as a JSON array (e.g. '["prompt","display"]'). Match scripts
-  // whose array contains the requested target using instr on the serialized form.
-  const conditions = [
-    "user_id = ?",
-    "disabled = 0",
-    `instr(target, '"' || ? || '"') > 0`,
-  ];
-  const params: any[] = [userId, opts.target];
-
-  // Scope filter: include global + character-scoped + chat-scoped matching the current context
   const scopeConditions: string[] = ["scope = 'global'"];
   if (opts.characterId) {
     scopeConditions.push("(scope = 'character' AND scope_id = ?)");
@@ -909,11 +903,9 @@ export function getActiveScripts(
   }
   conditions.push(`(${scopeConditions.join(" OR ")})`);
 
-  const where = conditions.join(" AND ");
-
-  const rows = db
+  const rows = getDb()
     .query(
-      `SELECT * FROM regex_scripts WHERE ${where}
+      `SELECT * FROM regex_scripts WHERE ${conditions.join(" AND ")}
        ORDER BY
          CASE scope WHEN 'global' THEN 0 WHEN 'character' THEN 1 WHEN 'chat' THEN 2 END ASC,
          sort_order ASC, created_at ASC`
@@ -921,6 +913,52 @@ export function getActiveScripts(
     .all(...params) as any[];
 
   return rows.map(rowToRegexScript);
+}
+
+/** Active scripts whose `target` array contains opts.target. */
+export function getActiveScripts(
+  userId: string,
+  opts: { characterId?: string; chatId?: string; target: RegexTarget }
+): RegexScript[] {
+  // target stored as a JSON array; instr matches the quoted needle.
+  return getScopedScripts(userId, opts, [`instr(target, '"' || ? || '"') > 0`], [opts.target]);
+}
+
+/**
+ * Active scripts carrying the "memory" placement, for stripping content at
+ * ingestion. Filters by placement, not target — a memory script applies
+ * whenever memory is written, regardless of prompt/response/display target.
+ */
+export function getActiveMemoryScripts(
+  userId: string,
+  opts: { characterId?: string | null; chatId?: string | null }
+): RegexScript[] {
+  // placement stored as a JSON array; instr matches the quoted needle.
+  return getScopedScripts(userId, opts, [`instr(placement, '"' || ? || '"') > 0`], ["memory"]);
+}
+
+/**
+ * Apply "memory"-placement scripts to text before it's persisted/embedded.
+ * No macro env at ingestion, so find/replace macros aren't resolved — memory
+ * scripts must use literal patterns.
+ */
+export async function applyMemoryIngestionRegex(
+  userId: string,
+  content: string,
+  opts: { characterId?: string | null; chatId?: string | null },
+): Promise<string> {
+  if (!content) return content;
+  const scripts = getActiveMemoryScripts(userId, opts);
+  if (scripts.length === 0) return content;
+  return applyRegexScripts(
+    content,
+    scripts,
+    "memory",
+    undefined,
+    undefined,
+    undefined,
+    { source: "prompt_backend" },
+  );
 }
 
 /**
@@ -931,39 +969,12 @@ export function getRunOnEditScripts(
   userId: string,
   opts: { characterId?: string; chatId?: string }
 ): RegexScript[] {
-  const db = getDb();
-
-  const conditions = [
-    "user_id = ?",
-    "disabled = 0",
-    "run_on_edit = 1",
-    `instr(target, '"response"') > 0`,
-  ];
-  const params: any[] = [userId];
-
-  const scopeConditions: string[] = ["scope = 'global'"];
-  if (opts.characterId) {
-    scopeConditions.push("(scope = 'character' AND scope_id = ?)");
-    params.push(opts.characterId);
-  }
-  if (opts.chatId) {
-    scopeConditions.push("(scope = 'chat' AND scope_id = ?)");
-    params.push(opts.chatId);
-  }
-  conditions.push(`(${scopeConditions.join(" OR ")})`);
-
-  const where = conditions.join(" AND ");
-
-  const rows = db
-    .query(
-      `SELECT * FROM regex_scripts WHERE ${where}
-       ORDER BY
-         CASE scope WHEN 'global' THEN 0 WHEN 'character' THEN 1 WHEN 'chat' THEN 2 END ASC,
-         sort_order ASC, created_at ASC`
-    )
-    .all(...params) as any[];
-
-  return rows.map(rowToRegexScript);
+  return getScopedScripts(
+    userId,
+    opts,
+    ["run_on_edit = 1", `instr(target, '"response"') > 0`],
+    [],
+  );
 }
 
 /**

--- a/src/types/regex-script.ts
+++ b/src/types/regex-script.ts
@@ -1,4 +1,4 @@
-export type RegexPlacement = "user_input" | "ai_output" | "world_info" | "reasoning";
+export type RegexPlacement = "user_input" | "ai_output" | "world_info" | "reasoning" | "memory";
 export type RegexScope = "global" | "character" | "chat";
 export type RegexTarget = "prompt" | "response" | "display";
 export type RegexMacroMode = "none" | "raw" | "escaped" | "after";

--- a/user-docs/docs/customization/regex-scripts.md
+++ b/user-docs/docs/customization/regex-scripts.md
@@ -52,8 +52,11 @@ This converts `*italic text*` into `<em>italic text</em>`.
 | **AI Output** | The AI's response |
 | **World Info** | World book entry content |
 | **Reasoning** | Reasoning/thinking blocks |
+| **Memory** | Content as it's written to long-term memory |
 
 You can select multiple placements for the same script.
+
+**Memory** placement is independent of target: it strips text as it's saved to long-term memory (vector search and the memory cortex), before storage and embedding, while the displayed message keeps the full text. Use it to keep tracker or HUD blocks out of recalled memory. Macros aren't available at ingestion, so memory scripts must use literal patterns.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR adds a `memory` placement for regex scripts so content can be stripped at memory ingestion. A `memory` regex rewrites the copy that is fed into vector memory and cortex. The displayed chat keeps the full text, but stored memory is clean (I use this to remove trackers, OOC, etc).

This works across both memory stores and both entry points:

- Live ingestion: the vector path (`updateChatChunks`) and cortex (`processChunk`), via the new `applyMemoryIngestionRegex`.
- Rebuild: `chunkAndPersistMessages` and `rebuildCortex`, so a "rebuild all memories" can't silently bypass the strip.

This also refactors `getActiveScripts`, `getActiveMemoryScripts`, and `getRunOnEditScripts` onto a shared `getScopedScripts` query helper (behaviour unchanged).

A new `memory` target was added to the regex panel.

Backend docs updated.

# Screenshots

<img width="717" height="613" alt="image" src="https://github.com/user-attachments/assets/31012353-ba33-4366-9f72-e610d0d211fc" />
<img width="351" height="172" alt="image" src="https://github.com/user-attachments/assets/e5062fd2-e5d7-4f81-ad84-14190a934323" />


## Testing

### Global 
- [ ] Create a global `memory`-placement script (find `<tracker>[\s\S]*?</tracker>`, replace with empty), save, and reload. The `Memory` tab should stay selected on the script.
- [ ] Send a message containing a `<tracker>` block. The chat should still display the block in full, since only the memory copy is stripped.
- [ ] Query the stored chunk directly and confirm the block is gone from memory: `sqlite3 data/lumiverse.db "SELECT substr(content,1,800) FROM chat_chunks WHERE chat_id='<chatId>' ORDER BY created_at DESC LIMIT 1;"`. The `<tracker>` block should be absent here while still visible in the chat.
- [ ] Disable the script, send another message with the block, and run the same query. The block should now be present in the stored chunk, confirming no-op when no memory scripts are active.

### Scoped
- [ ] Scope a memory script to one character. It should strip in that character's chat and leave an unrelated chat's stored memory untouched.

### Rebuild
- [ ] Rebuild memories for a chat that contains the block. Rebuilt chunks should be stripped too, matching the live path rather than bypassing it.
- [ ] With `Memory Cortex` enabled, confirm entity and salience extraction run on the stripped text, so tracker or HUD noise doesn't surface as entities.

### Regression
- [ ] Parity check for the refactor: a script with only `prompt`, `response`, or `display` targets and any placement other than `memory` should leave stored memory unchanged, exactly as before.
