### PR TITLE
fix(connections): drag-to-reorder refactor and iOS fixes

### DIFF
--- a/frontend/src/components/panels/ConnectionManager.tsx
+++ b/frontend/src/components/panels/ConnectionManager.tsx
@@ -1,28 +1,15 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { Plus, Shuffle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import {
-  DndContext,
-  closestCenter,
-  MouseSensor,
-  TouchSensor,
-  KeyboardSensor,
-  useSensor,
-  useSensors,
-  type DragEndEvent,
-} from '@dnd-kit/core'
-import {
-  SortableContext,
-  verticalListSortingStrategy,
-  arrayMove,
-  sortableKeyboardCoordinates,
-} from '@dnd-kit/sortable'
+import { DndContext, closestCenter, type DragEndEvent } from '@dnd-kit/core'
+import { SortableContext, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable'
 import { connectionsApi } from '@/api/connections'
 import { listAllConnections } from '@/api/listAllConnections'
 import { useStore } from '@/store'
 import ConfirmationModal from '@/components/shared/ConfirmationModal'
 import ConnectionForm from './connection-manager/ConnectionForm'
 import ConnectionItem from './connection-manager/ConnectionItem'
+import { useConnectionSensors, useVerticalSortModifier } from './connection-manager/useConnectionDragAndDrop'
 import type { ConnectionProfile, CreateConnectionProfileInput } from '@/types/api'
 import styles from './ConnectionManager.module.css'
 
@@ -52,10 +39,9 @@ export default function ConnectionManager() {
   const setSetting = useStore((s) => s.setSetting)
   const connectionsOrder = useStore((s) => s.connectionsOrder)
 
-  const mouseSensor = useSensor(MouseSensor, { activationConstraint: { distance: 4 } })
-  const touchSensor = useSensor(TouchSensor, { activationConstraint: { distance: 8 } })
-  const keyboardSensor = useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
-  const sensors = useSensors(mouseSensor, touchSensor, keyboardSensor)
+  const sensors = useConnectionSensors()
+  const listRef = useRef<HTMLDivElement>(null)
+  const restrictToVerticalAndBounds = useVerticalSortModifier(listRef)
 
   const orderedProfiles = useMemo(() => {
     const llmOrder = connectionsOrder?.llm ?? []
@@ -235,9 +221,9 @@ export default function ConnectionManager() {
         />
       )}
 
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} modifiers={[restrictToVerticalAndBounds]} onDragEnd={handleDragEnd}>
         <SortableContext items={orderedIds} strategy={verticalListSortingStrategy}>
-          <div className={styles.list}>
+          <div ref={listRef} className={styles.list}>
             {orderedProfiles.map((profile) => (
               <ConnectionItem
                 key={profile.id}

--- a/frontend/src/components/panels/connection-manager/ConnectionItem.module.css
+++ b/frontend/src/components/panels/connection-manager/ConnectionItem.module.css
@@ -42,12 +42,16 @@
   transition: background var(--lumiverse-transition-fast), color var(--lumiverse-transition-fast);
 }
 
-.dragHandle:hover {
-  background: var(--lumiverse-primary-015);
-  color: var(--lumiverse-text);
+@media (hover: hover) {
+  .dragHandle:hover {
+    background: var(--lumiverse-primary-015);
+    color: var(--lumiverse-text);
+  }
 }
 
 .dragHandle:active {
+  background: var(--lumiverse-primary-015);
+  color: var(--lumiverse-text);
   cursor: grabbing;
 }
 
@@ -281,4 +285,10 @@
 @keyframes fadeIn {
   from { opacity: 0; transform: translateY(-4px); }
   to { opacity: 1; transform: translateY(0); }
+}
+
+/* Hide credits/usage sections that aren't active, but keep them in DOM
+   so the card maintains a consistent height during drag operations. */
+.creditsHidden {
+  display: none;
 }

--- a/frontend/src/components/panels/connection-manager/ConnectionItem.tsx
+++ b/frontend/src/components/panels/connection-manager/ConnectionItem.tsx
@@ -14,6 +14,7 @@ import {
 import { formatAnthropicPromptCachingSummary } from '@/lib/anthropic-prompt-caching'
 import { formatNanoGptCachingSummary } from '@/lib/nanogpt-prompt-caching'
 import { useScaledSortableStyle } from '@/lib/dndUiScale'
+import { useDragHandleBlur } from './useDragHandleBlur'
 import type { ConnectionProfile, ProviderInfo, CreateConnectionProfileInput, NanoGptSubscriptionUsage } from '@/types/api'
 import ConnectionForm from './ConnectionForm'
 import { Spinner } from '@/components/shared/Spinner'
@@ -92,15 +93,27 @@ export default function ConnectionItem({
   const showNanoGptUsage = isNanoGpt && isActive && profile.has_api_key && !editing
   const unknownReset = t('connectionItem.unknown')
 
-  // Fetch credits when this is the active OpenRouter connection
+  // Fetch credits when this is the active OpenRouter connection.
+  // Preserve existing data when showCredits flickers false during drag
+  // re-renders — clearing then refetching causes a visible flash.
+  const creditsFetchedRef = useRef(false)
   useEffect(() => {
-    if (!showCredits) { setCredits(null); return }
+    if (!showCredits) {
+      if (!creditsFetchedRef.current) setCredits(null)
+      return
+    }
+    if (credits) return
+    creditsFetchedRef.current = true
     setCreditsLoading(true)
     openrouterApi.credits(profile.id)
       .then(setCredits)
       .catch(() => setCredits(null))
       .finally(() => setCreditsLoading(false))
-  }, [showCredits, profile.id])
+  }, [showCredits, profile.id, credits])
+
+  useEffect(() => {
+    if (!showCredits) creditsFetchedRef.current = false
+  }, [showCredits])
 
   const refreshCredits = useCallback(() => {
     if (!showCredits) return
@@ -111,14 +124,24 @@ export default function ConnectionItem({
       .finally(() => setCreditsLoading(false))
   }, [showCredits, profile.id])
 
+  const nanoGptFetchedRef = useRef(false)
   useEffect(() => {
-    if (!showNanoGptUsage) { setNanoGptUsage(null); return }
+    if (!showNanoGptUsage) {
+      if (!nanoGptFetchedRef.current) setNanoGptUsage(null)
+      return
+    }
+    if (nanoGptUsage) return
+    nanoGptFetchedRef.current = true
     setNanoGptUsageLoading(true)
     connectionsApi.nanogptUsage(profile.id)
       .then(setNanoGptUsage)
       .catch(() => setNanoGptUsage(null))
       .finally(() => setNanoGptUsageLoading(false))
-  }, [showNanoGptUsage, profile.id])
+  }, [showNanoGptUsage, profile.id, nanoGptUsage])
+
+  useEffect(() => {
+    if (!showNanoGptUsage) nanoGptFetchedRef.current = false
+  }, [showNanoGptUsage])
 
   const refreshNanoGptUsage = useCallback(() => {
     if (!showNanoGptUsage) return
@@ -263,6 +286,8 @@ export default function ConnectionItem({
   const { attributes, listeners, setNodeRef: setSortableRef, transform, transition, isDragging } = useSortable({ id: profile.id })
   const { setNodeRef, style } = useScaledSortableStyle({ setNodeRef: setSortableRef, transform, transition, isDragging })
 
+  const handleRef = useDragHandleBlur(isDragging)
+
   return (
     <div ref={setNodeRef} style={style} className={clsx(styles.item, isDragging && styles.itemDragging, isActive && styles.itemActive)}>
       {editing ? (
@@ -276,6 +301,7 @@ export default function ConnectionItem({
         <>
           <div className={styles.itemRow}>
             <button
+              ref={handleRef}
               type="button"
               className={styles.dragHandle}
               aria-label={t('connectionItem.dragToReorder')}
@@ -368,8 +394,8 @@ export default function ConnectionItem({
               {testResult.message}
             </div>
           )}
-          {showCredits && credits && (
-            <div key="credits" className={clsx(styles.creditsBar, !creditsAnimatedRef.current && styles.creditsBarAnimateIn)}>
+          {isOpenRouter && profile.has_api_key && (
+            <div key="credits" className={clsx(styles.creditsBar, !creditsAnimatedRef.current && styles.creditsBarAnimateIn, !(showCredits && credits) && styles.creditsHidden)}>
               <div className={styles.creditCell}>
                 <span className={styles.creditLabel}>{t('connectionItem.remaining')}</span>
                 <span className={styles.creditValue}>
@@ -393,8 +419,9 @@ export default function ConnectionItem({
               </button>
             </div>
           )}
-          {showNanoGptUsage && nanoGptUsage && (nanoGptUsageRows.length > 0 || nanoGptSubscriptionInactive) && (
-            nanoGptUsageRows.length > 0
+          {isNanoGpt && profile.has_api_key && (
+            <div className={clsx(!(showNanoGptUsage && nanoGptUsage && (nanoGptUsageRows.length > 0 || nanoGptSubscriptionInactive)) && styles.creditsHidden)}>
+              {nanoGptUsageRows.length > 0
               ? nanoGptUsageRows.map(({ key, label, window: win }, idx) => (
                 <div key={key} className={clsx(styles.creditsBar, styles.nanoGptUsageBar, idx === 0 && !nanoGptAnimatedRef.current && styles.creditsBarAnimateIn)}>
                   <div className={styles.creditCell}>
@@ -430,7 +457,8 @@ export default function ConnectionItem({
                     {nanoGptUsageLoading ? <Spinner size={10} /> : <RefreshCw size={10} />}
                   </button>
                 </div>
-              )
+              )}
+            </div>
           )}
         </>
       )}

--- a/frontend/src/components/panels/connection-manager/useConnectionDragAndDrop.ts
+++ b/frontend/src/components/panels/connection-manager/useConnectionDragAndDrop.ts
@@ -1,0 +1,30 @@
+import { useRef, useCallback } from 'react'
+import {
+  MouseSensor,
+  TouchSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  type Modifier,
+} from '@dnd-kit/core'
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
+
+export function useConnectionSensors() {
+  const mouseSensor = useSensor(MouseSensor, { activationConstraint: { distance: 4 } })
+  const touchSensor = useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } })
+  const keyboardSensor = useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  return useSensors(mouseSensor, touchSensor, keyboardSensor)
+}
+
+export function useVerticalSortModifier(listRef: React.RefObject<HTMLDivElement | null>) {
+  return useCallback<Modifier>(({ transform, activeNodeRect }) => {
+    if (!activeNodeRect || !listRef.current) return { ...transform, x: 0 }
+    const rect = listRef.current.getBoundingClientRect()
+    const activeTop = activeNodeRect.top + transform.y
+    const activeBottom = activeNodeRect.bottom + transform.y
+    let clampedY = transform.y
+    if (activeTop < rect.top) clampedY += rect.top - activeTop
+    if (activeBottom > rect.bottom) clampedY -= activeBottom - rect.bottom
+    return { ...transform, x: 0, y: clampedY }
+  }, [listRef])
+}

--- a/frontend/src/components/panels/connection-manager/useDragHandleBlur.ts
+++ b/frontend/src/components/panels/connection-manager/useDragHandleBlur.ts
@@ -1,0 +1,13 @@
+import { useRef, useEffect } from 'react'
+
+export function useDragHandleBlur(isDragging: boolean) {
+  const handleRef = useRef<HTMLButtonElement>(null)
+  const wasDraggingRef = useRef(false)
+  useEffect(() => {
+    if (wasDraggingRef.current && !isDragging) {
+      handleRef.current?.blur()
+    }
+    wasDraggingRef.current = isDragging
+  }, [isDragging])
+  return handleRef
+}

--- a/frontend/src/components/panels/image-gen-connections/ImageGenConnectionItem.tsx
+++ b/frontend/src/components/panels/image-gen-connections/ImageGenConnectionItem.tsx
@@ -11,6 +11,7 @@ import { ComfyWorkflowEditor } from './ComfyWorkflowEditor'
 import ContextMenu, { type ContextMenuEntry, type ContextMenuPos } from '@/components/shared/ContextMenu'
 import { Spinner } from '@/components/shared/Spinner'
 import { useScaledSortableStyle } from '@/lib/dndUiScale'
+import { useDragHandleBlur } from '../connection-manager/useDragHandleBlur'
 import ProviderIcon from '@/components/shared/ProviderIcon'
 import styles from '../connection-manager/ConnectionItem.module.css'
 import clsx from 'clsx'
@@ -174,6 +175,8 @@ export default function ImageGenConnectionItem({
   const { attributes, listeners, setNodeRef: setSortableRef, transform, transition, isDragging } = useSortable({ id: profile.id })
   const { setNodeRef, style } = useScaledSortableStyle({ setNodeRef: setSortableRef, transform, transition, isDragging })
 
+  const handleRef = useDragHandleBlur(isDragging)
+
   return (
     <div ref={setNodeRef} style={style} className={clsx(styles.item, isDragging && styles.itemDragging, isActive && styles.itemActive)}>
       {editing ? (
@@ -187,6 +190,7 @@ export default function ImageGenConnectionItem({
         <>
           <div className={styles.itemRow}>
             <button
+              ref={handleRef}
               type="button"
               className={styles.dragHandle}
               aria-label={t('connectionItem.dragToReorder')}

--- a/frontend/src/components/panels/image-gen-connections/ImageGenConnectionManager.tsx
+++ b/frontend/src/components/panels/image-gen-connections/ImageGenConnectionManager.tsx
@@ -1,23 +1,15 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import {
   DndContext,
-  DragOverlay,
   closestCenter,
-  MouseSensor,
-  TouchSensor,
-  KeyboardSensor,
-  useSensor,
-  useSensors,
   type DragEndEvent,
-  type DragStartEvent,
 } from '@dnd-kit/core'
 import {
   SortableContext,
   verticalListSortingStrategy,
   arrayMove,
-  sortableKeyboardCoordinates,
 } from '@dnd-kit/sortable'
 import { imageGenConnectionsApi } from '@/api/image-gen-connections'
 import { listAllConnections } from '@/api/listAllConnections'
@@ -27,6 +19,7 @@ import ImageGenConnectionForm from './ImageGenConnectionForm'
 import ImageGenConnectionItem from './ImageGenConnectionItem'
 import type { ImageGenConnectionProfile, CreateImageGenConnectionInput } from '@/types/api'
 import styles from '../ConnectionManager.module.css'
+import { useConnectionSensors, useVerticalSortModifier } from '../connection-manager/useConnectionDragAndDrop'
 
 export default function ImageGenConnectionManager() {
   const { t } = useTranslation('panels')
@@ -43,10 +36,9 @@ export default function ImageGenConnectionManager() {
   const setSetting = useStore((s) => s.setSetting)
   const connectionsOrder = useStore((s) => s.connectionsOrder)
 
-  const mouseSensor = useSensor(MouseSensor, { activationConstraint: { distance: 4 } })
-  const touchSensor = useSensor(TouchSensor, { activationConstraint: { distance: 8 } })
-  const keyboardSensor = useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
-  const sensors = useSensors(mouseSensor, touchSensor, keyboardSensor)
+  const sensors = useConnectionSensors()
+  const listRef = useRef<HTMLDivElement>(null)
+  const restrictToVerticalAndBounds = useVerticalSortModifier(listRef)
 
   const orderedProfiles = useMemo(() => {
     const imageGenOrder = connectionsOrder?.imageGen ?? []
@@ -63,9 +55,6 @@ export default function ImageGenConnectionManager() {
   const [loading, setLoading] = useState(false)
   const [creating, setCreating] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<ImageGenConnectionProfile | null>(null)
-  const [dragActiveId, setDragActiveId] = useState<string | null>(null)
-
-  const activeProfile = orderedProfiles.find((p) => p.id === dragActiveId) ?? null
 
   useEffect(() => {
     const returnedKey = sessionStorage.getItem('pollinations_byop_returned_api_key')
@@ -166,11 +155,7 @@ export default function ImageGenConnectionManager() {
     }
   }, [deleteTarget, removeProfile, connectionsOrder, setSetting])
 
-  const handleDragStart = useCallback(({ active }: DragStartEvent) => setDragActiveId(String(active.id)), [])
-  const handleDragCancel = useCallback(() => setDragActiveId(null), [])
-
   const handleDragEnd = useCallback((event: DragEndEvent) => {
-    setDragActiveId(null)
     const { active, over } = event
     if (!over || active.id === over.id) return
     const oldIndex = orderedIds.indexOf(String(active.id))
@@ -202,9 +187,9 @@ export default function ImageGenConnectionManager() {
         />
       )}
 
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragCancel={handleDragCancel} onDragEnd={handleDragEnd}>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} modifiers={[restrictToVerticalAndBounds]} onDragEnd={handleDragEnd}>
         <SortableContext items={orderedIds} strategy={verticalListSortingStrategy}>
-          <div className={styles.list}>
+          <div ref={listRef} className={styles.list}>
             {orderedProfiles.map((profile) => (
               <ImageGenConnectionItem
                 key={profile.id}
@@ -222,21 +207,6 @@ export default function ImageGenConnectionManager() {
             )}
           </div>
         </SortableContext>
-        <DragOverlay dropAnimation={null}>
-          {activeProfile && (
-            <div className={styles.itemDraggingOverlay}>
-              <ImageGenConnectionItem
-                profile={activeProfile}
-                isActive={activeId === activeProfile.id}
-                providers={providers}
-                onSelect={() => setActive(activeId === activeProfile.id ? null : activeProfile.id)}
-                onUpdate={handleUpdate}
-                onDuplicate={() => handleDuplicate(activeProfile.id)}
-                onDelete={() => setDeleteTarget(activeProfile)}
-              />
-            </div>
-          )}
-        </DragOverlay>
       </DndContext>
 
       {deleteTarget && (

--- a/frontend/src/components/panels/stt-connections/STTConnectionItem.tsx
+++ b/frontend/src/components/panels/stt-connections/STTConnectionItem.tsx
@@ -8,6 +8,7 @@ import type { SttConnectionProfile, SttProviderInfo, CreateSttConnectionInput } 
 import STTConnectionForm from './STTConnectionForm'
 import ContextMenu, { type ContextMenuEntry, type ContextMenuPos } from '@/components/shared/ContextMenu'
 import { useScaledSortableStyle } from '@/lib/dndUiScale'
+import { useDragHandleBlur } from '../connection-manager/useDragHandleBlur'
 import ProviderIcon from '@/components/shared/ProviderIcon'
 import styles from '../connection-manager/ConnectionItem.module.css'
 import clsx from 'clsx'
@@ -61,6 +62,8 @@ export default function STTConnectionItem({
   const { attributes, listeners, setNodeRef: setSortableRef, transform, transition, isDragging } = useSortable({ id: profile.id })
   const { setNodeRef, style } = useScaledSortableStyle({ setNodeRef: setSortableRef, transform, transition, isDragging })
 
+  const handleRef = useDragHandleBlur(isDragging)
+
   return (
     <div ref={setNodeRef} style={style} className={clsx(styles.item, isDragging && styles.itemDragging)}>
       {editing ? (
@@ -74,6 +77,7 @@ export default function STTConnectionItem({
         <>
           <div className={styles.itemRow}>
             <button
+              ref={handleRef}
               type="button"
               className={styles.dragHandle}
               aria-label={t('connectionItem.dragToReorder')}

--- a/frontend/src/components/panels/stt-connections/STTConnectionManager.tsx
+++ b/frontend/src/components/panels/stt-connections/STTConnectionManager.tsx
@@ -1,23 +1,15 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import {
   DndContext,
-  DragOverlay,
   closestCenter,
-  MouseSensor,
-  TouchSensor,
-  KeyboardSensor,
-  useSensor,
-  useSensors,
   type DragEndEvent,
-  type DragStartEvent,
 } from '@dnd-kit/core'
 import {
   SortableContext,
   verticalListSortingStrategy,
   arrayMove,
-  sortableKeyboardCoordinates,
 } from '@dnd-kit/sortable'
 import { sttConnectionsApi } from '@/api/stt-connections'
 import { listAllConnections } from '@/api/listAllConnections'
@@ -27,6 +19,7 @@ import STTConnectionForm from './STTConnectionForm'
 import STTConnectionItem from './STTConnectionItem'
 import type { SttConnectionProfile, CreateSttConnectionInput } from '@/types/api'
 import styles from '../ConnectionManager.module.css'
+import { useConnectionSensors, useVerticalSortModifier } from '../connection-manager/useConnectionDragAndDrop'
 
 export default function STTConnectionManager() {
   const { t } = useTranslation('panels')
@@ -41,10 +34,9 @@ export default function STTConnectionManager() {
   const setSetting = useStore((s) => s.setSetting)
   const connectionsOrder = useStore((s) => s.connectionsOrder)
 
-  const mouseSensor = useSensor(MouseSensor, { activationConstraint: { distance: 4 } })
-  const touchSensor = useSensor(TouchSensor, { activationConstraint: { distance: 8 } })
-  const keyboardSensor = useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
-  const sensors = useSensors(mouseSensor, touchSensor, keyboardSensor)
+  const sensors = useConnectionSensors()
+  const listRef = useRef<HTMLDivElement>(null)
+  const restrictToVerticalAndBounds = useVerticalSortModifier(listRef)
 
   const orderedProfiles = useMemo(() => {
     const sttOrder = connectionsOrder?.stt ?? []
@@ -61,9 +53,6 @@ export default function STTConnectionManager() {
   const [loading, setLoading] = useState(false)
   const [creating, setCreating] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<SttConnectionProfile | null>(null)
-  const [dragActiveId, setDragActiveId] = useState<string | null>(null)
-
-  const activeProfile = orderedProfiles.find((p) => p.id === dragActiveId) ?? null
 
   useEffect(() => {
     let cancelled = false
@@ -145,11 +134,7 @@ export default function STTConnectionManager() {
     }
   }, [deleteTarget, removeProfile, connectionsOrder, setSetting])
 
-  const handleDragStart = useCallback(({ active }: DragStartEvent) => setDragActiveId(String(active.id)), [])
-  const handleDragCancel = useCallback(() => setDragActiveId(null), [])
-
   const handleDragEnd = useCallback((event: DragEndEvent) => {
-    setDragActiveId(null)
     const { active, over } = event
     if (!over || active.id === over.id) return
     const oldIndex = orderedIds.indexOf(String(active.id))
@@ -181,9 +166,9 @@ export default function STTConnectionManager() {
         />
       )}
 
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragCancel={handleDragCancel} onDragEnd={handleDragEnd}>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} modifiers={[restrictToVerticalAndBounds]} onDragEnd={handleDragEnd}>
         <SortableContext items={orderedIds} strategy={verticalListSortingStrategy}>
-          <div className={styles.list}>
+          <div ref={listRef} className={styles.list}>
             {orderedProfiles.map((profile) => (
               <STTConnectionItem
                 key={profile.id}
@@ -199,19 +184,6 @@ export default function STTConnectionManager() {
             )}
           </div>
         </SortableContext>
-        <DragOverlay dropAnimation={null}>
-          {activeProfile && (
-            <div className={styles.itemDraggingOverlay}>
-              <STTConnectionItem
-                profile={activeProfile}
-                providers={providers}
-                onUpdate={handleUpdate}
-                onDuplicate={() => handleDuplicate(activeProfile.id)}
-                onDelete={() => setDeleteTarget(activeProfile)}
-              />
-            </div>
-          )}
-        </DragOverlay>
       </DndContext>
 
       {deleteTarget && (

--- a/frontend/src/components/panels/tts-connections/TTSConnectionItem.tsx
+++ b/frontend/src/components/panels/tts-connections/TTSConnectionItem.tsx
@@ -10,6 +10,7 @@ import type { TtsConnectionProfile, TtsProviderInfo, CreateTtsConnectionInput } 
 import TTSConnectionForm from './TTSConnectionForm'
 import ContextMenu, { type ContextMenuEntry, type ContextMenuPos } from '@/components/shared/ContextMenu'
 import { useScaledSortableStyle } from '@/lib/dndUiScale'
+import { useDragHandleBlur } from '../connection-manager/useDragHandleBlur'
 import ProviderIcon from '@/components/shared/ProviderIcon'
 import styles from '../connection-manager/ConnectionItem.module.css'
 import clsx from 'clsx'
@@ -66,6 +67,8 @@ export default function TTSConnectionItem({
   const { attributes, listeners, setNodeRef: setSortableRef, transform, transition, isDragging } = useSortable({ id: profile.id })
   const { setNodeRef, style } = useScaledSortableStyle({ setNodeRef: setSortableRef, transform, transition, isDragging })
 
+  const handleRef = useDragHandleBlur(isDragging)
+
   return (
     <div ref={setNodeRef} style={style} className={clsx(styles.item, isDragging && styles.itemDragging)}>
       {editing ? (
@@ -79,6 +82,7 @@ export default function TTSConnectionItem({
         <>
           <div className={styles.itemRow}>
             <button
+              ref={handleRef}
               type="button"
               className={styles.dragHandle}
               aria-label={t('connectionItem.dragToReorder')}

--- a/frontend/src/components/panels/tts-connections/TTSConnectionManager.tsx
+++ b/frontend/src/components/panels/tts-connections/TTSConnectionManager.tsx
@@ -1,23 +1,15 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import {
   DndContext,
-  DragOverlay,
   closestCenter,
-  MouseSensor,
-  TouchSensor,
-  KeyboardSensor,
-  useSensor,
-  useSensors,
   type DragEndEvent,
-  type DragStartEvent,
 } from '@dnd-kit/core'
 import {
   SortableContext,
   verticalListSortingStrategy,
   arrayMove,
-  sortableKeyboardCoordinates,
 } from '@dnd-kit/sortable'
 import { ttsConnectionsApi } from '@/api/tts-connections'
 import { listAllConnections } from '@/api/listAllConnections'
@@ -27,6 +19,7 @@ import TTSConnectionForm from './TTSConnectionForm'
 import TTSConnectionItem from './TTSConnectionItem'
 import type { TtsConnectionProfile, CreateTtsConnectionInput } from '@/types/api'
 import styles from '../ConnectionManager.module.css'
+import { useConnectionSensors, useVerticalSortModifier } from '../connection-manager/useConnectionDragAndDrop'
 
 export default function TTSConnectionManager() {
   const { t } = useTranslation('panels')
@@ -41,10 +34,9 @@ export default function TTSConnectionManager() {
   const setSetting = useStore((s) => s.setSetting)
   const connectionsOrder = useStore((s) => s.connectionsOrder)
 
-  const mouseSensor = useSensor(MouseSensor, { activationConstraint: { distance: 4 } })
-  const touchSensor = useSensor(TouchSensor, { activationConstraint: { distance: 8 } })
-  const keyboardSensor = useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
-  const sensors = useSensors(mouseSensor, touchSensor, keyboardSensor)
+  const sensors = useConnectionSensors()
+  const listRef = useRef<HTMLDivElement>(null)
+  const restrictToVerticalAndBounds = useVerticalSortModifier(listRef)
 
   const orderedProfiles = useMemo(() => {
     const ttsOrder = connectionsOrder?.tts ?? []
@@ -61,9 +53,6 @@ export default function TTSConnectionManager() {
   const [loading, setLoading] = useState(false)
   const [creating, setCreating] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<TtsConnectionProfile | null>(null)
-  const [dragActiveId, setDragActiveId] = useState<string | null>(null)
-
-  const activeProfile = orderedProfiles.find((p) => p.id === dragActiveId) ?? null
 
   // `useAppInit` preloads TTS profiles + providers right after auth. Only
   // show the loading placeholder on a true cold mount (empty store);
@@ -148,11 +137,7 @@ export default function TTSConnectionManager() {
     }
   }, [deleteTarget, removeProfile, connectionsOrder, setSetting])
 
-  const handleDragStart = useCallback(({ active }: DragStartEvent) => setDragActiveId(String(active.id)), [])
-  const handleDragCancel = useCallback(() => setDragActiveId(null), [])
-
   const handleDragEnd = useCallback((event: DragEndEvent) => {
-    setDragActiveId(null)
     const { active, over } = event
     if (!over || active.id === over.id) return
     const oldIndex = orderedIds.indexOf(String(active.id))
@@ -184,9 +169,9 @@ export default function TTSConnectionManager() {
         />
       )}
 
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragCancel={handleDragCancel} onDragEnd={handleDragEnd}>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} modifiers={[restrictToVerticalAndBounds]} onDragEnd={handleDragEnd}>
         <SortableContext items={orderedIds} strategy={verticalListSortingStrategy}>
-          <div className={styles.list}>
+          <div ref={listRef} className={styles.list}>
             {orderedProfiles.map((profile) => (
               <TTSConnectionItem
                 key={profile.id}
@@ -202,19 +187,6 @@ export default function TTSConnectionManager() {
             )}
           </div>
         </SortableContext>
-        <DragOverlay dropAnimation={null}>
-          {activeProfile && (
-            <div className={styles.itemDraggingOverlay}>
-              <TTSConnectionItem
-                profile={activeProfile}
-                providers={providers}
-                onUpdate={handleUpdate}
-                onDuplicate={() => handleDuplicate(activeProfile.id)}
-                onDelete={() => setDeleteTarget(activeProfile)}
-              />
-            </div>
-          )}
-        </DragOverlay>
       </DndContext>
 
       {deleteTarget && (

--- a/frontend/src/lib/dndUiScale.ts
+++ b/frontend/src/lib/dndUiScale.ts
@@ -50,10 +50,22 @@ function scaledTransform(
   transform: Transform | null,
   scrollDx: number,
   scrollDy: number,
+  isDragging: boolean,
 ): string | undefined {
   if (!transform) return CSS.Transform.toString(transform)
   const uiScale = getUiScale()
-  if (uiScale === 1) return CSS.Transform.toString(transform)
+  // During drag, the FLIP animation transform may include scaleX/scaleY
+  // from useDerivedTransform. These scale factors compound with the pointer
+  // delta and cause the card to visually stretch or squish. Strip them —
+  // only keep the translation.
+  if (isDragging) {
+    return CSS.Transform.toString({
+      x: uiScale !== 1 ? (transform.x - scrollDx) / uiScale + scrollDx : transform.x,
+      y: uiScale !== 1 ? (transform.y - scrollDy) / uiScale + scrollDy : transform.y,
+      scaleX: 1,
+      scaleY: 1,
+    })
+  }
   return CSS.Transform.toString({
     ...transform,
     x: (transform.x - scrollDx) / uiScale + scrollDx,
@@ -118,7 +130,7 @@ export function useScaledSortableStyle({
   return {
     setNodeRef: ref,
     style: {
-      transform: scaledTransform(transform, scrollDx, scrollDy),
+      transform: scaledTransform(transform, scrollDx, scrollDy, isDragging),
       transition,
     },
   }


### PR DESCRIPTION
### Sorting & drag behavior
- In-place sorting via useSortable (no DragOverlay) to avoid anchor-point and snap issues with CSS zoom containers
- Delay-based TouchSensor (200ms, tolerance 5) prevents scroll conflicts on mobile while allowing drag initiation
- Vertical-only modifier with live bounds clamping prevents horizontal drift and infinite auto-scroll past list boundaries

### Touch & mobile
- :active provides highlight during press; :hover gated behind @media (hover: hover) to prevent sticky hover on touch

### Credits stability
- Credits data preserved across showCredits flickers via creditsFetchedRef (and nanoGptFetchedRef)
- Non-active credit sections kept in DOM, hidden via CSS display:none to prevent height squash during drag

### Shared hooks extracted
- useConnectionSensors() — sensor config
- useVerticalSortModifier(listRef) — modifier + bounds clamping
- useDragHandleBlur(isDragging) — handle blur-on-end logic