### PR TITLE
Replace Author's Note resize handle with expandable editor and fix embeddings checklist tags

### DIFF
--- a/frontend/src/components/chat/AuthorsNotePanel.module.css
+++ b/frontend/src/components/chat/AuthorsNotePanel.module.css
@@ -79,7 +79,7 @@
   font-size: calc(12px * var(--lumiverse-font-scale, 1));
   font-family: inherit;
   line-height: 1.45;
-  resize: vertical;
+  resize: none;
   transition: border-color var(--lcs-transition-fast);
 }
 

--- a/frontend/src/components/chat/AuthorsNotePanel.tsx
+++ b/frontend/src/components/chat/AuthorsNotePanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { CloseButton } from '@/components/shared/CloseButton'
+import { ExpandableTextarea } from '@/components/shared/ExpandedTextEditor'
 import NumericInput from '@/components/shared/NumericInput'
 import { chatsApi } from '@/api/chats'
 import styles from './AuthorsNotePanel.module.css'
@@ -68,8 +69,7 @@ export default function AuthorsNotePanel({ chatId, isOpen, onClose }: AuthorsNot
     }
   }, [])
 
-  const handleTextChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const val = e.target.value
+  const handleTextChange = useCallback((val: string) => {
     setNoteText(val)
     setEnabled(!!val.trim())
     scheduleSave({ content: val })
@@ -111,13 +111,14 @@ export default function AuthorsNotePanel({ chatId, isOpen, onClose }: AuthorsNot
 
       <div className={styles.body}>
         <div className={styles.field}>
-          <textarea
+          <ExpandableTextarea
             name="authors-note"
             aria-label={t('authorsNote.ariaLabel')}
             className={styles.textarea}
             rows={3}
             value={noteText}
             onChange={handleTextChange}
+            title={t('authorsNote.title')}
             placeholder={t('authorsNote.placeholder')}
           />
         </div>

--- a/frontend/src/components/modals/SettingsModal.module.css
+++ b/frontend/src/components/modals/SettingsModal.module.css
@@ -239,6 +239,7 @@
 .embeddingChecklistItemBody {
   display: flex;
   flex-direction: column;
+  flex: 1;
   gap: 6px;
   min-width: 0;
 }

--- a/frontend/src/components/shared/ExpandedTextEditor.tsx
+++ b/frontend/src/components/shared/ExpandedTextEditor.tsx
@@ -12,6 +12,7 @@ import {
   type Ref,
   type ReactNode,
   type SyntheticEvent,
+  type TextareaHTMLAttributes,
 } from 'react'
 import { useTranslation } from 'react-i18next'
 import { createPortal } from 'react-dom'
@@ -530,7 +531,7 @@ export default function ExpandedTextEditor({
  * Drop-in wrapper: renders the original textarea with an expand button overlay.
  * When expanded, opens a full-screen ExpandedTextEditor modal.
  */
-interface ExpandableTextareaProps {
+interface ExpandableTextareaProps extends Pick<TextareaHTMLAttributes<HTMLTextAreaElement>, 'name' | 'aria-label'> {
   value: string
   onChange: (value: string) => void
   title: string
@@ -564,6 +565,8 @@ export const ExpandableTextarea = forwardRef<HTMLTextAreaElement, ExpandableText
   macros,
   onRefreshMacros,
   markdownOnly,
+  name,
+  'aria-label': ariaLabel,
 }, forwardedRef) {
   const { t } = useTranslation('shared', { keyPrefix: 'expandedTextEditor' })
   const [expanded, setExpanded] = useState(false)
@@ -601,6 +604,8 @@ export const ExpandableTextarea = forwardRef<HTMLTextAreaElement, ExpandableText
         placeholder={placeholder}
         rows={rows}
         spellCheck={spellCheck}
+        name={name}
+        aria-label={ariaLabel}
       />
       <button
         className={s.expandBtn}


### PR DESCRIPTION
This pull request refactors the `AuthorsNotePanel` to use the new `ExpandableTextarea` component for improved text editing, and makes minor style and prop improvements to shared components. The most significant changes are the integration of `ExpandableTextarea` into the author’s note UI, updates to prop handling for better accessibility, and minor CSS fixes.

**Component integration and UI improvements:**
* Replaced the native `<textarea>` in `AuthorsNotePanel` with the new `ExpandableTextarea` component, which allows for an expandable editing experience and adds a title prop for accessibility. (`frontend/src/components/chat/AuthorsNotePanel.tsx`) [[1]](diffhunk://#diff-172053c20ee7fc68ae6bd6a7c9b2f9665c0a83c11842319b590162dc1caa33cfR4) [[2]](diffhunk://#diff-172053c20ee7fc68ae6bd6a7c9b2f9665c0a83c11842319b590162dc1caa33cfL114-R121)
* Updated the `handleTextChange` callback in `AuthorsNotePanel` to match the new signature expected by `ExpandableTextarea`. (`frontend/src/components/chat/AuthorsNotePanel.tsx`)

**Component API and accessibility:**
* Updated `ExpandableTextareaProps` to extend standard textarea attributes (`name`, `aria-label`) and ensured these props are passed through to the underlying textarea for better accessibility and form integration. (`frontend/src/components/shared/ExpandedTextEditor.tsx`) [[1]](diffhunk://#diff-3fe2cf4abc0b5ed8db280cd469e8bd249abaf5d54274882c9ff963666329da34R15) [[2]](diffhunk://#diff-3fe2cf4abc0b5ed8db280cd469e8bd249abaf5d54274882c9ff963666329da34L533-R534) [[3]](diffhunk://#diff-3fe2cf4abc0b5ed8db280cd469e8bd249abaf5d54274882c9ff963666329da34R568-R569) [[4]](diffhunk://#diff-3fe2cf4abc0b5ed8db280cd469e8bd249abaf5d54274882c9ff963666329da34R607-R608)

**Styling adjustments:**
* Disabled manual resizing for the author’s note textarea to prevent UI issues, since expansion is now handled by the component. (`frontend/src/components/chat/AuthorsNotePanel.module.css`)
* Fixed flex layout in the settings modal checklist to ensure proper sizing and alignment. (`frontend/src/components/modals/SettingsModal.module.css`)