### PR TITLE
Stop nuking chat variables

### DIFF
--- a/src/services/chat-macro-render.local-preserve.test.ts
+++ b/src/services/chat-macro-render.local-preserve.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { buildPersistedMacroVariables } from "./chat-macro-render.service";
+
+describe("buildPersistedMacroVariables", () => {
+  test("preserves stored local untouched while merging incoming global", () => {
+    const existing = {
+      local: { exp: "50", ui_lang: "1", setup_complete: "1" },
+      global: { theme: "noir" },
+    };
+
+    const out = buildPersistedMacroVariables(existing, { theme: "neon", flag: "on" });
+
+    expect(out.local).toEqual({ exp: "50", ui_lang: "1", setup_complete: "1" });
+    expect(out.global).toEqual({ theme: "neon", flag: "on" });
+  });
+
+  test("does not invent a local key when none was stored", () => {
+    const out = buildPersistedMacroVariables({ global: { a: "1" } }, { b: "2" });
+    expect("local" in out).toBe(false);
+    expect(out.global).toEqual({ a: "1", b: "2" });
+  });
+
+  test("never merges transient env-local back in (caller passes only global)", () => {
+    const existing = { local: { kept: "yes" } };
+    const out = buildPersistedMacroVariables(existing, {});
+    expect(out.local).toEqual({ kept: "yes" });
+  });
+});

--- a/src/services/chat-macro-render.service.ts
+++ b/src/services/chat-macro-render.service.ts
@@ -70,6 +70,17 @@ export async function resolveRenderedMessageContent(
   return healFormattingArtifacts((await evaluate(content, env, registry)).text);
 }
 
+export function buildPersistedMacroVariables(
+  existingMacroVars: Record<string, unknown>,
+  incomingGlobal: Record<string, string>,
+): Record<string, unknown> {
+  const existingGlobal = (existingMacroVars.global as Record<string, string> | undefined) ?? {};
+  return {
+    ...existingMacroVars,
+    global: { ...existingGlobal, ...incomingGlobal },
+  };
+}
+
 export function persistMacroVariableState(
   userId: string,
   chatId: string,
@@ -79,16 +90,9 @@ export function persistMacroVariableState(
   if (!chat) return;
 
   const existingMacroVars = (chat.metadata?.macro_variables as Record<string, unknown> | undefined) ?? {};
-  const macroVarsWithoutLocal = { ...existingMacroVars };
-  delete macroVarsWithoutLocal.local;
-  const existingGlobal = (existingMacroVars.global as Record<string, string> | undefined) ?? {};
   const existingChatVars = (chat.metadata?.chat_variables as Record<string, string> | undefined) ?? {};
-  const macroVariables = {
-    ...macroVarsWithoutLocal,
-    global: { ...existingGlobal, ...Object.fromEntries(env.variables.global) },
-  };
   chatsSvc.mergeChatMetadata(userId, chatId, {
-    macro_variables: macroVariables,
+    macro_variables: buildPersistedMacroVariables(existingMacroVars, Object.fromEntries(env.variables.global)),
     chat_variables: { ...existingChatVars, ...Object.fromEntries(env.variables.chat) },
   });
 }
@@ -119,16 +123,9 @@ export async function reconcileChatMessageMacros(
     const chat = chatsSvc.getChat(input.userId, input.chatId);
     // Env values win on collision but concurrent extension writes survive.
     const existingMacroVars = (chat?.metadata?.macro_variables as Record<string, unknown> | undefined) ?? {};
-    const macroVarsWithoutLocal = { ...existingMacroVars };
-    delete macroVarsWithoutLocal.local;
-    const existingGlobal = (existingMacroVars.global as Record<string, string> | undefined) ?? {};
     const existingChatVars = (chat?.metadata?.chat_variables as Record<string, string> | undefined) ?? {};
-    const macroVariables = {
-      ...macroVarsWithoutLocal,
-      global: { ...existingGlobal, ...globalVariables },
-    };
     chatsSvc.mergeChatMetadata(input.userId, input.chatId, {
-      macro_variables: macroVariables,
+      macro_variables: buildPersistedMacroVariables(existingMacroVars, globalVariables),
       chat_variables: { ...existingChatVars, ...chatVariables },
     });
   }


### PR DESCRIPTION
`persistMacroVariableState` and `reconcileChatMessageMacros` rebuild `macro_variables` without the local key, and because `mergeChatMetadata` replaces that key entirely, every single generation silently deletes all local-scoped variables. This is irreversible, per-turn data loss, so any chat relying on durable local state is quietly destroyed :(