### PR TITLE
generation context contract, per-handler timeout, and display preprocess gating for extension-owned chats

### DIFF
--- a/developer-docs/docs/backend-api/context-handlers.md
+++ b/developer-docs/docs/backend-api/context-handlers.md
@@ -18,5 +18,47 @@ spindle.registerContextHandler(async (context) => {
 
 Use this when you need to influence how the prompt is built rather than modifying the final messages.
 
+## Generation context
+
+The context object carries:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `chatId` | `string` | Chat the generation targets. |
+| `generationType` | `string` | `'normal'`, `'continue'`, `'regenerate'`, `'swipe'`, or `'impersonate'`. |
+| `dryRun` | `boolean` | `true` for tokenize/preview assemblies that never reach an LLM. Skip side effects when set. |
+| `userId` | `string` | Requesting user. |
+
+Hosts that stamp these fields advertise it via `spindle.contracts.preAssemblyGenerationContext >= 1`. Check the contract before relying on them:
+
+```ts
+if ((spindle.contracts?.preAssemblyGenerationContext ?? 0) >= 1) {
+  spindle.registerContextHandler(handler)
+}
+```
+
+## Cancelling a generation
+
+Return the context with `cancelGeneration: true` to stop the generation before any LLM call. The host routes this through the same path as a user-initiated stop.
+
+```ts
+spindle.registerContextHandler(async (context) => {
+  if (await shouldBlock(context)) {
+    return { ...context, cancelGeneration: true }
+  }
+  return context
+})
+```
+
+## Timeout
+
+Each invocation runs inside a 10-second wall-clock budget by default. Handlers that legitimately need longer can request a bigger budget at registration (clamped to 1s–120s):
+
+```ts
+spindle.registerContextHandler(handler, 100, { timeoutMs: 30_000 })
+```
+
+On timeout the host logs an error and continues with the previous context, so a slow handler delays but never blocks generation.
+
 !!! tip "Context Handlers vs Interceptors"
     **Context handlers** run _before_ prompt assembly and modify the context that drives assembly. **Interceptors** run _after_ assembly and modify the final message array. Use context handlers when you need to affect how the prompt is constructed; use interceptors when you need to tweak the finished output.

--- a/developer-docs/docs/frontend-api/display-resolver.md
+++ b/developer-docs/docs/frontend-api/display-resolver.md
@@ -86,6 +86,12 @@ The method-specific arguments alongside `context` are: `content` for `resolveBod
 
 `resolveTemplates` returns the same information keyed per template: `resolved` (`Record<key, string>`), and optional `touchedVars` (`Record<key, string[]>`) and `cacheable` (`Record<key, boolean>`).
 
+## Regex waits for your resolver
+
+For chats you own, the host does not run display regex scripts against content your `resolveBody` has not processed yet: the regex pass waits until your result settles, then runs on it.
+
+Returning `null` (or throwing) from `resolveBody` shows the raw content for that render without caching it as resolved, so later renders retry.
+
 ## Caching and invalidation
 
 The host caches your results so it does not call you on every render, using `touchedVars` as the dependency key. When a variable changes, only cached entries that listed it are dropped. Mark a result `cacheable: false` if it depends on something that is not a variable (time, randomness).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "i18next": "^26.2.0",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^0.468.0",
-    "lumiverse-spindle-types": "0.6.1",
+    "lumiverse-spindle-types": "0.6.2",
     "marked": "^15.0.4",
     "motion": "^12.0.0",
     "react": "^19.2.6",

--- a/frontend/src/hooks/useDisplayRegex.ts
+++ b/frontend/src/hooks/useDisplayRegex.ts
@@ -56,6 +56,11 @@ interface DisplayPreprocessBody {
   rawContent: string
 }
 
+interface DisplayPreprocessOutcome {
+  content: string
+  ok: boolean
+}
+
 interface PendingDisplayPreprocess {
   body: DisplayPreprocessBody
   resolve: (value: string) => void
@@ -63,7 +68,7 @@ interface PendingDisplayPreprocess {
 
 const displayRegexResolutionCache = new Map<string, DisplayRegexCacheEntry>()
 const displayRegexContentCache = new Map<string, DisplayRegexContentCacheEntry>()
-const displayPreprocessCache = new Map<string, { value?: string; promise?: Promise<string>; touchedVars?: ReadonlySet<string>; messageId?: string }>()
+const displayPreprocessCache = new Map<string, { value?: string; promise?: Promise<DisplayPreprocessOutcome>; touchedVars?: ReadonlySet<string>; messageId?: string }>()
 const DISPLAY_PREPROCESS_CACHE_MAX = 500
 const displayRegexCacheListeners = new Set<() => void>()
 let displayRegexGlobalCv = 0
@@ -208,7 +213,7 @@ function enqueueDisplayPreprocess(chatId: string, body: DisplayPreprocessBody): 
   })
 }
 
-function fetchDisplayPreprocess(chatId: string, body: DisplayPreprocessBody): Promise<string> {
+function fetchDisplayPreprocess(chatId: string, body: DisplayPreprocessBody): Promise<DisplayPreprocessOutcome> {
   if (isDisplayChatOwned(chatId)) {
     const resolver = getDisplayResolverForChat(chatId)
     if (resolver) {
@@ -224,25 +229,31 @@ function fetchDisplayPreprocess(chatId: string, body: DisplayPreprocessBody): Pr
           },
         })
         .then((local) => {
-          if (local) return local.content
+          if (local) return { content: local.content, ok: true }
           console.error(`[display] resolver.resolveBody returned null for owned chat=${chatId}; showing raw (no backend fallback)`)
-          return body.rawContent
+          return { content: body.rawContent, ok: false }
         })
         .catch((err: unknown) => {
           console.error(`[display] resolver.resolveBody threw for owned chat=${chatId}; showing raw (no backend fallback)`, err)
-          return body.rawContent
+          return { content: body.rawContent, ok: false }
         })
     }
-    return Promise.resolve(body.rawContent)
+    return Promise.resolve({ content: body.rawContent, ok: false })
   }
-  return enqueueDisplayPreprocess(chatId, body)
+  return enqueueDisplayPreprocess(chatId, body).then((content) => ({ content, ok: true }))
 }
 
-export function useDisplayPreprocessed(
+interface DisplayPreprocessedState {
+  value: string
+  // False while the preprocess is pending or an owning resolver failed.
+  ready: boolean
+}
+
+function useDisplayPreprocessedState(
   content: string,
   chatId: string | null,
   opts: DisplayPreprocessOpts | undefined,
-): string {
+): DisplayPreprocessedState {
   const messageIdForSnapshot = opts?.messageId ?? null
   const getSnapshotForThisMessage = useCallback(
     () => getDisplayRegexCacheSnapshot(messageIdForSnapshot),
@@ -260,13 +271,13 @@ export function useDisplayPreprocessed(
   }, [content, opts?.messageId, opts?.role, chatId])
 
   const cached = key ? displayPreprocessCache.get(key)?.value : undefined
-  const [state, setState] = useState<{ key: string; value: string } | null>(() =>
-    key && cached !== undefined ? { key, value: cached } : null,
+  const [state, setState] = useState<{ key: string; value: string; ok: boolean } | null>(() =>
+    key && cached !== undefined ? { key, value: cached, ok: true } : null,
   )
 
   const lastRef = useRef<{ raw: string; value: string } | null>(null)
   if (key && cached !== undefined) lastRef.current = { raw: content, value: cached }
-  else if (key && state?.key === key) lastRef.current = { raw: content, value: state.value }
+  else if (key && state?.key === key && state.ok) lastRef.current = { raw: content, value: state.value }
 
   useEffect(() => {
     if (!key || !opts?.messageId || !chatId) {
@@ -274,17 +285,17 @@ export function useDisplayPreprocessed(
       return
     }
     let cancelled = false
-    const apply = (next: string) => {
-      if (!cancelled) setState({ key, value: next })
+    const apply = (next: DisplayPreprocessOutcome) => {
+      if (!cancelled) setState({ key, value: next.content, ok: next.ok })
     }
     const existing = displayPreprocessCache.get(key)
     if (existing?.value !== undefined) {
-      apply(existing.value)
+      apply({ content: existing.value, ok: true })
       return () => { cancelled = true }
     }
     if (!existing?.promise) {
       const messageIdForEntry = opts.messageId
-      let assignedPromise: Promise<string>
+      let assignedPromise: Promise<DisplayPreprocessOutcome>
       const promise = fetchDisplayPreprocess(chatId, {
         messageId: opts.messageId,
         role: opts.role,
@@ -292,14 +303,18 @@ export function useDisplayPreprocessed(
       })
         .then((next) => {
           if (displayPreprocessCache.get(key)?.promise === assignedPromise) {
-            displayPreprocessCache.set(key, { value: next, messageId: messageIdForEntry })
-            if (displayPreprocessCache.size > DISPLAY_PREPROCESS_CACHE_MAX) {
-              const drop = displayPreprocessCache.size - DISPLAY_PREPROCESS_CACHE_MAX
-              let i = 0
-              for (const k of displayPreprocessCache.keys()) {
-                if (i++ >= drop) break
-                displayPreprocessCache.delete(k)
+            if (next.ok) {
+              displayPreprocessCache.set(key, { value: next.content, messageId: messageIdForEntry })
+              if (displayPreprocessCache.size > DISPLAY_PREPROCESS_CACHE_MAX) {
+                const drop = displayPreprocessCache.size - DISPLAY_PREPROCESS_CACHE_MAX
+                let i = 0
+                for (const k of displayPreprocessCache.keys()) {
+                  if (i++ >= drop) break
+                  displayPreprocessCache.delete(k)
+                }
               }
+            } else {
+              displayPreprocessCache.delete(key)
             }
           }
           return next
@@ -308,7 +323,7 @@ export function useDisplayPreprocessed(
           if (displayPreprocessCache.get(key)?.promise === assignedPromise) {
             displayPreprocessCache.delete(key)
           }
-          return content
+          return { content, ok: false }
         })
       assignedPromise = promise
       displayPreprocessCache.set(key, { promise, messageId: messageIdForEntry })
@@ -317,11 +332,19 @@ export function useDisplayPreprocessed(
     return () => { cancelled = true }
   }, [key, opts?.messageId, opts?.role, chatId, content, cvSnapshot])
 
-  if (!key) return content
-  if (cached !== undefined) return cached
-  if (state?.key === key) return state.value
-  if (lastRef.current?.raw === content) return lastRef.current.value
-  return content
+  if (!key) return { value: content, ready: true }
+  if (cached !== undefined) return { value: cached, ready: true }
+  if (state?.key === key) return { value: state.value, ready: state.ok }
+  if (lastRef.current?.raw === content) return { value: lastRef.current.value, ready: true }
+  return { value: content, ready: false }
+}
+
+export function useDisplayPreprocessed(
+  content: string,
+  chatId: string | null,
+  opts: DisplayPreprocessOpts | undefined,
+): string {
+  return useDisplayPreprocessedState(content, chatId, opts).value
 }
 
 const RAW_MACRO_RE = /\{\{(?!\s*(?:user|char|bot|notChar|not_char|charName)\s*\}\})/i
@@ -486,8 +509,11 @@ export function useDisplayRegex(
   }, [messageIndex])
   const macroCharacterId = activeGroupCharacterId ?? activeCharacterId
 
-  const content = useDisplayPreprocessed(rawContent, activeChatId, preprocessOpts)
+  const { value: content, ready: preprocessReady } = useDisplayPreprocessedState(rawContent, activeChatId, preprocessOpts)
   const pendingSlowReportsRef = useRef<SlowRegexReport[]>([])
+
+  // When an extension owns display, regex runs on preprocessed content only.
+  const regexGated = !!activeChatId && isDisplayChatOwned(activeChatId) && !preprocessReady
 
   const displayScripts = useMemo(
     () =>
@@ -631,7 +657,7 @@ export function useDisplayRegex(
   const fallbackContent = useMemo(
     () => {
       const slowReports: SlowRegexReport[] = []
-      if (displayScripts.length === 0) {
+      if (displayScripts.length === 0 || regexGated) {
         pendingSlowReportsRef.current = slowReports
         return content
       }
@@ -648,7 +674,7 @@ export function useDisplayRegex(
       pendingSlowReportsRef.current = slowReports
       return next
     },
-    [content, displayScripts, isUser, depth, macroCtx, resolvedTemplates, dynamicMacros],
+    [content, displayScripts, isUser, depth, macroCtx, resolvedTemplates, dynamicMacros, regexGated],
   )
 
   useEffect(() => {
@@ -676,7 +702,7 @@ export function useDisplayRegex(
   )
 
   const contentCacheKey = useMemo(() => {
-    if (displayScripts.length === 0 || !hasAsyncMacroScripts) return null
+    if (displayScripts.length === 0 || !hasAsyncMacroScripts || regexGated) return null
 
     return JSON.stringify({
       activeChatId,
@@ -714,6 +740,7 @@ export function useDisplayRegex(
     content,
     resolvedTemplateKey,
     dynamicMacros,
+    regexGated,
   ])
 
   const cachedResolvedContent = contentCacheKey ? displayRegexContentCache.get(contentCacheKey)?.value : undefined

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "hono": "^4.7.0",
     "js-tiktoken": "^1.0.16",
     "jsdom": "^29.0.1",
-    "lumiverse-spindle-types": "0.6.1",
+    "lumiverse-spindle-types": "0.6.2",
     "mute-stream": "^3.0.0",
     "sharp": "^0.34.5",
     "ssh2-sftp-client": "^12.1.1"

--- a/src/services/generate.service.ts
+++ b/src/services/generate.service.ts
@@ -567,8 +567,18 @@ interface SpindleContext {
   connectionId?: string;
   personaId?: string;
   generationType: string;
+  dryRun?: boolean;
+  userId?: string;
+  cancelGeneration?: boolean;
   activatedWorldInfo?: ActivatedWorldInfoEntry[];
   [key: string]: unknown;
+}
+
+class GenerationCancelledByExtensionError extends Error {
+  constructor() {
+    super("Generation cancelled by extension context handler");
+    this.name = "GenerationCancelledByExtension";
+  }
 }
 
 /** Result of assembling + post-processing the prompt pipeline. */
@@ -1233,6 +1243,7 @@ async function runPromptPipeline(opts: {
   regenFeedback?: string;
   regenFeedbackPosition?: "system" | "user";
   signal?: AbortSignal;
+  isDryRun?: boolean;
 }): Promise<PromptPipelineResult> {
   // Yield to the event loop before entering the assembly pipeline so a stop
   // clicked in the first few ticks after the generation starts can actually
@@ -1250,13 +1261,19 @@ async function runPromptPipeline(opts: {
     connectionId: opts.connectionId,
     personaId: opts.personaId,
     generationType: opts.generationType,
+    dryRun: opts.isDryRun === true,
+    userId: opts.userId,
   };
   if (contextHandlerChain.count > 0) {
-    spindleContext = (await contextHandlerChain.run(
+    const handled = (await contextHandlerChain.run(
       spindleContext,
       opts.userId,
       opts.signal,
-    )) as SpindleContext;
+    )) as SpindleContext | undefined;
+    if (handled) spindleContext = handled;
+    if (spindleContext.cancelGeneration === true) {
+      throw new GenerationCancelledByExtensionError();
+    }
   }
 
   // Build messages: use explicit messages if provided, otherwise assemble from preset
@@ -2771,9 +2788,9 @@ export async function startGeneration(
           pendingCouncilRetries.delete(generationId);
         }
 
-        // If this was a user-initiated abort (stop request), emit proper events so the
-        // frontend can reset its streaming state and clean up.
-        if (abortController.signal.aborted) {
+        // User aborts and extension-requested cancels both emit stop events so
+        // the frontend resets its streaming state.
+        if (abortController.signal.aborted || err instanceof GenerationCancelledByExtensionError) {
           // Clean up staged message if one was created (sidecar council mode)
           if (stagedMessageId) {
             try {
@@ -2915,6 +2932,7 @@ export async function dryRunGeneration(
     excludeMessageId: input.exclude_message_id,
     targetCharacterId: input.target_character_id,
     signal: input.signal,
+    isDryRun: true,
   });
 
   // Compute token counts for the breakdown

--- a/src/spindle/context-handler.ts
+++ b/src/spindle/context-handler.ts
@@ -5,6 +5,8 @@ export interface ContextHandler {
   extensionName?: string;
   userId?: string | null;
   priority: number; // lower = runs first
+  /** Wall-clock budget for each invocation. Defaults to 10s. */
+  timeoutMs?: number;
   handler: (context: unknown) => Promise<unknown>;
 }
 
@@ -58,6 +60,7 @@ class ContextHandlerChain {
         extensionName: handler.extensionName,
       });
 
+      const timeoutMs = handler.timeoutMs ?? 10_000;
       let timeout: ReturnType<typeof setTimeout> | undefined;
       let abortHandler: (() => void) | undefined;
       try {
@@ -68,10 +71,10 @@ class ContextHandlerChain {
               () =>
                 reject(
                   new Error(
-                    `Context handler from ${handler.extensionId} timed out (10s)`
+                    `Context handler from ${handler.extensionId} timed out (${Math.round(timeoutMs / 1000)}s)`
                   )
                 ),
-              10_000,
+              timeoutMs,
             );
             if (signal) {
               abortHandler = () =>

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -341,6 +341,7 @@ type RuntimeWorkerToHost =
       input: SpindleAssembleInput;
       userId?: string;
     }
+  | { type: "register_context_handler"; priority?: number; timeoutMs?: number }
   | { type: "rpc_pool_sync"; endpoint: string; value: unknown; policy?: SharedRpcEndpointPolicy }
   | { type: "rpc_pool_register_handler"; endpoint: string; policy?: SharedRpcEndpointPolicy }
   | { type: "rpc_pool_unregister"; endpoint: string }
@@ -2364,7 +2365,7 @@ export class WorkerHost {
         this.handleCorsRequest(msg.requestId, msg.url, msg.options);
         break;
       case "register_context_handler":
-        this.handleRegisterContextHandler(msg.priority);
+        this.handleRegisterContextHandler(msg.priority, (msg as { timeoutMs?: number }).timeoutMs);
         break;
       case "context_handler_result":
         this.resolveRequest(msg.requestId, msg.context);
@@ -5786,7 +5787,7 @@ export class WorkerHost {
 
   // ─── Context handler ─────────────────────────────────────────────────
 
-  private handleRegisterContextHandler(priority?: number): void {
+  private handleRegisterContextHandler(priority?: number, timeoutMs?: number): void {
     if (
       !this.hasPermission("context_handler")
     ) {
@@ -5801,12 +5802,17 @@ export class WorkerHost {
       return;
     }
 
+    const budgetMs = typeof timeoutMs === "number" && Number.isFinite(timeoutMs)
+      ? Math.min(Math.max(timeoutMs, 1_000), 120_000)
+      : 10_000;
+
     this.contextHandlerUnregister?.();
     this.contextHandlerUnregister = contextHandlerChain.register({
       extensionId: this.extensionId,
       extensionName: this.manifest.name || this.manifest.identifier,
       userId: this.getScopedUserId(),
       priority: priority ?? 100,
+      timeoutMs: budgetMs,
       handler: async (context) => {
         const requestId = crypto.randomUUID();
 
@@ -5824,7 +5830,7 @@ export class WorkerHost {
                 `Context handler timeout from ${this.manifest.identifier}`
               )
             );
-          }, 10_000);
+          }, budgetMs);
 
           this.pendingRequests.set(requestId, {
             resolve: (val) => {

--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -534,6 +534,7 @@ type RuntimeSpindleAPI = Omit<SpindleAPI, "presets"> & {
     getCatalog(options?: { userId?: string }): Promise<LumiaDlcCatalog>;
   };
   assemble(input: AssembleRequest, userId?: string): Promise<AssembleResult>;
+  contracts: Readonly<Record<string, number>>;
   registerMessageContentProcessor(
     handler: (ctx: {
       chatId: string;
@@ -3327,6 +3328,8 @@ const spindleApi: RuntimeSpindleAPI = {
       options: options || {},
     });
   },
+
+  contracts: Object.freeze({ preAssemblyGenerationContext: 1 }),
 
   registerContextHandler(handler, priority?): void {
     assertMutationAllowed("spindle.registerContextHandler()");

--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -264,6 +264,7 @@ type RuntimeWorkerToHost =
       input: Omit<AssembleRequest, "signal">;
       userId?: string;
     }
+  | { type: "register_context_handler"; priority?: number; timeoutMs?: number }
   | {
       type: "chat_append_message";
       requestId: string;
@@ -535,6 +536,11 @@ type RuntimeSpindleAPI = Omit<SpindleAPI, "presets"> & {
   };
   assemble(input: AssembleRequest, userId?: string): Promise<AssembleResult>;
   contracts: Readonly<Record<string, number>>;
+  registerContextHandler(
+    handler: (context: unknown) => Promise<unknown>,
+    priority?: number,
+    opts?: { timeoutMs?: number }
+  ): void;
   registerMessageContentProcessor(
     handler: (ctx: {
       chatId: string;
@@ -3331,10 +3337,14 @@ const spindleApi: RuntimeSpindleAPI = {
 
   contracts: Object.freeze({ preAssemblyGenerationContext: 1 }),
 
-  registerContextHandler(handler, priority?): void {
+  registerContextHandler(
+    handler: (context: unknown) => Promise<unknown>,
+    priority?: number,
+    opts?: { timeoutMs?: number },
+  ): void {
     assertMutationAllowed("spindle.registerContextHandler()");
     contextHandlerFn = handler;
-    post({ type: "register_context_handler", priority });
+    post({ type: "register_context_handler", priority, timeoutMs: opts?.timeoutMs });
   },
 
   registerMessageContentProcessor(handler, priority?): void {
@@ -3906,6 +3916,12 @@ async function handleHostMessage(msg: RuntimeHostToWorker): Promise<void> {
             context: msg.context,
           });
         }
+      } else {
+        post({
+          type: "context_handler_result",
+          requestId: msg.requestId,
+          context: msg.context,
+        });
       }
       break;
     }


### PR DESCRIPTION
Adds spindle surface for pre-generation coordination. No default behavior changes.

a785b16a: The generation context passed to registerContextHandler now carries dryRun and userId, so handlers can skip side effects on previews and attribute work properly. A handler may return the context with cancelGeneration: true to stop the generation before any LLM call; this routes through the existing GENERATION_STOPPED path like a user stop.

c9e88178: The new `registerContextHandler(handler, priority, { timeoutMs })` lets a handler set its own wall-clock budget (max 120s), default 10s.

e3e2a924: When an extension has registered a display resolver and owns a chat, display regex now waits for the resolver's preprocess to settle instead of running against unprocessed content + a failed preprocess is no longer cached as if it were resolved. Running display scripts on content the owning preprocessor hasn't transformed yet is wrong input for those scripts.

Spindle: https://github.com/prolix-oc/lumiverse-spindle-types/pull/29