### PR TITLE
Flag World Info in prompt assembly and update interceptor docs

### DIFF
--- a/developer-docs/docs/backend-api/interceptors.md
+++ b/developer-docs/docs/backend-api/interceptors.md
@@ -129,6 +129,10 @@ interface LlmMessageDTO {
   role: "system" | "user" | "assistant"
   content: string | LlmMessagePartDTO[]
   name?: string
+  __isChatHistory?: boolean
+  __isWorldInfoEntry?: boolean
+  sourceMessageId?: string
+  sourceIndexInChat?: number
 }
 
 type LlmMessagePartDTO =
@@ -140,6 +144,10 @@ type LlmMessagePartDTO =
 ```
 
 `content` accepts a plain string or an array of typed parts. Tool calls and tool results are first-class parts — see [Generation › Tool calling](generation.md#tool-calling).
+
+`__isChatHistory` is set on interceptor input messages that originate from stored chat turns. When present, `sourceMessageId` and `sourceIndexInChat` identify the source chat message where available.
+
+`__isWorldInfoEntry` is set on interceptor input messages that are standalone World Info / world-book entries in the assembled prompt. World Info inserted inline through marker macros is part of the surrounding prompt block and is not flagged as a separate message.
 
 ## Context Object
 

--- a/developer-docs/docs/backend-api/prompt-regex.md
+++ b/developer-docs/docs/backend-api/prompt-regex.md
@@ -41,9 +41,11 @@ spindle.registerInterceptor(async (messages, context) => {
 
 The invariant is **apply if you own**. If you declare ownership but cannot apply (your runtime is unavailable, a fetch fails), the prompt ships with no prompt regex at all, because the host already skipped its pass. Release ownership in that case so the host runs its own pass, and log loudly when an owned chat would otherwise ship un-transformed.
 
-### Chat history flag
+### Assembly source flags
 
 Messages passed to your interceptor carry `__isChatHistory` when they are genuine chat-history turns, as opposed to depth-injected world info, preset, or author's note blocks spliced into the history range. The host gates `min_depth` / `max_depth` on chat-history messages only, so use this flag to rebuild the same depth frame and to number turns. Injected non-history blocks must not shift the index of real turns.
+
+Standalone World Info / world-book messages carry `__isWorldInfoEntry`. World Info inserted inline through marker macros is part of the surrounding prompt block and is not flagged as a separate message.
 
 ```ts
 interface LlmMessageDTO {
@@ -51,10 +53,11 @@ interface LlmMessageDTO {
   content: string | LlmMessagePartDTO[]
   name?: string
   __isChatHistory?: boolean // host-set, present only on interceptor input
+  __isWorldInfoEntry?: boolean // host-set, present only on interceptor input
 }
 ```
 
-The flag is set by the host on interceptor input only. It is never sent to the LLM.
+These flags are set by the host on interceptor input only. They are never sent to the LLM.
 
 ## `spindle.promptRegex.setOwnedChats(chatIds)`
 

--- a/src/services/prompt-assembly-regex-macros.test.ts
+++ b/src/services/prompt-assembly-regex-macros.test.ts
@@ -3,6 +3,7 @@ import type { LlmMessage } from "../llm/types";
 import { initMacros, type MacroEnv } from "../macros";
 import {
   isChatHistoryMessage,
+  isWorldInfoEntryMessage,
   resolvePromptMacrosAfterRegexPass,
 } from "./prompt-assembly.service";
 
@@ -78,6 +79,11 @@ function markChatHistory(message: LlmMessage): LlmMessage {
   return message;
 }
 
+function markWorldInfo(message: LlmMessage): LlmMessage {
+  (message as any).__worldInfoSource = true;
+  return message;
+}
+
 describe("resolvePromptMacrosAfterRegexPass", () => {
   beforeAll(() => {
     initMacros();
@@ -103,5 +109,22 @@ describe("resolvePromptMacrosAfterRegexPass", () => {
     expect(env.variables.local.get("scene")).toBe("lantern-lit alley");
     expect(isChatHistoryMessage(messages[0])).toBe(true);
     expect(isChatHistoryMessage(messages[1])).toBe(true);
+  });
+
+  test("preserves world info source markers while resolving prompt macros", async () => {
+    const env = makeEnv();
+    env.variables.local.set("lore", "the doors answer to moonlight");
+    const messages: LlmMessage[] = [
+      markWorldInfo({
+        role: "system",
+        content: "Lore: {{getvar::lore}}",
+      }),
+    ];
+
+    await resolvePromptMacrosAfterRegexPass(messages, env);
+
+    expect(messages[0].content).toBe("Lore: the doors answer to moonlight");
+    expect(isWorldInfoEntryMessage(messages[0])).toBe(true);
+    expect(isChatHistoryMessage(messages[0])).toBe(false);
   });
 });

--- a/src/services/prompt-assembly.service.ts
+++ b/src/services/prompt-assembly.service.ts
@@ -118,14 +118,14 @@ export type {
 } from "./world-info-vector-ranking";
 
 // ---------------------------------------------------------------------------
-// Chat history identity marker
+// Chat history and World Info identity markers
 // ---------------------------------------------------------------------------
-// Each LlmMessage that originates from the user's chat history (as opposed to
-// system blocks, world info, author's note, depth-injected blocks, etc.) is
-// tagged with this property. Downstream consumers (regex script depth filter,
-// tokenizer breakdown snapshot) use the tag to identify chat history messages
-// regardless of where they end up in the final assembled array, since later
-// insertions/merges can shift positions and even break contiguity.
+// LlmMessages that originate from the user's chat history or standalone World
+// Info entries are tagged with source properties. Downstream consumers (regex
+// script depth filters, tokenizer breakdown snapshots, Spindle interceptors)
+// use these tags to identify source messages regardless of where they end up in
+// the final assembled array, since later insertions/merges can shift positions
+// and even break contiguity.
 //
 // The tag is preserved by every mutation that uses object spread
 // (`{ ...result[i], content: ... }`). The merge function — which constructs
@@ -137,6 +137,7 @@ export type {
 // outbound requests, so the tag never leaks to the LLM.
 
 const CHAT_HISTORY_KEY = "__chatHistorySource";
+const WORLD_INFO_KEY = "__worldInfoSource";
 const SOURCE_ID_KEY = "__sourceMessageId";
 const SOURCE_INDEX_KEY = "__sourceIndexInChat";
 const PRESERVE_DISPLAY_REASONING_DELIMS_KEY =
@@ -156,6 +157,15 @@ function markAsChatHistory(
 
 export function isChatHistoryMessage(msg: LlmMessage): boolean {
   return (msg as any)[CHAT_HISTORY_KEY] === true;
+}
+
+function markAsWorldInfoEntry(msg: LlmMessage): LlmMessage {
+  (msg as any)[WORLD_INFO_KEY] = true;
+  return msg;
+}
+
+export function isWorldInfoEntryMessage(msg: LlmMessage): boolean {
+  return (msg as any)[WORLD_INFO_KEY] === true;
 }
 
 export function getSourceMessageId(msg: LlmMessage): string | undefined {
@@ -2514,7 +2524,7 @@ export async function assemblePrompt(
       if (wiCache.before.length > 0) {
         for (const entry of wiCache.before) {
           const role = (block.role as LlmMessage["role"]) || entry.role;
-          result.push({ role, content: entry.content });
+          result.push(markAsWorldInfoEntry({ role, content: entry.content }));
           breakdown.push({
             type: "world_info",
             name: formatWorldInfoBreakdownName(
@@ -2534,7 +2544,7 @@ export async function assemblePrompt(
       if (wiCache.after.length > 0) {
         for (const entry of wiCache.after) {
           const role = (block.role as LlmMessage["role"]) || entry.role;
-          result.push({ role, content: entry.content });
+          result.push(markAsWorldInfoEntry({ role, content: entry.content }));
           breakdown.push({
             type: "world_info",
             name: formatWorldInfoBreakdownName(
@@ -2764,7 +2774,11 @@ export async function assemblePrompt(
   for (const depthEntry of wiCache.depth) {
     const insertAt = Math.max(0, result.length - depthEntry.depth);
     const role = depthEntry.role as LlmMessage["role"];
-    result.splice(insertAt, 0, { role, content: depthEntry.content });
+    result.splice(
+      insertAt,
+      0,
+      markAsWorldInfoEntry({ role, content: depthEntry.content }),
+    );
     breakdown.push({
       type: "world_info",
       name: formatWorldInfoBreakdownName(
@@ -4722,7 +4736,11 @@ function injectWorldInfoAt(
   if (entries.length === 0) return 0;
   let idx = Math.max(0, Math.min(insertAt, result.length));
   for (const entry of entries) {
-    result.splice(idx, 0, { role: entry.role, content: entry.content });
+    result.splice(
+      idx,
+      0,
+      markAsWorldInfoEntry({ role: entry.role, content: entry.content }),
+    );
     breakdown.push({
       type: "world_info",
       name: formatWorldInfoBreakdownName(name, entry.entryLabel),
@@ -4746,7 +4764,9 @@ function pushPinnedMarkerEntries(
   entries: WorldInfoCache["pinnedMarkers"],
 ): void {
   for (const entry of entries) {
-    result.push({ role: entry.role, content: entry.content });
+    result.push(
+      markAsWorldInfoEntry({ role: entry.role, content: entry.content }),
+    );
     breakdown.push({
       type: "world_info",
       name: formatWorldInfoBreakdownName(`WI @ ${entry.marker}`, entry.entryLabel),
@@ -4913,10 +4933,12 @@ function mergeConsecutiveUserMessages(
         typeof b === "string" ? [] : b.filter((p) => p.type !== "text");
       const allParts = [...aParts, ...bParts];
 
-      // Preserve the chat-history marker if either source message carried it
-      // — both are typically chat-history user turns being merged.
+      // Preserve source markers if either source message carried them.
       const wasChatHistory =
         isChatHistoryMessage(result[i]) || isChatHistoryMessage(result[i + 1]);
+      const wasWorldInfo =
+        isWorldInfoEntryMessage(result[i]) ||
+        isWorldInfoEntryMessage(result[i + 1]);
       const mergedSourceId =
         getSourceMessageId(result[i]) ?? getSourceMessageId(result[i + 1]);
       const mergedSourceIndex =
@@ -4937,6 +4959,7 @@ function mergeConsecutiveUserMessages(
             : undefined,
         );
       }
+      if (wasWorldInfo) markAsWorldInfoEntry(result[i]);
       result.splice(i + 1, 1);
       remaining--;
       // Don't increment — next element slid into i+1, check again

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -3396,19 +3396,21 @@ export class WorkerHost {
         const requestId = crypto.randomUUID();
         const timeoutMs = resolveTimeoutMs();
 
-        // Expose chat-history membership explicitly on the DTO so an extension
-        // applying prompt-target regex inline can rebuild the host's depth frame
-        // (depth gating is chat-history-only; injected non-history blocks are
-        // ungated and must not shift real-turn numbering). Shallow-copy so the
-        // synthetic flag never leaks onto the outbound LLM payload.
-        const messagesWithHistoryFlag = messages.map((m) => {
+        // Expose assembly-source membership explicitly on the DTO so extensions
+        // can distinguish real chat turns and standalone World Info blocks
+        // from other prompt material. Shallow-copy so the synthetic flags never
+        // leak onto the outbound LLM payload.
+        const messagesWithSourceFlags = messages.map((m) => {
           const llm = m as unknown as LlmMessage;
-          if (!promptAssemblySvc.isChatHistoryMessage(llm)) return m;
+          const isChatHistory = promptAssemblySvc.isChatHistoryMessage(llm);
+          const isWorldInfoEntry = promptAssemblySvc.isWorldInfoEntryMessage(llm);
+          if (!isChatHistory && !isWorldInfoEntry) return m;
           const sourceMessageId = promptAssemblySvc.getSourceMessageId(llm);
           const sourceIndexInChat = promptAssemblySvc.getSourceIndexInChat(llm);
           return {
             ...m,
-            __isChatHistory: true,
+            ...(isChatHistory ? { __isChatHistory: true } : {}),
+            ...(isWorldInfoEntry ? { __isWorldInfoEntry: true } : {}),
             ...(sourceMessageId !== undefined ? { sourceMessageId } : {}),
             ...(sourceIndexInChat !== undefined ? { sourceIndexInChat } : {}),
           };
@@ -3417,7 +3419,7 @@ export class WorkerHost {
         this.postToWorker({
           type: "intercept_request",
           requestId,
-          messages: messagesWithHistoryFlag,
+          messages: messagesWithSourceFlags,
           context,
         });
 


### PR DESCRIPTION
This pull request expands and refines the handling of message source metadata in prompt assembly and Spindle interceptor APIs. The main improvement is the introduction of a distinct marker for standalone World Info entries, alongside the existing chat history marker. This enables downstream consumers and extensions to accurately distinguish between genuine chat turns, standalone World Info blocks, and other prompt material. The changes also update documentation, tests, and code comments to reflect these enhancements.

**Prompt assembly and source markers:**

* Added a new `__isWorldInfoEntry` marker to `LlmMessageDTO` and internal message objects, set on standalone World Info entries during prompt assembly. Updated all relevant insertion and merge points to preserve this marker. [[1]](diffhunk://#diff-20f3fd805092b3c65647cc031b128c8b36885d0681e61d74316db77682ef12d2R140) [[2]](diffhunk://#diff-20f3fd805092b3c65647cc031b128c8b36885d0681e61d74316db77682ef12d2R162-R170) [[3]](diffhunk://#diff-20f3fd805092b3c65647cc031b128c8b36885d0681e61d74316db77682ef12d2L2517-R2527) [[4]](diffhunk://#diff-20f3fd805092b3c65647cc031b128c8b36885d0681e61d74316db77682ef12d2L2537-R2547) [[5]](diffhunk://#diff-20f3fd805092b3c65647cc031b128c8b36885d0681e61d74316db77682ef12d2L2767-R2781) [[6]](diffhunk://#diff-20f3fd805092b3c65647cc031b128c8b36885d0681e61d74316db77682ef12d2L4725-R4743) [[7]](diffhunk://#diff-20f3fd805092b3c65647cc031b128c8b36885d0681e61d74316db77682ef12d2L4749-R4769) [[8]](diffhunk://#diff-20f3fd805092b3c65647cc031b128c8b36885d0681e61d74316db77682ef12d2L4916-R4941) [[9]](diffhunk://#diff-20f3fd805092b3c65647cc031b128c8b36885d0681e61d74316db77682ef12d2R4962)
* Updated the logic that exposes message source flags to Spindle interceptors, so both `__isChatHistory` and `__isWorldInfoEntry` are set as appropriate, and only on interceptor input. [[1]](diffhunk://#diff-1cc3a1bac974aa8a9f7b829a327f4774e60949f55652a3a665b8af960385f960L3399-R3413) [[2]](diffhunk://#diff-1cc3a1bac974aa8a9f7b829a327f4774e60949f55652a3a665b8af960385f960L3420-R3422)

**Documentation updates:**

* Updated backend API docs to describe the new `__isWorldInfoEntry` flag, its semantics, and its distinction from inline World Info. Clarified that both flags are host-set and never sent to the LLM. [[1]](diffhunk://#diff-3607cb35bc949fc946a84e4d4c9472e553085dfaac9e193aa4c1f111dc31a3e6R132-R135) [[2]](diffhunk://#diff-3607cb35bc949fc946a84e4d4c9472e553085dfaac9e193aa4c1f111dc31a3e6R148-R151) [[3]](diffhunk://#diff-b04fc7f5aba7aedfdc1ec79f32ade73c8ff07ab2db98fd156cea0f246d8db21fL44-R60)

**Testing and utility functions:**

* Added `isWorldInfoEntryMessage` and `markAsWorldInfoEntry` utility functions, and extended tests to verify that World Info source markers are preserved through macro resolution. [[1]](diffhunk://#diff-fa60f93f2a503f770102dca1d0bf95cfc96aac1423e353787dd9f8d4b5590456R6) [[2]](diffhunk://#diff-fa60f93f2a503f770102dca1d0bf95cfc96aac1423e353787dd9f8d4b5590456R82-R86) [[3]](diffhunk://#diff-fa60f93f2a503f770102dca1d0bf95cfc96aac1423e353787dd9f8d4b5590456R113-R129)

**Code comments and clarity:**

* Improved comments throughout `prompt-assembly.service.ts` to clarify the purpose and handling of chat history and World Info source markers.

These changes ensure that all downstream consumers, including Spindle interceptors and tokenizer breakdown tools, can reliably identify the origin of each message in the assembled prompt.