### PR TITLE
Improve world info vector recall and lexical reranking PT.2

### DIFF
--- a/frontend/src/components/panels/world-book/WorldBookDiagnosticsModal.tsx
+++ b/frontend/src/components/panels/world-book/WorldBookDiagnosticsModal.tsx
@@ -549,6 +549,14 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
       'QUERY PREVIEW',
       diagnostics.query_preview || '(empty)',
       '',
+      'LEXICAL QUERY PREVIEWS',
+      ...(diagnostics.lexical_query_previews.length > 0
+        ? diagnostics.lexical_query_previews.flatMap((batch, index) => [
+          `Batch ${index + 1} (${batch.kind})`,
+          batch.text,
+          '',
+        ])
+        : ['(none)', '']),
       'BLOCKERS / NOTES',
     ]
 
@@ -933,6 +941,13 @@ export default function WorldBookDiagnosticsModal({ book, chatId, onClose }: Pro
                     <div className={styles.queryBlock}>
                       {diagnostics.query_preview || t('worldBookDiagnostics.sections.noQuery')}
                     </div>
+                    {diagnostics.lexical_query_previews.map((batch, index) => (
+                      <div className={styles.queryBlock} key={`lexical-query-${index}`}>
+                        <strong>FTS batch {index + 1} ({batch.kind})</strong>
+                        {'\n'}
+                        {batch.text}
+                      </div>
+                    ))}
                   </section>
 
                   <section className={styles.sectionCard}>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -868,6 +868,10 @@ export interface WorldBookDiagnostics {
   };
   vector_summary: WorldBookVectorSummary;
   query_preview: string;
+  lexical_query_previews: Array<{
+    kind: 'anchors' | 'mixed' | 'topical';
+    text: string;
+  }>;
   eligible_entries: number;
   retrieval: {
     top_k: number;

--- a/src/routes/world-books.routes.ts
+++ b/src/routes/world-books.routes.ts
@@ -521,6 +521,7 @@ app.post("/:id/diagnostics", async (c) => {
         entries: [],
         candidateTrace: [],
         queryPreview,
+        lexicalQueryPreviews: [],
         eligibleCount: 0,
         hitsBeforeThreshold: 0,
         hitsAfterThreshold: 0,
@@ -682,6 +683,7 @@ app.post("/:id/diagnostics", async (c) => {
     },
     vector_summary: vectorSummary,
     query_preview: vectorDetail.queryPreview || queryPreview,
+    lexical_query_previews: vectorDetail.lexicalQueryPreviews,
     eligible_entries: isAttached ? selectedEligibleEntries.length : 0,
     retrieval: {
       top_k: vectorDetail.topK,

--- a/src/services/embeddings.service.ts
+++ b/src/services/embeddings.service.ts
@@ -234,9 +234,43 @@ export interface WorldBookSearchCandidate {
   entry_id: string;
   distance: number;
   lexical_score: number | null;
+  /** Bounded, provider-scale-independent BM25 evidence used by reranking. */
+  lexical_strength?: number;
   content: string;
   searchTextPreview: string;
   metadata: WorldBookEmbeddingMetadata;
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+}
+
+/**
+ * Convert provider-specific positive BM25 magnitudes into a bounded robust
+ * signal. Log centering makes the result exactly invariant to uniform positive
+ * scaling; median/MAD keeps isolated score outliers from setting the scale.
+ */
+export function normalizeBm25Scores(
+  scores: Array<number | null | undefined>,
+): number[] {
+  const positiveLogs = scores
+    .filter((score): score is number => typeof score === "number" && Number.isFinite(score) && score > 0)
+    .map((score) => Math.log(score));
+  if (positiveLogs.length === 0) return scores.map(() => 0);
+
+  const center = median(positiveLogs);
+  const mad = median(positiveLogs.map((value) => Math.abs(value - center)));
+  const scale = Math.max(1.4826 * mad, 0.25);
+  return scores.map((score) => {
+    if (typeof score !== "number" || !Number.isFinite(score) || score <= 0) return 0;
+    const z = Math.max(-6, Math.min(6, (Math.log(score) - center) / scale));
+    return 1 / (1 + Math.exp(-z));
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -2963,7 +2997,7 @@ function collapseWorldBookHitsBySource(
 export async function searchWorldBookEntriesHybridWithVector(
   userId: string,
   worldBookId: string,
-  queryText: string,
+  queryText: string | string[],
   vector: number[],
   requestedLimit = 8,
   hybridWeightMode?: EmbeddingConfig["hybrid_weight_mode"],
@@ -2973,7 +3007,10 @@ export async function searchWorldBookEntriesHybridWithVector(
   await ensureWorldBookVectorVersion(userId);
   if (signal?.aborted) return [];
 
-  const trimmedQuery = queryText.trim();
+  const lexicalQueries = (Array.isArray(queryText) ? queryText : [queryText])
+    .map((value) => value.trim())
+    .filter((value, index, values) => value.length > 0 && values.indexOf(value) === index);
+  const fallbackQuery = lexicalQueries[0] ?? "";
   const filter = ownerScope(userId, "world_book_entry", worldBookId);
   const finalLimit = Math.max(
     1,
@@ -2988,23 +3025,10 @@ export async function searchWorldBookEntriesHybridWithVector(
     : Math.min(200, Math.max(finalLimit * 3, finalLimit));
 
   const store = await getActiveVectorStore();
-  const nativeHybridSearch = store.hybridSearch?.bind(store);
-  const canUseNativeHybrid = !!nativeHybridSearch && !!trimmedQuery && hybridWeightMode !== "vector_first" && store.capabilities.nativeLexical;
   let vectorRows = await collectWorldBookHitsByUniqueSource(
     filter,
     candidateLimit,
-    (searchFilter) => canUseNativeHybrid
-      ? nativeHybridSearch({
-        collection: "embeddings_world_books",
-        vector,
-        queryText: trimmedQuery,
-        filter: searchFilter,
-        limit: candidateLimit,
-        withVector: false,
-        refine: true,
-        signal,
-      })
-      : store.vectorSearch({
+    (searchFilter) => store.vectorSearch({
         collection: "embeddings_world_books",
         vector,
         filter: searchFilter,
@@ -3016,77 +3040,13 @@ export async function searchWorldBookEntriesHybridWithVector(
     signal,
   );
 
-  if (vectorRows.length === 0 && canUseNativeHybrid && !signal?.aborted) {
-    try {
-      const denseFallbackRows = await collectWorldBookHitsByUniqueSource(
-        filter,
-        candidateLimit,
-        (searchFilter) => store.vectorSearch({
-          collection: "embeddings_world_books",
-          vector,
-          filter: searchFilter,
-          limit: candidateLimit,
-          withVector: false,
-          refine: true,
-          signal,
-        }),
-        signal,
-      );
-      if (denseFallbackRows.length > 0) {
-        let recoveredRows = denseFallbackRows;
-        if (trimmedQuery && store.capabilities.nativeLexical) {
-          const lexicalRows = await collectWorldBookHitsByUniqueSource(
-            filter,
-            candidateLimit,
-            (searchFilter) => store.lexicalSearch({
-              collection: "embeddings_world_books",
-              queryText: trimmedQuery,
-              filter: searchFilter,
-              limit: candidateLimit,
-              withVector: false,
-              signal,
-            }),
-            signal,
-          ).catch((err) => {
-            console.warn(
-              "[embeddings] WI lexical fallback failed after native hybrid miss for book=%s in provider=%s: %s",
-              worldBookId.slice(0, 8),
-              store.id,
-              err instanceof Error ? err.message : String(err),
-            );
-            return [] as VectorHit[];
-          });
-          recoveredRows = reciprocalRankFusion(
-            collapseWorldBookHitsBySource(denseFallbackRows, "similarity"),
-            collapseWorldBookHitsBySource(lexicalRows, "lexicalScore"),
-          ).slice(0, candidateLimit);
-        }
-        vectorRows = recoveredRows;
-        console.warn(
-          "[embeddings] WI vector search: native hybrid returned 0 rows for book=%s (provider=%s, limit=%d); dense fallback recovered %d row(s)",
-          worldBookId.slice(0, 8),
-          store.id,
-          finalLimit,
-          vectorRows.length,
-        );
-      }
-    } catch (err) {
-      console.warn(
-        "[embeddings] WI dense fallback failed after native hybrid miss for book=%s in provider=%s: %s",
-        worldBookId.slice(0, 8),
-        store.id,
-        err instanceof Error ? err.message : String(err),
-      );
-    }
-  }
-
   if (vectorRows.length === 0 && !signal?.aborted) {
     const fallback = await recoverWorldBookScopedRowsFromStore(
       store,
       filter,
       vector,
       candidateLimit,
-      trimmedQuery,
+      fallbackQuery,
       signal,
     );
 
@@ -3123,6 +3083,7 @@ export async function searchWorldBookEntriesHybridWithVector(
         entry_id: entryId,
         distance,
         lexical_score: existing?.lexical_score ?? null,
+        lexical_strength: existing?.lexical_strength ?? 0,
         content: String(row.content || ""),
         searchTextPreview: typeof metadata.search_text === "string" ? metadata.search_text : existing?.searchTextPreview || "",
         metadata: { ...(existing?.metadata ?? {}), ...metadata },
@@ -3130,23 +3091,30 @@ export async function searchWorldBookEntriesHybridWithVector(
     }
   }
 
-  if (!canUseNativeHybrid && trimmedQuery && hybridWeightMode !== "vector_first" && store.capabilities.nativeLexical && !signal?.aborted) {
-    try {
-      const lexicalRows = await collectWorldBookHitsByUniqueSource(
-        filter,
-        candidateLimit,
-        (searchFilter) => store.lexicalSearch({
-          collection: "embeddings_world_books",
-          queryText: trimmedQuery,
-          filter: searchFilter,
-          limit: candidateLimit,
-          withVector: false,
-          signal,
-        }),
-        signal,
-      );
+  if (lexicalQueries.length > 0 && hybridWeightMode !== "vector_first" && store.capabilities.nativeLexical && !signal?.aborted) {
+    for (const lexicalQuery of lexicalQueries) {
+      try {
+        const lexicalRows = collapseWorldBookHitsBySource(
+          await collectWorldBookHitsByUniqueSource(
+            filter,
+            candidateLimit,
+            (searchFilter) => store.lexicalSearch({
+              collection: "embeddings_world_books",
+              queryText: lexicalQuery,
+              filter: searchFilter,
+              limit: candidateLimit,
+              withVector: false,
+              signal,
+            }),
+            signal,
+          ),
+          "lexicalScore",
+        );
+        const strengths = normalizeBm25Scores(lexicalRows.map((row) => row.lexicalScore));
 
-      for (const row of lexicalRows) {
+        for (let index = 0; index < lexicalRows.length; index += 1) {
+          const row = lexicalRows[index];
+          const lexicalStrength = strengths[index] ?? 0;
         const entryId = String(row.source_id);
         const metadata = parseWorldBookEmbeddingMetadata(row.metadata_json);
         const lexicalScore = row.lexicalScore;
@@ -3156,6 +3124,7 @@ export async function searchWorldBookEntriesHybridWithVector(
           if (lexicalScore !== null && (existing.lexical_score === null || lexicalScore > existing.lexical_score)) {
             existing.lexical_score = lexicalScore;
           }
+          existing.lexical_strength = Math.max(existing.lexical_strength ?? 0, lexicalStrength);
           if (!existing.searchTextPreview && typeof metadata.search_text === "string") {
             existing.searchTextPreview = metadata.search_text;
           }
@@ -3170,25 +3139,32 @@ export async function searchWorldBookEntriesHybridWithVector(
             entry_id: entryId,
             distance: Number.POSITIVE_INFINITY,
             lexical_score: lexicalScore,
+            lexical_strength: lexicalStrength,
             content: String(row.content || ""),
             searchTextPreview: typeof metadata.search_text === "string" ? metadata.search_text : "",
             metadata,
           });
         }
-      }
-    } catch (err) {
-      if (!signal?.aborted && (err as any)?.name !== "AbortError") {
-        console.warn("[embeddings] World-book FTS candidate fetch failed:", err);
+        }
+      } catch (err) {
+        if (!signal?.aborted && (err as any)?.name !== "AbortError") {
+          console.warn("[embeddings] World-book FTS candidate fetch failed:", err);
+        }
       }
     }
   }
 
-  return Array.from(merged.values())
+  const rankedCandidates = Array.from(merged.values())
     .sort((a, b) => {
       if (a.distance !== b.distance) return a.distance - b.distance;
-      return (b.lexical_score ?? Number.NEGATIVE_INFINITY) - (a.lexical_score ?? Number.NEGATIVE_INFINITY);
-    })
-    .slice(0, finalLimit);
+      if ((b.lexical_strength ?? 0) !== (a.lexical_strength ?? 0)) {
+        return (b.lexical_strength ?? 0) - (a.lexical_strength ?? 0);
+      }
+      return a.entry_id.localeCompare(b.entry_id);
+    });
+  return options?.expandLimit === false
+    ? rankedCandidates
+    : rankedCandidates.slice(0, finalLimit);
 }
 
 async function recoverWorldBookScopedRowsFromStore(

--- a/src/services/prompt-assembly-vector-cache.test.ts
+++ b/src/services/prompt-assembly-vector-cache.test.ts
@@ -135,6 +135,7 @@ function retrievalResult(): VectorWorldInfoRetrievalResult {
     }],
     candidateTrace: [],
     queryPreview: "where is alpha",
+    lexicalQueryPreviews: [],
     eligibleCount: 1,
     hitsBeforeThreshold: 1,
     hitsAfterThreshold: 1,

--- a/src/services/prompt-assembly.service.ts
+++ b/src/services/prompt-assembly.service.ts
@@ -107,6 +107,7 @@ import * as regexScriptsSvc from "./regex-scripts.service";
 import { createPromptAssemblyProfiler } from "./prompt-assembly-profiler";
 import { rankVectorWorldInfoCandidatesInWorker } from "./world-info-vector-ranking-worker-host";
 import {
+  buildWorldInfoLexicalQueryBatches,
   getWorldInfoVectorCandidateRecallLimit,
   type VectorActivatedEntry,
   type VectorRetrievalTraceEntry,
@@ -4080,6 +4081,7 @@ export async function collectVectorActivatedWorldInfoDetailed(
     entries: [],
     candidateTrace: [],
     queryPreview: "",
+    lexicalQueryPreviews: [],
     eligibleCount: 0,
     hitsBeforeThreshold: 0,
     hitsAfterThreshold: 0,
@@ -4121,6 +4123,10 @@ export async function collectVectorActivatedWorldInfoDetailed(
   );
   const queryBuildMs = performance.now() - queryBuildStartedAt;
   const eligibleEntries = entries.filter(isVectorEligibleWorldInfoEntry);
+  const lexicalQueryPreviews = buildWorldInfoLexicalQueryBatches(
+    queryText,
+    eligibleEntries,
+  );
 
   // Check short-TTL cache for rapid dry-run reuse. Hash the complete retrieval
   // snapshot so same-length lore edits, activation fields, index commits, and
@@ -4168,6 +4174,7 @@ export async function collectVectorActivatedWorldInfoDetailed(
     const result = {
       ...emptyResult,
       queryPreview: queryText,
+      lexicalQueryPreviews,
       eligibleCount: eligibleEntries.length,
       topK,
       cap: topK,
@@ -4216,6 +4223,7 @@ export async function collectVectorActivatedWorldInfoDetailed(
       const result = {
         ...emptyResult,
         queryPreview: queryText,
+        lexicalQueryPreviews,
         eligibleCount: eligibleEntries.length,
         topK,
         cap: topK,
@@ -4266,7 +4274,7 @@ export async function collectVectorActivatedWorldInfoDetailed(
             const value = await embeddingsSvc.searchWorldBookEntriesHybridWithVector(
               userId,
               worldBookIds[i],
-              queryText,
+              lexicalQueryPreviews.map((batch) => batch.text),
               queryVector,
               candidateLimit,
               cfg.hybrid_weight_mode,
@@ -4334,6 +4342,7 @@ export async function collectVectorActivatedWorldInfoDetailed(
       entries: shortlistedEntries,
       candidateTrace,
       queryPreview: queryText,
+      lexicalQueryPreviews,
       eligibleCount: eligibleEntries.length,
       hitsBeforeThreshold,
       hitsAfterThreshold,
@@ -4361,6 +4370,7 @@ export async function collectVectorActivatedWorldInfoDetailed(
     return {
       ...emptyResult,
       queryPreview: queryText,
+      lexicalQueryPreviews,
       eligibleCount: eligibleEntries.length,
       topK,
       cap: topK,

--- a/src/services/world-info-vector-ranking.test.ts
+++ b/src/services/world-info-vector-ranking.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test";
+import type { WorldBookEntry } from "../types/world-book";
+import { normalizeBm25Scores } from "./embeddings.service";
+import {
+  buildWorldInfoLexicalQueryBatches,
+  rankVectorWorldInfoCandidates,
+  type VectorCandidatePoolEntry,
+} from "./world-info-vector-ranking";
+
+let entryCounter = 0;
+function makeEntry(overrides: Partial<WorldBookEntry>): WorldBookEntry {
+  entryCounter += 1;
+  return {
+    id: overrides.id ?? `entry-${entryCounter}`,
+    world_book_id: "book-a",
+    uid: overrides.uid ?? `uid-${entryCounter}`,
+    outlet_name: null,
+    wi_marker: null,
+    wi_marker_side: null,
+    key: [],
+    keysecondary: [],
+    content: `Synthetic lore ${entryCounter}`,
+    comment: "",
+    position: 0,
+    depth: 4,
+    role: null,
+    order_value: 100,
+    selective: false,
+    constant: false,
+    disabled: false,
+    group_name: "",
+    group_override: false,
+    group_weight: 100,
+    probability: 100,
+    scan_depth: null,
+    case_sensitive: false,
+    match_whole_words: false,
+    automation_id: null,
+    use_regex: false,
+    prevent_recursion: false,
+    exclude_recursion: false,
+    delay_until_recursion: false,
+    priority: 10,
+    sticky: 0,
+    cooldown: 0,
+    delay: 0,
+    selective_logic: 0,
+    use_probability: true,
+    vectorized: true,
+    vector_index_status: "indexed",
+    vector_indexed_at: 0,
+    vector_index_error: null,
+    extensions: {},
+    created_at: 0,
+    updated_at: 0,
+    ...overrides,
+  };
+}
+
+function candidate(
+  entry: WorldBookEntry,
+  distance: number,
+  lexicalScore: number,
+  lexicalStrength: number,
+): VectorCandidatePoolEntry {
+  return {
+    entry,
+    candidate: {
+      entry_id: entry.id,
+      distance,
+      lexical_score: lexicalScore,
+      lexical_strength: lexicalStrength,
+      content: entry.content,
+      searchTextPreview: entry.content,
+      metadata: { comment: entry.comment },
+    },
+  };
+}
+
+describe("normalizeBm25Scores", () => {
+  test("is bounded and exactly invariant under uniform positive scaling", () => {
+    const scores = [1, 1.5, 2.5, 4, 8, 16, null, 0];
+    const base = normalizeBm25Scores(scores);
+    const scaled = normalizeBm25Scores(
+      scores.map((score) => (typeof score === "number" ? score * 97 : score)),
+    );
+
+    expect(base.every((value) => value >= 0 && value <= 1)).toBe(true);
+    base.forEach((value, index) => expect(scaled[index]).toBeCloseTo(value, 12));
+    expect(base.at(-2)).toBe(0);
+    expect(base.at(-1)).toBe(0);
+  });
+
+  test("keeps existing ordering stable under isolated extreme outliers", () => {
+    const scores = [1, 1.4, 2, 2.8, 4, 5.6, 8, 11.2, 16, 22.4, 32, 44.8];
+    const base = normalizeBm25Scores(scores);
+    const withOutliers = normalizeBm25Scores([1e-12, ...scores, 1e12]).slice(1, -1);
+
+    for (let index = 1; index < withOutliers.length; index += 1) {
+      expect(withOutliers[index]).toBeGreaterThan(withOutliers[index - 1]);
+    }
+    base.forEach((value, index) => {
+      expect(Math.abs(withOutliers[index] - value)).toBeLessThanOrEqual(0.05);
+    });
+  });
+});
+
+describe("buildWorldInfoLexicalQueryBatches", () => {
+  test("packs sanitized anchors before topical terms without truncating them", () => {
+    const entries = [
+      makeEntry({ comment: 'Aster (OR) "Vale"' }),
+      makeEntry({ comment: "Mira Sol" }),
+      makeEntry({ key: ["Council:Founders"], comment: "Founders Accord" }),
+    ];
+    const query = `${"old scenery ".repeat(20)} Aster Vale met Mira Sol and Council Founders. `
+      + `Recent topic: succession, schism, reconciliation, observatory.`;
+    const batches = buildWorldInfoLexicalQueryBatches(query, entries, 28);
+    const combined = batches.map((batch) => batch.text).join(" ");
+
+    expect(batches.length).toBeGreaterThan(1);
+    expect(batches.every((batch) => batch.text.length <= 28)).toBe(true);
+    for (const anchor of ["aster", "vale", "mira", "sol", "council", "founders"]) {
+      expect(combined.split(" ")).toContain(anchor);
+    }
+    expect(combined).not.toMatch(/["():*\\]/);
+    expect(combined.split(" ")).not.toContain("or");
+    expect(combined.indexOf("founders")).toBeLessThan(combined.indexOf("observatory"));
+  });
+});
+
+describe("per-mention canonical ownership", () => {
+  test("gates only mention bonuses while preserving independent relevance", () => {
+    const arden = makeEntry({ comment: "Arden Vale", content: "Arden chairs the expedition." });
+    const residence = makeEntry({ comment: "Vale Residence", content: "A private house near the observatory." });
+    const mira = makeEntry({ comment: "Mira Sol", content: "Mira is the expedition navigator." });
+    const affection = makeEntry({ comment: '"Darling" (Mira Affection)', content: "A nickname Mira sometimes uses." });
+    const generic = makeEntry({ comment: "Spirit Protocol", content: "A broad emergency protocol." });
+    const aiName = makeEntry({ comment: "Ai Rowan", content: "Ai is an unrelated student." });
+    const support = makeEntry({ comment: "Founders Accord", content: "The founders split after the succession schism." });
+    const entries = [arden, residence, mira, affection, generic, aiName, support];
+    const pooled = [
+      candidate(arden, 0.44, 30, 0.7),
+      candidate(residence, 0.31, 80, 0.8),
+      candidate(mira, 0.39, 35, 0.72),
+      candidate(affection, 0.67, 60, 0.76),
+      candidate(generic, 0.58, 55, 0.7),
+      candidate(aiName, 0.64, 58, 0.72),
+      candidate(support, 0.28, 22, 0.62),
+    ];
+    const result = rankVectorWorldInfoCandidates({
+      eligibleEntries: entries,
+      pooledCandidates: pooled,
+      queryText: "Arden Vale briefed Mira and the ship AI about spirits and the founders' succession schism.",
+      hybridWeightMode: "balanced",
+      similarityThreshold: 0,
+      rerankCutoff: 0,
+      topK: 20,
+    });
+    const byName = new Map(result.shortlistedEntries.map((item) => [item.entry.comment, item]));
+
+    expect(byName.get("Arden Vale")!.scoreBreakdown.commentExact).toBeGreaterThan(0);
+    expect(byName.get("Vale Residence")!.scoreBreakdown.commentPartial).toBe(0);
+    expect(byName.get("Vale Residence")!.scoreBreakdown.focusBoost).toBe(0);
+    expect(byName.get("Mira Sol")!.scoreBreakdown.commentPartial).toBeGreaterThan(0);
+    expect(byName.get('"Darling" (Mira Affection)')!.scoreBreakdown.commentPartial).toBe(0);
+    expect(byName.get("Spirit Protocol")!.scoreBreakdown.commentPartial).toBe(0);
+    expect(byName.get("Spirit Protocol")!.scoreBreakdown.focusBoost).toBe(0);
+    expect(byName.get("Ai Rowan")!.scoreBreakdown.commentPartial).toBe(0);
+
+    // Non-owners still retain ordinary vector and independent lexical evidence.
+    expect(byName.get("Vale Residence")!.scoreBreakdown.vectorSimilarity).toBeGreaterThan(0);
+    expect(byName.get("Vale Residence")!.scoreBreakdown.lexicalContentBoost).toBeGreaterThan(0);
+    expect(byName.get("Founders Accord")!.scoreBreakdown.vectorSimilarity).toBeGreaterThan(0);
+    expect(byName.get("Founders Accord")!.finalScore).toBeGreaterThan(
+      byName.get('"Darling" (Mira Affection)')!.finalScore,
+    );
+
+    const weakestRelevant = Math.min(
+      byName.get("Arden Vale")!.finalScore,
+      byName.get("Mira Sol")!.finalScore,
+      byName.get("Founders Accord")!.finalScore,
+    );
+    const strongestAssociative = Math.max(
+      byName.get("Vale Residence")!.finalScore,
+      byName.get('"Darling" (Mira Affection)')!.finalScore,
+      byName.get("Spirit Protocol")!.finalScore,
+      byName.get("Ai Rowan")!.finalScore,
+    );
+    expect(weakestRelevant).toBeGreaterThan(strongestAssociative);
+  });
+});

--- a/src/services/world-info-vector-ranking.ts
+++ b/src/services/world-info-vector-ranking.ts
@@ -32,6 +32,7 @@ interface QueryTokenSignal {
   count: number;
   hasNameLikeForm: boolean;
   hasUppercaseForm: boolean;
+  hasTitleCaseForm: boolean;
 }
 
 interface VectorQueryLexicalState {
@@ -40,6 +41,30 @@ interface VectorQueryLexicalState {
   queryTokenSignals: Map<string, QueryTokenSignal>;
   focusTokenSet: Set<string>;
   specificityState: PhraseSpecificityState;
+  mentionOwnership: MentionOwnershipState | null;
+}
+
+export type WorldInfoLexicalQueryBatchKind = "anchors" | "mixed" | "topical";
+
+export interface WorldInfoLexicalQueryBatch {
+  kind: WorldInfoLexicalQueryBatchKind;
+  text: string;
+}
+
+interface DetectedMention {
+  start: number;
+  end: number;
+  normalizedText: string;
+  kind: "exact" | "partial";
+  candidateEntryIds: string[];
+  ownerEntryId: string | null;
+}
+
+interface MentionOwnershipState {
+  mentions: DetectedMention[];
+  exactValuesByEntryId: Map<string, Set<string>>;
+  partialTokensByEntryId: Map<string, Set<string>>;
+  focusTokensByEntryId: Map<string, Set<string>>;
 }
 
 export interface VectorScoreBreakdown {
@@ -118,6 +143,7 @@ export interface VectorWorldInfoRetrievalResult {
   entries: VectorActivatedEntry[];
   candidateTrace: VectorRetrievalTraceEntry[];
   queryPreview: string;
+  lexicalQueryPreviews: WorldInfoLexicalQueryBatch[];
   eligibleCount: number;
   hitsBeforeThreshold: number;
   hitsAfterThreshold: number;
@@ -218,6 +244,15 @@ const WORLD_INFO_FOCUS_GENERIC_TOKENS = new Set([
   "rules",
   "rule",
 ]);
+
+const WORLD_INFO_FTS_RESERVED_TOKENS = new Set([
+  "and",
+  "or",
+  "not",
+  "near",
+]);
+
+export const WORLD_INFO_FTS_QUERY_MAX_CHARS = 4096;
 
 const WORLD_INFO_REFERENCE_TITLE_KEYWORDS = new Set([
   "relationship",
@@ -361,8 +396,9 @@ function buildPhraseSpecificityState(
 
 function normalizeLexicalText(text: string): string {
   return text
+    .normalize("NFKC")
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
     .replace(/\s+/g, " ")
     .trim();
 }
@@ -373,6 +409,103 @@ function tokenizeLexicalText(text: string): string[] {
     .filter(
       (token) => token.length > 1 && !WORLD_INFO_VECTOR_STOPWORDS.has(token),
     );
+}
+
+function tokenizeSafeFtsText(text: string): string[] {
+  return (text.normalize("NFKC").match(/[\p{L}\p{N}]+/gu) ?? [])
+    .map((token) => token.toLowerCase())
+    .filter(
+      (token) =>
+        token.length > 1 &&
+        !WORLD_INFO_VECTOR_STOPWORDS.has(token) &&
+        !WORLD_INFO_FTS_RESERVED_TOKENS.has(token),
+    );
+}
+
+function getEntryAnchors(entry: WorldBookEntryModel): string[] {
+  return dedupeStringsCaseInsensitive([
+    ...(entry.key || []),
+    ...(entry.keysecondary || []),
+    entry.comment || "",
+  ]);
+}
+
+function appendLexicalBatchTerm(
+  batches: WorldInfoLexicalQueryBatch[],
+  term: string,
+  kind: "anchors" | "topical",
+  maxChars: number,
+): void {
+  if (!term || term.length > maxChars) return;
+  const current = batches[batches.length - 1];
+  const nextText = current?.text ? `${current.text} ${term}` : term;
+  if (!current || nextText.length > maxChars) {
+    batches.push({ kind, text: term });
+    return;
+  }
+  current.text = nextText;
+  if (current.kind !== kind) current.kind = "mixed";
+}
+
+/**
+ * Build parser-safe lexical query batches without allowing topical text to
+ * crowd explicit title/key anchors out of the provider's query limit.
+ */
+export function buildWorldInfoLexicalQueryBatches(
+  queryText: string,
+  entries: WorldBookEntryModel[],
+  maxChars = WORLD_INFO_FTS_QUERY_MAX_CHARS,
+): WorldInfoLexicalQueryBatch[] {
+  const normalizedQuery = normalizeLexicalText(queryText);
+  if (!normalizedQuery || maxChars < 1) return [];
+
+  const querySignals = buildQueryTokenSignals(queryText);
+  const anchorTerms: string[] = [];
+  const anchorTermSet = new Set<string>();
+  const appendAnchorTokens = (tokens: string[]) => {
+    for (const token of tokens) {
+      if (anchorTermSet.has(token)) continue;
+      anchorTermSet.add(token);
+      anchorTerms.push(token);
+    }
+  };
+
+  for (const entry of entries) {
+    for (const anchor of getEntryAnchors(entry)) {
+      const tokens = tokenizeSafeFtsText(anchor);
+      if (tokens.length === 0) continue;
+      const exact = hasExactPhraseMatch(normalizedQuery, anchor);
+      const mentionedTokens = tokens.filter((token) => {
+        if (WORLD_INFO_FOCUS_GENERIC_TOKENS.has(token)) return false;
+        const signal = querySignals.get(token);
+        return !!signal && (signal.hasNameLikeForm || signal.hasUppercaseForm);
+      });
+      if (exact) appendAnchorTokens(tokens);
+      else appendAnchorTokens(mentionedTokens);
+    }
+  }
+
+  const topicalTerms: string[] = [];
+  const topicalTermSet = new Set(anchorTermSet);
+  // Prefer the newest topical evidence while retaining anchors from the full
+  // context. Reverse/dedupe/reverse keeps the last occurrence of each term.
+  const recentTokens = tokenizeSafeFtsText(queryText.slice(-maxChars));
+  for (let index = recentTokens.length - 1; index >= 0; index -= 1) {
+    const token = recentTokens[index];
+    if (topicalTermSet.has(token)) continue;
+    topicalTermSet.add(token);
+    topicalTerms.push(token);
+  }
+  topicalTerms.reverse();
+
+  const batches: WorldInfoLexicalQueryBatch[] = [];
+  for (const term of anchorTerms) {
+    appendLexicalBatchTerm(batches, term, "anchors", maxChars);
+  }
+  for (const term of topicalTerms) {
+    appendLexicalBatchTerm(batches, term, "topical", maxChars);
+  }
+  return batches;
 }
 
 function dedupeStringsCaseInsensitive(values: string[]): string[] {
@@ -713,7 +846,7 @@ function buildQueryTokenSignals(
   queryText: string,
 ): Map<string, QueryTokenSignal> {
   const queryTokenSignals = new Map<string, QueryTokenSignal>();
-  for (const match of queryText.matchAll(/\b[A-Za-z0-9]+\b/g)) {
+  for (const match of queryText.normalize("NFKC").matchAll(/[\p{L}\p{N}]+/gu)) {
     const rawToken = match[0];
     const normalizedToken = normalizeLexicalText(rawToken);
     if (
@@ -728,17 +861,25 @@ function buildQueryTokenSignals(
       count: 0,
       hasNameLikeForm: false,
       hasUppercaseForm: false,
+      hasTitleCaseForm: false,
     };
+    const hasCasedLetter = rawToken.toLowerCase() !== rawToken.toUpperCase();
     const isUppercaseForm =
-      /[A-Z]/.test(rawToken) && rawToken === rawToken.toUpperCase();
+      hasCasedLetter && rawToken === rawToken.toUpperCase();
+    const first = Array.from(rawToken)[0] ?? "";
+    const isTitleCaseForm =
+      first.toUpperCase() === first &&
+      first.toLowerCase() !== first &&
+      rawToken !== rawToken.toUpperCase();
     const isNameLikeForm =
-      /^[A-Z][a-z0-9]+$/.test(rawToken) ||
+      isTitleCaseForm ||
       (isUppercaseForm && normalizedToken.length >= 3);
 
     queryTokenSignals.set(normalizedToken, {
       count: previous.count + 1,
       hasNameLikeForm: previous.hasNameLikeForm || isNameLikeForm,
       hasUppercaseForm: previous.hasUppercaseForm || isUppercaseForm,
+      hasTitleCaseForm: previous.hasTitleCaseForm || isTitleCaseForm,
     });
   }
 
@@ -815,8 +956,12 @@ function getEntryFocusOverlap(
   }
 
   const matchedSpecificities: number[] = [];
+  const ownedFocusTokens = queryState.mentionOwnership?.focusTokensByEntryId.get(
+    entry.id,
+  );
   for (const token of entryTokens) {
     if (!queryState.focusTokenSet.has(token)) continue;
+    if (queryState.mentionOwnership && !ownedFocusTokens?.has(token)) continue;
     matchedSpecificities.push(
       getTokenSpecificity(queryState.specificityState, token),
     );
@@ -916,6 +1061,7 @@ function getEntrySubjectMismatchPenalty(
 }
 
 function scorePhraseMatches(
+  entryId: string,
   values: string[],
   queryState: VectorQueryLexicalState,
   exactWeight: number,
@@ -946,20 +1092,34 @@ function scorePhraseMatches(
     bestSpecificity = Math.max(bestSpecificity, specificity);
 
     if (hasExactPhraseMatch(queryState.normalizedText, value)) {
-      exactSpecificities.push(specificity);
       matchedValues.push(value);
-      matchedSpecificity = Math.max(matchedSpecificity, specificity);
+      const ownsExact =
+        !queryState.mentionOwnership ||
+        queryState.mentionOwnership.exactValuesByEntryId
+          .get(entryId)
+          ?.has(normalizeLexicalText(value));
+      if (ownsExact) {
+        exactSpecificities.push(specificity);
+        matchedSpecificity = Math.max(matchedSpecificity, specificity);
+      }
       continue;
     }
+
+    const ownedPartialTokens = queryState.mentionOwnership?.partialTokensByEntryId.get(entryId);
+    const ownsPartial =
+      !queryState.mentionOwnership ||
+      tokenizeLexicalText(value).some((token) => ownedPartialTokens?.has(token));
 
     const overlap = getPhraseTokenOverlap(queryState.tokenSet, value);
     if (overlap >= getPartialMatchThreshold(value, kind)) {
       matchedValues.push(value);
-      matchedSpecificity = Math.max(matchedSpecificity, specificity);
-      partialScore = Math.max(
-        partialScore,
-        overlap * specificity * partialWeight,
-      );
+      if (ownsPartial) {
+        matchedSpecificity = Math.max(matchedSpecificity, specificity);
+        partialScore = Math.max(
+          partialScore,
+          overlap * specificity * partialWeight,
+        );
+      }
       continue;
     }
 
@@ -972,8 +1132,10 @@ function scorePhraseMatches(
     if (rareTokenPartialScore <= 0) continue;
 
     matchedValues.push(value);
-    matchedSpecificity = Math.max(matchedSpecificity, specificity);
-    partialScore = Math.max(partialScore, rareTokenPartialScore);
+    if (ownsPartial) {
+      matchedSpecificity = Math.max(matchedSpecificity, specificity);
+      partialScore = Math.max(partialScore, rareTokenPartialScore);
+    }
   }
 
   exactSpecificities.sort((a, b) => b - a);
@@ -1009,6 +1171,7 @@ function buildVectorQueryLexicalState(
       queryTokenSignals,
     ),
     specificityState,
+    mentionOwnership: null,
   };
 }
 
@@ -1087,6 +1250,7 @@ function buildExactAnchorCandidate(
     entry_id: entry.id,
     distance: Number.POSITIVE_INFINITY,
     lexical_score: EXACT_ANCHOR_LEXICAL_SCORE,
+    lexical_strength: 0.5,
     content: entry.content || "",
     searchTextPreview,
     metadata: {
@@ -1133,6 +1297,10 @@ function augmentPooledCandidatesWithExactAnchors(
       candidate: {
         ...existing.candidate,
         lexical_score,
+        lexical_strength: Math.max(
+          existing.candidate.lexical_strength ?? 0,
+          exactCandidate.lexical_strength ?? 0,
+        ),
         content: existing.candidate.content || exactCandidate.content,
         searchTextPreview:
           existing.candidate.searchTextPreview || exactCandidate.searchTextPreview,
@@ -1148,6 +1316,200 @@ function augmentPooledCandidatesWithExactAnchors(
   }
 
   return Array.from(byEntryId.values());
+}
+
+type EntryAnchorKind = "primary" | "secondary" | "comment";
+
+interface EntryAnchorRecord {
+  entry: WorldBookEntryModel;
+  kind: EntryAnchorKind;
+  value: string;
+  normalizedValue: string;
+  tokens: string[];
+  rawTokens: string[];
+}
+
+function buildEntryAnchorRecords(entries: WorldBookEntryModel[]): EntryAnchorRecord[] {
+  const records: EntryAnchorRecord[] = [];
+  for (const entry of entries) {
+    const append = (kind: EntryAnchorKind, values: string[]) => {
+      for (const value of dedupeStringsCaseInsensitive(values)) {
+        const normalizedValue = normalizeLexicalText(value);
+        const tokens = tokenizeLexicalText(value);
+        const rawTokens = value.normalize("NFKC").match(/[\p{L}\p{N}]+/gu) ?? [];
+        if (!normalizedValue || tokens.length === 0) continue;
+        records.push({ entry, kind, value, normalizedValue, tokens, rawTokens });
+      }
+    };
+    append("primary", entry.key || []);
+    append("secondary", entry.keysecondary || []);
+    append("comment", [entry.comment || ""]);
+  }
+  return records;
+}
+
+function anchorMatchQuality(kind: EntryAnchorKind, exact: boolean): number {
+  const kindScore = kind === "primary" ? 3 : kind === "secondary" ? 2 : 1;
+  return (exact ? 10 : 0) + kindScore;
+}
+
+function addOwnedValue(
+  map: Map<string, Set<string>>,
+  entryId: string,
+  value: string,
+): void {
+  const values = map.get(entryId) ?? new Set<string>();
+  values.add(value);
+  map.set(entryId, values);
+}
+
+function buildMentionOwnershipState(
+  queryText: string,
+  eligibleEntries: WorldBookEntryModel[],
+  candidates: VectorCandidatePoolEntry[],
+  specificityState: PhraseSpecificityState,
+): MentionOwnershipState {
+  const candidateByEntryId = new Map(
+    candidates.map((item) => [item.entry.id, item.candidate]),
+  );
+  const candidateIds = new Set(candidateByEntryId.keys());
+  const records = buildEntryAnchorRecords(eligibleEntries).filter((record) =>
+    candidateIds.has(record.entry.id),
+  );
+  const normalizedQuery = normalizeLexicalText(queryText);
+  const querySignals = buildQueryTokenSignals(queryText);
+  const mentions: DetectedMention[] = [];
+  const exactValuesByEntryId = new Map<string, Set<string>>();
+  const partialTokensByEntryId = new Map<string, Set<string>>();
+  const focusTokensByEntryId = new Map<string, Set<string>>();
+
+  const resolve = (
+    start: number,
+    end: number,
+    normalizedText: string,
+    kind: "exact" | "partial",
+    matchingRecords: EntryAnchorRecord[],
+  ) => {
+    const bestRecordByEntryId = new Map<string, EntryAnchorRecord>();
+    for (const record of matchingRecords) {
+      const existing = bestRecordByEntryId.get(record.entry.id);
+      if (
+        !existing ||
+        anchorMatchQuality(record.kind, kind === "exact") >
+          anchorMatchQuality(existing.kind, kind === "exact")
+      ) {
+        bestRecordByEntryId.set(record.entry.id, record);
+      }
+    }
+    const ranked = Array.from(bestRecordByEntryId.values()).sort((a, b) => {
+      const qualityDelta =
+        anchorMatchQuality(b.kind, kind === "exact") -
+        anchorMatchQuality(a.kind, kind === "exact");
+      if (qualityDelta !== 0) return qualityDelta;
+      const aCandidate = candidateByEntryId.get(a.entry.id)!;
+      const bCandidate = candidateByEntryId.get(b.entry.id)!;
+      const aFinite = Number.isFinite(aCandidate.distance);
+      const bFinite = Number.isFinite(bCandidate.distance);
+      if (aFinite !== bFinite) return aFinite ? -1 : 1;
+      if (aFinite && aCandidate.distance !== bCandidate.distance) {
+        return aCandidate.distance - bCandidate.distance;
+      }
+      const lexicalDelta =
+        (bCandidate.lexical_strength ?? 0) -
+        (aCandidate.lexical_strength ?? 0);
+      if (lexicalDelta !== 0) return lexicalDelta;
+      const specificityDelta =
+        getPhraseSpecificity(specificityState, b.value) -
+        getPhraseSpecificity(specificityState, a.value);
+      if (specificityDelta !== 0) return specificityDelta;
+      if (a.entry.priority !== b.entry.priority) {
+        return b.entry.priority - a.entry.priority;
+      }
+      if (a.entry.order_value !== b.entry.order_value) {
+        return a.entry.order_value - b.entry.order_value;
+      }
+      return a.entry.id.localeCompare(b.entry.id);
+    });
+    const owner = ranked[0] ?? null;
+    mentions.push({
+      start,
+      end,
+      normalizedText,
+      kind,
+      candidateEntryIds: ranked.map((record) => record.entry.id),
+      ownerEntryId: owner?.entry.id ?? null,
+    });
+    if (!owner) return;
+    if (kind === "exact") {
+      addOwnedValue(exactValuesByEntryId, owner.entry.id, owner.normalizedValue);
+      for (const token of owner.tokens) {
+        addOwnedValue(focusTokensByEntryId, owner.entry.id, token);
+      }
+    } else {
+      addOwnedValue(partialTokensByEntryId, owner.entry.id, normalizedText);
+      addOwnedValue(focusTokensByEntryId, owner.entry.id, normalizedText);
+    }
+  };
+
+  const exactGroups = new Map<string, EntryAnchorRecord[]>();
+  for (const record of records) {
+    if (!hasExactPhraseMatch(normalizedQuery, record.value)) continue;
+    const group = exactGroups.get(record.normalizedValue) ?? [];
+    group.push(record);
+    exactGroups.set(record.normalizedValue, group);
+  }
+  for (const [phrase, matchingRecords] of exactGroups) {
+    let fromIndex = 0;
+    while (fromIndex < normalizedQuery.length) {
+      const padded = ` ${normalizedQuery} `;
+      const found = padded.indexOf(` ${phrase} `, fromIndex);
+      if (found < 0) break;
+      const start = Math.max(0, found - 1);
+      resolve(start, start + phrase.length, phrase, "exact", matchingRecords);
+      fromIndex = found + phrase.length + 1;
+    }
+  }
+
+  for (const match of normalizedQuery.matchAll(/[\p{L}\p{N}]+/gu)) {
+    const token = match[0];
+    if (WORLD_INFO_FOCUS_GENERIC_TOKENS.has(token)) continue;
+    const signal = querySignals.get(token);
+    if (!signal || (!signal.hasNameLikeForm && !signal.hasUppercaseForm)) continue;
+    const acronymOnlyMention =
+      token.length <= 3 &&
+      signal.hasUppercaseForm &&
+      !signal.hasTitleCaseForm;
+    const matchingRecords = records.filter((record) => {
+      if (!record.tokens.includes(token)) return false;
+      if (!acronymOnlyMention) return true;
+      return record.rawTokens.some(
+        (rawToken) =>
+          normalizeLexicalText(rawToken) === token &&
+          rawToken === rawToken.toUpperCase(),
+      );
+    });
+    if (matchingRecords.length === 0) continue;
+    const start = match.index ?? 0;
+    const end = start + token.length;
+    if (
+      mentions.some(
+        (mention) =>
+          mention.kind === "exact" &&
+          start >= mention.start &&
+          end <= mention.end,
+      )
+    ) {
+      continue;
+    }
+    resolve(start, end, token, "partial", matchingRecords);
+  }
+
+  return {
+    mentions,
+    exactValuesByEntryId,
+    partialTokensByEntryId,
+    focusTokensByEntryId,
+  };
 }
 
 function getExactTitleAnchorBoost(
@@ -1172,9 +1534,9 @@ function getLexicalContentBoostScale(
     primaryMatches.partialScore > 0 ||
     secondaryMatches.partialScore > 0 ||
     rawCommentMatches.partialScore > 0;
-  if (hasPartialAnchor) return 0.22;
+  if (hasPartialAnchor) return 0.15;
 
-  return 0.18;
+  return 0.08;
 }
 
 function getActiveTitleTokenBoost(
@@ -1226,6 +1588,7 @@ function scoreVectorWorldInfoCandidate(
   preset: WorldInfoVectorRankingPreset,
 ): VectorActivatedEntry {
   const primaryMatches = scorePhraseMatches(
+    entry.id,
     entry.key || [],
     queryState,
     preset.weights.primaryExact,
@@ -1233,6 +1596,7 @@ function scoreVectorWorldInfoCandidate(
     "key",
   );
   const secondaryMatches = scorePhraseMatches(
+    entry.id,
     entry.keysecondary || [],
     queryState,
     preset.weights.secondaryExact,
@@ -1243,6 +1607,7 @@ function scoreVectorWorldInfoCandidate(
   const comment = (entry.comment || "").trim();
   const rawCommentMatches = comment
     ? scorePhraseMatches(
+        entry.id,
         [comment],
         queryState,
         preset.weights.commentExact,
@@ -1297,8 +1662,8 @@ function scoreVectorWorldInfoCandidate(
     rawCommentMatches,
   );
   const lexicalContentBoost =
-    candidate.lexical_score != null && candidate.lexical_score > 0
-      ? clamp01(Math.log1p(candidate.lexical_score) / Math.log1p(30)) *
+    (candidate.lexical_strength ?? 0) > 0
+      ? clamp01(candidate.lexical_strength ?? 0) *
         preset.weights.vector *
         lexicalContentBoostScale
       : 0;
@@ -1308,12 +1673,8 @@ function scoreVectorWorldInfoCandidate(
     secondaryMatches.matchedSpecificity,
     commentMatches.matchedSpecificity,
   );
-  const entrySpecificityAnchor = Math.max(
-    lexicalSpecificityAnchor,
-    commentMatches.bestSpecificity * 0.7,
-    primaryMatches.bestSpecificity * 0.45,
-    secondaryMatches.bestSpecificity * 0.35,
-  );
+  // Unmatched anchor specificity must not make a broad entry look focused.
+  const entrySpecificityAnchor = lexicalSpecificityAnchor;
   const lexicalSignalStrength =
     primaryExactScore +
     primaryPartialScore +
@@ -1423,6 +1784,12 @@ export function rankVectorWorldInfoCandidates(
     eligibleEntries,
     pooledCandidates,
     queryState,
+  );
+  queryState.mentionOwnership = buildMentionOwnershipState(
+    queryText,
+    eligibleEntries,
+    augmentedCandidates,
+    specificityState,
   );
   const hitsBeforeThreshold = augmentedCandidates.length;
   const scoredCandidates = augmentedCandidates.map(({ entry, candidate }) =>


### PR DESCRIPTION
This pull request introduces enhanced support for lexical query previews in the World Book diagnostics and retrieval system. The main improvements include generating and displaying detailed lexical query batches, normalizing lexical evidence scores, and updating the retrieval ranking logic to use these normalized scores. The changes affect both the backend (retrieval and scoring) and frontend (diagnostics display).

**Lexical Query Preview and Diagnostics Enhancements**

* Added `lexical_query_previews` to the World Book diagnostics API response and UI, showing detailed batch queries and their types in the diagnostics modal. [[1]](diffhunk://#diff-91601647bcbeae35841528706cb70328f00e1be1147e0051e92a3f202bc7edb2R871-R874) [[2]](diffhunk://#diff-9b87a2c92f60b07c686b68288480ec41972dc6eb6a885167afe07b320407d164R552-R559) [[3]](diffhunk://#diff-9b87a2c92f60b07c686b68288480ec41972dc6eb6a885167afe07b320407d164R944-R950) [[4]](diffhunk://#diff-f5221d0e77705a4cd910b5ea81edef9899a13be16723fd80b4a7ae0740129832R686) [[5]](diffhunk://#diff-20f3fd805092b3c65647cc031b128c8b36885d0681e61d74316db77682ef12d2R4126-R4129) [[6]](diffhunk://#diff-20f3fd805092b3c65647cc031b128c8b36885d0681e61d74316db77682ef12d2R4177) [[7]](diffhunk://#diff-20f3fd805092b3c65647cc031b128c8b36885d0681e61d74316db77682ef12d2R4226) [[8]](diffhunk://#diff-20f3fd805092b3c65647cc031b128c8b36885d0681e61d74316db77682ef12d2R4345) [[9]](diffhunk://#diff-20f3fd805092b3c65647cc031b128c8b36885d0681e61d74316db77682ef12d2R4373) [[10]](diffhunk://#diff-20f3fd805092b3c65647cc031b128c8b36885d0681e61d74316db77682ef12d2R4084) [[11]](diffhunk://#diff-f5221d0e77705a4cd910b5ea81edef9899a13be16723fd80b4a7ae0740129832R524) [[12]](diffhunk://#diff-dda0196ae7552c9741ab8d3ab651ebed585b13248403624acad8d6a5b9d80bffR138)

**Retrieval and Ranking Improvements**

* Modified the retrieval pipeline to generate lexical query batches using `buildWorldInfoLexicalQueryBatches` and pass them through to the hybrid search function, enabling multi-batch lexical retrieval. [[1]](diffhunk://#diff-20f3fd805092b3c65647cc031b128c8b36885d0681e61d74316db77682ef12d2R110) [[2]](diffhunk://#diff-20f3fd805092b3c65647cc031b128c8b36885d0681e61d74316db77682ef12d2L4269-R4277)
* Updated `searchWorldBookEntriesHybridWithVector` to accept and process multiple lexical queries, improving recall and flexibility in retrieval. [[1]](diffhunk://#diff-9f302e16ab575e16663b3231bcf98e8493ea6ee18c61ba2cde112e1da5b6ffbeL2966-R3000) [[2]](diffhunk://#diff-9f302e16ab575e16663b3231bcf98e8493ea6ee18c61ba2cde112e1da5b6ffbeL2976-R3013)

**Lexical Evidence Normalization and Ranking**

* Introduced a robust normalization function for BM25 lexical scores (`normalizeBm25Scores`), providing a bounded, provider-independent `lexical_strength` signal for each candidate.
* Candidates are now ranked primarily by normalized `lexical_strength`, then by vector distance, improving the relevance of retrieved entries.

**Data Model Updates**

* Extended the candidate and result interfaces to include `lexical_strength` and `lexicalQueryPreviews`/`lexical_query_previews` fields throughout the pipeline. [[1]](diffhunk://#diff-9f302e16ab575e16663b3231bcf98e8493ea6ee18c61ba2cde112e1da5b6ffbeR237-R275) [[2]](diffhunk://#diff-91601647bcbeae35841528706cb70328f00e1be1147e0051e92a3f202bc7edb2R871-R874) [[3]](diffhunk://#diff-dda0196ae7552c9741ab8d3ab651ebed585b13248403624acad8d6a5b9d80bffR138) [[4]](diffhunk://#diff-f5221d0e77705a4cd910b5ea81edef9899a13be16723fd80b4a7ae0740129832R524)

These changes collectively improve the transparency, flexibility, and quality of World Book retrieval diagnostics and results.