### PR TITLE
fix(chat): resolve {{outlet::name}} world-info outlets in displayed messages

### DIFF
--- a/src/routes/chats.routes.ts
+++ b/src/routes/chats.routes.ts
@@ -15,6 +15,10 @@ import {
 import { resolveRenderedMessageContent } from "../services/chat-macro-render.service";
 import { contentHasMacroHints } from "../services/vectorization-content.service";
 import { computeMessageTokenCount } from "../services/message-token-count";
+import {
+  getActivatedWorldInfoEntriesForChat,
+  resolveWorldInfoOutlets,
+} from "../services/prompt-assembly.service";
 
 async function runMessageContentProcessors(
   ctx: MessageContentProcessorCtx,
@@ -52,6 +56,9 @@ async function processChatGreeting(userId: string, chat: { id: string }) {
 
 const app = new Hono();
 
+/** Matches the `{{outlet::name}}` macro so display resolution can populate
+ *  the world-info outlet map only when a message actually references it. */
+const OUTLET_MACRO_RE = /\{\{outlet::/i;
 const DISPLAY_PREPROCESS_BATCH_MAX = 100;
 
 interface DisplayPreprocessItem {
@@ -102,7 +109,19 @@ async function runDisplayPreprocessItem(
   let content = processed.content ?? item.rawContent;
   if (contentHasMacroHints(content)) {
     const env = svc.buildMacroEnvForChat(userId, chatId);
-    if (env) content = await resolveRenderedMessageContent(content, env);
+    if (env) {
+      // {{outlet::name}} is only populated during prompt assembly; mirror it
+      // here so displayed messages match what the model actually receives.
+      if (OUTLET_MACRO_RE.test(content)) {
+        try {
+          const entries = await getActivatedWorldInfoEntriesForChat(userId, chatId);
+          await resolveWorldInfoOutlets(entries, env, signal);
+        } catch {
+          // Leave outlets unresolved — base macro resolution still runs.
+        }
+      }
+      content = await resolveRenderedMessageContent(content, env);
+    }
   }
 
   return { messageId: item.messageId, content };

--- a/src/services/chat-display-outlet-resolution.test.ts
+++ b/src/services/chat-display-outlet-resolution.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+import { closeDatabase, getDb, initDatabase } from "../db/connection";
+import * as charactersSvc from "./characters.service";
+import * as chatsSvc from "./chats.service";
+import * as worldBooksSvc from "./world-books.service";
+import { setCharacterWorldBookIds } from "../utils/character-world-books";
+import { resolveRenderedMessageContent } from "./chat-macro-render.service";
+import {
+  getActivatedWorldInfoEntriesForChat,
+  resolveWorldInfoOutlets,
+} from "./prompt-assembly.service";
+
+const USER_ID = "display-outlet-user";
+
+async function applyBaseline(): Promise<void> {
+  const db = getDb();
+  db.run("PRAGMA foreign_keys = OFF");
+  db.run(await Bun.file(join(import.meta.dir, "..", "db", "baseline.sql")).text());
+}
+
+/**
+ * Mirrors the composition used by runDisplayPreprocessItem (chats.routes.ts):
+ * build the macro env, populate world-info outlets from the activated entries,
+ * then resolve the message content. The display-preprocess path previously
+ * left {{outlet::name}} unresolved because it never ran WI activation — these
+ * tests pin the fix that makes displayed greetings match the assembled prompt.
+ */
+async function resolveForDisplay(content: string): Promise<string> {
+  const env = chatsSvc.buildMacroEnvForChat(USER_ID, chatId);
+  if (!env) throw new Error("buildMacroEnvForChat returned null");
+  const entries = await getActivatedWorldInfoEntriesForChat(USER_ID, chatId);
+  await resolveWorldInfoOutlets(entries, env);
+  return resolveRenderedMessageContent(content, env);
+}
+
+let chatId: string;
+const OUTLET_CONTENT = "Secret lore: the amulet glows blue at dusk.";
+
+describe("display-preprocess outlet macro resolution", () => {
+  beforeEach(async () => {
+    closeDatabase();
+    initDatabase(":memory:");
+    await applyBaseline();
+
+    const book = worldBooksSvc.createWorldBook(USER_ID, { name: "Lore Book" });
+    const entry = worldBooksSvc.createEntry(USER_ID, book.id, {
+      key: ["lore"],
+      content: OUTLET_CONTENT,
+      comment: "constant lore outlet",
+      constant: true,
+      outlet_name: "lore",
+    });
+    if (!entry) throw new Error("Failed to create world-book entry");
+
+    const character = charactersSvc.createCharacter(USER_ID, {
+      name: "TestChar",
+      first_mes: `Greetings, traveler. {{outlet::lore}}`,
+      extensions: setCharacterWorldBookIds({}, [book.id]),
+    });
+
+    chatId = chatsSvc.createChat(USER_ID, { character_id: character.id }).id;
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  test("{{outlet::name}} in a greeting resolves to the activated outlet entry content", async () => {
+    const resolved = await resolveForDisplay(`Greetings, traveler. {{outlet::lore}}`);
+    expect(resolved).toBe(`Greetings, traveler. ${OUTLET_CONTENT}`);
+  });
+
+  test("getActivatedWorldInfoEntriesForChat returns the constant outlet entry", async () => {
+    const entries = await getActivatedWorldInfoEntriesForChat(USER_ID, chatId);
+    const loreEntry = entries.find((e) => e.outlet_name === "lore");
+    expect(loreEntry).toBeTruthy();
+    expect(loreEntry!.content).toBe(OUTLET_CONTENT);
+  });
+
+  test("an unknown outlet resolves to empty string without throwing", async () => {
+    const resolved = await resolveForDisplay(`Before{{outlet::nonexistent}}After`);
+    expect(resolved).toBe("BeforeAfter");
+  });
+
+  test("base macros still resolve when no outlet is referenced", async () => {
+    const resolved = await resolveForDisplay(`Hi, I am {{char}}.`);
+    expect(resolved).toBe("Hi, I am TestChar.");
+  });
+});

--- a/src/services/prompt-assembly.service.ts
+++ b/src/services/prompt-assembly.service.ts
@@ -4282,14 +4282,15 @@ export async function collectVectorActivatedWorldInfo(
 }
 
 /**
- * Get all activated world info entries for a chat (keyword + vector).
- * Standalone helper for the Spindle RPC bridge — runs WI activation
- * without the full prompt assembly pipeline.
+ * Run WI activation (keyword + vector) for a chat and return the full merge
+ * result — both the lightweight `activatedWorldInfo` DTO (for the Spindle
+ * bridge) and the full `activatedEntries` models (with content + outlet_name),
+ * which `resolveWorldInfoOutlets` needs to populate `{{outlet::name}}`.
  */
-export async function getActivatedWorldInfoForChat(
+async function computeActivatedWorldInfoForChat(
   userId: string,
   chatId: string,
-): Promise<ActivatedWorldInfoEntry[]> {
+): Promise<MergedWorldInfoEntriesResult> {
   const chat = chatsSvc.getChat(userId, chatId);
   if (!chat) throw new Error("Chat not found");
 
@@ -4343,7 +4344,32 @@ export async function getActivatedWorldInfoForChat(
     vectorActivated,
     worldInfoSettings,
     wiSources.bookSourceMap,
-  ).activatedWorldInfo;
+  );
+}
+
+/**
+ * Get all activated world info entries for a chat (keyword + vector).
+ * Standalone helper for the Spindle RPC bridge — runs WI activation
+ * without the full prompt assembly pipeline.
+ */
+export async function getActivatedWorldInfoForChat(
+  userId: string,
+  chatId: string,
+): Promise<ActivatedWorldInfoEntry[]> {
+  return (await computeActivatedWorldInfoForChat(userId, chatId)).activatedWorldInfo;
+}
+
+/**
+ * Full activated world-info entry models for a chat (keyword + vector).
+ * Used to populate `{{outlet::name}}` outside prompt assembly — e.g. the
+ * display-preprocess path that resolves macros in rendered chat messages,
+ * so what the user sees matches what the model receives.
+ */
+export async function getActivatedWorldInfoEntriesForChat(
+  userId: string,
+  chatId: string,
+): Promise<WorldBookEntryModel[]> {
+  return (await computeActivatedWorldInfoForChat(userId, chatId)).activatedEntries;
 }
 
 /**


### PR DESCRIPTION
# Resolve `{{outlet::name}}` (world-info outlets) in displayed messages

## Problem
A character's first message (greeting) — and any chat message — can contain `{{outlet::name}}` macros. These resolve correctly **during prompt assembly**, so the model receives the resolved content. But the **displayed** message in the UI showed the raw macro (effectively empty), creating a disconnect: what the user sees ≠ what the model gets.

## Root cause
The display-preprocess path (`POST /chats/:id/display-preprocess` → `runDisplayPreprocessItem`) builds a macro environment via `buildMacroEnvForChat` and resolves macros, but it never runs world-info activation — so `env.extra.worldInfoOutlets` stays empty and `{{outlet::name}}` resolves to nothing.

Prompt assembly populates it independently: `resolveWorldInfoOutlets(mergedWorldInfo.activatedEntries, macroEnv)` (`prompt-assembly.service.ts:2092`). Simple macros like `{{user}}` / `{{char}}` / variables already resolve in display via the base env; only world-info-dependent macros (outlets) were the gap.

## Fix
When a displayed message references an `{{outlet::` macro, run WI activation and resolve the outlet map before resolving the message — so the displayed content matches the assembled prompt.

- **`src/services/prompt-assembly.service.ts`** — extracted the shared activation body into a private `computeActivatedWorldInfoForChat()` (returns the full merge result). `getActivatedWorldInfoForChat()` is unchanged (still returns the lightweight `ActivatedWorldInfoEntry[]` DTO the Spindle RPC bridge depends on). Added `getActivatedWorldInfoEntriesForChat()` returning the full entry models (content + `outlet_name`) that `resolveWorldInfoOutlets` needs.
- **`src/routes/chats.routes.ts`** — in `runDisplayPreprocessItem`, after building the env, if the content contains `{{outlet::`, call `getActivatedWorldInfoEntriesForChat` + `resolveWorldInfoOutlets` to populate the outlet map, then resolve as before.

### Design notes
- **Gated on `{{outlet::`** so messages without outlet macros skip WI activation entirely (no perf cost for the common case). WI keyword caching + the chat vector-WI cache amortize the rest; display-preprocess is already batched and client-cached.
- **`try/catch` fallback** — if activation/outlet resolution throws, base macro resolution still runs (outlets just stay unresolved), never breaking message rendering.
- **Zero frontend changes** — the UI already calls display-preprocess; it now receives fully resolved content.
- **No circular import**: `chats.routes → prompt-assembly → chats.service`; `chats.service` imports neither.

## Tests
New `src/services/chat-display-outlet-resolution.test.ts` (4 tests):
1. `{{outlet::lore}}` in a greeting resolves to the activated outlet entry's content.
2. `getActivatedWorldInfoEntriesForChat` returns the constant outlet entry.
3. An unknown outlet resolves to empty string (no crash).
4. Base `{{char}}` still resolves when no outlet is referenced.

Regression (unchanged code paths this touches): `prompt-assembly-outlets`, `world-info-sources`, `chat-macro-render`, `world-info-large-book`, `prompt-assembly-regex-macros` — **29 pass / 0 fail**. `bunx tsc --noEmit` clean.
