### PR TITLE
fix(connections): post-merge fixes for drag-to-reorder

### DIFF
--- a/frontend/src/components/panels/ConnectionManager.tsx
+++ b/frontend/src/components/panels/ConnectionManager.tsx
@@ -3,14 +3,12 @@ import { Plus, Shuffle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import {
   DndContext,
-  DragOverlay,
   closestCenter,
   MouseSensor,
   TouchSensor,
   KeyboardSensor,
   useSensor,
   useSensors,
-  type DragStartEvent,
   type DragEndEvent,
 } from '@dnd-kit/core'
 import {
@@ -55,7 +53,7 @@ export default function ConnectionManager() {
   const connectionsOrder = useStore((s) => s.connectionsOrder)
 
   const mouseSensor = useSensor(MouseSensor, { activationConstraint: { distance: 4 } })
-  const touchSensor = useSensor(TouchSensor, { activationConstraint: { delay: 180, tolerance: 5 } })
+  const touchSensor = useSensor(TouchSensor, { activationConstraint: { distance: 8 } })
   const keyboardSensor = useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   const sensors = useSensors(mouseSensor, touchSensor, keyboardSensor)
 
@@ -75,8 +73,6 @@ export default function ConnectionManager() {
   const [creating, setCreating] = useState(false)
   const [creatingProvider, setCreatingProvider] = useState('openai')
   const [deleteTarget, setDeleteTarget] = useState<ConnectionProfile | null>(null)
-  const [dragActiveId, setDragActiveId] = useState<string | null>(null)
-  const activeProfile = orderedProfiles.find((p) => p.id === dragActiveId) ?? null
 
   useEffect(() => {
     const returnedKey = sessionStorage.getItem('pollinations_byop_returned_api_key')
@@ -188,16 +184,7 @@ export default function ConnectionManager() {
   }, [deleteTarget, removeProfile, connectionsOrder, setSetting])
 
 
-  const handleDragStart = useCallback(({ active }: DragStartEvent) => {
-    setDragActiveId(String(active.id))
-  }, [])
-
-  const handleDragCancel = useCallback(() => {
-    setDragActiveId(null)
-  }, [])
-
   const handleDragEnd = useCallback((event: DragEndEvent) => {
-    setDragActiveId(null)
     const { active, over } = event
     if (!over || active.id === over.id) return
     const oldIndex = orderedIds.indexOf(String(active.id))
@@ -248,7 +235,7 @@ export default function ConnectionManager() {
         />
       )}
 
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragCancel={handleDragCancel} onDragEnd={handleDragEnd}>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
         <SortableContext items={orderedIds} strategy={verticalListSortingStrategy}>
           <div className={styles.list}>
             {orderedProfiles.map((profile) => (
@@ -268,21 +255,6 @@ export default function ConnectionManager() {
             )}
           </div>
         </SortableContext>
-        {activeProfile && (
-        <DragOverlay dropAnimation={null}>
-          <div className={styles.itemDraggingOverlay}>
-            <ConnectionItem
-              profile={activeProfile}
-              isActive={activeProfileId === activeProfile.id}
-              providers={providers}
-              onSelect={() => setActiveProfile(activeProfileId === activeProfile.id ? null : activeProfile.id)}
-              onUpdate={handleUpdate}
-              onDuplicate={() => handleDuplicate(activeProfile.id)}
-              onDelete={() => setDeleteTarget(activeProfile)}
-            />
-          </div>
-        </DragOverlay>
-        )}
       </DndContext>
 
       {deleteTarget && (

--- a/frontend/src/components/panels/connection-manager/ConnectionItem.module.css
+++ b/frontend/src/components/panels/connection-manager/ConnectionItem.module.css
@@ -3,35 +3,13 @@
   flex-direction: column;
   border-radius: 10px;
   transition: background var(--lumiverse-transition-fast);
-  /* Prevent the browser from interpreting a touch on the row as a scroll
-     gesture on .panelContent during the 180ms TouchSensor activation delay.
-     Without this, the panel scrolls a few px before drag activates and
-     useRect(activeNode) measures the card at its new (scrolled) position —
-     the DragOverlay then anchors there, making the overlay's top-left "snap"
-     away from the user's original touch point (top of handle ends up at thumb,
-     not handle bottom). The handle already has touch-action:none, but it's
-     only 24x32px and the touch can land on the row gap or below the row,
-     which inherits the default touch-action:auto from .panelContent. */
-  touch-action: none;
 }
 
 .itemDragging {
-  /* Hidden slot for the dragged card. The visible "lifted" card during a
-     reorder is the <DragOverlay> clone at the document-body level (via
-     React Portal) — it escapes the drawer panel's overflow:hidden +
-     isolation:isolate stacking context so it can be dragged over chat
-     and other panels without being clipped.
-
-     Without opacity:0 the slot would render as a translated ghost beside
-     the overlay (it still receives useSortable's transform during the
-     drag). Hiding it leaves only the overlay visible, but keeps the
-     layout footprint so neighbor cards reflow correctly.
-
-     The overlay clone sits outside SortableContext, so useSortable there
-     returns defaults (isDragging=false) and the overlay does NOT receive
-     .itemDragging — it's only this in-list slot that gets hidden. */
-  opacity: 0;
-  pointer-events: none;
+  z-index: 5;
+  box-shadow: 0 10px 30px -8px rgba(0, 0, 0, 0.45),
+    0 0 0 1px var(--lumiverse-primary-040, var(--lumiverse-primary));
+  background: color-mix(in srgb, var(--lumiverse-primary) 8%, var(--lumiverse-bg-deep));
 }
 
 .itemActive {


### PR DESCRIPTION
- Remove DragOverlay, use in-place sorting (matches ConfigureDrawerTabs)
- Distance-based TouchSensor (distance: 8) instead of delay-based
- Remove touch-action: none from .item so mobile users can scroll
- .itemDragging shows lift styling instead of hiding the item