### PR TITLE
Add stable vector-WI cache & Milvus similarity fixes

### DIFF
--- a/src/services/prompt-assembly-vector-cache.test.ts
+++ b/src/services/prompt-assembly-vector-cache.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type { WorldBookEntry } from "../types/world-book";
+import type { EmbeddingConfigWithStatus } from "./embeddings.service";
+import { __vectorWiCacheTest } from "./prompt-assembly.service";
+import type { VectorStoreConfig } from "./vector-store-config.service";
+import type { WorldBookVectorSettings } from "./world-book-vector-settings.service";
+import type { VectorWorldInfoRetrievalResult } from "./world-info-vector-ranking";
+
+function entry(overrides: Partial<WorldBookEntry> = {}): WorldBookEntry {
+  return {
+    id: "entry-1",
+    world_book_id: "book-1",
+    uid: "uid-1",
+    outlet_name: null,
+    wi_marker: null,
+    wi_marker_side: null,
+    key: ["alpha"],
+    keysecondary: ["beta"],
+    content: "old lore",
+    comment: "Old lore",
+    position: 0,
+    depth: 4,
+    role: null,
+    order_value: 100,
+    selective: false,
+    constant: false,
+    disabled: false,
+    group_name: "",
+    group_override: false,
+    group_weight: 100,
+    probability: 100,
+    scan_depth: null,
+    case_sensitive: false,
+    match_whole_words: false,
+    automation_id: null,
+    use_regex: false,
+    prevent_recursion: false,
+    exclude_recursion: false,
+    delay_until_recursion: false,
+    priority: 10,
+    sticky: 0,
+    cooldown: 0,
+    delay: 0,
+    selective_logic: 0,
+    use_probability: true,
+    vectorized: true,
+    vector_index_status: "indexed",
+    vector_indexed_at: 100,
+    vector_index_error: null,
+    extensions: { nested: { a: 1, b: 2 } },
+    created_at: 1,
+    updated_at: 2,
+    ...overrides,
+  };
+}
+
+interface FingerprintInput {
+  userId: string;
+  chatId: string;
+  worldBookIds: string[];
+  entries: WorldBookEntry[];
+  queryText: string;
+  embeddingConfig: EmbeddingConfigWithStatus;
+  worldBookVectorSettings: WorldBookVectorSettings;
+  vectorStoreConfig: VectorStoreConfig;
+}
+
+function fingerprintInput(): FingerprintInput {
+  return {
+    userId: "user-1",
+    chatId: "chat-1",
+    worldBookIds: ["book-1"],
+    entries: [entry()],
+    queryText: "where is alpha",
+    embeddingConfig: {
+      enabled: true,
+      provider: "openai" as const,
+      api_url: "https://api.openai.com/v1",
+      model: "text-embedding-3-small",
+      dimensions: 1536,
+      send_dimensions: true,
+      retrieval_top_k: 6,
+      hybrid_weight_mode: "balanced" as const,
+      preferred_context_size: 3,
+      batch_size: 32,
+      similarity_threshold: 0.8,
+      rerank_cutoff: 0.1,
+      vectorize_world_books: true,
+      vectorize_chat_messages: false,
+      vectorize_chat_documents: false,
+      chat_memory_mode: "balanced" as const,
+      request_timeout: 60,
+      vertex_region: "global",
+      has_api_key: true,
+    },
+    worldBookVectorSettings: {
+      presetMode: "balanced" as const,
+      chunkTargetTokens: 420,
+      chunkMaxTokens: 700,
+      chunkOverlapTokens: 80,
+      retrievalTopK: 6,
+      maxChunksPerEntry: 8,
+    },
+    vectorStoreConfig: { provider: "lancedb" as const },
+  };
+}
+
+function retrievalResult(): VectorWorldInfoRetrievalResult {
+  return {
+    entries: [{
+      entry: entry(),
+      score: 1,
+      distance: 0,
+      finalScore: 1,
+      lexicalCandidateScore: null,
+      matchedPrimaryKeys: ["alpha"],
+      matchedSecondaryKeys: [],
+      matchedComment: "Old lore",
+      scoreBreakdown: {
+        vectorSimilarity: 1,
+        lexicalContentBoost: 0,
+        primaryExact: 0,
+        primaryPartial: 0,
+        secondaryExact: 0,
+        secondaryPartial: 0,
+        commentExact: 0,
+        commentPartial: 0,
+        focusBoost: 0,
+        priority: 0,
+        broadPenalty: 0,
+        focusMissPenalty: 0,
+      },
+      searchTextPreview: "old lore",
+    }],
+    candidateTrace: [],
+    queryPreview: "where is alpha",
+    eligibleCount: 1,
+    hitsBeforeThreshold: 1,
+    hitsAfterThreshold: 1,
+    thresholdRejected: 0,
+    hitsAfterRerankCutoff: 1,
+    rerankRejected: 0,
+    topK: 1,
+    cap: 1,
+    blockerMessages: ["original"],
+    timingsMs: {
+      queryBuildMs: 1,
+      queryEmbedMs: 1,
+      searchMs: 1,
+      rankingMs: 1,
+      totalMs: 4,
+    },
+  };
+}
+
+afterEach(() => __vectorWiCacheTest.clear());
+
+describe("vector world-info retrieval cache", () => {
+  test("fingerprints same-length lore edits and retrieval-affecting state", () => {
+    const base = fingerprintInput();
+    const baseFingerprint = __vectorWiCacheTest.buildFingerprint(base);
+    const mutations: Array<(input: ReturnType<typeof fingerprintInput>) => void> = [
+      (input) => { input.entries[0].content = "new lore"; },
+      (input) => { input.entries[0].key = ["gamma"]; },
+      (input) => { input.entries[0].comment = "New lore"; },
+      (input) => { input.entries[0].priority = 11; },
+      (input) => { input.entries[0].group_name = "group"; },
+      (input) => { input.entries[0].group_override = true; },
+      (input) => { input.entries[0].group_weight = 50; },
+      (input) => { input.entries[0].position = 2; },
+      (input) => { input.entries[0].vector_index_status = "pending"; },
+      (input) => { input.entries[0].vector_indexed_at = 101; },
+      (input) => { input.embeddingConfig.model = "text-embedding-3-large"; },
+      (input) => { input.embeddingConfig.provider = "openrouter"; },
+      (input) => { input.embeddingConfig.has_api_key = false; },
+      (input) => { input.vectorStoreConfig = { provider: "milvus", milvus: { address: "127.0.0.1:19530" } }; },
+      (input) => { input.worldBookVectorSettings.chunkTargetTokens = 421; },
+    ];
+
+    for (const mutate of mutations) {
+      const changed = structuredClone(base);
+      mutate(changed);
+      expect(__vectorWiCacheTest.buildFingerprint(changed)).not.toBe(baseFingerprint);
+    }
+  });
+
+  test("uses stable object-key ordering while tracking extension changes", () => {
+    const first = fingerprintInput();
+    first.entries[0].extensions = { z: 3, nested: { b: 2, a: 1 } };
+    const second = fingerprintInput();
+    second.entries[0].extensions = { nested: { a: 1, b: 2 }, z: 3 };
+
+    expect(__vectorWiCacheTest.buildFingerprint(first)).toBe(
+      __vectorWiCacheTest.buildFingerprint(second),
+    );
+
+    second.entries[0].extensions.nested.b = 4;
+    expect(__vectorWiCacheTest.buildFingerprint(first)).not.toBe(
+      __vectorWiCacheTest.buildFingerprint(second),
+    );
+  });
+
+  test("normalizes book and entry ordering for equivalent snapshots", () => {
+    const first = fingerprintInput();
+    first.worldBookIds = ["book-2", "book-1"];
+    first.entries = [
+      entry({ id: "entry-2", world_book_id: "book-2" }),
+      entry({ id: "entry-1", world_book_id: "book-1" }),
+    ];
+    const second = fingerprintInput();
+    second.worldBookIds = ["book-1", "book-2"];
+    second.entries = [...first.entries].reverse();
+
+    expect(__vectorWiCacheTest.buildFingerprint(first)).toBe(
+      __vectorWiCacheTest.buildFingerprint(second),
+    );
+  });
+
+  test("isolates stored and returned object graphs", () => {
+    const original = retrievalResult();
+    __vectorWiCacheTest.set("key", original);
+
+    original.blockerMessages[0] = "mutated original";
+    original.entries[0].entry.content = "mutated original lore";
+
+    const firstHit = __vectorWiCacheTest.get("key");
+    expect(firstHit?.blockerMessages).toEqual(["original"]);
+    expect(firstHit?.entries[0].entry.content).toBe("old lore");
+
+    firstHit!.blockerMessages[0] = "mutated hit";
+    firstHit!.entries[0].entry.content = "mutated hit lore";
+    firstHit!.entries[0].matchedPrimaryKeys.push("extra");
+
+    const secondHit = __vectorWiCacheTest.get("key");
+    expect(secondHit?.blockerMessages).toEqual(["original"]);
+    expect(secondHit?.entries[0].entry.content).toBe("old lore");
+    expect(secondHit?.entries[0].matchedPrimaryKeys).toEqual(["alpha"]);
+  });
+});

--- a/src/services/prompt-assembly.service.ts
+++ b/src/services/prompt-assembly.service.ts
@@ -79,7 +79,14 @@ import * as worldBooksSvc from "./world-books.service";
 import * as settingsSvc from "./settings.service";
 import * as packsSvc from "./packs.service";
 import * as embeddingsSvc from "./embeddings.service";
-import { loadWorldBookVectorSettings } from "./world-book-vector-settings.service";
+import {
+  loadWorldBookVectorSettings,
+  type WorldBookVectorSettings,
+} from "./world-book-vector-settings.service";
+import {
+  getResolvedVectorStoreConfig,
+  type VectorStoreConfig,
+} from "./vector-store-config.service";
 import { isWorldBookEntryVectorSearchReady } from "./world-book-vector-state";
 import * as imagesSvc from "./images.service";
 import * as presetProfilesSvc from "./preset-profiles.service";
@@ -3954,6 +3961,66 @@ interface CachedVectorWiResult {
 
 const vectorWiCache = new Map<string, CachedVectorWiResult>();
 
+interface VectorWiCacheFingerprintInput {
+  userId: string;
+  chatId: string;
+  worldBookIds: string[];
+  entries: WorldBookEntryModel[];
+  queryText: string;
+  embeddingConfig: embeddingsSvc.EmbeddingConfigWithStatus;
+  worldBookVectorSettings: WorldBookVectorSettings;
+  vectorStoreConfig: VectorStoreConfig;
+}
+
+function stableVectorWiCacheValue(value: unknown): string {
+  if (value === undefined) return "u;";
+  if (value === null) return "l;";
+  if (typeof value === "string") return `s${value.length}:${value};`;
+  if (typeof value === "number") {
+    return `n${Number.isFinite(value) ? value : String(value)};`;
+  }
+  if (typeof value === "boolean") return value ? "b1;" : "b0;";
+  if (Array.isArray(value)) {
+    return `a${value.length}[${value.map(stableVectorWiCacheValue).join("")}]`;
+  }
+  if (typeof value === "object") {
+    const object = value as Record<string, unknown>;
+    const keys = Object.keys(object).sort();
+    return `o${keys.length}{${keys
+      .map((key) => `${stableVectorWiCacheValue(key)}${stableVectorWiCacheValue(object[key])}`)
+      .join("")}}`;
+  }
+  return `${typeof value}:${String(value)};`;
+}
+
+function buildVectorWiCacheFingerprint(input: VectorWiCacheFingerprintInput): string {
+  const snapshot = {
+    userId: input.userId,
+    chatId: input.chatId,
+    worldBookIds: [...input.worldBookIds].sort(),
+    queryText: input.queryText,
+    embeddingConfig: input.embeddingConfig,
+    worldBookVectorSettings: input.worldBookVectorSettings,
+    vectorStoreConfig: input.vectorStoreConfig,
+    worldBookVectorWriteFingerprint:
+      embeddingsSvc.getWorldBookVectorWriteFingerprint(input.embeddingConfig),
+  };
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(stableVectorWiCacheValue(snapshot));
+  for (const entry of [...input.entries].sort((a, b) =>
+    a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+  )) {
+    hasher.update(stableVectorWiCacheValue(entry));
+  }
+  return hasher.digest("hex");
+}
+
+function cloneVectorWiResult(
+  result: VectorWorldInfoRetrievalResult,
+): VectorWorldInfoRetrievalResult {
+  return structuredClone(result);
+}
+
 function pruneVectorWiCache(now = Date.now()): void {
   for (const [key, cached] of vectorWiCache) {
     if (now - cached.cachedAt > VECTOR_WI_CACHE_TTL_MS) {
@@ -3977,7 +4044,7 @@ function getCachedVectorWiResult(
     vectorWiCache.delete(cacheKey);
     return null;
   }
-  return cached.result;
+  return cloneVectorWiResult(cached.result);
 }
 
 function setCachedVectorWiResult(
@@ -3985,8 +4052,18 @@ function setCachedVectorWiResult(
   result: VectorWorldInfoRetrievalResult,
 ): void {
   pruneVectorWiCache();
-  vectorWiCache.set(cacheKey, { result, cachedAt: Date.now() });
+  vectorWiCache.set(cacheKey, {
+    result: cloneVectorWiResult(result),
+    cachedAt: Date.now(),
+  });
 }
+
+export const __vectorWiCacheTest = {
+  buildFingerprint: buildVectorWiCacheFingerprint,
+  clear: () => vectorWiCache.clear(),
+  get: getCachedVectorWiResult,
+  set: setCachedVectorWiResult,
+};
 
 export async function collectVectorActivatedWorldInfoDetailed(
   userId: string,
@@ -4043,21 +4120,19 @@ export async function collectVectorActivatedWorldInfoDetailed(
   const queryBuildMs = performance.now() - queryBuildStartedAt;
   const eligibleEntries = entries.filter(isVectorEligibleWorldInfoEntry);
 
-  // Check short-TTL cache for rapid dry-run reuse.
-  const cacheConfigSig = [
-    cfg.enabled ? 1 : 0,
-    cfg.vectorize_world_books ? 1 : 0,
-    cfg.dimensions ?? 0,
-    topK,
-    cfg.hybrid_weight_mode,
-    cfg.similarity_threshold,
-    cfg.rerank_cutoff,
-  ].join(":");
-  const cacheKey = `${userId}:${chatId}:${worldBookIds.join(",")}:${eligibleEntries
-    .map((e) => `${e.id}:${e.content?.length ?? 0}`)
-    .join(
-      ",",
-    )}:${queryText}:${cacheConfigSig}`;
+  // Check short-TTL cache for rapid dry-run reuse. Hash the complete retrieval
+  // snapshot so same-length lore edits, activation fields, index commits, and
+  // provider/config changes cannot reuse stale candidates.
+  const cacheKey = buildVectorWiCacheFingerprint({
+    userId,
+    chatId,
+    worldBookIds,
+    entries,
+    queryText,
+    embeddingConfig: cfg,
+    worldBookVectorSettings,
+    vectorStoreConfig: getResolvedVectorStoreConfig(),
+  });
   const cached = getCachedVectorWiResult(cacheKey);
   if (cached) {
     console.debug("[prompt-assembly] Vector WI cache hit for chat %s", chatId);

--- a/src/services/vector-store/providers/milvus.test.ts
+++ b/src/services/vector-store/providers/milvus.test.ts
@@ -5,6 +5,139 @@ import type { HybridSearchOptions, VectorHit } from "../types";
 import { MilvusStore } from "./milvus";
 
 describe("MilvusStore.hybridSearch", () => {
+  test("keeps RRF ordering but returns cosine similarity instead of the fused score", async () => {
+    const store = new MilvusStore({ address: "127.0.0.1:19530" }, null);
+    store.capabilities = { ...store.capabilities, nativeLexical: true };
+    let hybridRequest: any = null;
+    (store as any).getClient = async () => ({
+      hybridSearch: async (request: any) => {
+        hybridRequest = request;
+        return {
+          results: [
+            {
+              id: "row-identical",
+              source_id: "entry-identical",
+              content: "identical",
+              metadata_json: "{}",
+              score: 0.0325,
+              vector: [2, 0],
+            },
+            {
+              id: "row-orthogonal",
+              source_id: "entry-orthogonal",
+              content: "orthogonal",
+              metadata_json: "{}",
+              score: 0.032,
+              vector: [0, 3],
+            },
+          ],
+        };
+      },
+    });
+    (store as any).hasCollection = async () => true;
+    (store as any).hasSparseField = async () => true;
+    (store as any).loadCollection = async () => {};
+
+    const hits = await store.hybridSearch({
+      collection: "embeddings_world_books",
+      vector: [1, 0],
+      queryText: "sword",
+      filter: eq("user_id", "user-1"),
+      limit: 2,
+      withVector: false,
+    });
+
+    expect(hits.map((hit) => hit.source_id)).toEqual([
+      "entry-identical",
+      "entry-orthogonal",
+    ]);
+    expect(hits.map((hit) => hit.similarity)).toEqual([1, 0]);
+    expect(hits.every((hit) => hit.similarity !== 0.0325 && hit.similarity !== 0.032)).toBe(true);
+    expect(hits.every((hit) => hit.vector === null)).toBe(true);
+    expect(hybridRequest.output_fields).toContain("vector");
+  });
+
+  test("retains calibrated vectors when requested", async () => {
+    const store = new MilvusStore({ address: "127.0.0.1:19530" }, null);
+    store.capabilities = { ...store.capabilities, nativeLexical: true };
+    (store as any).getClient = async () => ({
+      hybridSearch: async () => ({
+        results: [{
+          id: "row-1",
+          source_id: "entry-1",
+          content: "content",
+          metadata_json: "{}",
+          score: 0.032,
+          vector: [1, 0],
+        }],
+      }),
+    });
+    (store as any).hasCollection = async () => true;
+    (store as any).hasSparseField = async () => true;
+    (store as any).loadCollection = async () => {};
+
+    const hits = await store.hybridSearch({
+      collection: "embeddings_world_books",
+      vector: [1, 0],
+      queryText: "sword",
+      filter: eq("user_id", "user-1"),
+      limit: 1,
+      withVector: true,
+    });
+
+    expect(hits[0]?.similarity).toBe(1);
+    expect(hits[0]?.vector).toEqual([1, 0]);
+  });
+
+  test("bounded dense fallback rescales missing vectors and leaves unresolved hits unknown", async () => {
+    const store = new MilvusStore({ address: "127.0.0.1:19530" }, null);
+    store.capabilities = { ...store.capabilities, nativeLexical: true };
+    (store as any).getClient = async () => ({
+      hybridSearch: async () => ({
+        results: [
+          { id: "row-missing", source_id: "entry-missing", content: "missing", metadata_json: "{}", score: 0.032 },
+          { id: "row-invalid", source_id: "entry-invalid", content: "invalid", metadata_json: "{}", score: 0.031, vector: [1] },
+        ],
+      }),
+    });
+    (store as any).hasCollection = async () => true;
+    (store as any).hasSparseField = async () => true;
+    (store as any).loadCollection = async () => {};
+    const rescoreOptions: HybridSearchOptions[] = [];
+    (store as any).vectorSearch = async (options: HybridSearchOptions) => {
+      rescoreOptions.push(options);
+      return [{
+        id: "row-missing",
+        source_id: "entry-missing",
+        content: "missing",
+        metadata_json: "{}",
+        similarity: 0.75,
+        lexicalScore: null,
+        vector: null,
+      } satisfies VectorHit];
+    };
+
+    const hits = await store.hybridSearch({
+      collection: "embeddings_world_books",
+      vector: [1, 0],
+      queryText: "sword",
+      filter: eq("user_id", "user-1"),
+      limit: 2,
+      withVector: false,
+    });
+
+    expect(hits.map((hit) => hit.source_id)).toEqual(["entry-missing", "entry-invalid"]);
+    expect(hits.map((hit) => hit.similarity)).toEqual([0.75, null]);
+    expect(rescoreOptions[0]?.limit).toBe(2);
+    expect(rescoreOptions[0]?.filter).toEqual({
+      op: "and",
+      clauses: [
+        eq("user_id", "user-1"),
+        { op: "in", field: "id", values: ["row-missing", "row-invalid"] },
+      ],
+    });
+  });
+
   test("falls back to app-side fusion and bypasses native hybrid after a zero-row anomaly", async () => {
     const store = new MilvusStore({ address: "127.0.0.1:19530" }, null);
     store.capabilities = { ...store.capabilities, nativeLexical: true };

--- a/src/services/vector-store/providers/milvus.ts
+++ b/src/services/vector-store/providers/milvus.ts
@@ -1,6 +1,12 @@
 import { connect as connectTcp } from "node:net";
 import type { MilvusConnectionConfig, MilvusHybridSearchConfig, VectorStoreTuningProfile } from "../../vector-store-config.service";
-import { adaptiveStorageBatch, isRetryableStorageError } from "../addressing";
+import {
+  adaptiveStorageBatch,
+  andFilter,
+  cosineSimilarity,
+  inSet,
+  isRetryableStorageError,
+} from "../addressing";
 import { milvusCapabilities } from "../capabilities";
 import type {
   CollectionName,
@@ -334,13 +340,57 @@ export class MilvusStore implements VectorStore {
         ],
         rerank: { strategy: "rrf", params: { k: 60 } },
         limit: requestedLimit,
-        output_fields: opts.withVector ? [...OUTPUT_FIELDS, "vector"] : OUTPUT_FIELDS,
+        // Milvus returns the fused RRF score as `score`. Pull dense vectors
+        // back so the provider contract can still expose real cosine
+        // similarity instead of mislabeling that rank-derived score.
+        output_fields: [...OUTPUT_FIELDS, "vector"],
       });
       if (opts.signal?.aborted) return [];
       const results = Array.isArray(res?.results) ? res.results : [];
-      const hits = results
-        .map((row: any) => milvusSearchRowToHit(row, opts.withVector))
-        .filter((hit: VectorHit | null): hit is VectorHit => hit != null);
+      let hits: VectorHit[] = results
+        .map((row: any) => milvusSearchRowToHit(row, true))
+        .filter((hit: VectorHit | null): hit is VectorHit => hit != null)
+        .map((hit: VectorHit): VectorHit => {
+          const vector = hit.vector;
+          const hasValidVector = !!vector && vector.length === opts.vector.length;
+          return {
+            ...hit,
+            similarity: hasValidVector ? cosineSimilarity(opts.vector, vector) : null,
+            lexicalScore: null,
+            vector: opts.withVector ? vector : null,
+          };
+        });
+
+      const unresolvedIds = hits
+        .filter((hit: VectorHit) => hit.similarity == null && hit.id)
+        .map((hit: VectorHit) => hit.id);
+      if (unresolvedIds.length > 0 && !opts.signal?.aborted) {
+        try {
+          const rescored = await this.vectorSearch({
+            ...opts,
+            filter: andFilter([opts.filter, inSet("id", unresolvedIds)]),
+            limit: unresolvedIds.length,
+          });
+          const rescoredById = new Map(rescored.map((hit: VectorHit) => [hit.id, hit]));
+          hits = hits.map((hit: VectorHit): VectorHit => {
+            const denseHit = rescoredById.get(hit.id);
+            if (!denseHit) return hit;
+            return {
+              ...hit,
+              similarity: denseHit.similarity,
+              vector: opts.withVector ? denseHit.vector : null,
+            };
+          });
+        } catch (err) {
+          if (opts.signal?.aborted) return [];
+          console.warn(
+            "[vector-store] Milvus could not dense-rescore %d native hybrid hit(s); leaving their cosine similarity unknown: %s",
+            unresolvedIds.length,
+            describeMilvusError(err),
+          );
+        }
+      }
+      if (opts.signal?.aborted) return [];
       if (hits.length > 0) return hits;
 
       const fusedHits = await this.appSideHybridSearch(opts);


### PR DESCRIPTION
This pull request introduces a comprehensive overhaul of the vector world-info retrieval cache and improves the Milvus vector store integration. The main goals are to ensure cache correctness by hashing all relevant retrieval state, prevent accidental cache hits from same-length but semantically different edits, and to provide accurate similarity scores from Milvus hybrid search results. The changes also include robust tests for the new cache logic and Milvus provider behavior.

### Vector world-info retrieval cache improvements

* Refactored cache key generation to use a deep, stable fingerprint of all relevant retrieval input state, including user, chat, world book IDs, entries, query text, embedding config, vector settings, and vector store config. This prevents stale cache hits due to subtle changes in input data. [[1]](diffhunk://#diff-20f3fd805092b3c65647cc031b128c8b36885d0681e61d74316db77682ef12d2R3964-R4023) [[2]](diffhunk://#diff-20f3fd805092b3c65647cc031b128c8b36885d0681e61d74316db77682ef12d2L4046-R4135)
* Implemented a stable object serialization and hashing function to ensure that cache keys are consistent and sensitive to all retrieval-affecting changes, including nested object properties and ordering.
* Ensured that cached retrieval results are deeply cloned on both set and get, so mutations to returned objects or input objects do not affect cache integrity.
* Added a new internal test utility (`__vectorWiCacheTest`) and a comprehensive test suite (`prompt-assembly-vector-cache.test.ts`) to verify fingerprinting, cache isolation, and ordering normalization. [[1]](diffhunk://#diff-dda0196ae7552c9741ab8d3ab651ebed585b13248403624acad8d6a5b9d80bffR1-R240) [[2]](diffhunk://#diff-20f3fd805092b3c65647cc031b128c8b36885d0681e61d74316db77682ef12d2L3980-R4067)

### Milvus vector store hybrid search improvements

* Modified the Milvus provider to always request dense vectors in hybrid search, then compute and return true cosine similarity for each hit, instead of the fused RRF score. This ensures the provider contract is correctly fulfilled and similarity scores are meaningful.
* Added logic to rescore hybrid hits with missing or invalid vectors by issuing a dense vector search for those entries, and leaving similarity as `null` if unresolved.
* Added and updated tests to verify correct hit ordering, similarity calculation, vector retention, and fallback behavior for missing vectors in Milvus hybrid search.

These changes collectively make the vector retrieval cache more robust and reliable, and ensure the Milvus provider returns accurate and expected results for downstream consumers.