### PR TITLE
Resolve world-info outlet macros in image-gen parser context

### DIFF
--- a/src/services/image-gen-context-macros.test.ts
+++ b/src/services/image-gen-context-macros.test.ts
@@ -4,9 +4,11 @@ import { closeDatabase, getDb, initDatabase } from "../db/connection";
 import { initMacros } from "../macros";
 import * as charactersSvc from "./characters.service";
 import * as chatsSvc from "./chats.service";
+import * as worldBooksSvc from "./world-books.service";
 import * as personasSvc from "./personas.service";
 import * as settingsSvc from "./settings.service";
 import { buildContextMessages, getImageGenSettings } from "./image-gen.service";
+import { setCharacterWorldBookIds } from "../utils/character-world-books";
 
 const USER_ID = "image-gen-context-macros-user";
 
@@ -165,5 +167,71 @@ describe("image-gen parser context macro resolution", () => {
     const assistant = messages.find((message) => message.role === "assistant");
 
     expect(assistant?.content).toBe("The wind blows.");
+  });
+
+  test("resolves world-info outlet macros before building parser context", async () => {
+    const OUTLET_CONTENT = "Secret lore: the amulet glows blue at dusk.";
+    const book = worldBooksSvc.createWorldBook(USER_ID, { name: "Lore Book" });
+    const entry = worldBooksSvc.createEntry(USER_ID, book.id, {
+      key: ["lore"],
+      content: OUTLET_CONTENT,
+      comment: "constant lore outlet",
+      constant: true,
+      outlet_name: "lore",
+    });
+    if (!entry) throw new Error("Failed to create world-book entry");
+
+    const character = charactersSvc.createCharacter(USER_ID, {
+      name: "TestChar",
+      first_mes: `Greetings, traveler. {{outlet::lore}}`,
+      extensions: setCharacterWorldBookIds({}, [book.id]),
+    });
+    const outletChatId = chatsSvc.createChat(USER_ID, { character_id: character.id }).id;
+
+    settingsSvc.putSetting(USER_ID, "imageGeneration", {
+      includeCharacters: false,
+      promptContextMessageLimit: 3,
+    });
+
+    const messages = await buildContextMessages(USER_ID, outletChatId, getImageGenSettings(USER_ID));
+    const assistant = messages.find((m) => m.role === "assistant");
+    expect(assistant?.content).toBe(`Greetings, traveler. ${OUTLET_CONTENT}`);
+  });
+  test("resolves world-info outlet macros in character card fields", async () => {
+    const OUTLET_CONTENT = "Forged of starlight.";
+    const book = worldBooksSvc.createWorldBook(USER_ID, { name: "Card Lore Book" });
+    const entry = worldBooksSvc.createEntry(USER_ID, book.id, {
+      key: ["lore"],
+      content: OUTLET_CONTENT,
+      comment: "constant lore outlet",
+      constant: true,
+      outlet_name: "lore",
+    });
+    if (!entry) throw new Error("Failed to create world-book entry");
+
+    const character = charactersSvc.createCharacter(USER_ID, {
+      name: "TestChar",
+      description: `Wields a relic. {{outlet::lore}}`,
+      scenario: `The {{outlet::lore}} shines.`,
+      extensions: setCharacterWorldBookIds({}, [book.id]),
+    });
+    const cardChatId = chatsSvc.createChat(USER_ID, { character_id: character.id }).id;
+
+    settingsSvc.putSetting(USER_ID, "imageGeneration", {
+      includeCharacters: false,
+      promptContextMessageLimit: 3,
+    });
+
+    const messages = await buildContextMessages(USER_ID, cardChatId, getImageGenSettings(USER_ID));
+    const charInfo = messages.find(
+      (message) =>
+        message.role === "system" &&
+        typeof message.content === "string" &&
+        message.content.startsWith("## Character Information"),
+    );
+
+    const content = charInfo?.content as string;
+    expect(content).toContain(`Description: Wields a relic. ${OUTLET_CONTENT}`);
+    expect(content).toContain(`Scenario: The ${OUTLET_CONTENT} shines.`);
   });
 });

--- a/src/services/image-gen.service.ts
+++ b/src/services/image-gen.service.ts
@@ -12,6 +12,7 @@ import { imageGenConnectionSecretKey } from "./image-gen-connections.service";
 import * as imageGenBindingsSvc from "./image-gen-preset-bindings.service";
 import * as characterLoraSvc from "./character-lora.service";
 import { buildMacroEnvForChat } from "./chats.service";
+import { getActivatedWorldInfoEntriesForChat, resolveWorldInfoOutlets } from "./prompt-assembly.service";
 import { evaluate as evaluateMacros, registry as macroRegistry } from "../macros";
 import sharp from "../utils/sharp-config";
 import { eventBus } from "../ws/bus";
@@ -36,6 +37,7 @@ import "../image-gen/index";
 const IMAGE_SETTINGS_KEY = "imageGeneration";
 const RELAY_IMAGE_PREVIEW_MAX_CHARS = 180 * 1024;
 const HAS_MACRO_RE = /\{\{|<(?:user|char|bot)>/i;
+const OUTLET_MACRO_RE = /\{\{outlet::/i;
 
 async function buildRelayImagePreview(dataUrl: string): Promise<string | undefined> {
   const match = dataUrl.match(/^data:([^;]+);base64,(.+)$/);
@@ -1227,7 +1229,7 @@ async function parseCustomPrompt(
         role: "system",
         content: CUSTOM_PROMPT_PARSER_SYSTEM,
       },
-      ...await buildContextMessages(userId, chatId, settings),
+      ...await buildContextMessages(userId, chatId, settings, signal),
       {
         role: "user",
         content: `Parser instructions from the user:\n${input.prompt}\n\nReturn the final image prompt now.`,
@@ -1303,7 +1305,7 @@ async function analyzeScene(userId: string, chatId: string, settings: ImageGenSe
         role: "system",
         content: `${tool.prompt}${settings.includeCharacters ? `\n\n${CHARACTER_AWARE_SCENE_INSTRUCTIONS}` : ""}\n\nYou must return ONLY valid JSON with the requested schema keys and no markdown fences.`,
       },
-      ...await buildContextMessages(userId, chatId, settings),
+      ...await buildContextMessages(userId, chatId, settings, signal),
       { role: "user", content: "Return scene JSON now." },
     ],
     parameters: {
@@ -1315,7 +1317,7 @@ async function analyzeScene(userId: string, chatId: string, settings: ImageGenSe
   return parseSceneJson(response.content || "");
 }
 
-export async function buildContextMessages(userId: string, chatId: string, settings: ImageGenSettings): Promise<LlmMessage[]> {
+export async function buildContextMessages(userId: string, chatId: string, settings: ImageGenSettings, signal?: AbortSignal): Promise<LlmMessage[]> {
   const includeCharacters = settings.includeCharacters;
   const msgs: LlmMessage[] = [];
   const env = buildMacroEnvForChat(userId, chatId);
@@ -1334,39 +1336,59 @@ export async function buildContextMessages(userId: string, chatId: string, setti
   };
 
   const chat = chatsSvc.getChat(userId, chatId);
-  if (chat) {
-    const char = chat.character_id ? charactersSvc.getCharacter(userId, chat.character_id) : null;
-    if (char) {
-      const description = await resolve(char.description);
-      const scenario = await resolve(char.scenario);
-      const charInfo = [
-        char.name && `Name: ${char.name}`,
-        description && `Description: ${description}`,
-        scenario && `Scenario: ${scenario}`,
-      ]
-        .filter(Boolean)
-        .join("\n");
-      if (charInfo) msgs.push({ role: "system", content: `## Character Information\n${charInfo}` });
+  const char = chat?.character_id ? charactersSvc.getCharacter(userId, chat.character_id) : null;
+  const persona = includeCharacters ? personasSvc.resolvePersonaOrDefault(userId) : null;
+  const recentMessages = chatsSvc.getMessages(userId, chatId).slice(-resolveContextMessageLimit(settings));
+
+  // {{outlet::name}} only resolves after world-info activation. Mirror the
+  // display-preprocess path (chats.routes.ts, PR #205) so the parser sees the
+  // same outlet content the user sees. Activation is chat-wide, so populate
+  // the outlet map once before resolving any field.
+  if (env) {
+    const outletCandidates = [
+      char?.description,
+      char?.scenario,
+      persona?.title,
+      persona?.description,
+      ...recentMessages.map((m) => m.content),
+    ];
+    if (outletCandidates.some((s) => s && OUTLET_MACRO_RE.test(s))) {
+      try {
+        const entries = await getActivatedWorldInfoEntriesForChat(userId, chatId);
+        await resolveWorldInfoOutlets(entries, env, signal);
+      } catch {
+        // Leave outlets unresolved — base macro resolution still runs.
+      }
     }
   }
-  if (includeCharacters) {
-    const persona = personasSvc.resolvePersonaOrDefault(userId);
-    if (persona) {
-      const title = await resolve(persona.title);
-      const description = await resolve(persona.description);
-      const personaInfo = [
-        persona.name && `Name: ${persona.name}`,
-        title && `Title: ${title}`,
-        description && `Description: ${description}`,
-        (persona.subjective_pronoun || persona.objective_pronoun || persona.possessive_pronoun) &&
-          `Pronouns: ${[persona.subjective_pronoun, persona.objective_pronoun, persona.possessive_pronoun].filter(Boolean).join("/")}`,
-      ]
-        .filter(Boolean)
-        .join("\n");
-      if (personaInfo) msgs.push({ role: "system", content: `## User Persona\n${personaInfo}` });
-    }
+
+  if (chat && char) {
+    const description = await resolve(char.description);
+    const scenario = await resolve(char.scenario);
+    const charInfo = [
+      char.name && `Name: ${char.name}`,
+      description && `Description: ${description}`,
+      scenario && `Scenario: ${scenario}`,
+    ]
+      .filter(Boolean)
+      .join("\n");
+    if (charInfo) msgs.push({ role: "system", content: `## Character Information\n${charInfo}` });
   }
-  for (const m of chatsSvc.getMessages(userId, chatId).slice(-resolveContextMessageLimit(settings))) {
+  if (persona) {
+    const title = await resolve(persona.title);
+    const description = await resolve(persona.description);
+    const personaInfo = [
+      persona.name && `Name: ${persona.name}`,
+      title && `Title: ${title}`,
+      description && `Description: ${description}`,
+      (persona.subjective_pronoun || persona.objective_pronoun || persona.possessive_pronoun) &&
+        `Pronouns: ${[persona.subjective_pronoun, persona.objective_pronoun, persona.possessive_pronoun].filter(Boolean).join("/")}`,
+    ]
+      .filter(Boolean)
+      .join("\n");
+    if (personaInfo) msgs.push({ role: "system", content: `## User Persona\n${personaInfo}` });
+  }
+  for (const m of recentMessages) {
     msgs.push({ role: m.is_user ? "user" : "assistant", content: await resolve(m.content) });
   }
   return msgs;


### PR DESCRIPTION
## Problem

Follow-up to #219 (which resolved base macros like `{{user}}` / `{{char}}` in the image-gen parser context). World-info **outlet** macros (`{{outlet::name}}`) in a character's card or greeting still collapsed to **empty string** in that context, because `buildContextMessages` — unlike prompt assembly and the UI display path — never ran world-info activation, so `env.extra.worldInfoOutlets` stayed empty.

This is the same class of gap PR #205 fixed for the UI display-preprocess path.

## Fix

Mirror PR #205's display-preprocess pattern inside `buildContextMessages`: when any parser-context field references an `{{outlet::` macro, run world-info activation (`getActivatedWorldInfoEntriesForChat`) and populate the outlet map (`resolveWorldInfoOutlets`) **once** (chat-wide) before resolving any field — so the parser sees the same outlet content the user sees.

- Gated on the `{{outlet::` marker, so chats without outlets skip activation entirely (no perf cost for the common case).
- Best-effort `try/catch`: an activation failure leaves outlets unresolved while base-macro resolution still runs; it never blocks a generation.
- Threaded the existing `AbortSignal` from `analyzeScene` / `parseCustomPrompt` through `buildContextMessages` into `resolveWorldInfoOutlets`.
- The char/persona/message loading was flattened (behavior-preserving — emitted messages are byte-identical for the non-outlet case) so the outlet gate can inspect every field that gets resolved.

## Scope notes (consistent with #219 / system-wide behavior)

- Outlets resolve against the same `buildMacroEnvForChat`-based activation the display path uses; no divergence from what the user sees.
- Chat-context macros (`{{lastMessage}}`, etc.) remain out of scope, consistent with the display and preset-prompt paths.

## Testing

- `src/services/image-gen-context-macros.test.ts` — outlet resolution in both the **greeting/first-message** and **character-card** (description/scenario) fields, with exact resolved-string assertions; plus the base-macro coverage from #219.
- `src/services/chat-display-outlet-resolution.test.ts` (4) still passes — no regression to the sibling display path.
- `bunx tsc --noEmit` is clean for all `image-gen` files. (Staging currently carries 4 pre-existing type errors in `images.routes.ts` / `world-info-vector-ranking.ts` / `worker-runtime.ts` from other recently-merged PRs — unrelated to this change.)