### PR TITLE
Convert world-book and entry deletions to async with cleanup-first

### DIFF
--- a/src/routes/world-books.routes.ts
+++ b/src/routes/world-books.routes.ts
@@ -449,7 +449,7 @@ app.post("/bulk-delete", async (c) => {
   const ids = body ? parseBulkWorldBookIds(body.ids) : null;
   if (!ids) return c.json({ error: "ids must be a non-empty array of strings" }, 400);
 
-  const result = svc.bulkDeleteWorldBooks(userId, ids);
+  const result = await svc.bulkDeleteWorldBooks(userId, ids);
   return c.json({ deleted: result.deleted });
 });
 
@@ -492,9 +492,9 @@ app.put("/:id", async (c) => {
   return c.json(book);
 });
 
-app.delete("/:id", (c) => {
+app.delete("/:id", async (c) => {
   const userId = c.get("userId");
-  if (!svc.deleteWorldBook(userId, c.req.param("id"))) return c.json({ error: "Not found" }, 404);
+  if (!(await svc.deleteWorldBook(userId, c.req.param("id")))) return c.json({ error: "Not found" }, 404);
   return c.json({ success: true });
 });
 
@@ -1006,7 +1006,7 @@ app.post("/:id/entries/bulk", async (c) => {
     return c.json({ error: "entry_ids is required" }, 400);
   }
   try {
-    const result = svc.bulkOperateEntries(userId, bookId, body);
+    const result = await svc.bulkOperateEntries(userId, bookId, body);
     if (!result) return c.json({ error: "World book not found" }, 404);
     return c.json(result);
   } catch (err: any) {
@@ -1035,9 +1035,9 @@ app.post("/:id/entries/:eid/duplicate", async (c) => {
   return c.json(duplicated, 201);
 });
 
-app.delete("/:id/entries/:eid", (c) => {
+app.delete("/:id/entries/:eid", async (c) => {
   const userId = c.get("userId");
-  if (!svc.deleteEntry(userId, c.req.param("eid"))) return c.json({ error: "Not found" }, 404);
+  if (!(await svc.deleteEntry(userId, c.req.param("eid")))) return c.json({ error: "Not found" }, 404);
   return c.json({ success: true });
 });
 

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -1081,10 +1081,10 @@ async function runCharacterDeletionCascade(userId: string, id: string): Promise<
 
   await imagesSvc.unlinkPaths(plan.paths);
   if (existing.avatar_path) await filesSvc.deleteAvatar(existing.avatar_path).catch(() => {});
+  await deleteAutoManagedCharacterWorldBooks(userId, id);
 
   getDb().transaction(() => {
     imagesSvc.deleteImageRowsOnly(userId, plan.rowIds);
-    deleteAutoManagedCharacterWorldBooks(userId, id);
     deleteRegexScriptsByCharacterId(userId, id);
     getDb().query("DELETE FROM characters WHERE id = ? AND user_id = ?").run(id, userId);
   })();

--- a/src/services/embeddings-world-book-index-race.test.ts
+++ b/src/services/embeddings-world-book-index-race.test.ts
@@ -129,6 +129,57 @@ beforeEach(() => {
 afterEach(() => closeDatabase());
 
 describe("world-book vector commit races", () => {
+  test("keeps the source when vector cleanup fails", async () => {
+    let sourceDeleteCalled = false;
+    await expect(__test__.coordinateWorldBookVectorAndSourceDelete(
+      "user",
+      ["entry-1"],
+      async () => { throw new Error("vector store unavailable"); },
+      () => {
+        sourceDeleteCalled = true;
+        getDb().query("DELETE FROM world_book_entries WHERE id = 'entry-1'").run();
+      },
+    )).rejects.toThrow("vector store unavailable");
+
+    expect(sourceDeleteCalled).toBe(false);
+    expect(getDb().query("SELECT 1 FROM world_book_entries WHERE id = 'entry-1'").get()).not.toBeNull();
+  });
+
+  test("holds the entry gate through source deletion", async () => {
+    const events: string[] = [];
+    let releaseVectorDelete!: () => void;
+    let vectorDeleteStarted!: () => void;
+    const started = new Promise<void>((resolve) => { vectorDeleteStarted = resolve; });
+    const blocked = new Promise<void>((resolve) => { releaseVectorDelete = resolve; });
+
+    const deletion = __test__.coordinateWorldBookVectorAndSourceDelete(
+      "user",
+      ["entry-1"],
+      async () => {
+        events.push("vector-delete");
+        vectorDeleteStarted();
+        await blocked;
+      },
+      () => {
+        events.push("source-delete");
+        getDb().query("DELETE FROM world_book_entries WHERE id = 'entry-1'").run();
+      },
+    );
+    await started;
+
+    const competingCommit = __test__.withWorldBookEntryVectorCommitLocks("user", ["entry-1"], async () => {
+      events.push("competing-commit");
+      expect(getDb().query("SELECT 1 FROM world_book_entries WHERE id = 'entry-1'").get()).toBeNull();
+    });
+    await Promise.resolve();
+    expect(events).toEqual(["vector-delete"]);
+
+    releaseVectorDelete();
+    await deletion;
+    await competingCommit;
+    expect(events).toEqual(["vector-delete", "source-delete", "competing-commit"]);
+  });
+
   test("compare-and-set rejects an edit after final snapshot validation", async () => {
     const vectors = new Map<string, VectorRow[]>();
     let filterCalls = 0;

--- a/src/services/embeddings.service.ts
+++ b/src/services/embeddings.service.ts
@@ -2206,9 +2206,7 @@ export async function testEmbeddingConfig(
 }
 
 export async function deleteWorldBookEntryEmbeddings(userId: string, entryId: string): Promise<void> {
-  await withWorldBookEntryVectorCommitLocks(userId, [entryId], async () => {
-    await deleteWorldBookEntryRowsUnlocked(userId, [entryId]);
-  });
+  await deleteWorldBookEntryEmbeddingsBeforeSourceDelete(userId, [entryId], () => {});
 }
 
 const worldBookEntryVectorCommitTails = new Map<string, Promise<void>>();
@@ -2255,6 +2253,56 @@ async function deleteWorldBookEntryRowsUnlocked(userId: string, entryIds: string
     eq("source_type", "world_book_entry"),
     inSet("source_id", entryIds),
   ]));
+}
+
+async function deleteWorldBookRowsUnlocked(userId: string, worldBookIds: string[]): Promise<void> {
+  if (worldBookIds.length === 0) return;
+  await deleteStoreRows("embeddings_world_books", andFilter([
+    eq("user_id", userId),
+    eq("source_type", "world_book_entry"),
+    inSet("owner_id", worldBookIds),
+  ]));
+}
+
+async function coordinateWorldBookVectorAndSourceDelete<T>(
+  userId: string,
+  lockEntryIds: string[],
+  deleteVectors: () => Promise<void>,
+  deleteSource: () => T | Promise<T>,
+): Promise<T> {
+  return withWorldBookEntryVectorCommitLocks(userId, lockEntryIds, async () => {
+    await deleteVectors();
+    return await deleteSource();
+  });
+}
+
+export async function deleteWorldBookEntryEmbeddingsBeforeSourceDelete<T>(
+  userId: string,
+  entryIds: string[],
+  deleteSource: () => T | Promise<T>,
+): Promise<T> {
+  const uniqueEntryIds = Array.from(new Set(entryIds));
+  return coordinateWorldBookVectorAndSourceDelete(
+    userId,
+    uniqueEntryIds,
+    () => deleteWorldBookEntryRowsUnlocked(userId, uniqueEntryIds),
+    deleteSource,
+  );
+}
+
+export async function deleteWorldBookEmbeddingsBeforeSourceDelete<T>(
+  userId: string,
+  worldBookIds: string[],
+  lockEntryIds: string[],
+  deleteSource: () => T | Promise<T>,
+): Promise<T> {
+  const uniqueWorldBookIds = Array.from(new Set(worldBookIds));
+  return coordinateWorldBookVectorAndSourceDelete(
+    userId,
+    Array.from(new Set(lockEntryIds)),
+    () => deleteWorldBookRowsUnlocked(userId, uniqueWorldBookIds),
+    deleteSource,
+  );
 }
 
 function getDesiredWorldBookVectorStatus(entry: WorldBookEntry): WorldBookVectorIndexStatus {
@@ -2520,6 +2568,7 @@ async function commitWorldBookVectorWritesIfCurrent(
 
 export const __test__ = {
   commitWorldBookVectorWritesIfCurrent,
+  coordinateWorldBookVectorAndSourceDelete,
   updateWorldBookEntriesVectorStateIfCurrent,
   withWorldBookEntryVectorCommitLocks,
 };

--- a/src/services/world-books-delete.test.ts
+++ b/src/services/world-books-delete.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { closeDatabase, getDb, initDatabase } from "../db/connection";
+
+interface FakeVectorRow {
+  userId: string;
+  ownerId: string;
+  sourceId: string;
+}
+
+let vectors: FakeVectorRow[] = [];
+let failCleanup = false;
+let sourceVisibleDuringCleanup = false;
+let cleanupStarted: (() => void) | null = null;
+let cleanupBarrier: Promise<void> | null = null;
+
+mock.module("./embeddings.service", () => ({
+  deleteWorldBookEmbeddingsBeforeSourceDelete: async <T>(
+    userId: string,
+    worldBookIds: string[],
+    _lockEntryIds: string[],
+    deleteSource: () => T | Promise<T>,
+  ): Promise<T> => {
+    const placeholders = worldBookIds.map(() => "?").join(", ");
+    sourceVisibleDuringCleanup = worldBookIds.length === 0 || (getDb().query(
+      `SELECT COUNT(*) AS count FROM world_books WHERE user_id = ? AND id IN (${placeholders})`
+    ).get(userId, ...worldBookIds) as { count: number }).count === worldBookIds.length;
+    cleanupStarted?.();
+    if (cleanupBarrier) await cleanupBarrier;
+    if (failCleanup) throw new Error("vector cleanup failed");
+    const bookIds = new Set(worldBookIds);
+    vectors = vectors.filter((row) => row.userId !== userId || !bookIds.has(row.ownerId));
+    return await deleteSource();
+  },
+  deleteWorldBookEntryEmbeddingsBeforeSourceDelete: async <T>(
+    userId: string,
+    entryIds: string[],
+    deleteSource: () => T | Promise<T>,
+  ): Promise<T> => {
+    const placeholders = entryIds.map(() => "?").join(", ");
+    sourceVisibleDuringCleanup = entryIds.length === 0 || (getDb().query(
+      `SELECT COUNT(*) AS count FROM world_book_entries WHERE id IN (${placeholders})`
+    ).get(...entryIds) as { count: number }).count === entryIds.length;
+    if (failCleanup) throw new Error("vector cleanup failed");
+    const ids = new Set(entryIds);
+    vectors = vectors.filter((row) => row.userId !== userId || !ids.has(row.sourceId));
+    return await deleteSource();
+  },
+  deleteWorldBookEntryEmbeddings: async () => {},
+}));
+
+const worldBooksSvc = await import("./world-books.service");
+
+function insertBook(id: string, userId: string, metadata: Record<string, unknown> = {}): void {
+  getDb().query(`INSERT INTO world_books (
+    id, user_id, name, description, folder, metadata, created_at, updated_at
+  ) VALUES (?, ?, ?, '', '', ?, 1, 1)`).run(id, userId, id, JSON.stringify(metadata));
+}
+
+function insertEntry(id: string, bookId: string): void {
+  getDb().query(`INSERT INTO world_book_entries (
+    id, world_book_id, key, keysecondary, content, comment, vectorized, disabled,
+    vector_index_status, vector_indexed_at, vector_index_error, extensions, updated_at
+  ) VALUES (?, ?, '[]', '[]', 'lore', '', 1, 0, 'indexed', 1, NULL, '{}', 1)`)
+    .run(id, bookId);
+}
+
+function rowExists(table: "world_books" | "world_book_entries", id: string): boolean {
+  return getDb().query(`SELECT 1 FROM ${table} WHERE id = ?`).get(id) != null;
+}
+
+beforeEach(() => {
+  closeDatabase();
+  initDatabase(":memory:");
+  const db = getDb();
+  db.run("PRAGMA foreign_keys = ON");
+  db.run(`CREATE TABLE world_books (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    folder TEXT NOT NULL DEFAULT '',
+    metadata TEXT NOT NULL DEFAULT '{}',
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  )`);
+  db.run(`CREATE TABLE world_book_entries (
+    id TEXT PRIMARY KEY,
+    world_book_id TEXT NOT NULL REFERENCES world_books(id) ON DELETE CASCADE,
+    key TEXT NOT NULL,
+    keysecondary TEXT NOT NULL,
+    content TEXT NOT NULL,
+    comment TEXT NOT NULL,
+    vectorized INTEGER NOT NULL,
+    disabled INTEGER NOT NULL,
+    vector_index_status TEXT NOT NULL,
+    vector_indexed_at INTEGER,
+    vector_index_error TEXT,
+    extensions TEXT NOT NULL DEFAULT '{}',
+    updated_at INTEGER NOT NULL
+  )`);
+  vectors = [];
+  failCleanup = false;
+  sourceVisibleDuringCleanup = false;
+  cleanupStarted = null;
+  cleanupBarrier = null;
+});
+
+afterEach(() => closeDatabase());
+
+describe("world-book cleanup-first deletion", () => {
+  test("deletes whole-book vectors, including orphans, before cascading SQLite", async () => {
+    insertBook("book-1", "user");
+    insertEntry("entry-1", "book-1");
+    vectors = [
+      { userId: "user", ownerId: "book-1", sourceId: "entry-1" },
+      { userId: "user", ownerId: "book-1", sourceId: "orphan" },
+    ];
+
+    expect(await worldBooksSvc.deleteWorldBook("user", "book-1")).toBe(true);
+    expect(sourceVisibleDuringCleanup).toBe(true);
+    expect(rowExists("world_books", "book-1")).toBe(false);
+    expect(rowExists("world_book_entries", "entry-1")).toBe(false);
+    expect(vectors).toEqual([]);
+  });
+
+  test("preserves book and entry sources when vector cleanup fails", async () => {
+    insertBook("book-1", "user");
+    insertEntry("entry-1", "book-1");
+    vectors = [{ userId: "user", ownerId: "book-1", sourceId: "entry-1" }];
+    failCleanup = true;
+
+    await expect(worldBooksSvc.deleteWorldBook("user", "book-1")).rejects.toThrow("vector cleanup failed");
+    expect(rowExists("world_books", "book-1")).toBe(true);
+    expect(rowExists("world_book_entries", "entry-1")).toBe(true);
+    expect(vectors).toHaveLength(1);
+
+    await expect(worldBooksSvc.deleteEntry("user", "entry-1")).rejects.toThrow("vector cleanup failed");
+    expect(rowExists("world_book_entries", "entry-1")).toBe(true);
+  });
+
+  test("bulk deletion is all-or-nothing and never touches foreign books", async () => {
+    insertBook("book-1", "user");
+    insertBook("book-2", "user");
+    insertBook("foreign", "other");
+    insertEntry("entry-1", "book-1");
+    insertEntry("entry-2", "book-2");
+    insertEntry("entry-f", "foreign");
+    vectors = [
+      { userId: "user", ownerId: "book-1", sourceId: "entry-1" },
+      { userId: "user", ownerId: "book-2", sourceId: "entry-2" },
+      { userId: "other", ownerId: "foreign", sourceId: "entry-f" },
+    ];
+    failCleanup = true;
+    await expect(worldBooksSvc.bulkDeleteWorldBooks("user", ["book-1", "foreign", "book-2"]))
+      .rejects.toThrow("vector cleanup failed");
+    expect(rowExists("world_books", "book-1")).toBe(true);
+    expect(rowExists("world_books", "book-2")).toBe(true);
+
+    failCleanup = false;
+    expect(await worldBooksSvc.bulkDeleteWorldBooks("user", ["book-1", "foreign", "book-2"]))
+      .toEqual({ deleted: ["book-1", "book-2"] });
+    expect(rowExists("world_books", "foreign")).toBe(true);
+    expect(vectors).toEqual([{ userId: "other", ownerId: "foreign", sourceId: "entry-f" }]);
+  });
+
+  test("single-entry deletion removes vectors before deleting SQLite", async () => {
+    insertBook("book-1", "user");
+    insertEntry("entry-1", "book-1");
+    vectors = [{ userId: "user", ownerId: "book-1", sourceId: "entry-1" }];
+
+    expect(await worldBooksSvc.deleteEntry("user", "entry-1")).toBe(true);
+    expect(sourceVisibleDuringCleanup).toBe(true);
+    expect(rowExists("world_book_entries", "entry-1")).toBe(false);
+    expect(vectors).toEqual([]);
+  });
+
+  test("bulk-entry deletion validates ownership and is cleanup-first", async () => {
+    insertBook("book-1", "user");
+    insertBook("book-2", "user");
+    insertEntry("entry-1", "book-1");
+    insertEntry("entry-2", "book-1");
+    insertEntry("foreign-entry", "book-2");
+    vectors = [
+      { userId: "user", ownerId: "book-1", sourceId: "entry-1" },
+      { userId: "user", ownerId: "book-1", sourceId: "entry-2" },
+      { userId: "user", ownerId: "book-2", sourceId: "foreign-entry" },
+    ];
+
+    await expect(worldBooksSvc.bulkOperateEntries("user", "book-1", {
+      action: "delete",
+      entry_ids: ["entry-1", "foreign-entry"],
+    })).rejects.toThrow("One or more entries were not found");
+    expect(vectors).toHaveLength(3);
+    expect(rowExists("world_book_entries", "entry-1")).toBe(true);
+
+    failCleanup = true;
+    await expect(worldBooksSvc.bulkOperateEntries("user", "book-1", {
+      action: "delete",
+      entry_ids: ["entry-1", "entry-2"],
+    })).rejects.toThrow("vector cleanup failed");
+    expect(rowExists("world_book_entries", "entry-1")).toBe(true);
+    expect(rowExists("world_book_entries", "entry-2")).toBe(true);
+
+    failCleanup = false;
+    expect(await worldBooksSvc.bulkOperateEntries("user", "book-1", {
+      action: "delete",
+      entry_ids: ["entry-1", "entry-2"],
+    })).toEqual({ action: "delete", affected: 2 });
+    expect(rowExists("world_book_entries", "entry-1")).toBe(false);
+    expect(rowExists("world_book_entries", "entry-2")).toBe(false);
+    expect(vectors).toEqual([{ userId: "user", ownerId: "book-2", sourceId: "foreign-entry" }]);
+  });
+
+  test("auto-managed character cleanup awaits vector deletion", async () => {
+    insertBook("book-1", "user", {
+      auto_managed_by_character: true,
+      source_character_id: "character-1",
+    });
+    insertEntry("entry-1", "book-1");
+    vectors = [{ userId: "user", ownerId: "book-1", sourceId: "entry-1" }];
+    let releaseCleanup!: () => void;
+    let markCleanupStarted!: () => void;
+    cleanupBarrier = new Promise<void>((resolve) => { releaseCleanup = resolve; });
+    const started = new Promise<void>((resolve) => { markCleanupStarted = resolve; });
+    cleanupStarted = markCleanupStarted;
+
+    const deletion = worldBooksSvc.deleteAutoManagedCharacterWorldBooks("user", "character-1");
+    await started;
+    expect(rowExists("world_books", "book-1")).toBe(true);
+    releaseCleanup();
+
+    expect(await deletion).toBe(1);
+    expect(rowExists("world_books", "book-1")).toBe(false);
+    expect(vectors).toEqual([]);
+  });
+});

--- a/src/services/world-books.service.ts
+++ b/src/services/world-books.service.ts
@@ -637,23 +637,58 @@ export function updateWorldBook(userId: string, id: string, input: UpdateWorldBo
   return getWorldBook(userId, id)!;
 }
 
-export function deleteWorldBook(userId: string, id: string): boolean {
-  const deleted = getDb().query("DELETE FROM world_books WHERE id = ? AND user_id = ?").run(id, userId).changes > 0;
+function getWorldBookEntryIdsForDelete(userId: string, worldBookIds: string[]): string[] {
+  if (worldBookIds.length === 0) return [];
+  const placeholders = worldBookIds.map(() => "?").join(", ");
+  return (getDb().query(
+    `SELECT e.id
+     FROM world_book_entries e
+     JOIN world_books wb ON wb.id = e.world_book_id
+     WHERE wb.user_id = ? AND e.world_book_id IN (${placeholders})`
+  ).all(userId, ...worldBookIds) as Array<{ id: string }>).map((row) => row.id);
+}
+
+export async function deleteWorldBook(userId: string, id: string): Promise<boolean> {
+  if (!getWorldBook(userId, id)) return false;
+  const entryIds = getWorldBookEntryIdsForDelete(userId, [id]);
+  const deleted = await embeddingsSvc.deleteWorldBookEmbeddingsBeforeSourceDelete(
+    userId,
+    [id],
+    entryIds,
+    () => getDb().query("DELETE FROM world_books WHERE id = ? AND user_id = ?").run(id, userId).changes > 0,
+  );
   if (deleted) emitWorldBookDeleted(userId, id);
   return deleted;
 }
 
-export function bulkDeleteWorldBooks(userId: string, ids: string[]): { deleted: string[] } {
+export async function bulkDeleteWorldBooks(userId: string, ids: string[]): Promise<{ deleted: string[] }> {
   const uniqueIds = dedupeWorldBookIds(ids);
-  const deleted: string[] = [];
+  if (uniqueIds.length === 0) return { deleted: [] };
   const db = getDb();
+  const placeholders = uniqueIds.map(() => "?").join(", ");
+  const ownedIds = (db.query(
+    `SELECT id FROM world_books WHERE user_id = ? AND id IN (${placeholders})`
+  ).all(userId, ...uniqueIds) as Array<{ id: string }>).map((row) => row.id);
+  const ownedSet = new Set(ownedIds);
+  const orderedOwnedIds = uniqueIds.filter((id) => ownedSet.has(id));
+  if (orderedOwnedIds.length === 0) return { deleted: [] };
+  const entryIds = getWorldBookEntryIdsForDelete(userId, orderedOwnedIds);
 
-  db.transaction(() => {
-    const stmt = db.query("DELETE FROM world_books WHERE id = ? AND user_id = ?");
-    for (const id of uniqueIds) {
-      if (stmt.run(id, userId).changes > 0) deleted.push(id);
-    }
-  })();
+  const deleted = await embeddingsSvc.deleteWorldBookEmbeddingsBeforeSourceDelete(
+    userId,
+    orderedOwnedIds,
+    entryIds,
+    () => {
+      const removed: string[] = [];
+      db.transaction(() => {
+        const stmt = db.query("DELETE FROM world_books WHERE id = ? AND user_id = ?");
+        for (const id of orderedOwnedIds) {
+          if (stmt.run(id, userId).changes > 0) removed.push(id);
+        }
+      })();
+      return removed;
+    },
+  );
 
   for (const id of deleted) {
     emitWorldBookDeleted(userId, id);
@@ -734,7 +769,7 @@ function buildWorldBooksExportFilename(date: Date = new Date()): string {
   return `world-books-${year}${month}${day}.zip`;
 }
 
-export function deleteAutoManagedCharacterWorldBooks(userId: string, characterId: string): number {
+export async function deleteAutoManagedCharacterWorldBooks(userId: string, characterId: string): Promise<number> {
   const rows = getDb().query(
     `SELECT id
        FROM world_books
@@ -743,12 +778,7 @@ export function deleteAutoManagedCharacterWorldBooks(userId: string, characterId
         AND json_extract(metadata, '$.source_character_id') = ?`
   ).all(userId, characterId) as Array<{ id: string }>;
 
-  let deleted = 0;
-  for (const row of rows) {
-    if (deleteWorldBook(userId, row.id)) deleted += 1;
-  }
-
-  return deleted;
+  return (await bulkDeleteWorldBooks(userId, rows.map((row) => row.id))).deleted.length;
 }
 
 export function getWorldBookVectorSummary(userId: string, worldBookId: string): WorldBookVectorSummary | null {
@@ -1204,17 +1234,21 @@ export function updateEntry(userId: string, id: string, input: UpdateWorldBookEn
   return updated;
 }
 
-export function deleteEntry(userId: string, id: string): boolean {
+export async function deleteEntry(userId: string, id: string): Promise<boolean> {
   // Verify the entry belongs to a world book owned by this user
   const entry = getEntry(userId, id);
   if (!entry) return false;
 
-  const deleted = getDb().query("DELETE FROM world_book_entries WHERE id = ?").run(id).changes > 0;
+  const deleted = await embeddingsSvc.deleteWorldBookEntryEmbeddingsBeforeSourceDelete(
+    userId,
+    [id],
+    () => {
+      const removed = getDb().query("DELETE FROM world_book_entries WHERE id = ?").run(id).changes > 0;
+      if (removed) touchWorldBook(entry.world_book_id);
+      return removed;
+    },
+  );
   if (deleted) {
-    touchWorldBook(entry.world_book_id);
-    void embeddingsSvc.deleteWorldBookEntryEmbeddings(userId, id).catch((err: unknown) => {
-      console.warn("[embeddings] Failed to remove world book entry vectors:", err);
-    });
     eventBus.emit(EventType.WORLD_BOOK_ENTRY_DELETED, { id, worldBookId: entry.world_book_id }, userId);
   }
   return deleted;
@@ -1301,11 +1335,11 @@ export function reorderEntries(userId: string, worldBookId: string, orderedIds: 
   return true;
 }
 
-export function bulkOperateEntries(
+export async function bulkOperateEntries(
   userId: string,
   worldBookId: string,
   input: WorldBookEntryBulkActionInput,
-): WorldBookEntryBulkActionResult | null {
+): Promise<WorldBookEntryBulkActionResult | null> {
   const book = getWorldBook(userId, worldBookId);
   if (!book) return null;
 
@@ -1324,16 +1358,13 @@ export function bulkOperateEntries(
   const db = getDb();
 
   if (input.action === "delete") {
-    db.transaction(() => {
-      const stmt = db.query("DELETE FROM world_book_entries WHERE id = ? AND world_book_id = ?");
-      uniqueIds.forEach((entryId) => stmt.run(entryId, worldBookId));
-      touchWorldBook(worldBookId, now);
-    })();
-    for (const entry of orderedEntries) {
-      void embeddingsSvc.deleteWorldBookEntryEmbeddings(userId, entry.id).catch((err: unknown) => {
-        console.warn("[embeddings] Failed to remove world book entry vectors:", err);
-      });
-    }
+    await embeddingsSvc.deleteWorldBookEntryEmbeddingsBeforeSourceDelete(userId, uniqueIds, () => {
+      db.transaction(() => {
+        const stmt = db.query("DELETE FROM world_book_entries WHERE id = ? AND world_book_id = ?");
+        uniqueIds.forEach((entryId) => stmt.run(entryId, worldBookId));
+        touchWorldBook(worldBookId, now);
+      })();
+    });
     emitWorldBookChanged(userId, worldBookId);
     return { action: input.action, affected: uniqueIds.length };
   }

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -7425,7 +7425,7 @@ export class WorkerHost {
     }
   }
 
-  private handleWorldBooksDelete(requestId: string, worldBookId: string, userId?: string): void {
+  private async handleWorldBooksDelete(requestId: string, worldBookId: string, userId?: string): Promise<void> {
     try {
       if (!this.hasPermission("world_books")) {
         throw new Error(`${PERMISSION_DENIED_PREFIX} world_books — World Books permission not granted`);
@@ -7434,7 +7434,7 @@ export class WorkerHost {
       if (!resolvedUserId) throw new Error("userId is required for operator-scoped extensions");
       this.enforceScopedUser(resolvedUserId);
 
-      const deleted = worldBooksSvc.deleteWorldBook(resolvedUserId, worldBookId);
+      const deleted = await worldBooksSvc.deleteWorldBook(resolvedUserId, worldBookId);
       this.postToWorker({ type: "response", requestId, result: deleted });
     } catch (err: any) {
       this.postToWorker({ type: "response", requestId, error: err.message });
@@ -7525,7 +7525,7 @@ export class WorkerHost {
     }
   }
 
-  private handleWorldBookEntriesDelete(requestId: string, entryId: string, userId?: string): void {
+  private async handleWorldBookEntriesDelete(requestId: string, entryId: string, userId?: string): Promise<void> {
     try {
       if (!this.hasPermission("world_books")) {
         throw new Error(`${PERMISSION_DENIED_PREFIX} world_books — World Books permission not granted`);
@@ -7534,7 +7534,7 @@ export class WorkerHost {
       if (!resolvedUserId) throw new Error("userId is required for operator-scoped extensions");
       this.enforceScopedUser(resolvedUserId);
 
-      const deleted = worldBooksSvc.deleteEntry(resolvedUserId, entryId);
+      const deleted = await worldBooksSvc.deleteEntry(resolvedUserId, entryId);
       this.postToWorker({ type: "response", requestId, result: deleted });
     } catch (err: any) {
       this.postToWorker({ type: "response", requestId, error: err.message });


### PR DESCRIPTION
This pull request introduces a cleanup-first deletion strategy for world books and world book entries, ensuring that associated vector embeddings are deleted before the corresponding database records. The changes make deletion operations asynchronous, transactional, and all-or-nothing, preventing partial data loss and improving data integrity. Comprehensive tests are added to verify failure handling and correct sequencing of cleanup operations.

**Cleanup-first deletion and transactional safety:**

* Refactored `deleteWorldBook`, `bulkDeleteWorldBooks`, `deleteEntry`, and `deleteAutoManagedCharacterWorldBooks` in `world-books.service.ts` to be asynchronous and to delete vector embeddings before removing database records, ensuring that database entries are only deleted if vector cleanup succeeds. Bulk operations are now all-or-nothing and validate ownership. [[1]](diffhunk://#diff-bdb1d875b5ff9181d4481be356481f3048f6b4d1d8fe7124ce74c44c89339737L640-R691) [[2]](diffhunk://#diff-bdb1d875b5ff9181d4481be356481f3048f6b4d1d8fe7124ce74c44c89339737L737-R772) [[3]](diffhunk://#diff-bdb1d875b5ff9181d4481be356481f3048f6b4d1d8fe7124ce74c44c89339737L746-R781) [[4]](diffhunk://#diff-bdb1d875b5ff9181d4481be356481f3048f6b4d1d8fe7124ce74c44c89339737L1207-L1217)
* Updated route handlers in `world-books.routes.ts` to await these new asynchronous deletion methods, ensuring proper error handling and response timing. [[1]](diffhunk://#diff-f5221d0e77705a4cd910b5ea81edef9899a13be16723fd80b4a7ae0740129832L452-R452) [[2]](diffhunk://#diff-f5221d0e77705a4cd910b5ea81edef9899a13be16723fd80b4a7ae0740129832L495-R497) [[3]](diffhunk://#diff-f5221d0e77705a4cd910b5ea81edef9899a13be16723fd80b4a7ae0740129832L1009-R1009) [[4]](diffhunk://#diff-f5221d0e77705a4cd910b5ea81edef9899a13be16723fd80b4a7ae0740129832L1038-R1040)

**Embeddings service improvements:**

* Added `deleteWorldBookEmbeddingsBeforeSourceDelete` and `deleteWorldBookEntryEmbeddingsBeforeSourceDelete` to `embeddings.service.ts` to coordinate vector and source deletions, with robust locking and error handling. Internal helpers and test exports were added for coordination and testing. [[1]](diffhunk://#diff-9f302e16ab575e16663b3231bcf98e8493ea6ee18c61ba2cde112e1da5b6ffbeL2209-R2209) [[2]](diffhunk://#diff-9f302e16ab575e16663b3231bcf98e8493ea6ee18c61ba2cde112e1da5b6ffbeR2258-R2307) [[3]](diffhunk://#diff-9f302e16ab575e16663b3231bcf98e8493ea6ee18c61ba2cde112e1da5b6ffbeR2571)

**Testing and reliability:**

* Introduced `world-books-delete.test.ts` with comprehensive tests for cleanup-first deletion, failure cases, transactional guarantees, and correct sequencing of vector and source deletions. This ensures that deletions are all-or-nothing and that foreign or unrelated data is never affected.
* Added additional tests to `embeddings-world-book-index-race.test.ts` to verify correct locking and sequencing under concurrent operations.

**Character deletion cascade update:**

* Ensured that auto-managed character world books are deleted asynchronously and await vector cleanup before database removal in `characters.service.ts`.