### PR TITLE
Add character tags macro family

### DIFF
--- a/src/macros/definitions/chat-utils.ts
+++ b/src/macros/definitions/chat-utils.ts
@@ -138,36 +138,6 @@ export function registerChatUtilsMacros(): void {
     },
   });
 
-  registry.registerMacro({
-    builtIn: true,
-    terminal: true,
-    name: "charTags",
-    category: "Chat Utils",
-    description: "Comma-separated list of the character's tags",
-    returnType: "string",
-    aliases: ["char_tags", "characterTags"],
-    handler: (ctx) => {
-      const tags = ctx.env.extra.characterTags as string[] | undefined;
-      return Array.isArray(tags) ? tags.join(", ") : "";
-    },
-  });
-
-  registry.registerMacro({
-    builtIn: true,
-    terminal: true,
-    name: "charTag",
-    category: "Chat Utils",
-    description: "Check if the character has a specific tag (returns 'true' or 'false')",
-    returnType: "boolean",
-    args: [{ name: "tag", description: "Tag to check" }],
-    aliases: ["char_tag", "hasTag", "has_tag"],
-    handler: (ctx) => {
-      const tags = ctx.env.extra.characterTags as string[] | undefined;
-      const tag = (ctx.args[0] ?? "").trim().toLowerCase();
-      if (!Array.isArray(tags) || !tag) return "false";
-      return tags.some((t) => t.toLowerCase() === tag) ? "true" : "false";
-    },
-  });
 }
 
 function getMessages(extra: Record<string, any>): SimpleMessage[] {

--- a/src/macros/definitions/tags.ts
+++ b/src/macros/definitions/tags.ts
@@ -1,0 +1,95 @@
+/**
+ * Character tag macros — character-card tag accessors.
+ *
+ * All macros read from ctx.env.extra.characterTags which is populated by
+ * buildEnv() in MacroEnv.ts from the active character card's tags field.
+ *
+ * Tags are normalized by trimming blanks so they compose cleanly with the
+ * comma-separated list family.
+ */
+
+import { registry } from "../MacroRegistry";
+import { formatList, resolveIndex } from "../list-utils";
+import type { MacroExecContext } from "../types";
+
+function getCharacterTags(ctx: MacroExecContext): string[] {
+  const tags = ctx.env.extra.characterTags;
+  if (!Array.isArray(tags)) return [];
+  // Imported/legacy cards can carry non-string tag entries; coerce defensively
+  // so one bad element never makes every tag macro resolve to empty.
+  return tags
+    .filter((tag): tag is string => typeof tag === "string")
+    .map((tag) => tag.trim())
+    .filter((tag) => tag !== "");
+}
+
+export function registerTagMacros(): void {
+  registry.registerMacro({
+    builtIn: true,
+    terminal: true,
+    name: "charTags",
+    category: "Character",
+    description: "Comma-separated list of the character's tags.",
+    returnType: "string",
+    aliases: ["characterTags", "char_tags", "tags"],
+    handler: (ctx) => formatList(getCharacterTags(ctx)),
+  });
+
+  registry.registerMacro({
+    builtIn: true,
+    terminal: true,
+    name: "tag",
+    category: "Character",
+    description: "Character tag at a 0-based index. Negative indexes count from the end.",
+    returnType: "string",
+    args: [{ name: "index", description: "0-based index; negative counts from the end" }],
+    aliases: ["tagAt", "tag_at", "charTagAt", "nthTag"],
+    handler: (ctx) => {
+      const items = getCharacterTags(ctx);
+      const i = resolveIndex(parseInt(ctx.args[0] ?? "", 10), items.length);
+      return items[i] ?? "";
+    },
+  });
+
+  registry.registerMacro({
+    builtIn: true,
+    terminal: true,
+    name: "tagCount",
+    category: "Character",
+    description: "Number of tags on the character card.",
+    returnType: "integer",
+    aliases: ["tag_count", "tags_count", "numTags", "charTagCount"],
+    handler: (ctx) => String(getCharacterTags(ctx).length),
+  });
+
+  registry.registerMacro({
+    builtIn: true,
+    volatile: true,
+    name: "randomTag",
+    category: "Character",
+    description: "Random tag from the character card.",
+    returnType: "string",
+    aliases: ["random_tag", "randomCharTag"],
+    handler: (ctx) => {
+      const items = getCharacterTags(ctx);
+      if (items.length === 0) return "";
+      return items[Math.floor(Math.random() * items.length)] ?? "";
+    },
+  });
+
+  registry.registerMacro({
+    builtIn: true,
+    terminal: true,
+    name: "hasTag",
+    category: "Character",
+    description: "Check whether the character has a specific tag (case-insensitive).",
+    returnType: "boolean",
+    args: [{ name: "tag", description: "Tag to check (case-insensitive)" }],
+    aliases: ["charTag", "char_tag", "has_tag", "tagged"],
+    handler: (ctx) => {
+      const needle = (ctx.args[0] ?? "").trim().toLowerCase();
+      if (!needle) return "";
+      return getCharacterTags(ctx).some((tag) => tag.toLowerCase() === needle) ? "true" : "";
+    },
+  });
+}

--- a/src/macros/index.ts
+++ b/src/macros/index.ts
@@ -15,6 +15,7 @@ export type {
 import { registerCoreMacros } from "./definitions/primitives";
 import { registerNamesMacros } from "./definitions/identity";
 import { registerCharacterMacros } from "./definitions/persona-card";
+import { registerTagMacros } from "./definitions/tags";
 import { registerChatMacros } from "./definitions/conversation";
 import { registerTimeMacros } from "./definitions/temporal";
 import { registerRandomMacros } from "./definitions/entropy";
@@ -49,6 +50,7 @@ export function initMacros(): void {
   registerCoreMacros();
   registerNamesMacros();
   registerCharacterMacros();
+  registerTagMacros();
   registerChatMacros();
   registerTimeMacros();
   registerRandomMacros();

--- a/src/macros/macros.test.ts
+++ b/src/macros/macros.test.ts
@@ -241,6 +241,68 @@ describe("Persona pronoun macros", () => {
   });
 });
 
+describe("Character Tags macros", () => {
+  test("charTags and tags alias return a clean list", async () => {
+    expect(await ev("{{charTags}}")).toBe("fantasy, warrior, male");
+    expect(await ev("{{tags}}")).toBe("fantasy, warrior, male");
+  });
+
+  test("tag indexes support positive, negative, and out-of-range access", async () => {
+    expect(await ev("{{tag::0}}")).toBe("fantasy");
+    expect(await ev("{{tag::2}}")).toBe("male");
+    expect(await ev("{{tag::-1}}")).toBe("male");
+    expect(await ev("{{tag::-3}}")).toBe("fantasy");
+    expect(await ev("{{tag::5}}")).toBe("");
+  });
+
+  test("tag aliases resolve indexed tags", async () => {
+    expect(await ev("{{tagAt::1}}")).toBe("warrior");
+    expect(await ev("{{charTagAt::2}}")).toBe("male");
+    expect(await ev("{{nthTag::-1}}")).toBe("male");
+  });
+
+  test("tagCount and numTags alias count character tags", async () => {
+    expect(await ev("{{tagCount}}")).toBe("3");
+    expect(await ev("{{numTags}}")).toBe("3");
+  });
+
+  test("randomTag returns one of the character tags", async () => {
+    expect(["fantasy", "warrior", "male"]).toContain(await ev("{{randomTag}}"));
+  });
+
+  test("hasTag is case-insensitive and condition-compatible", async () => {
+    expect(await ev("{{hasTag::fantasy}}")).toBe("true");
+    expect(await ev("{{hasTag::WARRIOR}}")).toBe("true");
+    expect(await ev("{{hasTag::scifi}}")).toBe("");
+    expect(await ev("{{tagged::male}}")).toBe("true");
+    expect(await ev("{{if::{{hasTag::fantasy}}}}has{{/if}}")).toBe("has");
+  });
+
+  test("charTags composes with list macros", async () => {
+    expect(await ev("{{count::{{charTags}}}}")).toBe("3");
+    expect(await ev("{{first::{{charTags}}}}")).toBe("fantasy");
+    expect(await ev("{{includes::{{charTags}}::warrior}}")).toBe("true");
+  });
+
+  test("empty character tags produce empty-friendly results", async () => {
+    const env = makeEnv({ characterTags: [] });
+    expect(await ev("{{charTags}}", env)).toBe("");
+    expect(await ev("{{tagCount}}", env)).toBe("0");
+    expect(await ev("{{tag::0}}", env)).toBe("");
+    expect(await ev("{{randomTag}}", env)).toBe("");
+    expect(await ev("{{hasTag::anything}}", env)).toBe("");
+  });
+  test("non-string tag entries are ignored without throwing", async () => {
+    const env = makeEnv({
+      characterTags: ["fantasy", 3, null, "warrior", "  "] as unknown as string[],
+    });
+    expect(await ev("{{charTags}}", env)).toBe("fantasy, warrior");
+    expect(await ev("{{tagCount}}", env)).toBe("2");
+    expect(await ev("{{tag::1}}", env)).toBe("warrior");
+    expect(await ev("{{hasTag::warrior}}", env)).toBe("true");
+  });
+});
+
 describe("if / else", () => {
   test("truthy condition with ::", async () => {
     expect(await ev("{{if::1}}yes{{/if}}")).toBe("yes");
@@ -1220,21 +1282,6 @@ describe("Chat Utils macros", () => {
     expect(await ev(template, env)).toBe("1. A\n2. C");
   });
 
-  test("charTags", async () => {
-    expect(await ev("{{charTags}}")).toBe("fantasy, warrior, male");
-  });
-
-  test("charTag exists", async () => {
-    expect(await ev("{{charTag::fantasy}}")).toBe("true");
-  });
-
-  test("charTag case insensitive", async () => {
-    expect(await ev("{{charTag::WARRIOR}}")).toBe("true");
-  });
-
-  test("charTag missing", async () => {
-    expect(await ev("{{charTag::scifi}}")).toBe("false");
-  });
 });
 
 // ===========================================================================

--- a/user-docs/docs/characters/creating-characters.md
+++ b/user-docs/docs/characters/creating-characters.md
@@ -78,6 +78,8 @@ Notes for other users (or yourself) about the character. These are **never sent 
 
 Labels for organizing your library. Add tags like "fantasy," "sci-fi," "male," "OC," etc. You can filter your Character Browser by tags.
 
+Tags are also available to your prompts through macros, so a character's tags can shape what gets generated. Gate content on a tag with `{{if::{{hasTag::villain}}}}...{{/if}}`, list them with `{{charTags}}`, grab a specific one with `{{tag::0}}`, or pick one at random with `{{randomTag}}`. See the [Character Tags macros](../presets/macros-reference.md#character-tags) in the Macros Reference for the full set.
+
 ---
 
 ## Uploading an Avatar

--- a/user-docs/docs/customization/macros.md
+++ b/user-docs/docs/customization/macros.md
@@ -45,7 +45,7 @@ Current time: 14:30 on Wednesday.
 | Category | Examples | Full List |
 |----------|----------|-----------|
 | **Names** | `{{user}}`, `{{char}}`, `{{group}}` | [Identity macros](../presets/macros-reference.md#identity-names) |
-| **Character data** | `{{description}}`, `{{personality}}`, `{{scenario}}` | [Character macros](../presets/macros-reference.md#character-data) |
+| **Character data** | `{{description}}`, `{{personality}}`, `{{scenario}}`, `{{charTags}}`, `{{hasTag}}` | [Character macros](../presets/macros-reference.md#character-data) |
 | **Chat state** | `{{lastMessage}}`, `{{messageCount}}`, `{{messageAt::0}}` | [Chat macros](../presets/macros-reference.md#chat-conversation) |
 | **String** | `{{upper}}`, `{{replace}}`, `{{len}}`, `{{split}}` | [String macros](../presets/macros-reference.md#string-manipulation) |
 | **Math** | `{{calc::2+3}}`, `{{clamp}}`, `{{min}}`, `{{max}}` | [Math macros](../presets/macros-reference.md#math) |

--- a/user-docs/docs/presets/macros-reference.md
+++ b/user-docs/docs/presets/macros-reference.md
@@ -424,6 +424,35 @@ Macros that pull from the character card fields. These respect [alternate field]
 | `{{firstMessage}}` | `{{firstMes}}`, `{{first_message}}` | Character's first/greeting message |
 | `{{original}}` | — | Character description (original card text) |
 
+### Character Tags
+
+Macros that read the current character card's tags — categorical labels such as `Fantasy`, `Warrior`, `OC`, or `Female`.
+
+| Macro | Aliases | Returns |
+|-------|---------|---------|
+| `{{charTags}}` | `{{characterTags}}`, `{{char_tags}}`, `{{tags}}` | Comma-separated list of all the character's tags |
+| `{{tag::index}}` | `{{tagAt}}`, `{{tag_at}}`, `{{charTagAt}}`, `{{nthTag}}` | Single tag at a 0-based index (negative counts from the end); empty if out of range |
+| `{{tagCount}}` | `{{tag_count}}`, `{{tags_count}}`, `{{numTags}}`, `{{charTagCount}}` | Number of tags |
+| `{{randomTag}}` | `{{random_tag}}`, `{{randomCharTag}}` | One randomly chosen tag (empty if the character has none) |
+| `{{hasTag::name}}` | `{{charTag}}`, `{{char_tag}}`, `{{has_tag}}`, `{{tagged}}` | `"true"` if the character has the tag (case-insensitive), else empty — usable as a condition |
+
+```
+{{charTags}}                         — "Fantasy, Warrior, Male"
+{{tagCount}}                         — "3"
+{{tag::0}}                           — "Fantasy" (first tag)
+{{tag::-1}}                          — "Male" (last tag)
+{{hasTag::warrior}}                  — "true" (case-insensitive)
+{{randomTag}}                        — one of the tags at random
+
+{{if::{{hasTag::villain}}}}The character is a villain.{{/if}}
+{{foreach::{{charTags}}::t}}- {{.t}}{{newline}}{{/foreach}}
+{{count::{{charTags}}}}              — same as {{tagCount}}
+{{includes::{{charTags}}::Warrior}}  — "true"
+```
+
+!!! tip "Composing with Lists"
+    `{{charTags}}` returns the same clean comma-separated list form used by the [Lists](#lists) macros, so it feeds directly into `{{count}}`, `{{first}}`, `{{includes}}`, `{{foreach}}`, `{{slice}}`, and the rest of the Lists/Iteration family. Use `{{hasTag}}` when you need a condition-friendly gate for tag-specific content. Like the rest of the list family, these macros split on commas, so a tag label that itself contains a comma is treated as two entries.
+
 ---
 
 ## Chat & Conversation
@@ -632,7 +661,7 @@ Include internal thoughts
 
 ## Chat Utilities
 
-Access individual messages, track state, and query character metadata.
+Access individual messages, track state, and query chat metadata.
 
 | Macro | Aliases | Returns | Args |
 |-------|---------|---------|------|
@@ -641,8 +670,6 @@ Access individual messages, track state, and query character metadata.
 | `{{chatAge}}` | `{{chat_age}}` | Human-readable time since chat creation | — |
 | `{{counter::name}}` | — | Incremented value (1, 2, 3...) | Counter name (stored as local variable) |
 | `{{toggle::name}}` | — | Flipped boolean (`"true"` ↔ `"false"`) | Toggle name (stored as local variable) |
-| `{{charTags}}` | `{{char_tags}}`, `{{characterTags}}` | Comma-separated list of the character's tags | — |
-| `{{charTag::tag}}` | `{{char_tag}}`, `{{hasTag}}`, `{{has_tag}}` | `"true"` / `"false"` — whether character has this tag | Tag name (case-insensitive) |
 | `{{rcounter::name}}` | — | Render-scoped counter (resets each prompt build, never persisted) | Counter name; optional second arg `reset` to zero it |
 
 **Examples:**
@@ -654,10 +681,6 @@ Access individual messages, track state, and query character metadata.
 
 {{counter::scene_count}}          — auto-incrementing scene counter
 {{toggle::narrator_mode}}         — flip between narrator on/off
-
-{{if::{{charTag::fantasy}}}}
-Include world-building details.
-{{/if}}
 
 This chat started {{chatAge}} ago.
 ```
@@ -1005,7 +1028,7 @@ Macros for the Loom narrative system.
 
 ## Condition-Compatible Macros
 
-These macros return `"yes"` / `"no"` or `"true"` / `"false"` and are designed for use with `{{if}}`:
+These macros return condition-friendly truthy/falsy values (such as `"yes"` / `"no"` or `"true"` / empty) and are designed for use with `{{if}}`:
 
 | Macro | True When |
 |-------|-----------|
@@ -1022,8 +1045,8 @@ These macros return `"yes"` / `"no"` or `"true"` / `"false"` and are designed fo
 | `{{haschatvar::key}}` | Chat-persisted variable exists |
 | `{{hasgvar::key}}` | Global variable exists |
 | `{{hasPromptVar::name}}` | A prompt variable is available |
+| `{{hasTag::name}}` | Character has the given tag (case-insensitive) |
 | `{{var::name::ison::keyA,keyB}}` | All listed option keys are selected on a multi-select prompt variable |
-| `{{charTag::tag}}` | Character has the specified tag |
 | `{{regexInstalled::id}}` | Regex script with that ID is installed and enabled |
 | `{{and::a::b}}` | All arguments are truthy |
 | `{{or::a::b}}` | Any argument is truthy |
@@ -1041,7 +1064,7 @@ Council deliberation results:
 {{lumiaCouncilDeliberation}}
 {{/if}}
 
-{{if::{{and::{{charTag::fantasy}}::{{gt::{{messageCount}}::5}}}}}}
+{{if::{{and::{{hasTag::fantasy}}::{{gt::{{messageCount}}::5}}}}}}
 The adventure is well underway.
 {{/if}}
 ```


### PR DESCRIPTION
## Summary

Exposes a character card's `tags` to the macro engine as a cohesive family, so presets can read, index, count, sample, and gate on a character's tags. The list form composes with the existing Lists/Iteration family the same way `{{players}}` and `{{group}}` do.

`env.extra.characterTags` was already populated by `buildEnv()` (and by the display path via `buildMacroEnvForChat`), but nothing surfaced it — so this is purely new macro definitions plus consolidation of the two pre-existing tag macros.

## New / changed macros

| Macro | Aliases | Returns |
|-------|---------|---------|
| `{{charTags}}` | `{{characterTags}}`, `{{char_tags}}`, `{{tags}}` | Comma-separated list of all tags |
| `{{tag::index}}` | `{{tagAt}}`, `{{tag_at}}`, `{{charTagAt}}`, `{{nthTag}}` | Single tag at a 0-based index (negative from end; empty if out of range) |
| `{{tagCount}}` | `{{tag_count}}`, `{{tags_count}}`, `{{numTags}}`, `{{charTagCount}}` | Number of tags |
| `{{randomTag}}` | `{{random_tag}}`, `{{randomCharTag}}` | One tag at random (empty if none) |
| `{{hasTag::name}}` | `{{charTag}}`, `{{char_tag}}`, `{{has_tag}}`, `{{tagged}}` | `"true"` if the character has the tag (case-insensitive), else empty |

Examples:

```
{{charTags}}                         — "Fantasy, Warrior, Male"
{{tagCount}}                         — "3"
{{tag::0}} / {{tag::-1}}             — first / last tag
{{if::{{hasTag::villain}}}}...{{/if}}
{{foreach::{{charTags}}::t}}- {{.t}}{{newline}}{{/foreach}}
{{count::{{charTags}}}}              — same as {{tagCount}}
```

## Consolidation & categorization

The two pre-existing tag macros (`charTags` list + `charTag` membership) lived in `chat-utils.ts` under the **Chat Utils** category. They are relocated to a dedicated `definitions/tags.ts` module and recategorized as **Character**, since tags are character-card data. All prior names and aliases are preserved, so existing presets keep resolving unchanged.

## One behavioural alignment

`{{charTag}}` / `{{hasTag}}` previously returned the literal `"false"` on a miss; it now returns `""` (empty), matching every other boolean macro (`{{includes}}`, `{{some}}`, `{{every}}`, `{{hasvar}}`). `{{if}}` condition behaviour is unchanged — both `"false"` and `""` are falsy. No callsite in the repo depended on the literal `"false"`.

Tag values are normalized (trimmed; blanks and non-string entries from imported/legacy cards are dropped) so the list form round-trips cleanly with the comma-separated list macros.

## Verification

- `bunx tsc --noEmit -p tsconfig.json` — clean (the one remaining diagnostic, in `src/services/world-info-outlet-only.test.ts`, is pre-existing on `staging` and unrelated to this change).
- `bun test src/macros/macros.test.ts` — 314 pass / 0 fail. The new `describe("Character Tags macros")` block covers list/index (positive, negative, out-of-range)/count/random/membership (case-insensitive, condition-compatible)/composition with the list family, plus empty-tag and malformed-array (non-string entries) edge cases.
- Documented under **Character Data** in `user-docs/docs/presets/macros-reference.md`, and `{{hasTag}}` added to the Condition-Compatible Macros table.