### PR TITLE
Resolve character/greeting macros in image-gen parser context

### DIFF
--- a/src/services/image-gen-context-macros.test.ts
+++ b/src/services/image-gen-context-macros.test.ts
@@ -1,0 +1,169 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { join } from "path";
+import { closeDatabase, getDb, initDatabase } from "../db/connection";
+import { initMacros } from "../macros";
+import * as charactersSvc from "./characters.service";
+import * as chatsSvc from "./chats.service";
+import * as personasSvc from "./personas.service";
+import * as settingsSvc from "./settings.service";
+import { buildContextMessages, getImageGenSettings } from "./image-gen.service";
+
+const USER_ID = "image-gen-context-macros-user";
+
+async function applyBaseline(): Promise<void> {
+  const baselinePath = join(import.meta.dir, "..", "db", "baseline.sql");
+  const sql = await Bun.file(baselinePath).text();
+  const db = getDb();
+  // Baseline references the `user` table for FK constraints. We don't drive
+  // auth here, so just disable FK enforcement for the in-memory test DB.
+  db.run("PRAGMA foreign_keys = OFF");
+  db.run(sql);
+}
+
+function insertChat(userId: string, characterId: string): string {
+  const chatId = crypto.randomUUID();
+  const now = Math.floor(Date.now() / 1000);
+  getDb()
+    .query(
+      "INSERT INTO chats (id, user_id, character_id, name, metadata, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .run(chatId, userId, characterId, "macro context", "{}", now, now);
+  return chatId;
+}
+
+// Seed a default persona so {{user}} resolves to a deterministic name rather
+// than the "User" fallback, making the resolved-output assertions meaningful.
+function seedDefaultPersona(
+  userId: string,
+  opts: { name?: string; title?: string; description?: string } = {},
+): void {
+  personasSvc.createPersona(userId, {
+    name: opts.name ?? "Traveler",
+    title: opts.title,
+    description: opts.description,
+    is_default: true,
+  });
+}
+
+beforeAll(() => {
+  initMacros();
+});
+
+afterAll(() => {
+  closeDatabase();
+});
+
+describe("image-gen parser context macro resolution", () => {
+  beforeEach(async () => {
+    closeDatabase();
+    initDatabase(":memory:");
+    await applyBaseline();
+  });
+
+  test("resolves character card macros before building parser context", async () => {
+    seedDefaultPersona(USER_ID);
+    const char = charactersSvc.createCharacter(USER_ID, {
+      name: "Elara",
+      description: "A guardian who watches over {{user}}.",
+      scenario: "{{char}} arrives at the gates at dawn.",
+    });
+    const chatId = insertChat(USER_ID, char.id);
+    settingsSvc.putSetting(USER_ID, "imageGeneration", {
+      includeCharacters: false,
+      promptContextMessageLimit: 3,
+    });
+
+    const messages = await buildContextMessages(USER_ID, chatId, getImageGenSettings(USER_ID));
+    const charInfo = messages.find(
+      (message) =>
+        message.role === "system" &&
+        typeof message.content === "string" &&
+        message.content.startsWith("## Character Information"),
+    );
+
+    // Exact resolved strings prove {{user}}→persona name and {{char}}→character
+    // name specifically (not merely that some brace token disappeared).
+    const content = charInfo?.content as string;
+    expect(content).toContain("Description: A guardian who watches over Traveler.");
+    expect(content).toContain("Scenario: Elara arrives at the gates at dawn.");
+    expect(content).not.toContain("{{");
+  });
+
+  test("resolves raw greeting macros before building parser context", async () => {
+    seedDefaultPersona(USER_ID);
+    const char = charactersSvc.createCharacter(USER_ID, { name: "Elara" });
+    const chatId = insertChat(USER_ID, char.id);
+    // Greetings are stored verbatim from character.first_mes (chats.service.ts),
+    // so macros only resolve at read time — mirroring this raw insert.
+    chatsSvc.createMessage(
+      chatId,
+      {
+        is_user: false,
+        name: "Elara",
+        content: "Welcome, {{user}}. I am {{char}}.",
+        extra: { greeting: true },
+      },
+      USER_ID,
+    );
+    settingsSvc.putSetting(USER_ID, "imageGeneration", {
+      includeCharacters: false,
+      promptContextMessageLimit: 3,
+    });
+
+    const messages = await buildContextMessages(USER_ID, chatId, getImageGenSettings(USER_ID));
+    const assistant = messages.find((message) => message.role === "assistant");
+
+    expect(assistant?.content).toBe("Welcome, Traveler. I am Elara.");
+  });
+
+  test("resolves persona block macros when Include Characters is on", async () => {
+    seedDefaultPersona(USER_ID, {
+      name: "Traveler",
+      title: "Traveler the Brave",
+      description: "Wandering as {{user}} does.",
+    });
+    const char = charactersSvc.createCharacter(USER_ID, { name: "Elara" });
+    const chatId = insertChat(USER_ID, char.id);
+    settingsSvc.putSetting(USER_ID, "imageGeneration", {
+      includeCharacters: true,
+      promptContextMessageLimit: 3,
+    });
+
+    const messages = await buildContextMessages(USER_ID, chatId, getImageGenSettings(USER_ID));
+    const persona = messages.find(
+      (message) =>
+        message.role === "system" &&
+        typeof message.content === "string" &&
+        message.content.startsWith("## User Persona"),
+    );
+
+    const content = persona?.content as string;
+    expect(content).toContain("Description: Wandering as Traveler does.");
+    expect(content).not.toContain("{{");
+  });
+
+  test("passes macro-free messages through verbatim", async () => {
+    seedDefaultPersona(USER_ID);
+    const char = charactersSvc.createCharacter(USER_ID, { name: "Elara" });
+    const chatId = insertChat(USER_ID, char.id);
+    chatsSvc.createMessage(
+      chatId,
+      {
+        is_user: false,
+        name: "Elara",
+        content: "The wind blows.",
+        extra: {},
+      },
+      USER_ID,
+    );
+    settingsSvc.putSetting(USER_ID, "imageGeneration", {
+      includeCharacters: false,
+      promptContextMessageLimit: 3,
+    });
+
+    const messages = await buildContextMessages(USER_ID, chatId, getImageGenSettings(USER_ID));
+    const assistant = messages.find((message) => message.role === "assistant");
+
+    expect(assistant?.content).toBe("The wind blows.");
+  });
+});

--- a/src/services/image-gen.service.ts
+++ b/src/services/image-gen.service.ts
@@ -35,6 +35,7 @@ import "../image-gen/index";
 
 const IMAGE_SETTINGS_KEY = "imageGeneration";
 const RELAY_IMAGE_PREVIEW_MAX_CHARS = 180 * 1024;
+const HAS_MACRO_RE = /\{\{|<(?:user|char|bot)>/i;
 
 async function buildRelayImagePreview(dataUrl: string): Promise<string | undefined> {
   const match = dataUrl.match(/^data:([^;]+);base64,(.+)$/);
@@ -1226,7 +1227,7 @@ async function parseCustomPrompt(
         role: "system",
         content: CUSTOM_PROMPT_PARSER_SYSTEM,
       },
-      ...buildContextMessages(userId, chatId, settings),
+      ...await buildContextMessages(userId, chatId, settings),
       {
         role: "user",
         content: `Parser instructions from the user:\n${input.prompt}\n\nReturn the final image prompt now.`,
@@ -1302,7 +1303,7 @@ async function analyzeScene(userId: string, chatId: string, settings: ImageGenSe
         role: "system",
         content: `${tool.prompt}${settings.includeCharacters ? `\n\n${CHARACTER_AWARE_SCENE_INSTRUCTIONS}` : ""}\n\nYou must return ONLY valid JSON with the requested schema keys and no markdown fences.`,
       },
-      ...buildContextMessages(userId, chatId, settings),
+      ...await buildContextMessages(userId, chatId, settings),
       { role: "user", content: "Return scene JSON now." },
     ],
     parameters: {
@@ -1314,17 +1315,34 @@ async function analyzeScene(userId: string, chatId: string, settings: ImageGenSe
   return parseSceneJson(response.content || "");
 }
 
-function buildContextMessages(userId: string, chatId: string, settings: ImageGenSettings): LlmMessage[] {
+export async function buildContextMessages(userId: string, chatId: string, settings: ImageGenSettings): Promise<LlmMessage[]> {
   const includeCharacters = settings.includeCharacters;
   const msgs: LlmMessage[] = [];
+  const env = buildMacroEnvForChat(userId, chatId);
+
+  // Resolve base macros ({{user}}/{{char}}/vars, etc.) in any text sent to the
+  // image-gen prompt parser. Mirrors resolvePromptPreset's best-effort path:
+  // macros are a convenience, so a resolution failure must never block a
+  // generation — the raw text is returned instead.
+  const resolve = async (text: string | undefined | null): Promise<string> => {
+    if (!text || !env || !HAS_MACRO_RE.test(text)) return text ?? "";
+    try {
+      return (await evaluateMacros(text, env, macroRegistry)).text;
+    } catch {
+      return text;
+    }
+  };
+
   const chat = chatsSvc.getChat(userId, chatId);
   if (chat) {
     const char = chat.character_id ? charactersSvc.getCharacter(userId, chat.character_id) : null;
     if (char) {
+      const description = await resolve(char.description);
+      const scenario = await resolve(char.scenario);
       const charInfo = [
         char.name && `Name: ${char.name}`,
-        char.description && `Description: ${char.description}`,
-        char.scenario && `Scenario: ${char.scenario}`,
+        description && `Description: ${description}`,
+        scenario && `Scenario: ${scenario}`,
       ]
         .filter(Boolean)
         .join("\n");
@@ -1334,10 +1352,12 @@ function buildContextMessages(userId: string, chatId: string, settings: ImageGen
   if (includeCharacters) {
     const persona = personasSvc.resolvePersonaOrDefault(userId);
     if (persona) {
+      const title = await resolve(persona.title);
+      const description = await resolve(persona.description);
       const personaInfo = [
         persona.name && `Name: ${persona.name}`,
-        persona.title && `Title: ${persona.title}`,
-        persona.description && `Description: ${persona.description}`,
+        title && `Title: ${title}`,
+        description && `Description: ${description}`,
         (persona.subjective_pronoun || persona.objective_pronoun || persona.possessive_pronoun) &&
           `Pronouns: ${[persona.subjective_pronoun, persona.objective_pronoun, persona.possessive_pronoun].filter(Boolean).join("/")}`,
       ]
@@ -1347,7 +1367,7 @@ function buildContextMessages(userId: string, chatId: string, settings: ImageGen
     }
   }
   for (const m of chatsSvc.getMessages(userId, chatId).slice(-resolveContextMessageLimit(settings))) {
-    msgs.push({ role: m.is_user ? "user" : "assistant", content: m.content });
+    msgs.push({ role: m.is_user ? "user" : "assistant", content: await resolve(m.content) });
   }
   return msgs;
 }


### PR DESCRIPTION
## Problem

When image generation runs in **scene** or **parsed-custom** mode, the context sent to the prompt-parser model is assembled by `buildContextMessages`. That function passed **raw** character-card fields (`description`, `scenario`) and **raw** chat-message content, so macros in a character's card or greeting/first message reached the parser unresolved:

- base macros like `{{user}}` / `{{char}}` arrived as literal tokens, and
- world-info **outlet** macros (`{{outlet::name}}`) collapsed to empty string, because the env never ran world-info activation — the same gap PR #205 fixed for the UI display-preprocess path.

## Fix

`buildContextMessages` now resolves macros through the same `buildMacroEnvForChat` environment already used by the image-gen preset-prompt path (`resolvePromptPreset`) and the display-preprocess path that renders messages in the UI — so the parser sees the **same resolved text the user sees**.

- **Base macros** (`{{user}}`, `{{char}}`, variables): resolved in character description/scenario, persona title/description, and each chat message's content, through one shared env in array order.
- **Outlet macros** (`{{outlet::name}}`): mirroring PR #205, when any context field references an outlet, world-info activation runs once (chat-wide) and the outlet map is populated before resolution. Gated on the `{{outlet::` marker so chats without outlets skip activation entirely.

Resolution is **best-effort**: a `null` env or an activation/macro failure falls back to the raw text and never blocks a generation. The `AbortSignal` from the parser callers is threaded into `resolveWorldInfoOutlets`.

## Scope notes (intentional non-goals)

Pre-existing, system-wide behaviors shared with the display-preprocess and prompt-assembly paths, kept consistent here rather than diverging:

- **Group-chat per-speaker `{{char}}`:** greetings resolve `{{char}}` against the env's effective character, exactly as the UI display does. Per-speaker resolution would be a coordinated cross-layer change (display + assembly + image-gen); resolving it only in image-gen would desync the parser from what the user sees.
- **Chat-context macros** (`{{lastMessage}}`, `{{messageCount}}`, …): resolved against the base env (`messages: []`), consistent with `buildMacroEnvForChat` usage in the display and preset-prompt paths.

## Testing

- `bunx tsc --noEmit -p tsconfig.json` — clean.
- New `src/services/image-gen-context-macros.test.ts` (6 tests): character-card base-macro resolution, greeting base-macro resolution, persona-block resolution, macro-free passthrough, outlet resolution in the greeting, and outlet resolution in character-card fields — with exact resolved-string assertions.
- `src/services/chat-display-outlet-resolution.test.ts` (4) and `src/services/image-gen.character-lora-smoke.test.ts` (2) still pass — no regression.
