### PR TITLE
feat(world-info): add 'Outlet Only' position for outlet-exclusive entries

### DIFF
--- a/frontend/src/components/shared/WorldBookEntriesSection.tsx
+++ b/frontend/src/components/shared/WorldBookEntriesSection.tsx
@@ -15,6 +15,7 @@ import {
   MoreVertical,
   MoveRight,
   Plus,
+  Plug,
   Search,
   Square,
   Tag,
@@ -1077,7 +1078,9 @@ export default function WorldBookEntriesSection({
                 ? <BetweenHorizontalEnd size={14} />
                 : option.value === 7
                   ? <MapPin size={14} />
-                  : <Hash size={14} />,
+                  : option.value === 8
+                    ? <Plug size={14} />
+                    : <Hash size={14} />,
         active: selectedPositionEntry.position === option.value,
         onClick: () => {
           updateEntry(selectedPositionEntry.id, { position: option.value })

--- a/frontend/src/components/shared/WorldBookEntryEditor.module.css
+++ b/frontend/src/components/shared/WorldBookEntryEditor.module.css
@@ -55,6 +55,11 @@
   align-items: center;
   justify-content: space-between;
 }
+.fieldHint {
+  color: var(--lumiverse-text-muted);
+  font-size: calc(11.5px * var(--lumiverse-font-scale, 1));
+  margin: 4px 0 0;
+}
 
 .entryInput {
   background: var(--lumiverse-bg);

--- a/frontend/src/components/shared/WorldBookEntryEditor.tsx
+++ b/frontend/src/components/shared/WorldBookEntryEditor.tsx
@@ -206,6 +206,9 @@ export default function WorldBookEntryEditor({ entry, onUpdate, onImmediateUpdat
             />
           </div>
         </div>
+        {entry.position === 8 && !(entry.outlet_name || '').trim() && (
+          <p className={styles.fieldHint}>{t('outletOnlyHint')}</p>
+        )}
       </div>
 
       {/* Activation */}

--- a/frontend/src/i18n/locales/en/panels.json
+++ b/frontend/src/i18n/locales/en/panels.json
@@ -1378,6 +1378,8 @@
       "depthShort": "@ Depth",
       "atMarker": "At Marker",
       "markerShort": "@ Marker",
+      "outletOnly": "Outlet Only",
+      "outletOnlyShort": "Outlet",
       "fallback": "Pos {{position}}"
     },
     "entryType": {
@@ -1496,6 +1498,7 @@
         "automationId": "Automation ID"
       },
       "outletPlaceholder": "Use with {{outlet::name}}",
+      "outletOnlyHint": "No outlet name set — this entry will not be output anywhere.",
       "countTokens": "Count tokens",
       "countTokensTitle": "Estimate token count using current model's tokenizer",
       "tokenCount": "{{count}} tokens",

--- a/frontend/src/i18n/locales/fr/panels.json
+++ b/frontend/src/i18n/locales/fr/panels.json
@@ -1298,6 +1298,8 @@
       "afterAN": "Après AN",
       "atDepth": "En profondeur",
       "depthShort": "@ Profondeur",
+      "outletOnly": "Sortie uniquement",
+      "outletOnlyShort": "Sortie",
       "fallback": "Pos {{position}}"
     },
     "entryType": {
@@ -1416,6 +1418,7 @@
         "automationId": "ID d'automatisation"
       },
       "outletPlaceholder": "Utiliser avec {{outlet::name}}",
+      "outletOnlyHint": "Aucun nom de sortie défini — cette entrée ne sera affichée nulle part.",
       "countTokens": "Compter les jetons",
       "countTokensTitle": "Estimer le nombre de jetons à l'aide du tokenizer du modèle actuel",
       "tokenCount": "Jetons {{count}}",

--- a/frontend/src/i18n/locales/it/panels.json
+++ b/frontend/src/i18n/locales/it/panels.json
@@ -1299,6 +1299,8 @@
       "depthShort": "@ profondità",
       "atMarker": "Al marker",
       "markerShort": "@ marker",
+      "outletOnly": "Solo outlet",
+      "outletOnlyShort": "Outlet",
       "fallback": "Pos {{position}}"
     },
     "entryType": {
@@ -1417,6 +1419,7 @@
         "automationId": "ID automazione"
       },
       "outletPlaceholder": "Usa con {{outlet::name}}",
+      "outletOnlyHint": "Nessun nome outlet impostato — questa voce non verrà mostrata da nessuna parte.",
       "countTokens": "Conta token",
       "countTokensTitle": "Stima il conteggio token usando il tokenizer del modello attuale",
       "tokenCount": "{{count}} token",

--- a/frontend/src/i18n/locales/ja/panels.json
+++ b/frontend/src/i18n/locales/ja/panels.json
@@ -1298,6 +1298,8 @@
       "afterAN": "AN後",
       "atDepth": "深度",
       "depthShort": "@深さ",
+      "outletOnly": "アウトレットのみ",
+      "outletOnlyShort": "アウトレット",
       "fallback": "位置 {{position}}"
     },
     "entryType": {
@@ -1416,6 +1418,7 @@
         "automationId": "オートメーションID"
       },
       "outletPlaceholder": "{{outlet::name}} と一緒に使用する",
+      "outletOnlyHint": "アウトレット名が未設定 — このエントリはどこにも出力されません。",
       "countTokens": "トークンを数える",
       "countTokensTitle": "現在のトークン数を推定するモデルのトークナイザー",
       "tokenCount": "{{count}} トークン",

--- a/frontend/src/i18n/locales/zh-TW/panels.json
+++ b/frontend/src/i18n/locales/zh-TW/panels.json
@@ -1298,6 +1298,8 @@
       "afterAN": "作者注後",
       "atDepth": "指定深度",
       "depthShort": "@ 深度",
+      "outletOnly": "僅出口",
+      "outletOnlyShort": "出口",
       "fallback": "位置 {{position}}"
     },
     "entryType": {
@@ -1416,6 +1418,7 @@
         "automationId": "自動化 ID"
       },
       "outletPlaceholder": "配合 {{outlet::name}} 使用",
+      "outletOnlyHint": "未設定出口名稱 — 此條目不會在任何位置輸出。",
       "countTokens": "統計 token",
       "countTokensTitle": "使用當前模型的分詞器估算 token 數",
       "tokenCount": "{{count}} tokens",

--- a/frontend/src/i18n/locales/zh/panels.json
+++ b/frontend/src/i18n/locales/zh/panels.json
@@ -1298,6 +1298,8 @@
       "afterAN": "作者注后",
       "atDepth": "指定深度",
       "depthShort": "@ 深度",
+      "outletOnly": "仅出口",
+      "outletOnlyShort": "出口",
       "fallback": "位置 {{position}}"
     },
     "entryType": {
@@ -1416,6 +1418,7 @@
         "automationId": "自动化 ID"
       },
       "outletPlaceholder": "配合 {{outlet::name}} 使用",
+      "outletOnlyHint": "未设置出口名称 — 此条目不会在任何位置输出。",
       "countTokens": "统计 token",
       "countTokensTitle": "使用当前模型的分词器估算 token 数",
       "tokenCount": "{{count}} tokens",

--- a/frontend/src/lib/i18n/worldBookEntryLabels.ts
+++ b/frontend/src/lib/i18n/worldBookEntryLabels.ts
@@ -22,6 +22,7 @@ export function useWorldBookEntryLabels() {
       { value: 3, label: t('entryPosition.afterAN') },
       { value: 4, label: t('entryPosition.atDepth') },
       { value: 7, label: t('entryPosition.atMarker') },
+      { value: 8, label: t('entryPosition.outletOnly') },
     ] as const
 
     const typeOptions = [
@@ -61,7 +62,9 @@ export function useWorldBookEntryLabels() {
     const positionLabel = (position: number) =>
       position === 7
         ? t('entryPosition.markerShort')
-        : positionShort[position] ?? t('entryPosition.fallback', { position })
+        : position === 8
+          ? t('entryPosition.outletOnlyShort')
+          : positionShort[position] ?? t('entryPosition.fallback', { position })
 
     const entryTypeLabel = (entry: WorldBookEntry) =>
       entry.constant ? t('entryType.constant') : entry.vectorized ? t('entryType.vector') : t('entryType.trigger')

--- a/src/services/world-books.service.ts
+++ b/src/services/world-books.service.ts
@@ -1238,8 +1238,8 @@ export function bulkOperateEntries(
 
   if (input.action === "set_position") {
     const position = Number.isFinite(input.position) ? Math.trunc(input.position) : 0;
-    if (position < 0 || position > 7) {
-      throw new Error("position must be between 0 and 7");
+    if (position < 0 || position > 8) {
+      throw new Error("position must be between 0 and 8");
     }
     const depth = position === 4 && Number.isFinite(input.depth) ? Math.trunc(input.depth!) : 4;
     db.transaction(() => {

--- a/src/services/world-info-activation.service.ts
+++ b/src/services/world-info-activation.service.ts
@@ -656,7 +656,8 @@ function applyGroupLogic(entries: WorldBookEntry[]): WorldBookEntry[] {
 /**
  * Bucket activated entries into WorldInfoCache positions:
  *  0 = before, 1 = after, 2 = AN before, 3 = AN after,
- *  4 = depth-based, 5 = EM before, 6 = EM after
+ *  4 = depth-based, 5 = EM before, 6 = EM after, 7 = at-marker,
+ *  8 = outlet-only (excluded from all position buckets; surfaces only via {{outlet::name}})
  */
 function bucketByPosition(entries: WorldBookEntry[]): WorldInfoCache {
   const cache: WorldInfoCache = {
@@ -706,13 +707,16 @@ function bucketByPosition(entries: WorldBookEntry[]): WorldInfoCache {
       case 7:
         cache.atMarker.push({ content, role, entryLabel });
         break;
+      case 8:
+        // Outlet-only: not injected at any position; resolved solely via the
+        // {{outlet::name}} macro from `activatedEntries`.
+        break;
       default:
         // Unknown position — treat as "before"
         cache.before.push({ content, role, entryLabel });
         break;
     }
   }
-
   return cache;
 }
 

--- a/src/services/world-info-outlet-only.test.ts
+++ b/src/services/world-info-outlet-only.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for world-info "Outlet Only" position (8).
+ *
+ * Position 8 is a no-op bucket in `bucketByPosition`: such an entry is still
+ * activated and still resolved into the outlet map via `resolveWorldInfoOutlets`
+ * (`{{outlet::name}}`), but is NEVER injected at any prompt position. This fixes
+ * the previous double-output where a position-2 + outlet entry appeared both at
+ * its position AND via the outlet macro.
+ */
+import { describe, it, expect } from "bun:test";
+
+import type { WorldBookEntry, WorldInfoCache } from "../types/world-book";
+import type { MacroEnv } from "../macros";
+
+import { finalizeActivatedWorldInfoEntries } from "./world-info-activation.service";
+import { resolveWorldInfoOutlets } from "./prompt-assembly.service";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeEntry(overrides: Partial<WorldBookEntry> = {}): WorldBookEntry {
+  return {
+    id: overrides.id ?? crypto.randomUUID(),
+    world_book_id: "book-a",
+    uid: overrides.uid ?? crypto.randomUUID(),
+    outlet_name: null,
+    key: [],
+    keysecondary: [],
+    content: "",
+    comment: "",
+    position: 0,
+    depth: 4,
+    role: null,
+    order_value: 100,
+    selective: true,
+    constant: false,
+    disabled: false,
+    group_name: "",
+    group_override: false,
+    group_weight: 100,
+    probability: 100,
+    scan_depth: null,
+    case_sensitive: false,
+    match_whole_words: false,
+    automation_id: null,
+    use_regex: false,
+    prevent_recursion: true,
+    exclude_recursion: false,
+    delay_until_recursion: false,
+    priority: 10,
+    sticky: 0,
+    cooldown: 0,
+    delay: 0,
+    selective_logic: 0,
+    use_probability: true,
+    vectorized: true,
+    vector_index_status: "indexed",
+    vector_indexed_at: 0,
+    vector_index_error: null,
+    extensions: {},
+    created_at: 0,
+    updated_at: 0,
+    ...overrides,
+  };
+}
+
+/** Minimal macro env: `resolveWorldInfoOutlets` only touches `extra.worldInfoOutlets`. */
+function makeEnv(): MacroEnv {
+  return { extra: {} } as unknown as MacroEnv;
+}
+
+/** Collect every bucket's content strings into one flat array. */
+function allBucketContents(cache: WorldInfoCache): string[] {
+  return [
+    ...cache.before,
+    ...cache.after,
+    ...cache.anBefore,
+    ...cache.anAfter,
+    ...cache.depth,
+    ...cache.emBefore,
+    ...cache.emAfter,
+    ...cache.atMarker,
+  ].map((item) => item.content);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("world-info outlet-only position (8)", () => {
+  it("position-8 entry with outlet is excluded from all position buckets", () => {
+    const entry = makeEntry({
+      id: "outlet-only",
+      uid: "outlet-only",
+      position: 8,
+      outlet_name: "lore",
+      content: "X",
+    });
+
+    const result = finalizeActivatedWorldInfoEntries([entry], undefined, {
+      skipGroupLogic: true,
+      preserveOrder: true,
+    });
+
+    // Still activated (so it can flow into outlet resolution)...
+    expect(result.activatedEntries.map((e) => e.id)).toContain("outlet-only");
+
+    // ...but present in NO position bucket.
+    const { cache } = result;
+    expect(cache.before).toEqual([]);
+    expect(cache.after).toEqual([]);
+    expect(cache.anBefore).toEqual([]);
+    expect(cache.anAfter).toEqual([]);
+    expect(cache.emBefore).toEqual([]);
+    expect(cache.emAfter).toEqual([]);
+    expect(cache.atMarker).toEqual([]);
+    expect(cache.depth).toEqual([]);
+    expect(allBucketContents(cache)).not.toContain("X");
+  });
+
+  it("position-8 entry with outlet still resolves into the outlet map", async () => {
+    const entry = makeEntry({
+      id: "outlet-only",
+      uid: "outlet-only",
+      position: 8,
+      outlet_name: "lore",
+      content: "X",
+    });
+
+    const result = finalizeActivatedWorldInfoEntries([entry], undefined, {
+      skipGroupLogic: true,
+      preserveOrder: true,
+    });
+
+    const env = makeEnv();
+    await resolveWorldInfoOutlets(result.activatedEntries, env);
+
+    expect(env.extra.worldInfoOutlets).toBeDefined();
+    expect(env.extra.worldInfoOutlets["lore"]).toBe("X");
+  });
+
+  it("contrast: position-2 entry with outlet still double-outputs (legacy unchanged)", async () => {
+    const entry = makeEntry({
+      id: "legacy",
+      uid: "legacy",
+      position: 2,
+      outlet_name: "lore",
+      content: "Y",
+    });
+
+    const result = finalizeActivatedWorldInfoEntries([entry], undefined, {
+      skipGroupLogic: true,
+      preserveOrder: true,
+    });
+
+    // Legacy behavior untouched: position 2 lands in the AN-before bucket...
+    expect(result.cache.anBefore.map((item) => item.content)).toContain("Y");
+
+    // ...AND is also surfaced via the outlet macro.
+    const env = makeEnv();
+    await resolveWorldInfoOutlets(result.activatedEntries, env);
+
+    expect(env.extra.worldInfoOutlets["lore"]).toBe("Y");
+  });
+
+  it("position-8 entry with no outlet name outputs nowhere", async () => {
+    const entry = makeEntry({
+      id: "orphan",
+      uid: "orphan",
+      position: 8,
+      outlet_name: null,
+      content: "Z",
+    });
+
+    const result = finalizeActivatedWorldInfoEntries([entry], undefined, {
+      skipGroupLogic: true,
+      preserveOrder: true,
+    });
+
+    // Not injected at any position...
+    expect(allBucketContents(result.cache)).not.toContain("Z");
+
+    // ...and, with no outlet name, never enters the outlet map.
+    const env = makeEnv();
+    const outlets = await resolveWorldInfoOutlets(result.activatedEntries, env);
+
+    expect(Object.values(outlets)).not.toContain("Z");
+  });
+});


### PR DESCRIPTION
## Summary

Adds **"Outlet Only"** as a new lorebook/world-book entry **position**. An entry at this position is activated normally and still resolves into its declared outlet (`{{outlet::name}}`), but is **never injected at any prompt position** — fixing the current double-output where an outlet-named entry appears both at its position *and* via the outlet macro.

## The problem this solves

Today, if an entry has `position: Before Main` **and** an `outlet_name` that is referenced somewhere via `{{outlet::name}}`, its content is emitted **twice**: once at position 2 (Before Main) and once wherever the outlet macro is used. There was no way to say "this entry should *only* ever surface through its outlet." This PR adds exactly that.

## How it works

- New position value **8 = "Outlet Only"**.
- In `bucketByPosition`, position 8 is a **no-op**: the entry lands in **none** of the position cache buckets (before / after / anBefore / anAfter / depth / emBefore / emAfter / atMarker).
- The entry is still part of `activatedEntries`, so `resolveWorldInfoOutlets` (which iterates activated entries independent of position) still writes its content to `{{outlet::name}}` — unchanged.
- Net effect: the entry surfaces **only** through `{{outlet::name}}`, nowhere else.

## Changes

**Backend**
- `src/services/world-info-activation.service.ts`: `bucketByPosition` gains `case 8: break;` (skips bucketing); doc comment updated.
- `src/services/world-books.service.ts`: bulk set-position range check widened from `0–7` to `0–8` (per-entry paths intentionally don't range-check, unchanged).

**Frontend**
- `frontend/src/lib/i18n/worldBookEntryLabels.ts`: "Outlet Only" added to `positionOptions`; `positionLabel` handles 8 (chip shows "Outlet").
- `frontend/src/components/shared/WorldBookEntryEditor.tsx`: the position dropdown auto-surfaces the option; a muted hint appears when "Outlet Only" is selected but no outlet name is set (prevents a silently-empty entry).
- `frontend/src/components/shared/WorldBookEntriesSection.tsx`: context-menu gets a dedicated `Plug` icon for the new position (chip + bulk dialog auto-pick up the option).
- `frontend/src/i18n/locales/{en,fr,it,ja,zh,zh-TW}/panels.json`: new `entryPosition.outletOnly` / `outletOnlyShort` and `entryEditor.outletOnlyHint` keys in all six locales.

## Backward compatibility

Positions 0–7 are entirely unchanged. The `{{outlet::name}}` and `{{wi_marker}}` macros are untouched. No schema change — `position` remains a number; value 8 is additive. Existing entries are unaffected.

## Validation

- Backend `tsc --noEmit`: clean.
- Frontend `tsc --noEmit`: clean.
- New test `src/services/world-info-outlet-only.test.ts` asserts the four invariants: (1) position-8-with-outlet is in no position bucket; (2) it still resolves into the outlet map; (3) a contrast position-2-with-outlet still double-outputs (legacy preserved); (4) position-8 with no outlet name outputs nowhere.

