### PR TITLE
feat(connections): drag-to-reorder

### DIFF
--- a/frontend/src/components/chat/MessageContent.tsx
+++ b/frontend/src/components/chat/MessageContent.tsx
@@ -11,6 +11,10 @@ import { resolveDisplayMacros } from '@/lib/resolveDisplayMacros'
 import { copyTextToClipboard } from '@/lib/clipboard'
 import { sanitizeHtmlIsland, sanitizeRichHtml } from '@/lib/richHtmlSanitizer'
 import {
+  dispatchCollapsibleToggleLayoutEvent,
+  findDetailsToggleLayoutTarget,
+} from './collapsibleLayout'
+import {
   dispatchMessageTagIntercepts,
   stripMessageTags,
   subscribeTagInterceptorRegistry,
@@ -317,6 +321,7 @@ marked.setOptions({
 const HTML_ISLAND_TOKEN = 'LUMIVERSE_HTML_ISLAND'
 const YOUTUBE_EMBED_TOKEN = 'LUMIVERSE_YOUTUBE_EMBED'
 const MESSAGE_CONTENT_LAYOUT_EVENT = 'lumiverse:message-content-layout'
+const DETAILS_TOGGLE_KEYS = new Set(['Enter', ' ', 'Spacebar'])
 const SPECIAL_PIECE_RE = new RegExp(`<!--(${HTML_ISLAND_TOKEN}|${YOUTUBE_EMBED_TOKEN})_(\\d+)-->`, 'g')
 const YOUTUBE_NOCOOKIE_ORIGIN = 'https://www.youtube-nocookie.com'
 const YOUTUBE_EMBED_PATH_RE = /^\/embed\/[A-Za-z0-9_-]{6,}$/
@@ -1438,6 +1443,36 @@ export default function MessageContent({
     const container = containerRef.current
     if (!container) return
     return attachCodeCopyHandler(container)
+  }, [])
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const signalCollapsibleToggle = (event: Event) => {
+      const details = findDetailsToggleLayoutTarget(event)
+      if (details) dispatchCollapsibleToggleLayoutEvent(details)
+    }
+
+    const handleSummaryClickCapture = (event: MouseEvent) => {
+      signalCollapsibleToggle(event)
+    }
+
+    const handleSummaryKeyDownCapture = (event: KeyboardEvent) => {
+      if (!DETAILS_TOGGLE_KEYS.has(event.key)) return
+      signalCollapsibleToggle(event)
+    }
+
+    // Native <details> elements toggle immediately after activation. Mark the
+    // row before that happens so the virtualizer treats the resulting resize as
+    // a user-controlled collapse/expand, just like the dedicated reasoning box.
+    container.addEventListener('click', handleSummaryClickCapture, true)
+    container.addEventListener('keydown', handleSummaryKeyDownCapture, true)
+
+    return () => {
+      container.removeEventListener('click', handleSummaryClickCapture, true)
+      container.removeEventListener('keydown', handleSummaryKeyDownCapture, true)
+    }
   }, [])
 
   useLayoutEffect(() => {

--- a/frontend/src/components/chat/MessageList.tsx
+++ b/frontend/src/components/chat/MessageList.tsx
@@ -13,6 +13,7 @@ import MessageCard from './MessageCard'
 import GroupChatProgressBar from './GroupChatProgressBar'
 import GroupChatMemberBar from './GroupChatMemberBar'
 import { shouldAdjustMessageListScrollOnResize } from './messageListScrollAdjust'
+import { COLLAPSIBLE_TOGGLE_LAYOUT_EVENT } from './collapsibleLayout'
 import type { Message } from '@/types/api'
 import type { OOCStyleType } from '@/types/store'
 import styles from './MessageList.module.css'
@@ -26,7 +27,6 @@ interface MessageListProps {
 const TOP_LOAD_THRESHOLD = 96
 const CHAT_SCROLL_TO_BOTTOM_EVENT = 'lumiverse:chat-scroll-bottom'
 const MESSAGE_CONTENT_LAYOUT_EVENT = 'lumiverse:message-content-layout'
-const REASONING_TOGGLE_LAYOUT_EVENT = 'lumiverse:reasoning-toggle-layout'
 // TanStack recommends a forgiving end threshold for chat so that minor
 // overscroll, mobile momentum settling, and soft-keyboard shrink/growth don't
 // immediately unpin the viewport from new output.
@@ -88,10 +88,10 @@ function getFocusedEditableMessageId(root: HTMLElement | null) {
   return active.closest<HTMLElement>('[data-message-id]')?.dataset.messageId ?? null
 }
 
-function getFocusedReasoningToggleMessageId(root: HTMLElement | null) {
+function getFocusedCollapsibleToggleMessageId(root: HTMLElement | null) {
   const active = document.activeElement
   if (!root || !active || !root.contains(active)) return null
-  if (!(active instanceof Element) || !active.matches('[data-reasoning-toggle]')) return null
+  if (!(active instanceof Element) || !active.matches('[data-reasoning-toggle], summary')) return null
   return active.closest<HTMLElement>('[data-message-id]')?.dataset.messageId ?? null
 }
 
@@ -205,9 +205,9 @@ export default function MessageList({ messages, chatId, isStreaming }: MessageLi
   // all land at the true bottom of the list.
   const [inputSafeZone, setInputSafeZone] = useState(100)
   const [editableFocusInList, setEditableFocusInList] = useState(false)
-  const recentReasoningToggleMessageIdRef = useRef<string | null>(null)
-  const recentReasoningToggleUntilRef = useRef(0)
-  const recentReasoningToggleTimerRef = useRef<number | null>(null)
+  const recentCollapsibleToggleMessageIdRef = useRef<string | null>(null)
+  const recentCollapsibleToggleUntilRef = useRef(0)
+  const recentCollapsibleToggleTimerRef = useRef<number | null>(null)
   const interceptorRegistryVersion = useSyncExternalStore(
     subscribeTagInterceptorRegistry,
     getTagInterceptorRegistryVersion,
@@ -267,11 +267,11 @@ export default function MessageList({ messages, chatId, isStreaming }: MessageLi
     initialBottomPinnedChatRef.current = null
     initialScrollStartedAtRef.current = 0
     setEditableFocusInList(false)
-    recentReasoningToggleMessageIdRef.current = null
-    recentReasoningToggleUntilRef.current = 0
-    if (recentReasoningToggleTimerRef.current != null) {
-      window.clearTimeout(recentReasoningToggleTimerRef.current)
-      recentReasoningToggleTimerRef.current = null
+    recentCollapsibleToggleMessageIdRef.current = null
+    recentCollapsibleToggleUntilRef.current = 0
+    if (recentCollapsibleToggleTimerRef.current != null) {
+      window.clearTimeout(recentCollapsibleToggleTimerRef.current)
+      recentCollapsibleToggleTimerRef.current = null
     }
     if (initialScrollRafRef.current != null) {
       cancelAnimationFrame(initialScrollRafRef.current)
@@ -504,36 +504,36 @@ export default function MessageList({ messages, chatId, isStreaming }: MessageLi
     const el = scrollRef.current
     if (!el) return
 
-    const clearRecentReasoningToggle = () => {
-      recentReasoningToggleMessageIdRef.current = null
-      recentReasoningToggleUntilRef.current = 0
-      recentReasoningToggleTimerRef.current = null
+    const clearRecentCollapsibleToggle = () => {
+      recentCollapsibleToggleMessageIdRef.current = null
+      recentCollapsibleToggleUntilRef.current = 0
+      recentCollapsibleToggleTimerRef.current = null
     }
 
-    const handleReasoningToggle = (event: Event) => {
+    const handleCollapsibleToggle = (event: Event) => {
       const target = event.target
       const messageId = target instanceof Element
         ? target.closest<HTMLElement>('[data-message-id]')?.dataset.messageId ?? null
         : null
       if (!messageId) return
 
-      recentReasoningToggleMessageIdRef.current = messageId
-      recentReasoningToggleUntilRef.current = performance.now() + USER_CONTROLLED_ROW_RESIZE_SETTLE_MS
-      if (recentReasoningToggleTimerRef.current != null) {
-        window.clearTimeout(recentReasoningToggleTimerRef.current)
+      recentCollapsibleToggleMessageIdRef.current = messageId
+      recentCollapsibleToggleUntilRef.current = performance.now() + USER_CONTROLLED_ROW_RESIZE_SETTLE_MS
+      if (recentCollapsibleToggleTimerRef.current != null) {
+        window.clearTimeout(recentCollapsibleToggleTimerRef.current)
       }
-      recentReasoningToggleTimerRef.current = window.setTimeout(
-        clearRecentReasoningToggle,
+      recentCollapsibleToggleTimerRef.current = window.setTimeout(
+        clearRecentCollapsibleToggle,
         USER_CONTROLLED_ROW_RESIZE_SETTLE_MS + 120,
       )
     }
 
-    el.addEventListener(REASONING_TOGGLE_LAYOUT_EVENT, handleReasoningToggle)
+    el.addEventListener(COLLAPSIBLE_TOGGLE_LAYOUT_EVENT, handleCollapsibleToggle)
     return () => {
-      el.removeEventListener(REASONING_TOGGLE_LAYOUT_EVENT, handleReasoningToggle)
-      if (recentReasoningToggleTimerRef.current != null) {
-        window.clearTimeout(recentReasoningToggleTimerRef.current)
-        recentReasoningToggleTimerRef.current = null
+      el.removeEventListener(COLLAPSIBLE_TOGGLE_LAYOUT_EVENT, handleCollapsibleToggle)
+      if (recentCollapsibleToggleTimerRef.current != null) {
+        window.clearTimeout(recentCollapsibleToggleTimerRef.current)
+        recentCollapsibleToggleTimerRef.current = null
       }
     }
   }, [])
@@ -642,13 +642,13 @@ export default function MessageList({ messages, chatId, isStreaming }: MessageLi
       const row = virtualListItems[item.index]
       const isStreamingTail = row?.type === 'message' && row.message.id === streamingTargetMessageId
       const focusedEditableMessageId = getFocusedEditableMessageId(scrollRef.current)
-      const focusedReasoningToggleMessageId = getFocusedReasoningToggleMessageId(scrollRef.current)
+      const focusedCollapsibleToggleMessageId = getFocusedCollapsibleToggleMessageId(scrollRef.current)
       const isFocusedEditableRow = row?.type === 'message' && row.message.id === focusedEditableMessageId
       const isUserToggledCollapsibleRow = row?.type === 'message' && (
-        row.message.id === focusedReasoningToggleMessageId
+        row.message.id === focusedCollapsibleToggleMessageId
         || (
-          row.message.id === recentReasoningToggleMessageIdRef.current
-          && performance.now() <= recentReasoningToggleUntilRef.current
+          row.message.id === recentCollapsibleToggleMessageIdRef.current
+          && performance.now() <= recentCollapsibleToggleUntilRef.current
         )
       )
       return shouldAdjustMessageListScrollOnResize({

--- a/frontend/src/components/chat/ReasoningBlock.tsx
+++ b/frontend/src/components/chat/ReasoningBlock.tsx
@@ -6,6 +6,7 @@ import { createEmphasisAwareRenderer } from '@/lib/markedEmphasisRenderer'
 import { createStrictTildeTokenizer } from '@/lib/markedTokenizer'
 import { sanitizeRichHtml } from '@/lib/richHtmlSanitizer'
 import { ChevronRight, Brain } from 'lucide-react'
+import { dispatchCollapsibleToggleLayoutEvent } from './collapsibleLayout'
 import styles from './ReasoningBlock.module.css'
 import clsx from 'clsx'
 
@@ -24,7 +25,6 @@ type ReasoningRenderMode = 'markdown' | 'text'
 // Approximate cutoff where full markdown rendering starts to create enough DOM
 // churn during long CoT streams that switching to plain text is noticeably smoother.
 const LARGE_REASONING_RENDER_THRESHOLD = 40_000
-const REASONING_TOGGLE_LAYOUT_EVENT = 'lumiverse:reasoning-toggle-layout'
 
 const md = new Marked({
   gfm: true,
@@ -61,7 +61,7 @@ export default function ReasoningBlock({ reasoning, reasoningDuration, reasoning
   const deferredReasoning = useDeferredValue(reasoning)
 
   const toggle = useCallback(() => {
-    containerRef.current?.dispatchEvent(new CustomEvent(REASONING_TOGGLE_LAYOUT_EVENT, { bubbles: true }))
+    dispatchCollapsibleToggleLayoutEvent(containerRef.current)
     setIsOpen((o) => !o)
   }, [])
 

--- a/frontend/src/components/chat/collapsibleLayout.test.ts
+++ b/frontend/src/components/chat/collapsibleLayout.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test'
+import { findDetailsToggleLayoutTargetFromPath } from './collapsibleLayout'
+
+function tagTarget(tagName: string): EventTarget & { tagName: string } {
+  return Object.assign(new EventTarget(), { tagName })
+}
+
+describe('findDetailsToggleLayoutTargetFromPath', () => {
+  test('returns the details element for a summary activation path', () => {
+    const details = tagTarget('DETAILS')
+    const path = [
+      tagTarget('SPAN'),
+      tagTarget('SUMMARY'),
+      details,
+      tagTarget('DIV'),
+    ]
+
+    expect(findDetailsToggleLayoutTargetFromPath(path)).toBe(details)
+  })
+
+  test('ignores details elements that are not reached through a summary', () => {
+    const details = tagTarget('DETAILS')
+    const path = [
+      tagTarget('SPAN'),
+      details,
+      tagTarget('DIV'),
+    ]
+
+    expect(findDetailsToggleLayoutTargetFromPath(path)).toBeNull()
+  })
+
+  test('prefers the innermost details following the activated summary', () => {
+    const innerDetails = tagTarget('DETAILS')
+    const outerDetails = tagTarget('DETAILS')
+    const path = [
+      tagTarget('SPAN'),
+      tagTarget('SUMMARY'),
+      innerDetails,
+      outerDetails,
+      tagTarget('DIV'),
+    ]
+
+    expect(findDetailsToggleLayoutTargetFromPath(path)).toBe(innerDetails)
+  })
+})

--- a/frontend/src/components/chat/collapsibleLayout.ts
+++ b/frontend/src/components/chat/collapsibleLayout.ts
@@ -1,0 +1,49 @@
+export const COLLAPSIBLE_TOGGLE_LAYOUT_EVENT = 'lumiverse:collapsible-toggle-layout'
+
+function getTagName(target: EventTarget | null | undefined): string | null {
+  if (!target || typeof target !== 'object') return null
+  const rawTagName = (target as { tagName?: unknown }).tagName
+  return typeof rawTagName === 'string' ? rawTagName.toLowerCase() : null
+}
+
+export function getEventPath(event: Event): readonly EventTarget[] {
+  if (typeof event.composedPath === 'function') {
+    const path = event.composedPath()
+    if (Array.isArray(path) && path.length > 0) return path
+  }
+  return event.target ? [event.target] : []
+}
+
+export function findDetailsToggleLayoutTargetFromPath(path: readonly EventTarget[]): EventTarget | null {
+  let sawSummary = false
+
+  for (const entry of path) {
+    const tagName = getTagName(entry)
+    if (!tagName) continue
+
+    if (tagName === 'summary') {
+      sawSummary = true
+      continue
+    }
+
+    if (sawSummary && tagName === 'details') {
+      return entry
+    }
+  }
+
+  return null
+}
+
+export function findDetailsToggleLayoutTarget(event: Event): EventTarget | null {
+  return findDetailsToggleLayoutTargetFromPath(getEventPath(event))
+}
+
+export function dispatchCollapsibleToggleLayoutEvent(target: EventTarget | null): void {
+  const dispatchEventFn = (target as { dispatchEvent?: unknown } | null)?.dispatchEvent
+  if (typeof dispatchEventFn !== 'function') return
+
+  ;(target as EventTarget).dispatchEvent(new CustomEvent(COLLAPSIBLE_TOGGLE_LAYOUT_EVENT, {
+    bubbles: true,
+    composed: true,
+  }))
+}

--- a/frontend/src/components/panels/ConnectionManager.module.css
+++ b/frontend/src/components/panels/ConnectionManager.module.css
@@ -127,3 +127,33 @@
   flex-direction: column;
   gap: 2px;
 }
+
+/* Lift visual applied to the <DragOverlay> clone wrapper in
+   ConnectionManager.tsx. Gives the dragged card the tinted opaque
+   surface, drop shadow, and primary outline ring at the cursor.
+   Needed because the clone sits outside SortableContext, where
+   useSortable returns defaults — so the cloned <ConnectionItem>
+   does not receive .itemDragging or .itemActive state classes on
+   its own and would otherwise render without the lift styling. */
+.itemDraggingOverlay {
+  background: color-mix(in srgb, var(--lumiverse-primary) 8%, var(--lumiverse-bg-deep));
+  box-shadow: 0 10px 30px -8px rgba(0, 0, 0, 0.45),
+    0 0 0 1px var(--lumiverse-primary-040, var(--lumiverse-primary));
+  border-radius: 10px;
+  cursor: grabbing;
+}
+
+/* Suppress all CSS animations on the DragOverlay clone. The dnd-kit
+   DragOverlay portal mounts a fresh React instance, so any animation
+   on the cloned subtree re-fires on drag-begin. The in-list row is
+   outside this wrapper, so its first-visit fade-ins still play. */
+.itemDraggingOverlay * { animation: none !important; }
+
+/* Also suppress CSS transitions on the clone. Without this, the .item
+   background transition animates the clone's tinted surface from
+   transparent to opaque over ~100 ms on drag-begin, producing a brief
+   "handle disappears then fades back in" flicker. */
+.itemDraggingOverlay,
+.itemDraggingOverlay * {
+  transition: none !important;
+}

--- a/frontend/src/components/panels/ConnectionManager.tsx
+++ b/frontend/src/components/panels/ConnectionManager.tsx
@@ -1,6 +1,24 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { Plus, Shuffle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import {
+  DndContext,
+  DragOverlay,
+  closestCenter,
+  MouseSensor,
+  TouchSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  type DragStartEvent,
+  type DragEndEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  arrayMove,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable'
 import { connectionsApi } from '@/api/connections'
 import { listAllConnections } from '@/api/listAllConnections'
 import { useStore } from '@/store'
@@ -32,11 +50,33 @@ export default function ConnectionManager() {
   const setActiveProfile = useStore((s) => s.setActiveProfile)
   const providers = useStore((s) => s.providers)
   const setProviders = useStore((s) => s.setProviders)
+  const applyProfileOrder = useStore((s) => s.applyProfileOrder)
+  const setSetting = useStore((s) => s.setSetting)
+  const connectionsOrder = useStore((s) => s.connectionsOrder)
+
+  const mouseSensor = useSensor(MouseSensor, { activationConstraint: { distance: 4 } })
+  const touchSensor = useSensor(TouchSensor, { activationConstraint: { delay: 180, tolerance: 5 } })
+  const keyboardSensor = useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  const sensors = useSensors(mouseSensor, touchSensor, keyboardSensor)
+
+  const orderedProfiles = useMemo(() => {
+    const llmOrder = connectionsOrder?.llm ?? []
+    if (llmOrder.length === 0) return profiles
+    const byId = new Map(profiles.map((p) => [p.id, p]))
+    const ordered = llmOrder.map((id) => byId.get(id)).filter((p): p is ConnectionProfile => Boolean(p))
+    const seen = new Set(ordered.map((p) => p.id))
+    const missing = profiles.filter((p) => !seen.has(p.id))
+    return [...ordered, ...missing]
+  }, [profiles, connectionsOrder])
+
+  const orderedIds = useMemo(() => orderedProfiles.map((p) => p.id), [orderedProfiles])
 
   const [loading, setLoading] = useState(false)
   const [creating, setCreating] = useState(false)
   const [creatingProvider, setCreatingProvider] = useState('openai')
   const [deleteTarget, setDeleteTarget] = useState<ConnectionProfile | null>(null)
+  const [dragActiveId, setDragActiveId] = useState<string | null>(null)
+  const activeProfile = orderedProfiles.find((p) => p.id === dragActiveId) ?? null
 
   useEffect(() => {
     const returnedKey = sessionStorage.getItem('pollinations_byop_returned_api_key')
@@ -139,11 +179,34 @@ export default function ConnectionManager() {
     try {
       await connectionsApi.delete(deleteTarget.id)
       removeProfile(deleteTarget.id)
+      const nextOrder = (connectionsOrder?.llm ?? []).filter((id) => id !== deleteTarget.id)
+      setSetting('connectionsOrder', { ...connectionsOrder, llm: nextOrder })
       setDeleteTarget(null)
     } catch (err) {
       console.error('[ConnectionManager] Failed to delete:', err)
     }
-  }, [deleteTarget, removeProfile])
+  }, [deleteTarget, removeProfile, connectionsOrder, setSetting])
+
+
+  const handleDragStart = useCallback(({ active }: DragStartEvent) => {
+    setDragActiveId(String(active.id))
+  }, [])
+
+  const handleDragCancel = useCallback(() => {
+    setDragActiveId(null)
+  }, [])
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    setDragActiveId(null)
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = orderedIds.indexOf(String(active.id))
+    const newIndex = orderedIds.indexOf(String(over.id))
+    if (oldIndex < 0 || newIndex < 0) return
+    const newOrder = arrayMove(orderedIds, oldIndex, newIndex)
+    applyProfileOrder(newOrder)
+    setSetting('connectionsOrder', { ...connectionsOrder, llm: newOrder })
+  }, [orderedIds, connectionsOrder, applyProfileOrder, setSetting])
 
   if (loading) {
     return <div className={styles.loading}>{t('connectionManager.loading')}</div>
@@ -185,23 +248,42 @@ export default function ConnectionManager() {
         />
       )}
 
-      <div className={styles.list}>
-        {profiles.map((profile) => (
-          <ConnectionItem
-            key={profile.id}
-            profile={profile}
-            isActive={activeProfileId === profile.id}
-            providers={providers}
-            onSelect={() => setActiveProfile(activeProfileId === profile.id ? null : profile.id)}
-            onUpdate={handleUpdate}
-            onDuplicate={() => handleDuplicate(profile.id)}
-            onDelete={() => setDeleteTarget(profile)}
-          />
-        ))}
-        {profiles.length === 0 && !creating && (
-          <div className={styles.empty}>{t('connectionManager.empty')}</div>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragCancel={handleDragCancel} onDragEnd={handleDragEnd}>
+        <SortableContext items={orderedIds} strategy={verticalListSortingStrategy}>
+          <div className={styles.list}>
+            {orderedProfiles.map((profile) => (
+              <ConnectionItem
+                key={profile.id}
+                profile={profile}
+                isActive={activeProfileId === profile.id}
+                providers={providers}
+                onSelect={() => setActiveProfile(activeProfileId === profile.id ? null : profile.id)}
+                onUpdate={handleUpdate}
+                onDuplicate={() => handleDuplicate(profile.id)}
+                onDelete={() => setDeleteTarget(profile)}
+              />
+            ))}
+            {profiles.length === 0 && !creating && (
+              <div className={styles.empty}>{t('connectionManager.empty')}</div>
+            )}
+          </div>
+        </SortableContext>
+        {activeProfile && (
+        <DragOverlay dropAnimation={null}>
+          <div className={styles.itemDraggingOverlay}>
+            <ConnectionItem
+              profile={activeProfile}
+              isActive={activeProfileId === activeProfile.id}
+              providers={providers}
+              onSelect={() => setActiveProfile(activeProfileId === activeProfile.id ? null : activeProfile.id)}
+              onUpdate={handleUpdate}
+              onDuplicate={() => handleDuplicate(activeProfile.id)}
+              onDelete={() => setDeleteTarget(activeProfile)}
+            />
+          </div>
+        </DragOverlay>
         )}
-      </div>
+      </DndContext>
 
       {deleteTarget && (
         <ConfirmationModal

--- a/frontend/src/components/panels/connection-manager/ConnectionItem.module.css
+++ b/frontend/src/components/panels/connection-manager/ConnectionItem.module.css
@@ -3,16 +3,79 @@
   flex-direction: column;
   border-radius: 10px;
   transition: background var(--lumiverse-transition-fast);
+  /* Prevent the browser from interpreting a touch on the row as a scroll
+     gesture on .panelContent during the 180ms TouchSensor activation delay.
+     Without this, the panel scrolls a few px before drag activates and
+     useRect(activeNode) measures the card at its new (scrolled) position —
+     the DragOverlay then anchors there, making the overlay's top-left "snap"
+     away from the user's original touch point (top of handle ends up at thumb,
+     not handle bottom). The handle already has touch-action:none, but it's
+     only 24x32px and the touch can land on the row gap or below the row,
+     which inherits the default touch-action:auto from .panelContent. */
+  touch-action: none;
+}
+
+.itemDragging {
+  /* Hidden slot for the dragged card. The visible "lifted" card during a
+     reorder is the <DragOverlay> clone at the document-body level (via
+     React Portal) — it escapes the drawer panel's overflow:hidden +
+     isolation:isolate stacking context so it can be dragged over chat
+     and other panels without being clipped.
+
+     Without opacity:0 the slot would render as a translated ghost beside
+     the overlay (it still receives useSortable's transform during the
+     drag). Hiding it leaves only the overlay visible, but keeps the
+     layout footprint so neighbor cards reflow correctly.
+
+     The overlay clone sits outside SortableContext, so useSortable there
+     returns defaults (isDragging=false) and the overlay does NOT receive
+     .itemDragging — it's only this in-list slot that gets hidden. */
+  opacity: 0;
+  pointer-events: none;
 }
 
 .itemActive {
-  background: var(--lumiverse-primary-light);
+  /* Solid color-mix (not --lumiverse-primary-light's 10% alpha overlay) so
+     the active card reads as opaque instead of see-through against the
+     page background. */
+  background: color-mix(in srgb, var(--lumiverse-primary) 8%, var(--lumiverse-bg-deep));
 }
 
 .itemRow {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
+}
+
+.dragHandle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 32px;
+  margin-left: 6px;
+  flex-shrink: 0;
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+  color: var(--lumiverse-text-dim);
+  cursor: grab;
+  touch-action: none;
+  transition: background var(--lumiverse-transition-fast), color var(--lumiverse-transition-fast);
+}
+
+.dragHandle:hover {
+  background: var(--lumiverse-primary-015);
+  color: var(--lumiverse-text);
+}
+
+.dragHandle:active {
+  cursor: grabbing;
+}
+
+.dragHandle:focus-visible {
+  outline: 2px solid var(--lumiverse-primary);
+  outline-offset: 1px;
 }
 
 .itemBtn {
@@ -126,7 +189,7 @@
 }
 
 .testMessage {
-  padding: 0 8px 8px 50px;
+  padding: 0 8px 8px 82px;
   font-size: calc(11px * var(--lumiverse-font-scale, 1));
   animation: fadeIn 0.2s ease-out;
 }
@@ -143,7 +206,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 12px 8px 50px;
+  padding: 8px 12px 8px 82px;
   background: var(--lumiverse-primary-light);
   border: none;
   border-radius: 0 0 10px 10px;
@@ -169,7 +232,14 @@
   display: flex;
   align-items: baseline;
   gap: 0;
-  padding: 0 10px 10px 50px;
+  padding: 0 10px 10px 82px;
+}
+
+/* The fadeIn animation runs only on the bar's initial mount for a given
+   profile (controlled by JS via the `animatedBarKeys` Set and a per-
+   instance ref in ConnectionItem.tsx — false→true of `show*` adds the key,
+   true→false removes it so re-activation animates again). */
+.creditsBarAnimateIn {
   animation: fadeIn 0.2s ease-out;
 }
 

--- a/frontend/src/components/panels/connection-manager/ConnectionItem.tsx
+++ b/frontend/src/components/panels/connection-manager/ConnectionItem.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSortable } from '@dnd-kit/sortable'
 
-import { Trash2, Edit3, Zap, Check, Star, BrainCircuit, Copy, LogIn, RefreshCw, MoreVertical, Shuffle } from 'lucide-react'
+import { Trash2, Edit3, Zap, Check, Star, BrainCircuit, Copy, LogIn, RefreshCw, MoreVertical, Shuffle, GripVertical } from 'lucide-react'
 import { connectionsApi } from '@/api/connections'
 import { buildOpenRouterOAuthCallbackUrl, openrouterApi, type OpenRouterCreditsInfo } from '@/api/openrouter'
 import { buildNanoGptOAuthCallbackUrl, nanoGptApi } from '@/api/nanogpt'
@@ -12,6 +13,7 @@ import {
 } from '@/lib/reasoning-binding'
 import { formatAnthropicPromptCachingSummary } from '@/lib/anthropic-prompt-caching'
 import { formatNanoGptCachingSummary } from '@/lib/nanogpt-prompt-caching'
+import { useScaledSortableStyle } from '@/lib/dndUiScale'
 import type { ConnectionProfile, ProviderInfo, CreateConnectionProfileInput, NanoGptSubscriptionUsage } from '@/types/api'
 import ConnectionForm from './ConnectionForm'
 import { Spinner } from '@/components/shared/Spinner'
@@ -68,7 +70,9 @@ interface ConnectionItemProps {
 }
 
 export default function ConnectionItem({
-profile, isActive, providers, onSelect, onUpdate, onDuplicate, onDelete }: ConnectionItemProps) {
+  profile, isActive, providers, onSelect, onUpdate, onDuplicate, onDelete,
+}: ConnectionItemProps) {
+
   const { t } = useTranslation('panels')
   const [editing, setEditing] = useState(false)
   const [testing, setTesting] = useState(false)
@@ -236,168 +240,199 @@ profile, isActive, providers, onSelect, onUpdate, onDuplicate, onDelete }: Conne
       ].filter((entry): entry is typeof entry & { window: NonNullable<typeof entry.window> } => entry.window != null)
     : []
 
-  if (editing) {
-    return (
-      <div className={styles.item}>
+  // Track whether the credits/usage bars have already animated in.
+  // The ref survives re-renders so the fadeIn class only plays once
+  // per activation cycle (profile toggled on → bar appears with animation,
+  // profile toggled off → ref resets, next activation animates again).
+  const creditsAnimatedRef = useRef(false)
+  if (showCredits && credits && !creditsAnimatedRef.current) {
+    creditsAnimatedRef.current = true
+  } else if (!showCredits && creditsAnimatedRef.current) {
+    creditsAnimatedRef.current = false
+  }
+
+  const nanoGptShown = showNanoGptUsage && nanoGptUsage && (nanoGptUsageRows.length > 0 || nanoGptSubscriptionInactive)
+  const nanoGptAnimatedRef = useRef(false)
+  if (nanoGptShown && !nanoGptAnimatedRef.current) {
+    nanoGptAnimatedRef.current = true
+  } else if (!nanoGptShown && nanoGptAnimatedRef.current) {
+    nanoGptAnimatedRef.current = false
+  }
+
+
+  const { attributes, listeners, setNodeRef: setSortableRef, transform, transition, isDragging } = useSortable({ id: profile.id })
+  const { setNodeRef, style } = useScaledSortableStyle({ setNodeRef: setSortableRef, transform, transition, isDragging })
+
+  return (
+    <div ref={setNodeRef} style={style} className={clsx(styles.item, isDragging && styles.itemDragging, isActive && styles.itemActive)}>
+      {editing ? (
         <ConnectionForm
           providers={providers}
           profile={profile}
           onSave={handleSaveEdit}
           onCancel={() => setEditing(false)}
         />
-      </div>
-    )
-  }
-
-  return (
-    <div className={clsx(styles.item, isActive && styles.itemActive)}>
-      <div className={styles.itemRow}>
-        <button type="button" className={styles.itemBtn} onClick={onSelect}>
-          {isRoulette ? (
-            <span className={clsx(styles.itemIcon, styles.rouletteIcon)}>
-              <Shuffle size={16} />
-            </span>
-          ) : (
-            <ProviderIcon kind="llm" provider={profile.provider} size={32} iconSize={16} className={styles.itemIcon} />
-          )}
-            <div className={styles.itemInfo}>
-              <span className={styles.itemName}>
-                {profile.name}
-                {profile.is_default && <Star size={11} className={styles.defaultStar} fill="#f5a623" />}
-                {boundReasoning && <span title={boundReasoningTitle}><BrainCircuit size={11} className={styles.reasoningBound} /></span>}
-              </span>
-              <span className={styles.itemMeta}>
-                {isRoulette
-                  ? t('connectionItem.modelRouletteMeta', { count: rouletteCount })
-                  : `${profile.provider}${profile.model ? ` / ${profile.model}` : ''}`}
-              </span>
-              {boundReasoningSummary && (
-                <span className={styles.itemReasoningMeta} title={boundReasoningTitle}>
-                  {boundReasoningSummary}
+      ) : (
+        <>
+          <div className={styles.itemRow}>
+            <button
+              type="button"
+              className={styles.dragHandle}
+              aria-label={t('connectionItem.dragToReorder')}
+              title={t('connectionItem.dragToReorder')}
+              {...attributes}
+              {...listeners}
+            >
+              <GripVertical size={16} />
+            </button>
+            <button type="button" className={styles.itemBtn} onClick={onSelect}>
+              {isRoulette ? (
+                <span className={clsx(styles.itemIcon, styles.rouletteIcon)}>
+                  <Shuffle size={16} />
                 </span>
+              ) : (
+                <ProviderIcon kind="llm" provider={profile.provider} size={32} iconSize={16} className={styles.itemIcon} />
               )}
-              {cachingSummary && (
-                <span className={styles.itemCachingMeta} title={cachingSummary}>
-                  {cachingSummary}
+              <div className={styles.itemInfo}>
+                <span className={styles.itemName}>
+                  {profile.name}
+                  {profile.is_default && <Star size={11} className={styles.defaultStar} fill="#f5a623" />}
+                  {boundReasoning && <span title={boundReasoningTitle}><BrainCircuit size={11} className={styles.reasoningBound} /></span>}
                 </span>
+                <span className={styles.itemMeta}>
+                  {isRoulette
+                    ? t('connectionItem.modelRouletteMeta', { count: rouletteCount })
+                    : `${profile.provider}${profile.model ? ` / ${profile.model}` : ''}`}
+                </span>
+                {boundReasoningSummary && (
+                  <span className={styles.itemReasoningMeta} title={boundReasoningTitle}>
+                    {boundReasoningSummary}
+                  </span>
+                )}
+                {cachingSummary && (
+                  <span className={styles.itemCachingMeta} title={cachingSummary}>
+                    {cachingSummary}
+                  </span>
+                )}
+              </div>
+              {isActive && <Check size={14} className={styles.activeCheck} />}
+            </button>
+            <div className={styles.itemActions}>
+              {(isOpenRouter || isNanoGpt) && (
+                <Button
+                  size="icon-sm" variant="ghost"
+                  onClick={handleOAuthLogin}
+                  title={profile.has_api_key
+                    ? (isNanoGpt ? t('connectionItem.reauthorizeNanoGpt') : t('connectionItem.reauthorizeOpenRouter'))
+                    : (isNanoGpt ? t('connectionItem.signInNanoGpt') : t('connectionItem.signInOpenRouter'))}
+                  disabled={oauthLoading}
+                  icon={oauthLoading ? <Spinner size={13} /> : <LogIn size={13} />}
+                />
               )}
+              <Button size="icon-sm" variant="ghost" onClick={() => setEditing(true)} title={t('connectionItem.edit')} icon={<Edit3 size={13} />} />
+              <Button
+                size="icon-sm" variant="ghost"
+                onClick={(e) => {
+                  const rect = e.currentTarget.getBoundingClientRect()
+                  setMenuPos({ x: rect.right, y: rect.bottom + 4 })
+                }}
+                title={t('connectionItem.moreActions')}
+                icon={<MoreVertical size={13} />}
+              />
+              <ContextMenu
+                position={menuPos}
+                onClose={() => setMenuPos(null)}
+                items={[
+                  { key: 'test', label: testing ? t('connectionItem.testing') : t('connectionItem.testConnection'), icon: <Zap size={14} />, onClick: () => { setMenuPos(null); handleTest() }, disabled: testing },
+                  { key: 'duplicate', label: t('connectionItem.duplicate'), icon: <Copy size={14} />, onClick: () => { setMenuPos(null); onDuplicate() } },
+                  { key: 'div', type: 'divider' as const },
+                  { key: 'delete', label: t('connectionItem.delete'), icon: <Trash2 size={14} />, onClick: () => { setMenuPos(null); onDelete() }, danger: true },
+                ] satisfies ContextMenuEntry[]}
+              />
             </div>
-          {isActive && <Check size={14} className={styles.activeCheck} />}
-        </button>
-        <div className={styles.itemActions}>
-          {(isOpenRouter || isNanoGpt) && (
-            <Button
-              size="icon-sm" variant="ghost"
-              onClick={handleOAuthLogin}
-              title={profile.has_api_key
-                ? (isNanoGpt ? t('connectionItem.reauthorizeNanoGpt') : t('connectionItem.reauthorizeOpenRouter'))
-                : (isNanoGpt ? t('connectionItem.signInNanoGpt') : t('connectionItem.signInOpenRouter'))}
-              disabled={oauthLoading}
-              icon={oauthLoading ? <Spinner size={13} /> : <LogIn size={13} />}
-            />
+          </div>
+          {isOpenRouter && !profile.has_api_key && !editing && (
+            <button type="button" className={styles.oauthBanner} onClick={handleOAuthLogin} disabled={oauthLoading}>
+              {oauthLoading ? <Spinner size={12} /> : <LogIn size={12} />}
+              <span>{t('connectionItem.signInOpenRouterHint')}</span>
+            </button>
           )}
-          <Button size="icon-sm" variant="ghost" onClick={() => setEditing(true)} title={t('connectionItem.edit')} icon={<Edit3 size={13} />} />
-          <Button
-            size="icon-sm" variant="ghost"
-            onClick={(e) => {
-              const rect = e.currentTarget.getBoundingClientRect()
-              setMenuPos({ x: rect.right, y: rect.bottom + 4 })
-            }}
-            title={t('connectionItem.moreActions')}
-            icon={<MoreVertical size={13} />}
-          />
-          <ContextMenu
-            position={menuPos}
-            onClose={() => setMenuPos(null)}
-            items={[
-              { key: 'test', label: testing ? t('connectionItem.testing') : t('connectionItem.testConnection'), icon: <Zap size={14} />, onClick: () => { setMenuPos(null); handleTest() }, disabled: testing },
-              { key: 'duplicate', label: t('connectionItem.duplicate'), icon: <Copy size={14} />, onClick: () => { setMenuPos(null); onDuplicate() } },
-              { key: 'div', type: 'divider' as const },
-              { key: 'delete', label: t('connectionItem.delete'), icon: <Trash2 size={14} />, onClick: () => { setMenuPos(null); onDelete() }, danger: true },
-            ] satisfies ContextMenuEntry[]}
-          />
-        </div>
-      </div>
-      {isOpenRouter && !profile.has_api_key && !editing && (
-        <button type="button" className={styles.oauthBanner} onClick={handleOAuthLogin} disabled={oauthLoading}>
-          {oauthLoading ? <Spinner size={12} /> : <LogIn size={12} />}
-          <span>{t('connectionItem.signInOpenRouterHint')}</span>
-        </button>
-      )}
-      {isNanoGpt && !profile.has_api_key && !editing && (
-        <button type="button" className={styles.oauthBanner} onClick={handleOAuthLogin} disabled={oauthLoading}>
-          {oauthLoading ? <Spinner size={12} /> : <LogIn size={12} />}
-          <span>{t('connectionItem.signInNanoGptHint')}</span>
-        </button>
-      )}
-      {testResult && (
-        <div className={clsx(styles.testMessage, testResult.success ? styles.testMessageSuccess : styles.testMessageFail)}>
-          {testResult.message}
-        </div>
-      )}
-      {showCredits && credits && (
-        <div className={styles.creditsBar}>
-          <div className={styles.creditCell}>
-            <span className={styles.creditLabel}>{t('connectionItem.remaining')}</span>
-            <span className={styles.creditValue}>
-              {credits.limit_remaining !== null && credits.limit !== null
-                ? `$${credits.limit_remaining.toFixed(2)} / $${credits.limit.toFixed(2)}`
-                : credits.limit_remaining !== null
-                  ? `$${credits.limit_remaining.toFixed(2)}`
-                  : t('connectionItem.unlimited')}
-            </span>
-          </div>
-          <div className={styles.creditCell}>
-            <span className={styles.creditLabel}>{t('connectionItem.today')}</span>
-            <span className={styles.creditValue}>${credits.usage_daily.toFixed(4)}</span>
-          </div>
-          <div className={styles.creditCell}>
-            <span className={styles.creditLabel}>{t('connectionItem.thisMonth')}</span>
-            <span className={styles.creditValue}>${credits.usage_monthly.toFixed(4)}</span>
-          </div>
-          <button type="button" className={styles.creditsRefresh} onClick={refreshCredits} disabled={creditsLoading}>
-            {creditsLoading ? <Spinner size={10} /> : <RefreshCw size={10} />}
-          </button>
-        </div>
-      )}
-      {showNanoGptUsage && nanoGptUsage && (nanoGptUsageRows.length > 0 || nanoGptSubscriptionInactive) && (
-        nanoGptUsageRows.length > 0
-          ? nanoGptUsageRows.map(({ key, label, window: win }, idx) => (
-            <div key={key} className={clsx(styles.creditsBar, styles.nanoGptUsageBar)}>
+          {isNanoGpt && !profile.has_api_key && !editing && (
+            <button type="button" className={styles.oauthBanner} onClick={handleOAuthLogin} disabled={oauthLoading}>
+              {oauthLoading ? <Spinner size={12} /> : <LogIn size={12} />}
+              <span>{t('connectionItem.signInNanoGptHint')}</span>
+            </button>
+          )}
+          {testResult && (
+            <div className={clsx(styles.testMessage, testResult.success ? styles.testMessageSuccess : styles.testMessageFail)}>
+              {testResult.message}
+            </div>
+          )}
+          {showCredits && credits && (
+            <div key="credits" className={clsx(styles.creditsBar, !creditsAnimatedRef.current && styles.creditsBarAnimateIn)}>
               <div className={styles.creditCell}>
-                <span className={styles.creditLabel}>{label}</span>
+                <span className={styles.creditLabel}>{t('connectionItem.remaining')}</span>
                 <span className={styles.creditValue}>
-                  {win.limit !== null
-                    ? `${formatCompactCount(win.remaining)} / ${formatCompactCount(win.limit)}`
-                    : formatCompactCount(win.remaining)}
+                  {credits.limit_remaining !== null && credits.limit !== null
+                    ? `$${credits.limit_remaining.toFixed(2)} / $${credits.limit.toFixed(2)}`
+                    : credits.limit_remaining !== null
+                      ? `$${credits.limit_remaining.toFixed(2)}`
+                      : t('connectionItem.unlimited')}
                 </span>
               </div>
               <div className={styles.creditCell}>
-                <span className={styles.creditLabel}>{t('connectionItem.used')}</span>
-                <span className={styles.creditValue}>{formatCompactCount(win.used)}</span>
+                <span className={styles.creditLabel}>{t('connectionItem.today')}</span>
+                <span className={styles.creditValue}>${credits.usage_daily.toFixed(4)}</span>
               </div>
               <div className={styles.creditCell}>
-                <span className={styles.creditLabel}>{nanoGptSubscriptionInactive ? t('connectionItem.status') : t('connectionItem.resetsIn')}</span>
-                <span className={styles.creditValue}>{nanoGptSubscriptionInactive ? t('connectionItem.inactive') : (formatTimeUntil(win.resetAt) || unknownReset)}</span>
+                <span className={styles.creditLabel}>{t('connectionItem.thisMonth')}</span>
+                <span className={styles.creditValue}>${credits.usage_monthly.toFixed(4)}</span>
               </div>
-              {idx === 0 && (
-                <button type="button" className={styles.creditsRefresh} onClick={refreshNanoGptUsage} disabled={nanoGptUsageLoading}>
-                  {nanoGptUsageLoading ? <Spinner size={10} /> : <RefreshCw size={10} />}
-                </button>
-              )}
-            </div>
-          ))
-          : (
-            <div className={clsx(styles.creditsBar, styles.nanoGptUsageBar)}>
-              <div className={styles.creditCell}>
-                <span className={styles.creditLabel}>{t('connectionItem.status')}</span>
-                <span className={styles.creditValue}>{t('connectionItem.inactive')}</span>
-              </div>
-              <button type="button" className={styles.creditsRefresh} onClick={refreshNanoGptUsage} disabled={nanoGptUsageLoading}>
-                {nanoGptUsageLoading ? <Spinner size={10} /> : <RefreshCw size={10} />}
+              <button type="button" className={styles.creditsRefresh} onClick={refreshCredits} disabled={creditsLoading}>
+                {creditsLoading ? <Spinner size={10} /> : <RefreshCw size={10} />}
               </button>
             </div>
-          )
+          )}
+          {showNanoGptUsage && nanoGptUsage && (nanoGptUsageRows.length > 0 || nanoGptSubscriptionInactive) && (
+            nanoGptUsageRows.length > 0
+              ? nanoGptUsageRows.map(({ key, label, window: win }, idx) => (
+                <div key={key} className={clsx(styles.creditsBar, styles.nanoGptUsageBar, idx === 0 && !nanoGptAnimatedRef.current && styles.creditsBarAnimateIn)}>
+                  <div className={styles.creditCell}>
+                    <span className={styles.creditLabel}>{label}</span>
+                    <span className={styles.creditValue}>
+                      {win.limit !== null
+                        ? `${formatCompactCount(win.remaining)} / ${formatCompactCount(win.limit)}`
+                        : formatCompactCount(win.remaining)}
+                    </span>
+                  </div>
+                  <div className={styles.creditCell}>
+                    <span className={styles.creditLabel}>{t('connectionItem.used')}</span>
+                    <span className={styles.creditValue}>{formatCompactCount(win.used)}</span>
+                  </div>
+                  <div className={styles.creditCell}>
+                    <span className={styles.creditLabel}>{nanoGptSubscriptionInactive ? t('connectionItem.status') : t('connectionItem.resetsIn')}</span>
+                    <span className={styles.creditValue}>{nanoGptSubscriptionInactive ? t('connectionItem.inactive') : (formatTimeUntil(win.resetAt) || unknownReset)}</span>
+                  </div>
+                  {idx === 0 && (
+                    <button type="button" className={styles.creditsRefresh} onClick={refreshNanoGptUsage} disabled={nanoGptUsageLoading}>
+                      {nanoGptUsageLoading ? <Spinner size={10} /> : <RefreshCw size={10} />}
+                    </button>
+                  )}
+                </div>
+              ))
+              : (
+                <div key="nanoGpt-inactive" className={clsx(styles.creditsBar, styles.nanoGptUsageBar, !nanoGptAnimatedRef.current && styles.creditsBarAnimateIn)}>
+                  <div className={styles.creditCell}>
+                    <span className={styles.creditLabel}>{t('connectionItem.status')}</span>
+                    <span className={styles.creditValue}>{t('connectionItem.inactive')}</span>
+                  </div>
+                  <button type="button" className={styles.creditsRefresh} onClick={refreshNanoGptUsage} disabled={nanoGptUsageLoading}>
+                    {nanoGptUsageLoading ? <Spinner size={10} /> : <RefreshCw size={10} />}
+                  </button>
+                </div>
+              )
+          )}
+        </>
       )}
     </div>
   )

--- a/frontend/src/components/panels/image-gen-connections/ImageGenConnectionItem.tsx
+++ b/frontend/src/components/panels/image-gen-connections/ImageGenConnectionItem.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSortable } from '@dnd-kit/sortable'
 
-import { Trash2, Edit3, Zap, Check, Star, Copy, MoreVertical, RefreshCw, Workflow } from 'lucide-react'
+import { Trash2, Edit3, Zap, Check, Star, Copy, MoreVertical, RefreshCw, Workflow, GripVertical } from 'lucide-react'
 import { imageGenConnectionsApi } from '@/api/image-gen-connections'
 import type { ComfyUIFieldMapping, ComfyUIWorkflowConfig } from '@/api/image-gen-connections'
 import type { ImageGenConnectionProfile, ImageGenProviderInfo, CreateImageGenConnectionInput, NanoGptSubscriptionUsage } from '@/types/api'
@@ -9,6 +10,7 @@ import ImageGenConnectionForm from './ImageGenConnectionForm'
 import { ComfyWorkflowEditor } from './ComfyWorkflowEditor'
 import ContextMenu, { type ContextMenuEntry, type ContextMenuPos } from '@/components/shared/ContextMenu'
 import { Spinner } from '@/components/shared/Spinner'
+import { useScaledSortableStyle } from '@/lib/dndUiScale'
 import ProviderIcon from '@/components/shared/ProviderIcon'
 import styles from '../connection-manager/ConnectionItem.module.css'
 import clsx from 'clsx'
@@ -49,17 +51,27 @@ interface Props {
   onUpdate: (profile: ImageGenConnectionProfile) => void
   onDuplicate: () => void
   onDelete: () => void
+  nanoGptUsage?: NanoGptSubscriptionUsage | null
+  nanoGptUsageLoading?: boolean
+  onRefreshNanoGptUsage?: () => void
 }
 
 export default function ImageGenConnectionItem({
- profile, isActive, providers, onSelect, onUpdate, onDuplicate, onDelete }: Props) {
+ profile, isActive, providers, onSelect, onUpdate, onDuplicate, onDelete,
+ nanoGptUsage: externalNanoGptUsage, nanoGptUsageLoading: externalNanoGptUsageLoading,
+ onRefreshNanoGptUsage,
+}: Props) {
   const { t: tc } = useTranslation('common')
   const { t } = useTranslation('panels')
   const [editing, setEditing] = useState(false)
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null)
-  const [nanoGptUsage, setNanoGptUsage] = useState<NanoGptSubscriptionUsage | null>(null)
-  const [nanoGptUsageLoading, setNanoGptUsageLoading] = useState(false)
+  const [localNanoGptUsage, setLocalNanoGptUsage] = useState<NanoGptSubscriptionUsage | null>(null)
+  const [localNanoGptUsageLoading, setLocalNanoGptUsageLoading] = useState(false)
+
+  // Effective values: prefer externally-provided data (from parent) when defined
+  const nanoGptUsage = externalNanoGptUsage !== undefined ? externalNanoGptUsage : localNanoGptUsage
+  const nanoGptUsageLoading = externalNanoGptUsageLoading !== undefined ? externalNanoGptUsageLoading : localNanoGptUsageLoading
   const [menuPos, setMenuPos] = useState<ContextMenuPos | null>(null)
   const [workflowEditorOpen, setWorkflowEditorOpen] = useState(false)
   const [workflowConfig, setWorkflowConfig] = useState<ComfyUIWorkflowConfig | null>(null)
@@ -82,22 +94,24 @@ export default function ImageGenConnectionItem({
   }, [testResult])
 
   useEffect(() => {
-    if (!showNanoGptUsage) { setNanoGptUsage(null); return }
-    setNanoGptUsageLoading(true)
+    if (externalNanoGptUsage !== undefined) return
+    if (!showNanoGptUsage) { setLocalNanoGptUsage(null); return }
+    setLocalNanoGptUsageLoading(true)
     imageGenConnectionsApi.nanogptUsage(profile.id)
-      .then(setNanoGptUsage)
-      .catch(() => setNanoGptUsage(null))
-      .finally(() => setNanoGptUsageLoading(false))
-  }, [showNanoGptUsage, profile.id])
+      .then(setLocalNanoGptUsage)
+      .catch(() => setLocalNanoGptUsage(null))
+      .finally(() => setLocalNanoGptUsageLoading(false))
+  }, [showNanoGptUsage, profile.id, externalNanoGptUsage])
 
   const refreshNanoGptUsage = useCallback(() => {
+    if (onRefreshNanoGptUsage) { onRefreshNanoGptUsage(); return }
     if (!showNanoGptUsage) return
-    setNanoGptUsageLoading(true)
+    setLocalNanoGptUsageLoading(true)
     imageGenConnectionsApi.nanogptUsage(profile.id)
-      .then(setNanoGptUsage)
-      .catch(() => setNanoGptUsage(null))
-      .finally(() => setNanoGptUsageLoading(false))
-  }, [showNanoGptUsage, profile.id])
+      .then(setLocalNanoGptUsage)
+      .catch(() => setLocalNanoGptUsage(null))
+      .finally(() => setLocalNanoGptUsageLoading(false))
+  }, [showNanoGptUsage, profile.id, onRefreshNanoGptUsage])
 
   const handleTest = useCallback(async () => {
     setTesting(true)
@@ -157,115 +171,126 @@ export default function ImageGenConnectionItem({
     }
   }, [profile.id, onUpdate])
 
-  if (editing) {
-    return (
-      <div className={styles.item}>
+  const { attributes, listeners, setNodeRef: setSortableRef, transform, transition, isDragging } = useSortable({ id: profile.id })
+  const { setNodeRef, style } = useScaledSortableStyle({ setNodeRef: setSortableRef, transform, transition, isDragging })
+
+  return (
+    <div ref={setNodeRef} style={style} className={clsx(styles.item, isDragging && styles.itemDragging, isActive && styles.itemActive)}>
+      {editing ? (
         <ImageGenConnectionForm
           providers={providers}
           profile={profile}
           onSave={handleSaveEdit}
           onCancel={() => setEditing(false)}
         />
-      </div>
-    )
-  }
-
-  return (
-    <div className={clsx(styles.item, isActive && styles.itemActive)}>
-      <div className={styles.itemRow}>
-        <button type="button" className={styles.itemBtn} onClick={onSelect}>
-          <ProviderIcon kind="imageGen" provider={profile.provider} size={32} iconSize={16} className={styles.itemIcon} />
-          <div className={styles.itemInfo}>
-            <span className={styles.itemName}>
-              {profile.name}
-              {profile.is_default && <Star size={11} className={styles.defaultStar} fill="#f5a623" />}
-            </span>
-            <span className={styles.itemMeta}>
-              {profile.provider}{profile.model ? ` / ${profile.model}` : ''}
-            </span>
-          </div>
-          {isActive && <Check size={14} className={styles.activeCheck} />}
-        </button>
-        <div className={styles.itemActions}>
-          <button type="button" className={styles.actionBtn} onClick={() => setEditing(true)} title={tc('actions.edit')}>
-            <Edit3 size={13} />
-          </button>
-          <button
-            type="button"
-            className={styles.actionBtn}
-            onClick={(e) => {
-              const rect = e.currentTarget.getBoundingClientRect()
-              setMenuPos({ x: rect.right, y: rect.bottom + 4 })
-            }}
-            title={t('connectionItem.moreActions')}
-          >
-            <MoreVertical size={13} />
-          </button>
-          <ContextMenu
-            position={menuPos}
-            onClose={() => setMenuPos(null)}
-            items={[
-              { key: 'test', label: testing ? t('connectionItem.testing') : t('connectionItem.testConnection'), icon: <Zap size={14} />, onClick: () => { setMenuPos(null); handleTest() }, disabled: testing },
-              ...(isComfyUI ? [{ key: 'workflow', label: t('connectionItem.comfyWorkflow'), icon: <Workflow size={14} />, onClick: openWorkflowEditor }] : []),
-              { key: 'duplicate', label: t('connectionItem.duplicate'), icon: <Copy size={14} />, onClick: () => { setMenuPos(null); onDuplicate() } },
-              { key: 'div', type: 'divider' as const },
-              { key: 'delete', label: t('connectionItem.delete'), icon: <Trash2 size={14} />, onClick: () => { setMenuPos(null); onDelete() }, danger: true },
-            ] satisfies ContextMenuEntry[]}
-          />
-        </div>
-      </div>
-      {testResult && (
-        <div className={clsx(styles.testMessage, testResult.success ? styles.testMessageSuccess : styles.testMessageFail)}>
-          {testResult.message}
-        </div>
-      )}
-      {showNanoGptUsage && nanoGptUsage && (nanoGptUsageRows.length > 0 || nanoGptSubscriptionInactive) && (
-        nanoGptUsageRows.length > 0
-          ? nanoGptUsageRows.map(({ key, label, window: win }, idx) => (
-            <div key={key} className={clsx(styles.creditsBar, styles.nanoGptUsageBar)}>
-              <div className={styles.creditCell}>
-                <span className={styles.creditLabel}>{label}</span>
-                <span className={styles.creditValue}>
-                  {win.limit !== null
-                    ? `${formatCompactCount(win.remaining)} / ${formatCompactCount(win.limit)}`
-                    : formatCompactCount(win.remaining)}
+      ) : (
+        <>
+          <div className={styles.itemRow}>
+            <button
+              type="button"
+              className={styles.dragHandle}
+              aria-label={t('connectionItem.dragToReorder')}
+              title={t('connectionItem.dragToReorder')}
+              {...attributes}
+              {...listeners}
+            >
+              <GripVertical size={16} />
+            </button>
+            <button type="button" className={styles.itemBtn} onClick={onSelect}>
+              <ProviderIcon kind="imageGen" provider={profile.provider} size={32} iconSize={16} className={styles.itemIcon} />
+              <div className={styles.itemInfo}>
+                <span className={styles.itemName}>
+                  {profile.name}
+                  {profile.is_default && <Star size={11} className={styles.defaultStar} fill="#f5a623" />}
+                </span>
+                <span className={styles.itemMeta}>
+                  {profile.provider}{profile.model ? ` / ${profile.model}` : ''}
                 </span>
               </div>
-              <div className={styles.creditCell}>
-                <span className={styles.creditLabel}>{t('connectionItem.used')}</span>
-                <span className={styles.creditValue}>{formatCompactCount(win.used)}</span>
-              </div>
-              <div className={styles.creditCell}>
-                <span className={styles.creditLabel}>{nanoGptSubscriptionInactive ? t('connectionItem.status') : t('connectionItem.resetsIn')}</span>
-                <span className={styles.creditValue}>{nanoGptSubscriptionInactive ? t('connectionItem.inactive') : formatTimeUntil(win.resetAt, t('connectionItem.unknown'))}</span>
-              </div>
-              {idx === 0 && (
-                <button type="button" className={styles.creditsRefresh} onClick={refreshNanoGptUsage} disabled={nanoGptUsageLoading}>
-                  {nanoGptUsageLoading ? <Spinner size={10} /> : <RefreshCw size={10} />}
-                </button>
-              )}
-            </div>
-          ))
-          : (
-            <div className={clsx(styles.creditsBar, styles.nanoGptUsageBar)}>
-              <div className={styles.creditCell}>
-                <span className={styles.creditLabel}>{t('connectionItem.status')}</span>
-                <span className={styles.creditValue}>{t('connectionItem.inactive')}</span>
-              </div>
-              <button type="button" className={styles.creditsRefresh} onClick={refreshNanoGptUsage} disabled={nanoGptUsageLoading}>
-                {nanoGptUsageLoading ? <Spinner size={10} /> : <RefreshCw size={10} />}
+              {isActive && <Check size={14} className={styles.activeCheck} />}
+            </button>
+            <div className={styles.itemActions}>
+              <button type="button" className={styles.actionBtn} onClick={() => setEditing(true)} title={tc('actions.edit')}>
+                <Edit3 size={13} />
               </button>
+              <button
+                type="button"
+                className={styles.actionBtn}
+                onClick={(e) => {
+                  const rect = e.currentTarget.getBoundingClientRect()
+                  setMenuPos({ x: rect.right, y: rect.bottom + 4 })
+                }}
+                title={t('connectionItem.moreActions')}
+              >
+                <MoreVertical size={13} />
+              </button>
+              <ContextMenu
+                position={menuPos}
+                onClose={() => setMenuPos(null)}
+                items={[
+                  { key: 'test', label: testing ? t('connectionItem.testing') : t('connectionItem.testConnection'), icon: <Zap size={14} />, onClick: () => { setMenuPos(null); handleTest() }, disabled: testing },
+                  ...(isComfyUI ? [{ key: 'workflow', label: t('connectionItem.comfyWorkflow'), icon: <Workflow size={14} />, onClick: openWorkflowEditor }] : []),
+                  { key: 'duplicate', label: t('connectionItem.duplicate'), icon: <Copy size={14} />, onClick: () => { setMenuPos(null); onDuplicate() } },
+                  { key: 'div', type: 'divider' as const },
+                  { key: 'delete', label: t('connectionItem.delete'), icon: <Trash2 size={14} />, onClick: () => { setMenuPos(null); onDelete() }, danger: true },
+                ] satisfies ContextMenuEntry[]}
+              />
             </div>
-          )
-      )}
-      {workflowEditorOpen && (
-        <ComfyWorkflowEditor
-          config={workflowConfig}
-          error={workflowError}
-          onImportWorkflow={importComfyWorkflow}
-          onUpdateMappings={updateComfyMappings}
-          onClose={() => setWorkflowEditorOpen(false)}
-        />
+          </div>
+          {testResult && (
+            <div className={clsx(styles.testMessage, testResult.success ? styles.testMessageSuccess : styles.testMessageFail)}>
+              {testResult.message}
+            </div>
+          )}
+          {showNanoGptUsage && nanoGptUsage && (nanoGptUsageRows.length > 0 || nanoGptSubscriptionInactive) && (
+            nanoGptUsageRows.length > 0
+              ? nanoGptUsageRows.map(({ key, label, window: win }, idx) => (
+                <div key={key} className={clsx(styles.creditsBar, styles.nanoGptUsageBar)}>
+                  <div className={styles.creditCell}>
+                    <span className={styles.creditLabel}>{label}</span>
+                    <span className={styles.creditValue}>
+                      {win.limit !== null
+                        ? `${formatCompactCount(win.remaining)} / ${formatCompactCount(win.limit)}`
+                        : formatCompactCount(win.remaining)}
+                    </span>
+                  </div>
+                  <div className={styles.creditCell}>
+                    <span className={styles.creditLabel}>{t('connectionItem.used')}</span>
+                    <span className={styles.creditValue}>{formatCompactCount(win.used)}</span>
+                  </div>
+                  <div className={styles.creditCell}>
+                    <span className={styles.creditLabel}>{nanoGptSubscriptionInactive ? t('connectionItem.status') : t('connectionItem.resetsIn')}</span>
+                    <span className={styles.creditValue}>{nanoGptSubscriptionInactive ? t('connectionItem.inactive') : formatTimeUntil(win.resetAt, t('connectionItem.unknown'))}</span>
+                  </div>
+                  {idx === 0 && (
+                    <button type="button" className={styles.creditsRefresh} onClick={refreshNanoGptUsage} disabled={nanoGptUsageLoading}>
+                      {nanoGptUsageLoading ? <Spinner size={10} /> : <RefreshCw size={10} />}
+                    </button>
+                  )}
+                </div>
+              ))
+              : (
+                <div className={clsx(styles.creditsBar, styles.nanoGptUsageBar)}>
+                  <div className={styles.creditCell}>
+                    <span className={styles.creditLabel}>{t('connectionItem.status')}</span>
+                    <span className={styles.creditValue}>{t('connectionItem.inactive')}</span>
+                  </div>
+                  <button type="button" className={styles.creditsRefresh} onClick={refreshNanoGptUsage} disabled={nanoGptUsageLoading}>
+                    {nanoGptUsageLoading ? <Spinner size={10} /> : <RefreshCw size={10} />}
+                  </button>
+                </div>
+              )
+          )}
+          {workflowEditorOpen && (
+            <ComfyWorkflowEditor
+              config={workflowConfig}
+              error={workflowError}
+              onImportWorkflow={importComfyWorkflow}
+              onUpdateMappings={updateComfyMappings}
+              onClose={() => setWorkflowEditorOpen(false)}
+            />
+          )}
+        </>
       )}
     </div>
   )

--- a/frontend/src/components/panels/image-gen-connections/ImageGenConnectionManager.tsx
+++ b/frontend/src/components/panels/image-gen-connections/ImageGenConnectionManager.tsx
@@ -1,6 +1,24 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import {
+  DndContext,
+  DragOverlay,
+  closestCenter,
+  MouseSensor,
+  TouchSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  arrayMove,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable'
 import { imageGenConnectionsApi } from '@/api/image-gen-connections'
 import { listAllConnections } from '@/api/listAllConnections'
 import { useStore } from '@/store'
@@ -17,14 +35,37 @@ export default function ImageGenConnectionManager() {
   const addProfile = useStore((s) => s.addImageGenProfile)
   const updateProfile = useStore((s) => s.updateImageGenProfile)
   const removeProfile = useStore((s) => s.removeImageGenProfile)
+  const applyProfileOrder = useStore((s) => s.applyImageGenProfileOrder)
   const activeId = useStore((s) => s.activeImageGenConnectionId)
   const setActive = useStore((s) => s.setActiveImageGenConnection)
   const providers = useStore((s) => s.imageGenProviders)
   const setProviders = useStore((s) => s.setImageGenProviders)
+  const setSetting = useStore((s) => s.setSetting)
+  const connectionsOrder = useStore((s) => s.connectionsOrder)
+
+  const mouseSensor = useSensor(MouseSensor, { activationConstraint: { distance: 4 } })
+  const touchSensor = useSensor(TouchSensor, { activationConstraint: { distance: 8 } })
+  const keyboardSensor = useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  const sensors = useSensors(mouseSensor, touchSensor, keyboardSensor)
+
+  const orderedProfiles = useMemo(() => {
+    const imageGenOrder = connectionsOrder?.imageGen ?? []
+    if (imageGenOrder.length === 0) return profiles
+    const byId = new Map(profiles.map((p) => [p.id, p]))
+    const ordered = imageGenOrder.map((id) => byId.get(id)).filter((p): p is ImageGenConnectionProfile => Boolean(p))
+    const seen = new Set(ordered.map((p) => p.id))
+    const missing = profiles.filter((p) => !seen.has(p.id))
+    return [...ordered, ...missing]
+  }, [profiles, connectionsOrder])
+
+  const orderedIds = useMemo(() => orderedProfiles.map((p) => p.id), [orderedProfiles])
 
   const [loading, setLoading] = useState(false)
   const [creating, setCreating] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<ImageGenConnectionProfile | null>(null)
+  const [dragActiveId, setDragActiveId] = useState<string | null>(null)
+
+  const activeProfile = orderedProfiles.find((p) => p.id === dragActiveId) ?? null
 
   useEffect(() => {
     const returnedKey = sessionStorage.getItem('pollinations_byop_returned_api_key')
@@ -117,11 +158,28 @@ export default function ImageGenConnectionManager() {
     try {
       await imageGenConnectionsApi.delete(deleteTarget.id)
       removeProfile(deleteTarget.id)
+      const nextOrder = (connectionsOrder?.imageGen ?? []).filter((id) => id !== deleteTarget.id)
+      setSetting('connectionsOrder', { ...connectionsOrder, imageGen: nextOrder })
       setDeleteTarget(null)
     } catch (err) {
       console.error('[ImageGenConnectionManager] Failed to delete:', err)
     }
-  }, [deleteTarget, removeProfile])
+  }, [deleteTarget, removeProfile, connectionsOrder, setSetting])
+
+  const handleDragStart = useCallback(({ active }: DragStartEvent) => setDragActiveId(String(active.id)), [])
+  const handleDragCancel = useCallback(() => setDragActiveId(null), [])
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    setDragActiveId(null)
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = orderedIds.indexOf(String(active.id))
+    const newIndex = orderedIds.indexOf(String(over.id))
+    if (oldIndex < 0 || newIndex < 0) return
+    const newOrder = arrayMove(orderedIds, oldIndex, newIndex)
+    applyProfileOrder(newOrder)
+    setSetting('connectionsOrder', { ...connectionsOrder, imageGen: newOrder })
+  }, [orderedIds, connectionsOrder, applyProfileOrder, setSetting])
 
   if (loading) {
     return <div className={styles.loading}>{t('imageGenConnectionManager.loading')}</div>
@@ -144,23 +202,42 @@ export default function ImageGenConnectionManager() {
         />
       )}
 
-      <div className={styles.list}>
-        {profiles.map((profile) => (
-          <ImageGenConnectionItem
-            key={profile.id}
-            profile={profile}
-            isActive={activeId === profile.id}
-            providers={providers}
-            onSelect={() => setActive(activeId === profile.id ? null : profile.id)}
-            onUpdate={handleUpdate}
-            onDuplicate={() => handleDuplicate(profile.id)}
-            onDelete={() => setDeleteTarget(profile)}
-          />
-        ))}
-        {profiles.length === 0 && !creating && (
-          <div className={styles.empty}>{t('imageGenConnectionManager.empty')}</div>
-        )}
-      </div>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragCancel={handleDragCancel} onDragEnd={handleDragEnd}>
+        <SortableContext items={orderedIds} strategy={verticalListSortingStrategy}>
+          <div className={styles.list}>
+            {orderedProfiles.map((profile) => (
+              <ImageGenConnectionItem
+                key={profile.id}
+                profile={profile}
+                isActive={activeId === profile.id}
+                providers={providers}
+                onSelect={() => setActive(activeId === profile.id ? null : profile.id)}
+                onUpdate={handleUpdate}
+                onDuplicate={() => handleDuplicate(profile.id)}
+                onDelete={() => setDeleteTarget(profile)}
+              />
+            ))}
+            {profiles.length === 0 && !creating && (
+              <div className={styles.empty}>{t('imageGenConnectionManager.empty')}</div>
+            )}
+          </div>
+        </SortableContext>
+        <DragOverlay dropAnimation={null}>
+          {activeProfile && (
+            <div className={styles.itemDraggingOverlay}>
+              <ImageGenConnectionItem
+                profile={activeProfile}
+                isActive={activeId === activeProfile.id}
+                providers={providers}
+                onSelect={() => setActive(activeId === activeProfile.id ? null : activeProfile.id)}
+                onUpdate={handleUpdate}
+                onDuplicate={() => handleDuplicate(activeProfile.id)}
+                onDelete={() => setDeleteTarget(activeProfile)}
+              />
+            </div>
+          )}
+        </DragOverlay>
+      </DndContext>
 
       {deleteTarget && (
         <ConfirmationModal

--- a/frontend/src/components/panels/stt-connections/STTConnectionItem.tsx
+++ b/frontend/src/components/panels/stt-connections/STTConnectionItem.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSortable } from '@dnd-kit/sortable'
 
-import { Trash2, Edit3, Zap, Star, Copy, MoreVertical } from 'lucide-react'
+import { Trash2, Edit3, Zap, Star, Copy, MoreVertical, GripVertical } from 'lucide-react'
 import { sttConnectionsApi } from '@/api/stt-connections'
 import type { SttConnectionProfile, SttProviderInfo, CreateSttConnectionInput } from '@/types/api'
 import STTConnectionForm from './STTConnectionForm'
 import ContextMenu, { type ContextMenuEntry, type ContextMenuPos } from '@/components/shared/ContextMenu'
+import { useScaledSortableStyle } from '@/lib/dndUiScale'
 import ProviderIcon from '@/components/shared/ProviderIcon'
 import styles from '../connection-manager/ConnectionItem.module.css'
 import clsx from 'clsx'
@@ -56,66 +58,77 @@ export default function STTConnectionItem({
     }
   }, [profile.id, onUpdate])
 
-  if (editing) {
-    return (
-      <div className={styles.item}>
+  const { attributes, listeners, setNodeRef: setSortableRef, transform, transition, isDragging } = useSortable({ id: profile.id })
+  const { setNodeRef, style } = useScaledSortableStyle({ setNodeRef: setSortableRef, transform, transition, isDragging })
+
+  return (
+    <div ref={setNodeRef} style={style} className={clsx(styles.item, isDragging && styles.itemDragging)}>
+      {editing ? (
         <STTConnectionForm
           providers={providers}
           profile={profile}
           onSave={handleSaveEdit}
           onCancel={() => setEditing(false)}
         />
-      </div>
-    )
-  }
-
-  return (
-    <div className={styles.item}>
-      <div className={styles.itemRow}>
-        <div className={styles.itemBtn} style={{ cursor: 'default' }}>
-          <ProviderIcon kind="stt" provider={profile.provider} size={32} iconSize={16} className={styles.itemIcon} />
-          <div className={styles.itemInfo}>
-            <span className={styles.itemName}>
-              {profile.name}
-              {profile.is_default && <Star size={11} className={styles.defaultStar} fill="#f5a623" />}
-            </span>
-            <span className={styles.itemMeta}>
-              {profile.provider}
-              {profile.model ? ` / ${profile.model}` : ''}
-            </span>
+      ) : (
+        <>
+          <div className={styles.itemRow}>
+            <button
+              type="button"
+              className={styles.dragHandle}
+              aria-label={t('connectionItem.dragToReorder')}
+              title={t('connectionItem.dragToReorder')}
+              {...attributes}
+              {...listeners}
+            >
+              <GripVertical size={16} />
+            </button>
+            <div className={styles.itemBtn} style={{ cursor: 'default' }}>
+              <ProviderIcon kind="stt" provider={profile.provider} size={32} iconSize={16} className={styles.itemIcon} />
+              <div className={styles.itemInfo}>
+                <span className={styles.itemName}>
+                  {profile.name}
+                  {profile.is_default && <Star size={11} className={styles.defaultStar} fill="#f5a623" />}
+                </span>
+                <span className={styles.itemMeta}>
+                  {profile.provider}
+                  {profile.model ? ` / ${profile.model}` : ''}
+                </span>
+              </div>
+            </div>
+            <div className={styles.itemActions}>
+              <button type="button" className={styles.actionBtn} onClick={() => setEditing(true)} title={tc('actions.edit')}>
+                <Edit3 size={13} />
+              </button>
+              <button
+                type="button"
+                className={styles.actionBtn}
+                onClick={(e) => {
+                  const rect = e.currentTarget.getBoundingClientRect()
+                  setMenuPos({ x: rect.right, y: rect.bottom + 4 })
+                }}
+                title={t('connectionItem.moreActions')}
+              >
+                <MoreVertical size={13} />
+              </button>
+              <ContextMenu
+                position={menuPos}
+                onClose={() => setMenuPos(null)}
+                items={[
+                  { key: 'test', label: testing ? t('connectionItem.testing') : t('connectionItem.testConnection'), icon: <Zap size={14} />, onClick: () => { setMenuPos(null); handleTest() }, disabled: testing },
+                  { key: 'duplicate', label: t('connectionItem.duplicate'), icon: <Copy size={14} />, onClick: () => { setMenuPos(null); onDuplicate() } },
+                  { key: 'div', type: 'divider' as const },
+                  { key: 'delete', label: t('connectionItem.delete'), icon: <Trash2 size={14} />, onClick: () => { setMenuPos(null); onDelete() }, danger: true },
+                ] satisfies ContextMenuEntry[]}
+              />
+            </div>
           </div>
-        </div>
-        <div className={styles.itemActions}>
-          <button type="button" className={styles.actionBtn} onClick={() => setEditing(true)} title={tc('actions.edit')}>
-            <Edit3 size={13} />
-          </button>
-          <button
-            type="button"
-            className={styles.actionBtn}
-            onClick={(e) => {
-              const rect = e.currentTarget.getBoundingClientRect()
-              setMenuPos({ x: rect.right, y: rect.bottom + 4 })
-            }}
-            title={t('connectionItem.moreActions')}
-          >
-            <MoreVertical size={13} />
-          </button>
-          <ContextMenu
-            position={menuPos}
-            onClose={() => setMenuPos(null)}
-            items={[
-              { key: 'test', label: testing ? t('connectionItem.testing') : t('connectionItem.testConnection'), icon: <Zap size={14} />, onClick: () => { setMenuPos(null); handleTest() }, disabled: testing },
-              { key: 'duplicate', label: t('connectionItem.duplicate'), icon: <Copy size={14} />, onClick: () => { setMenuPos(null); onDuplicate() } },
-              { key: 'div', type: 'divider' as const },
-              { key: 'delete', label: t('connectionItem.delete'), icon: <Trash2 size={14} />, onClick: () => { setMenuPos(null); onDelete() }, danger: true },
-            ] satisfies ContextMenuEntry[]}
-          />
-        </div>
-      </div>
-      {testResult && (
-        <div className={clsx(styles.testMessage, testResult.success ? styles.testMessageSuccess : styles.testMessageFail)}>
-          {testResult.message}
-        </div>
+          {testResult && (
+            <div className={clsx(styles.testMessage, testResult.success ? styles.testMessageSuccess : styles.testMessageFail)}>
+              {testResult.message}
+            </div>
+          )}
+        </>
       )}
     </div>
   )

--- a/frontend/src/components/panels/stt-connections/STTConnectionManager.tsx
+++ b/frontend/src/components/panels/stt-connections/STTConnectionManager.tsx
@@ -1,6 +1,24 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import {
+  DndContext,
+  DragOverlay,
+  closestCenter,
+  MouseSensor,
+  TouchSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  arrayMove,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable'
 import { sttConnectionsApi } from '@/api/stt-connections'
 import { listAllConnections } from '@/api/listAllConnections'
 import { useStore } from '@/store'
@@ -17,12 +35,35 @@ export default function STTConnectionManager() {
   const addProfile = useStore((s) => s.addSttProfile)
   const updateProfile = useStore((s) => s.updateSttProfile)
   const removeProfile = useStore((s) => s.removeSttProfile)
+  const applyProfileOrder = useStore((s) => s.applySttProfileOrder)
   const providers = useStore((s) => s.sttProviders)
   const setProviders = useStore((s) => s.setSttProviders)
+  const setSetting = useStore((s) => s.setSetting)
+  const connectionsOrder = useStore((s) => s.connectionsOrder)
+
+  const mouseSensor = useSensor(MouseSensor, { activationConstraint: { distance: 4 } })
+  const touchSensor = useSensor(TouchSensor, { activationConstraint: { distance: 8 } })
+  const keyboardSensor = useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  const sensors = useSensors(mouseSensor, touchSensor, keyboardSensor)
+
+  const orderedProfiles = useMemo(() => {
+    const sttOrder = connectionsOrder?.stt ?? []
+    if (sttOrder.length === 0) return profiles
+    const byId = new Map(profiles.map((p) => [p.id, p]))
+    const ordered = sttOrder.map((id) => byId.get(id)).filter((p): p is SttConnectionProfile => Boolean(p))
+    const seen = new Set(ordered.map((p) => p.id))
+    const missing = profiles.filter((p) => !seen.has(p.id))
+    return [...ordered, ...missing]
+  }, [profiles, connectionsOrder])
+
+  const orderedIds = useMemo(() => orderedProfiles.map((p) => p.id), [orderedProfiles])
 
   const [loading, setLoading] = useState(false)
   const [creating, setCreating] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<SttConnectionProfile | null>(null)
+  const [dragActiveId, setDragActiveId] = useState<string | null>(null)
+
+  const activeProfile = orderedProfiles.find((p) => p.id === dragActiveId) ?? null
 
   useEffect(() => {
     let cancelled = false
@@ -96,11 +137,28 @@ export default function STTConnectionManager() {
     try {
       await sttConnectionsApi.delete(deleteTarget.id)
       removeProfile(deleteTarget.id)
+      const nextOrder = (connectionsOrder?.stt ?? []).filter((id) => id !== deleteTarget.id)
+      setSetting('connectionsOrder', { ...connectionsOrder, stt: nextOrder })
       setDeleteTarget(null)
     } catch (err) {
       console.error('[STTConnectionManager] Failed to delete:', err)
     }
-  }, [deleteTarget, removeProfile])
+  }, [deleteTarget, removeProfile, connectionsOrder, setSetting])
+
+  const handleDragStart = useCallback(({ active }: DragStartEvent) => setDragActiveId(String(active.id)), [])
+  const handleDragCancel = useCallback(() => setDragActiveId(null), [])
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    setDragActiveId(null)
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = orderedIds.indexOf(String(active.id))
+    const newIndex = orderedIds.indexOf(String(over.id))
+    if (oldIndex < 0 || newIndex < 0) return
+    const newOrder = arrayMove(orderedIds, oldIndex, newIndex)
+    applyProfileOrder(newOrder)
+    setSetting('connectionsOrder', { ...connectionsOrder, stt: newOrder })
+  }, [orderedIds, connectionsOrder, applyProfileOrder, setSetting])
 
   if (loading) {
     return <div className={styles.loading}>{t('sttConnectionManager.loading')}</div>
@@ -123,21 +181,38 @@ export default function STTConnectionManager() {
         />
       )}
 
-      <div className={styles.list}>
-        {profiles.map((profile) => (
-          <STTConnectionItem
-            key={profile.id}
-            profile={profile}
-            providers={providers}
-            onUpdate={handleUpdate}
-            onDuplicate={() => handleDuplicate(profile.id)}
-            onDelete={() => setDeleteTarget(profile)}
-          />
-        ))}
-        {profiles.length === 0 && !creating && (
-          <div className={styles.empty}>{t('sttConnectionManager.empty')}</div>
-        )}
-      </div>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragCancel={handleDragCancel} onDragEnd={handleDragEnd}>
+        <SortableContext items={orderedIds} strategy={verticalListSortingStrategy}>
+          <div className={styles.list}>
+            {orderedProfiles.map((profile) => (
+              <STTConnectionItem
+                key={profile.id}
+                profile={profile}
+                providers={providers}
+                onUpdate={handleUpdate}
+                onDuplicate={() => handleDuplicate(profile.id)}
+                onDelete={() => setDeleteTarget(profile)}
+              />
+            ))}
+            {profiles.length === 0 && !creating && (
+              <div className={styles.empty}>{t('sttConnectionManager.empty')}</div>
+            )}
+          </div>
+        </SortableContext>
+        <DragOverlay dropAnimation={null}>
+          {activeProfile && (
+            <div className={styles.itemDraggingOverlay}>
+              <STTConnectionItem
+                profile={activeProfile}
+                providers={providers}
+                onUpdate={handleUpdate}
+                onDuplicate={() => handleDuplicate(activeProfile.id)}
+                onDelete={() => setDeleteTarget(activeProfile)}
+              />
+            </div>
+          )}
+        </DragOverlay>
+      </DndContext>
 
       {deleteTarget && (
         <ConfirmationModal

--- a/frontend/src/components/panels/tts-connections/TTSConnectionItem.tsx
+++ b/frontend/src/components/panels/tts-connections/TTSConnectionItem.tsx
@@ -1,13 +1,15 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSortable } from '@dnd-kit/sortable'
 
-import { Trash2, Edit3, Zap, Star, Copy, MoreVertical, Volume2 } from 'lucide-react'
+import { Trash2, Edit3, Zap, Star, Copy, MoreVertical, Volume2, GripVertical } from 'lucide-react'
 import { ttsConnectionsApi } from '@/api/tts-connections'
 import { formatTtsConnectionVoiceLabel, isQwenTtsProvider } from '@/lib/qwenTts'
 import { useStore } from '@/store'
 import type { TtsConnectionProfile, TtsProviderInfo, CreateTtsConnectionInput } from '@/types/api'
 import TTSConnectionForm from './TTSConnectionForm'
 import ContextMenu, { type ContextMenuEntry, type ContextMenuPos } from '@/components/shared/ContextMenu'
+import { useScaledSortableStyle } from '@/lib/dndUiScale'
 import ProviderIcon from '@/components/shared/ProviderIcon'
 import styles from '../connection-manager/ConnectionItem.module.css'
 import clsx from 'clsx'
@@ -61,78 +63,89 @@ export default function TTSConnectionItem({
     }
   }, [profile.id, onUpdate])
 
-  if (editing) {
-    return (
-      <div className={styles.item}>
+  const { attributes, listeners, setNodeRef: setSortableRef, transform, transition, isDragging } = useSortable({ id: profile.id })
+  const { setNodeRef, style } = useScaledSortableStyle({ setNodeRef: setSortableRef, transform, transition, isDragging })
+
+  return (
+    <div ref={setNodeRef} style={style} className={clsx(styles.item, isDragging && styles.itemDragging)}>
+      {editing ? (
         <TTSConnectionForm
           providers={providers}
           profile={profile}
           onSave={handleSaveEdit}
           onCancel={() => setEditing(false)}
         />
-      </div>
-    )
-  }
-
-  return (
-    <div className={styles.item}>
-      <div className={styles.itemRow}>
-        <div className={styles.itemBtn} style={{ cursor: 'default' }}>
-          <ProviderIcon kind="tts" provider={profile.provider} size={32} iconSize={16} className={styles.itemIcon} />
-          <div className={styles.itemInfo}>
-            <span className={styles.itemName}>
-              {profile.name}
-              {profile.is_default && <Star size={11} className={styles.defaultStar} fill="#f5a623" />}
-            </span>
-            <span className={styles.itemMeta}>
-              {profile.provider}
-              {profile.model ? ` / ${profile.model}` : ''}
-              {voiceLabel ? ` / ${voiceLabel}` : ''}
-            </span>
+      ) : (
+        <>
+          <div className={styles.itemRow}>
+            <button
+              type="button"
+              className={styles.dragHandle}
+              aria-label={t('connectionItem.dragToReorder')}
+              title={t('connectionItem.dragToReorder')}
+              {...attributes}
+              {...listeners}
+            >
+              <GripVertical size={16} />
+            </button>
+            <div className={styles.itemBtn} style={{ cursor: 'default' }}>
+              <ProviderIcon kind="tts" provider={profile.provider} size={32} iconSize={16} className={styles.itemIcon} />
+              <div className={styles.itemInfo}>
+                <span className={styles.itemName}>
+                  {profile.name}
+                  {profile.is_default && <Star size={11} className={styles.defaultStar} fill="#f5a623" />}
+                </span>
+                <span className={styles.itemMeta}>
+                  {profile.provider}
+                  {profile.model ? ` / ${profile.model}` : ''}
+                  {voiceLabel ? ` / ${voiceLabel}` : ''}
+                </span>
+              </div>
+            </div>
+            <div className={styles.itemActions}>
+              <button type="button" className={styles.actionBtn} onClick={() => setEditing(true)} title={tc('actions.edit')}>
+                <Edit3 size={13} />
+              </button>
+              <button
+                type="button"
+                className={styles.actionBtn}
+                onClick={(e) => {
+                  const rect = e.currentTarget.getBoundingClientRect()
+                  setMenuPos({ x: rect.right, y: rect.bottom + 4 })
+                }}
+                title={t('connectionItem.moreActions')}
+              >
+                <MoreVertical size={13} />
+              </button>
+              <ContextMenu
+                position={menuPos}
+                onClose={() => setMenuPos(null)}
+                items={[
+                  { key: 'test', label: testing ? t('connectionItem.testing') : t('connectionItem.testConnection'), icon: <Zap size={14} />, onClick: () => { setMenuPos(null); handleTest() }, disabled: testing },
+                  ...(isQwen
+                    ? [{
+                        key: 'qwen-clones',
+                        label: t('qwenCustomVoiceManager.menuAction'),
+                        icon: <Volume2 size={14} />,
+                        onClick: () => {
+                          setMenuPos(null)
+                          openModal('qwenCustomVoice', { connectionId: profile.id })
+                        },
+                      }]
+                    : []),
+                  { key: 'duplicate', label: t('connectionItem.duplicate'), icon: <Copy size={14} />, onClick: () => { setMenuPos(null); onDuplicate() } },
+                  { key: 'div', type: 'divider' as const },
+                  { key: 'delete', label: t('connectionItem.delete'), icon: <Trash2 size={14} />, onClick: () => { setMenuPos(null); onDelete() }, danger: true },
+                ] satisfies ContextMenuEntry[]}
+              />
+            </div>
           </div>
-        </div>
-        <div className={styles.itemActions}>
-          <button type="button" className={styles.actionBtn} onClick={() => setEditing(true)} title={tc('actions.edit')}>
-            <Edit3 size={13} />
-          </button>
-          <button
-            type="button"
-            className={styles.actionBtn}
-            onClick={(e) => {
-              const rect = e.currentTarget.getBoundingClientRect()
-              setMenuPos({ x: rect.right, y: rect.bottom + 4 })
-            }}
-            title={t('connectionItem.moreActions')}
-          >
-            <MoreVertical size={13} />
-          </button>
-          <ContextMenu
-            position={menuPos}
-            onClose={() => setMenuPos(null)}
-            items={[
-              { key: 'test', label: testing ? t('connectionItem.testing') : t('connectionItem.testConnection'), icon: <Zap size={14} />, onClick: () => { setMenuPos(null); handleTest() }, disabled: testing },
-              ...(isQwen
-                ? [{
-                    key: 'qwen-clones',
-                    label: t('qwenCustomVoiceManager.menuAction'),
-                    icon: <Volume2 size={14} />,
-                    onClick: () => {
-                      setMenuPos(null)
-                      openModal('qwenCustomVoice', { connectionId: profile.id })
-                    },
-                  }]
-                : []),
-              { key: 'duplicate', label: t('connectionItem.duplicate'), icon: <Copy size={14} />, onClick: () => { setMenuPos(null); onDuplicate() } },
-              { key: 'div', type: 'divider' as const },
-              { key: 'delete', label: t('connectionItem.delete'), icon: <Trash2 size={14} />, onClick: () => { setMenuPos(null); onDelete() }, danger: true },
-            ] satisfies ContextMenuEntry[]}
-          />
-        </div>
-      </div>
-      {testResult && (
-        <div className={clsx(styles.testMessage, testResult.success ? styles.testMessageSuccess : styles.testMessageFail)}>
-          {testResult.message}
-        </div>
+          {testResult && (
+            <div className={clsx(styles.testMessage, testResult.success ? styles.testMessageSuccess : styles.testMessageFail)}>
+              {testResult.message}
+            </div>
+          )}
+        </>
       )}
     </div>
   )

--- a/frontend/src/components/panels/tts-connections/TTSConnectionManager.tsx
+++ b/frontend/src/components/panels/tts-connections/TTSConnectionManager.tsx
@@ -1,6 +1,24 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import {
+  DndContext,
+  DragOverlay,
+  closestCenter,
+  MouseSensor,
+  TouchSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  arrayMove,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable'
 import { ttsConnectionsApi } from '@/api/tts-connections'
 import { listAllConnections } from '@/api/listAllConnections'
 import { useStore } from '@/store'
@@ -17,12 +35,35 @@ export default function TTSConnectionManager() {
   const addProfile = useStore((s) => s.addTtsProfile)
   const updateProfile = useStore((s) => s.updateTtsProfile)
   const removeProfile = useStore((s) => s.removeTtsProfile)
+  const applyProfileOrder = useStore((s) => s.applyTtsProfileOrder)
   const providers = useStore((s) => s.ttsProviders)
   const setProviders = useStore((s) => s.setTtsProviders)
+  const setSetting = useStore((s) => s.setSetting)
+  const connectionsOrder = useStore((s) => s.connectionsOrder)
+
+  const mouseSensor = useSensor(MouseSensor, { activationConstraint: { distance: 4 } })
+  const touchSensor = useSensor(TouchSensor, { activationConstraint: { distance: 8 } })
+  const keyboardSensor = useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  const sensors = useSensors(mouseSensor, touchSensor, keyboardSensor)
+
+  const orderedProfiles = useMemo(() => {
+    const ttsOrder = connectionsOrder?.tts ?? []
+    if (ttsOrder.length === 0) return profiles
+    const byId = new Map(profiles.map((p) => [p.id, p]))
+    const ordered = ttsOrder.map((id) => byId.get(id)).filter((p): p is TtsConnectionProfile => Boolean(p))
+    const seen = new Set(ordered.map((p) => p.id))
+    const missing = profiles.filter((p) => !seen.has(p.id))
+    return [...ordered, ...missing]
+  }, [profiles, connectionsOrder])
+
+  const orderedIds = useMemo(() => orderedProfiles.map((p) => p.id), [orderedProfiles])
 
   const [loading, setLoading] = useState(false)
   const [creating, setCreating] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<TtsConnectionProfile | null>(null)
+  const [dragActiveId, setDragActiveId] = useState<string | null>(null)
+
+  const activeProfile = orderedProfiles.find((p) => p.id === dragActiveId) ?? null
 
   // `useAppInit` preloads TTS profiles + providers right after auth. Only
   // show the loading placeholder on a true cold mount (empty store);
@@ -99,11 +140,28 @@ export default function TTSConnectionManager() {
     try {
       await ttsConnectionsApi.delete(deleteTarget.id)
       removeProfile(deleteTarget.id)
+      const nextOrder = (connectionsOrder?.tts ?? []).filter((id) => id !== deleteTarget.id)
+      setSetting('connectionsOrder', { ...connectionsOrder, tts: nextOrder })
       setDeleteTarget(null)
     } catch (err) {
       console.error('[TTSConnectionManager] Failed to delete:', err)
     }
-  }, [deleteTarget, removeProfile])
+  }, [deleteTarget, removeProfile, connectionsOrder, setSetting])
+
+  const handleDragStart = useCallback(({ active }: DragStartEvent) => setDragActiveId(String(active.id)), [])
+  const handleDragCancel = useCallback(() => setDragActiveId(null), [])
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    setDragActiveId(null)
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = orderedIds.indexOf(String(active.id))
+    const newIndex = orderedIds.indexOf(String(over.id))
+    if (oldIndex < 0 || newIndex < 0) return
+    const newOrder = arrayMove(orderedIds, oldIndex, newIndex)
+    applyProfileOrder(newOrder)
+    setSetting('connectionsOrder', { ...connectionsOrder, tts: newOrder })
+  }, [orderedIds, connectionsOrder, applyProfileOrder, setSetting])
 
   if (loading) {
     return <div className={styles.loading}>{t('ttsConnectionManager.loading')}</div>
@@ -126,21 +184,38 @@ export default function TTSConnectionManager() {
         />
       )}
 
-      <div className={styles.list}>
-        {profiles.map((profile) => (
-          <TTSConnectionItem
-            key={profile.id}
-            profile={profile}
-            providers={providers}
-            onUpdate={handleUpdate}
-            onDuplicate={() => handleDuplicate(profile.id)}
-            onDelete={() => setDeleteTarget(profile)}
-          />
-        ))}
-        {profiles.length === 0 && !creating && (
-          <div className={styles.empty}>{t('ttsConnectionManager.empty')}</div>
-        )}
-      </div>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragCancel={handleDragCancel} onDragEnd={handleDragEnd}>
+        <SortableContext items={orderedIds} strategy={verticalListSortingStrategy}>
+          <div className={styles.list}>
+            {orderedProfiles.map((profile) => (
+              <TTSConnectionItem
+                key={profile.id}
+                profile={profile}
+                providers={providers}
+                onUpdate={handleUpdate}
+                onDuplicate={() => handleDuplicate(profile.id)}
+                onDelete={() => setDeleteTarget(profile)}
+              />
+            ))}
+            {profiles.length === 0 && !creating && (
+              <div className={styles.empty}>{t('ttsConnectionManager.empty')}</div>
+            )}
+          </div>
+        </SortableContext>
+        <DragOverlay dropAnimation={null}>
+          {activeProfile && (
+            <div className={styles.itemDraggingOverlay}>
+              <TTSConnectionItem
+                profile={activeProfile}
+                providers={providers}
+                onUpdate={handleUpdate}
+                onDuplicate={() => handleDuplicate(activeProfile.id)}
+                onDelete={() => setDeleteTarget(activeProfile)}
+              />
+            </div>
+          )}
+        </DragOverlay>
+      </DndContext>
 
       {deleteTarget && (
         <ConfirmationModal

--- a/frontend/src/i18n/locales/en/panels.json
+++ b/frontend/src/i18n/locales/en/panels.json
@@ -406,7 +406,8 @@
     "dailyImages": "Daily images",
     "comfyWorkflow": "ComfyUI workflow",
     "loadComfyWorkflowFailed": "Failed to load ComfyUI workflow",
-    "modelRouletteMeta": "Model Roulette / {{count}} profiles"
+    "modelRouletteMeta": "Model Roulette / {{count}} profiles",
+    "dragToReorder": "Drag to reorder"
   },
   "connectionForm": {
     "pollinationsSaved": "Signed in with Pollinations. API key saved automatically.",

--- a/frontend/src/i18n/locales/fr/panels.json
+++ b/frontend/src/i18n/locales/fr/panels.json
@@ -353,7 +353,8 @@
     "daily": "Quotidien",
     "monthly": "Mensuel",
     "comfyWorkflow": "Flux de travail ComfyUI",
-    "loadComfyWorkflowFailed": "Échec du chargement du flux de travail ComfyUI"
+    "loadComfyWorkflowFailed": "Échec du chargement du flux de travail ComfyUI",
+    "dragToReorder": "Réorganiser par glisser-déposer"
   },
   "connectionForm": {
     "pollinationsSaved": "Connecté avec Pollinations. Clé API enregistrée automatiquement.",

--- a/frontend/src/i18n/locales/it/panels.json
+++ b/frontend/src/i18n/locales/it/panels.json
@@ -353,7 +353,8 @@
     "daily": "Giornaliero",
     "monthly": "Mensile",
     "comfyWorkflow": "Flusso di lavoro ComfyUI",
-    "loadComfyWorkflowFailed": "Errore nel caricamento del flusso di lavoro ComfyUI"
+    "loadComfyWorkflowFailed": "Errore nel caricamento del flusso di lavoro ComfyUI",
+    "dragToReorder": "Trascina per riordinare"
   },
   "connectionForm": {
     "pollinationsSaved": "Accesso con Pollinations effettuato. Chiave API salvata automaticamente.",

--- a/frontend/src/i18n/locales/ja/panels.json
+++ b/frontend/src/i18n/locales/ja/panels.json
@@ -353,7 +353,8 @@
     "daily": "日次",
     "monthly": "月次",
     "comfyWorkflow": "ComfyUI ワークフロー",
-    "loadComfyWorkflowFailed": "ComfyUI ワークフローの読み込みに失敗しました"
+    "loadComfyWorkflowFailed": "ComfyUI ワークフローの読み込みに失敗しました",
+    "dragToReorder": "ドラッグして並べ替え"
   },
   "connectionForm": {
     "pollinationsSaved": "Pollinations でサインインしました。 API キーは自動的に保存されました。",

--- a/frontend/src/i18n/locales/zh-TW/panels.json
+++ b/frontend/src/i18n/locales/zh-TW/panels.json
@@ -353,7 +353,8 @@
     "daily": "每日",
     "monthly": "每月",
     "comfyWorkflow": "ComfyUI 工作流",
-    "loadComfyWorkflowFailed": "加載 ComfyUI 工作流失敗"
+    "loadComfyWorkflowFailed": "加載 ComfyUI 工作流失敗",
+    "dragToReorder": "拖曳以重新排序"
   },
   "connectionForm": {
     "pollinationsSaved": "已登錄 Pollinations，API Key 已自動保存。",

--- a/frontend/src/i18n/locales/zh/panels.json
+++ b/frontend/src/i18n/locales/zh/panels.json
@@ -353,7 +353,8 @@
     "daily": "每日",
     "monthly": "每月",
     "comfyWorkflow": "ComfyUI 工作流",
-    "loadComfyWorkflowFailed": "加载 ComfyUI 工作流失败"
+    "loadComfyWorkflowFailed": "加载 ComfyUI 工作流失败",
+    "dragToReorder": "拖动以重新排序"
   },
   "connectionForm": {
     "pollinationsSaved": "已登录 Pollinations，API Key 已自动保存。",

--- a/frontend/src/store/slices/connections-order-merge.test.ts
+++ b/frontend/src/store/slices/connections-order-merge.test.ts
@@ -1,0 +1,61 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { reorderProfiles, deriveReorderArgs } from './connections-order-merge'
+
+describe('reorderProfiles', () => {
+  test('reorders by id, drops unknown ids, and appends missing', () => {
+    const slice = [{ id: 'a' }, { id: 'b' }, { id: 'c' }]
+    const out = reorderProfiles(slice, ['c', 'a', 'ghost'])
+    expect(out.map((p) => p.id)).toEqual(['c', 'a', 'b'])
+  })
+
+  test('appends profiles not in the order at the end', () => {
+    const slice = [{ id: 'a' }, { id: 'b' }, { id: 'c' }]
+    const out = reorderProfiles(slice, ['b'])
+    expect(out.map((p) => p.id)).toEqual(['b', 'a', 'c'])
+  })
+
+  test('returns the original slice when orderedIds is undefined', () => {
+    const slice = [{ id: 'a' }, { id: 'b' }]
+    const out = reorderProfiles(slice, undefined)
+    expect(out.map((p) => p.id)).toEqual(['a', 'b'])
+  })
+
+  test('handles empty order array', () => {
+    const slice = [{ id: 'a' }, { id: 'b' }]
+    const out = reorderProfiles(slice, [])
+    expect(out.map((p) => p.id)).toEqual(['a', 'b'])
+  })
+})
+
+describe('deriveReorderArgs', () => {
+  test('returns id arrays for slices with a matching order entry', () => {
+    const out = deriveReorderArgs(
+      { llm: ['b', 'a'] },
+      { llm: [{ id: 'a' }, { id: 'b' }] },
+    )
+    expect(out.llm).toEqual(['b', 'a'])
+    expect(out.imageGen).toBeUndefined()
+    expect(out.stt).toBeUndefined()
+    expect(out.tts).toBeUndefined()
+  })
+
+  test('skips types with no live slice', () => {
+    const out = deriveReorderArgs(
+      { llm: ['a'], imageGen: ['x'] },
+      { llm: [{ id: 'a' }] },
+    )
+    expect(out.llm).toEqual(['a'])
+    expect(out.imageGen).toBeUndefined()
+  })
+
+  test('skips types with no order entry', () => {
+    const out = deriveReorderArgs(
+      { llm: ['a'] },
+      { llm: [{ id: 'a' }, { id: 'b' }], imageGen: [{ id: 'x' }] },
+    )
+    expect(out.llm).toEqual(['a', 'b'])
+    expect(out.imageGen).toBeUndefined()
+  })
+})

--- a/frontend/src/store/slices/connections-order-merge.ts
+++ b/frontend/src/store/slices/connections-order-merge.ts
@@ -1,0 +1,62 @@
+export type ConnectionsOrder = Partial<Record<'llm' | 'imageGen' | 'stt' | 'tts', string[]>>
+
+export type ProfileType = 'llm' | 'imageGen' | 'stt' | 'tts'
+
+export interface OrderableProfile {
+  id: string
+}
+
+export type OrderedProfiles<T extends OrderableProfile> = T[]
+
+/**
+ * Reorder a single slice of profiles to match a persisted order.
+ *
+ * - Ids listed in the order come first, in the order given.
+ * - Profiles missing from the order are appended at the end, preserving
+ *   their existing slice order.
+ * - Ids in the order that don't resolve to a live profile are dropped.
+ *
+ * Returns the reordered slice. If `orderedIds` is undefined, returns
+ * the original slice (no-op).
+ */
+export function reorderProfiles<T extends OrderableProfile>(
+  slice: readonly T[],
+  orderedIds: string[] | undefined,
+): T[] {
+  if (!orderedIds) return [...slice]
+  const byId = new Map(slice.map((p) => [p.id, p]))
+  const seen = new Set<string>()
+  const reordered: T[] = []
+  for (const id of orderedIds) {
+    const profile = byId.get(id)
+    if (profile && !seen.has(id)) {
+      reordered.push(profile)
+      seen.add(id)
+    }
+  }
+  for (const profile of slice) {
+    if (!seen.has(profile.id)) reordered.push(profile)
+  }
+  return reordered
+}
+
+/**
+ * Apply a persisted `connectionsOrder` to the four profile slices. Returns
+ * the id arrays that should be passed to the per-type slice mutators. Each
+ * entry is undefined when there is no live slice or no order entry.
+ */
+export function deriveReorderArgs(
+  order: ConnectionsOrder,
+  slices: Partial<Record<ProfileType, readonly { id: string }[]>>,
+): Partial<Record<ProfileType, string[] | undefined>> {
+  const out: Partial<Record<ProfileType, string[] | undefined>> = {}
+  for (const type of ['llm', 'imageGen', 'stt', 'tts'] as const) {
+    const slice = slices[type]
+    if (!slice) continue
+    const orderedIds = order[type]
+    if (!orderedIds) continue
+    const reordered = reorderProfiles(slice as readonly { id: string }[], orderedIds)
+    out[type] = reordered.map((p) => p.id)
+  }
+  return out
+}

--- a/frontend/src/store/slices/connections.ts
+++ b/frontend/src/store/slices/connections.ts
@@ -1,5 +1,6 @@
 import type { StateCreator } from 'zustand'
 import type { AppStore, ConnectionsSlice } from '@/types/store'
+import type { ConnectionProfile } from '@/types/api'
 import { settingsApi } from '@/api/settings'
 import { areReasoningSettingsEqual, normalizeReasoningSettingsForProvider } from '@/lib/reasoning-binding'
 import { REASONING_DEFAULTS, clearDirtyKey } from './settings'
@@ -61,7 +62,13 @@ export const createConnectionsSlice: StateCreator<AppStore, [], [], ConnectionsS
     }
   },
 
-  addProfile: (profile) => set((state) => ({ profiles: [...state.profiles, profile] })),
+  addProfile: (profile) => set((state) => {
+    const order = state.connectionsOrder.llm
+    return {
+      profiles: [...state.profiles, profile],
+      connectionsOrder: { ...state.connectionsOrder, llm: [...order, profile.id] },
+    }
+  }),
   updateProfile: (id, updates) =>
     set((state) => ({
       profiles: state.profiles.map((p) => (p.id === id ? { ...p, ...updates } : p)),
@@ -88,6 +95,13 @@ export const createConnectionsSlice: StateCreator<AppStore, [], [], ConnectionsS
       clearDirtyKey('promptBias')
     }
   },
+
+  applyProfileOrder: (orderedIds) =>
+    set((state) => ({
+      profiles: orderedIds
+        .map((id) => state.profiles.find((p) => p.id === id))
+        .filter((p): p is ConnectionProfile => Boolean(p)),
+    })),
 
   providers: [],
   setProviders: (providers) => set({ providers }),

--- a/frontend/src/store/slices/image-gen-connections.ts
+++ b/frontend/src/store/slices/image-gen-connections.ts
@@ -1,5 +1,6 @@
 import type { StateCreator } from 'zustand'
 import type { AppStore, ImageGenConnectionsSlice } from '@/types/store'
+import type { ImageGenConnectionProfile } from '@/types/api'
 import { settingsApi } from '@/api/settings'
 import { clearDirtyKey } from './settings'
 
@@ -55,7 +56,13 @@ export const createImageGenConnectionsSlice: StateCreator<AppStore, [], [], Imag
         : { ...state.imageGeneration, activeImageGenConnectionId }
 
       if (imageGeneration !== state.imageGeneration) persistImageGeneration(imageGeneration)
-      return { imageGenProfiles, activeImageGenConnectionId, imageGeneration }
+      const order = state.connectionsOrder.imageGen
+      return {
+        imageGenProfiles,
+        activeImageGenConnectionId,
+        imageGeneration,
+        connectionsOrder: { ...state.connectionsOrder, imageGen: [...order, profile.id] },
+      }
     }),
 
   updateImageGenProfile: (id, updates) =>
@@ -87,6 +94,13 @@ export const createImageGenConnectionsSlice: StateCreator<AppStore, [], [], Imag
       if (imageGeneration !== state.imageGeneration) persistImageGeneration(imageGeneration)
       return { imageGenProfiles, activeImageGenConnectionId, imageGeneration }
     }),
+
+  applyImageGenProfileOrder: (orderedIds) =>
+    set((state) => ({
+      imageGenProfiles: orderedIds
+        .map((id) => state.imageGenProfiles.find((p) => p.id === id))
+        .filter((p): p is ImageGenConnectionProfile => Boolean(p)),
+    })),
 
   setImageGenProviders: (providers) => set({ imageGenProviders: providers }),
 })

--- a/frontend/src/store/slices/settings.ts
+++ b/frontend/src/store/slices/settings.ts
@@ -5,6 +5,7 @@ import { themeAssetsApi } from '@/api/theme-assets'
 import { BASE_URL } from '@/api/client'
 import { generateUUID } from '@/lib/uuid'
 import { DEFAULT_THEME, normalizeTheme } from '@/theme/presets'
+import { deriveReorderArgs, type ConnectionsOrder } from './connections-order-merge'
 
 /** Default reasoning settings — used as initial state and for restore-on-unbind. */
 export const REASONING_DEFAULTS: ReasoningSettings = {
@@ -111,6 +112,8 @@ const DATA_KEYS: ReadonlySet<string> = new Set([
   'thumbnailSettings',
   // Push notification preferences
   'pushNotificationPreferences',
+  // Connection reorder persistence
+  'connectionsOrder',
   'customCSS',
   'componentOverrides',
   // Saved theme library (My Themes)
@@ -372,6 +375,8 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
     narrationVoice: null,
   },
 
+  connectionsOrder: { llm: [], imageGen: [], stt: [], tts: [] },
+
   hydrateStartupSettings: (settings: StartupSettings) => {
     const patch: Record<string, any> = { settingsLoaded: true }
 
@@ -394,6 +399,9 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
     }
     if (settings.drawerSettings && typeof settings.drawerSettings === 'object') {
       patch.drawerSettings = { ...get().drawerSettings, ...settings.drawerSettings }
+    }
+    if (settings.connectionsOrder && typeof settings.connectionsOrder === 'object') {
+      patch.connectionsOrder = { llm: [], imageGen: [], stt: [], tts: [], ...settings.connectionsOrder }
     }
 
     set(patch as any)
@@ -673,6 +681,24 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
       }
       if (Object.keys(patch).length > 0) {
         set(patch as any)
+      }
+
+      // Reorder profile slices to match persisted connectionsOrder. Without
+      // this, consumers that read state.profiles directly (input bar dropdown,
+      // ConnectionSelect, etc.) keep the backend order until the user drags
+      // something in the panel — which is the visible divergence C3 found.
+      if (patch.connectionsOrder) {
+        const order = patch.connectionsOrder as ConnectionsOrder
+        const args = deriveReorderArgs(order, {
+          llm: get().profiles,
+          imageGen: get().imageGenProfiles,
+          stt: get().sttProfiles,
+          tts: get().ttsProfiles,
+        })
+        if (args.llm) get().applyProfileOrder(args.llm)
+        if (args.imageGen) get().applyImageGenProfileOrder(args.imageGen)
+        if (args.stt) get().applySttProfileOrder(args.stt)
+        if (args.tts) get().applyTtsProfileOrder(args.tts)
       }
       if (migratedCharacterFilterTab) {
         settingsApi.put('filterTab', 'characters').catch(() => {})

--- a/frontend/src/store/slices/stt-connections.ts
+++ b/frontend/src/store/slices/stt-connections.ts
@@ -1,5 +1,6 @@
 import type { StateCreator } from 'zustand'
 import type { SttConnectionsSlice } from '@/types/store'
+import type { SttConnectionProfile } from '@/types/api'
 
 export const createSttConnectionsSlice: StateCreator<SttConnectionsSlice> = (set) => ({
   sttProfiles: [],
@@ -8,7 +9,13 @@ export const createSttConnectionsSlice: StateCreator<SttConnectionsSlice> = (set
   setSttProfiles: (profiles) => set({ sttProfiles: profiles }),
 
   addSttProfile: (profile) =>
-    set((state) => ({ sttProfiles: [...state.sttProfiles, profile] })),
+    set((state) => {
+      const order = (state as any).connectionsOrder.stt as string[]
+      return {
+        sttProfiles: [...state.sttProfiles, profile],
+        connectionsOrder: { ...(state as any).connectionsOrder, stt: [...order, profile.id] },
+      }
+    }),
 
   updateSttProfile: (id, updates) =>
     set((state) => ({
@@ -18,6 +25,13 @@ export const createSttConnectionsSlice: StateCreator<SttConnectionsSlice> = (set
   removeSttProfile: (id) =>
     set((state) => ({
       sttProfiles: state.sttProfiles.filter((p) => p.id !== id),
+    })),
+
+  applySttProfileOrder: (orderedIds) =>
+    set((state) => ({
+      sttProfiles: orderedIds
+        .map((id) => state.sttProfiles.find((p) => p.id === id))
+        .filter((p): p is SttConnectionProfile => Boolean(p)),
     })),
 
   setSttProviders: (providers) => set({ sttProviders: providers }),

--- a/frontend/src/store/slices/tts-connections.ts
+++ b/frontend/src/store/slices/tts-connections.ts
@@ -1,5 +1,6 @@
 import type { StateCreator } from 'zustand'
 import type { TtsConnectionsSlice } from '@/types/store'
+import type { TtsConnectionProfile } from '@/types/api'
 
 export const createTtsConnectionsSlice: StateCreator<TtsConnectionsSlice> = (set) => ({
   ttsProfiles: [],
@@ -8,7 +9,13 @@ export const createTtsConnectionsSlice: StateCreator<TtsConnectionsSlice> = (set
   setTtsProfiles: (profiles) => set({ ttsProfiles: profiles }),
 
   addTtsProfile: (profile) =>
-    set((state) => ({ ttsProfiles: [...state.ttsProfiles, profile] })),
+    set((state) => {
+      const order = (state as any).connectionsOrder.tts as string[]
+      return {
+        ttsProfiles: [...state.ttsProfiles, profile],
+        connectionsOrder: { ...(state as any).connectionsOrder, tts: [...order, profile.id] },
+      }
+    }),
 
   updateTtsProfile: (id, updates) =>
     set((state) => ({
@@ -18,6 +25,13 @@ export const createTtsConnectionsSlice: StateCreator<TtsConnectionsSlice> = (set
   removeTtsProfile: (id) =>
     set((state) => ({
       ttsProfiles: state.ttsProfiles.filter((p) => p.id !== id),
+    })),
+
+  applyTtsProfileOrder: (orderedIds) =>
+    set((state) => ({
+      ttsProfiles: orderedIds
+        .map((id) => state.ttsProfiles.find((p) => p.id === id))
+        .filter((p): p is TtsConnectionProfile => Boolean(p)),
     })),
 
   setTtsProviders: (providers) => set({ ttsProviders: providers }),

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -120,6 +120,7 @@ export interface StartupSettings {
   landingPageLayoutMode?: 'cards' | 'compact'
   wallpaper?: WallpaperSettings
   drawerSettings?: DrawerSettings
+  connectionsOrder?: Partial<Record<'llm' | 'imageGen' | 'stt' | 'tts', string[]>>
 }
 
 export interface CharactersSlice {
@@ -506,6 +507,7 @@ export interface SettingsSlice {
   savedThemes: SavedTheme[]
   spindleSettings: SpindleSettings
   voiceSettings: VoiceSettings
+  connectionsOrder: Record<'llm' | 'imageGen' | 'stt' | 'tts', string[]>
   hydrateStartupSettings: (settings: StartupSettings) => void
   setVoiceSettings: (partial: Partial<VoiceSettings>) => void
   setWallpaper: (settings: Partial<WallpaperSettings>) => void
@@ -582,6 +584,7 @@ export interface ConnectionsSlice {
   addProfile: (profile: ConnectionProfile) => void
   updateProfile: (id: string, updates: Partial<ConnectionProfile>) => void
   removeProfile: (id: string) => void
+  applyProfileOrder: (orderedIds: string[]) => void
 
   providers: ProviderInfo[]
   setProviders: (providers: ProviderInfo[]) => void
@@ -1259,6 +1262,7 @@ export interface ImageGenConnectionsSlice {
   addImageGenProfile: (profile: ImageGenConnectionProfile) => void
   updateImageGenProfile: (id: string, updates: Partial<ImageGenConnectionProfile>) => void
   removeImageGenProfile: (id: string) => void
+  applyImageGenProfileOrder: (orderedIds: string[]) => void
   setImageGenProviders: (providers: ImageGenProviderInfo[]) => void
 }
 
@@ -1283,6 +1287,7 @@ export interface SttConnectionsSlice {
   addSttProfile: (profile: import('@/types/api').SttConnectionProfile) => void
   updateSttProfile: (id: string, updates: Partial<import('@/types/api').SttConnectionProfile>) => void
   removeSttProfile: (id: string) => void
+  applySttProfileOrder: (orderedIds: string[]) => void
   setSttProviders: (providers: import('@/types/api').SttProviderInfo[]) => void
 }
 
@@ -1295,6 +1300,7 @@ export interface TtsConnectionsSlice {
   addTtsProfile: (profile: import('@/types/api').TtsConnectionProfile) => void
   updateTtsProfile: (id: string, updates: Partial<import('@/types/api').TtsConnectionProfile>) => void
   removeTtsProfile: (id: string) => void
+  applyTtsProfileOrder: (orderedIds: string[]) => void
   setTtsProviders: (providers: import('@/types/api').TtsProviderInfo[]) => void
 }
 

--- a/src/services/bootstrap.service.ts
+++ b/src/services/bootstrap.service.ts
@@ -102,6 +102,7 @@ interface StartupSettings {
   landingPageLayoutMode?: "cards" | "compact";
   wallpaper?: unknown;
   drawerSettings?: unknown;
+  connectionsOrder?: Partial<Record<"llm" | "imageGen" | "stt" | "tts", string[]>>;
 }
 
 const LIST_LIMIT_CONNECTIONS = 100;
@@ -121,6 +122,7 @@ const STARTUP_SETTINGS_KEYS = [
   "landingPageLayoutMode",
   "wallpaper",
   "drawerSettings",
+  "connectionsOrder",
 ] as const;
 
 /**
@@ -154,6 +156,31 @@ function collectAll<T>(
     if (page.data.length === 0 || offset >= page.total) break;
   }
   return { data, total: data.length, limit: data.length, offset: 0 };
+}
+
+/**
+ * Validate and sanitize a raw `connectionsOrder` value from the settings store.
+ *
+ * - Drops keys that aren't valid connection types.
+ * - Drops non-array values.
+ * - Drops arrays that contain non-string elements.
+ *
+ * Returns the sanitized object (which may be empty) and whether anything was
+ * kept. When `Object.keys(sanitized).length === 0`, the caller should skip
+ * setting the field entirely.
+ */
+export function sanitizeConnectionsOrder(
+  raw: unknown,
+): Partial<Record<"llm" | "imageGen" | "stt" | "tts", string[]>> {
+  const sanitized: Partial<Record<"llm" | "imageGen" | "stt" | "tts", string[]>> = {};
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return sanitized;
+  for (const key of ["llm", "imageGen", "stt", "tts"] as const) {
+    const value = (raw as Record<string, unknown>)[key];
+    if (Array.isArray(value) && value.every((id) => typeof id === "string")) {
+      sanitized[key] = value;
+    }
+  }
+  return sanitized;
 }
 
 function getStartupSettings(userId: string): StartupSettings {
@@ -210,6 +237,11 @@ function getStartupSettings(userId: string): StartupSettings {
 
   if (rows.has("drawerSettings")) {
     startupSettings.drawerSettings = rows.get("drawerSettings");
+  }
+
+  const connectionsOrder = sanitizeConnectionsOrder(rows.get("connectionsOrder"));
+  if (Object.keys(connectionsOrder).length > 0) {
+    startupSettings.connectionsOrder = connectionsOrder;
   }
 
   return startupSettings;


### PR DESCRIPTION
Adds DragOverlay + SortableContext to all four connection panels (LLM, ImageGen, STT, TTS). Order is persisted to settings so it survives page reload.

Attempts to mirror existing drag-to-reorder behavior and visuals as much as possible (like those seen in ConfigureDrawerTabsModal).

- DragOverlay clone in-place (no portal)
- connectionsOrder hydrated via loadSettings + deriveReorderArgs
- applyProfileOrder / applyImageGenProfileOrder / applySttProfileOrder / applyTtsProfileOrder mutators 
- touch-action: none on .item to suppress scroll during touch drag delay
- 7 unit tests for reorderProfiles + deriveReorderArgs
- connectionsOrder sanitized in bootstrap.service.ts on server startup
- dragToReorder i18n key in en/fr/it/ja/zh/zh-TW