### PR TITLE
feat(cortex): add arc summaries retrieval checkbox

### DIFF
--- a/frontend/src/components/settings/MemoryCortexSettings.tsx
+++ b/frontend/src/components/settings/MemoryCortexSettings.tsx
@@ -805,6 +805,9 @@ export default function MemoryCortexSettings() {
                     <div className={styles.toggleRow}>
                       <Toggle.Checkbox checked={config.retrieval.relationshipInjection} onChange={(v) => updateConfig({ retrieval: { ...config.retrieval, relationshipInjection: v } })} label={t("memoryCortex.relationshipEdges")} hint={t("memoryCortex.relationshipEdgesHint")} />
                     </div>
+                    <div className={styles.toggleRow}>
+                      <Toggle.Checkbox checked={config.retrieval.arcInjection} onChange={(v) => updateConfig({ retrieval: { ...config.retrieval, arcInjection: v } })} label={t("memoryCortex.arcSummaries")} hint={t("memoryCortex.arcSummariesHint")} />
+                    </div>
                     <div className={styles.infoRow}>
                       <span className={styles.infoLabel}>{t("memoryCortex.contextTokenBudget")}</span>
                       <NumericInput className={styles.numberInput} value={config.contextTokenBudget} min={100} max={2000} step={50} integer onChange={(value) => updateConfig({ contextTokenBudget: value ?? 600 })} />

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -1100,6 +1100,8 @@
     "entitySnapshotsHint": "Include character/location summaries in the prompt",
     "relationshipEdges": "Relationship edges",
     "relationshipEdgesHint": "Include character relationships in the prompt",
+    "arcSummaries": "Arc summaries",
+    "arcSummariesHint": "Include story arc summaries in the prompt",
     "contextTokenBudget": "Context token budget",
     "memoryDecay": "Memory decay",
     "halfLifeTurns": "Half-life (turns)",


### PR DESCRIPTION
PR adds a checkbox in the Memory Cortex settings for Arc Summaries, apparently it can be turned off by flipping to a non-advanced mode and back.

<img width="802" height="381" alt="image" src="https://github.com/user-attachments/assets/6095dca5-93c7-423a-9792-def475ee5da2" />
