### PR TITLE
fix(settings): clear scroll target to prevent snap-back to Extensions tab

### DIFF
--- a/frontend/src/components/modals/SettingsModal.tsx
+++ b/frontend/src/components/modals/SettingsModal.tsx
@@ -122,8 +122,8 @@ export default function SettingsModal({ onClose }: SettingsModalProps) {
   }, [scrollTarget])
 
   useEffect(() => {
-    const extensionId = settingsScrollTarget?.extensionId
-    if (!extensionId) return
+    const target = settingsScrollTarget
+    if (!target) return
 
     if (activeView !== 'extensions') {
       setActiveView('extensions')
@@ -132,10 +132,12 @@ export default function SettingsModal({ onClose }: SettingsModalProps) {
 
     let frame = 0
     let attempts = 0
-    const selector = [
-      `[data-spindle-extension-root="${CSS.escape(extensionId)}"]`,
-      '[data-spindle-mount-point="settings_extensions"]',
-    ].join('')
+    const selector = target.extensionId
+      ? [
+          `[data-spindle-extension-root="${CSS.escape(target.extensionId)}"]`,
+          '[data-spindle-mount-point="settings_extensions"]',
+        ].join('')
+      : '[data-spindle-mount-point="settings_extensions"]'
     const scrollToExtension = () => {
       const container = contentRef.current
       const el = container?.querySelector<HTMLElement>(selector)
@@ -143,6 +145,9 @@ export default function SettingsModal({ onClose }: SettingsModalProps) {
         el.scrollIntoView({ block: 'start', behavior: 'smooth' })
         el.classList.add(styles.sectionFlash)
         window.setTimeout(() => el.classList.remove(styles.sectionFlash), 1400)
+        // One-shot: clear the directive so a subsequent sidebar click
+        // (activeView change) does not retrigger this effect and snap back.
+        useStore.getState().clearSettingsScrollTarget()
         return
       }
       if (++attempts < 20) frame = requestAnimationFrame(scrollToExtension)

--- a/frontend/src/store/slices/ui.ts
+++ b/frontend/src/store/slices/ui.ts
@@ -39,6 +39,7 @@ export const createUISlice: StateCreator<UISlice> = (set) => ({
       settingsScrollTarget: target ? { ...target, nonce: ++settingsScrollCounter } : null,
     }),
   closeSettings: () => set({ settingsModalOpen: false }),
+  clearSettingsScrollTarget: () => set({ settingsScrollTarget: null }),
 
   openCommandPalette: () => set({ commandPaletteOpen: true }),
   closeCommandPalette: () => set({ commandPaletteOpen: false }),

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -257,6 +257,7 @@ export interface UISlice {
   setDrawerTab: (tab: string) => void
   openSettings: (view?: string, target?: { extensionId?: string }) => void
   closeSettings: () => void
+  clearSettingsScrollTarget: () => void
   togglePortraitPanel: () => void
   openCommandPalette: () => void
   closeCommandPalette: () => void


### PR DESCRIPTION
**Problem:** Opening an extension's settings from the Extensions tab, then clicking another sidebar tab (Chat, Guided Gen, Quick Replies, etc.) causes the view to flicker and swap back to the Extensions tab. User is effectively unable to access other settings tabs, even though they are visible.

**Root cause:** `settingsScrollTarget` (a "scroll to this extension" directive in the UI store) was set when the gear icon was clicked but never cleared. The SettingsModal's scroll-to-extension effect, whose deps include `[activeView, settingsScrollTarget]`, re-fired on every sidebar tab click, read the stale target, and forced `activeView` back to `'extensions'`.

**Fix:** Make the scroll directive a one-shot. Add `clearSettingsScrollTarget` to the UI store; the scroll effect now clears the target once the extension's DOM root has been found and scrolled to. Subsequent sidebar clicks find `settingsScrollTarget === null` and the effect bails on the first line.

**Files:** 3 changed, 13 insertions, 6 deletions.
- `frontend/src/store/slices/ui.ts` — new `clearSettingsScrollTarget` action
- `frontend/src/types/store.ts` — typed the new action
- `frontend/src/components/modals/SettingsModal.tsx` — one-shot clear after successful scroll

**Verification:** `bun run typecheck` in `frontend/` exits 0. Manual repro: open Settings → Extensions → gear on an extension → click any other tab — the view now stays on the clicked tab with no flicker.