### PR TITLE
Harden preset editor integration and save coordination

### DIFF
--- a/developer-docs/docs/backend-api/presets.md
+++ b/developer-docs/docs/backend-api/presets.md
@@ -38,8 +38,9 @@ const newPreset = await spindle.presets.create({
   metadata: { description: 'Created by my extension' },
 })
 
-// Update the preset metadata
+// Update the preset metadata using the revision returned by create/get.
 const updated = await spindle.presets.update(newPreset.id, {
+  expected_cache_revision: newPreset.cache_revision,
   metadata: {
     ...newPreset.metadata,
     description: 'Updated description',
@@ -57,7 +58,7 @@ const deleted = await spindle.presets.delete(newPreset.id)
 | `list(options?)` | `Promise<{ data: UserPresetDTO[], total: number }>` | List presets. Options: `{ limit?, offset? }`. Defaults: limit 50, max 200. |
 | `get(presetId)` | `Promise<UserPresetDTO \| null>` | Get a preset by ID. Returns `null` if not found. |
 | `create(input)` | `Promise<UserPresetDTO>` | Create a new preset. `name` and `provider` are required. |
-| `update(presetId, input)` | `Promise<UserPresetDTO>` | Update a preset. All fields are optional. |
+| `update(presetId, input)` | `Promise<UserPresetDTO>` | Update a preset. `expected_cache_revision` is required; pass the `cache_revision` from the read/create response. |
 | `delete(presetId)` | `Promise<boolean>` | Delete a preset. Returns `true` if deleted. |
 
 ## UserPresetDTO
@@ -72,6 +73,7 @@ const deleted = await spindle.presets.delete(newPreset.id)
   prompt_order: PromptBlockDTO[]
   prompts: Record<string, unknown>
   metadata: Record<string, unknown>
+  cache_revision: number
   created_at: number   // unix epoch seconds
   updated_at: number
 }
@@ -91,7 +93,10 @@ const deleted = await spindle.presets.delete(newPreset.id)
 
 ## UserPresetUpdateDTO
 
-Same fields as `UserPresetCreateDTO`, but all are optional, including `name` and `provider`.
+`expected_cache_revision` is required and must be the `cache_revision` returned by
+the most recent `get`, `list`, `create`, or successful `update` response. All
+other fields from `UserPresetCreateDTO` are optional, including `name` and
+`provider`.
 
 !!! note "Prompt variable cleanup"
     When `prompt_order` or `metadata` is updated, Lumiverse prunes stale `metadata.promptVariables` entries that no longer correspond to a variable definition on a block. This matches the built-in preset editor behavior.

--- a/developer-docs/docs/frontend-api/ui-placement.md
+++ b/developer-docs/docs/frontend-api/ui-placement.md
@@ -209,6 +209,48 @@ Unknown preset metadata is preserved across native edits, duplication, and
 internal Loom export/import. Loom-owned fields remain authoritative if a
 passthrough metadata bag contains a colliding key.
 
+### Preset-editor toolbar items
+
+`ctx.ui.registerPresetEditorToolbarItem({ id, ariaLabel })` registers one
+extension-owned root above Loom's list/edit branch. Each extension can register
+one item; four items are available globally. The returned handle exposes `root`,
+`itemId`, `setVisible(visible)`, and `destroy()`. The host supplies placement
+only: extension code owns the toolbar's controls, labels, and accessibility
+semantics beneath its required `ariaLabel`.
+
+### `ctx.ui.presetEditor.extension`
+
+This additive helper is scoped to the calling extension's manifest identifier:
+
+```ts
+const editor = ctx.ui.presetEditor.extension
+const state = editor.getState()
+
+editor.updateMetadata((current) => ({
+  ...(current && typeof current === 'object' ? current : {}),
+  mode: 'parallel',
+}), { immediate: true })
+
+editor.activateBuiltinTab('blocks')
+await editor.flush()
+```
+
+`getState()` and `onChange()` expose structured clones of the active preset id,
+tab, Main blocks, prompt-variable values, and only
+`metadata[callingExtensionIdentifier]`. `setMetadata()` and `updateMetadata()`
+can replace only that top-level metadata key. `activateBuiltinTab('blocks')`
+selects the host's stable native Blocks tab.
+
+The helper is cooperative least-authority API design, **not** isolation against
+hostile same-origin extension code. It shares Loom's one per-preset serialized
+save coordinator with native edits, recovery, rename, duplicate, prompt-variable
+updates, and generation flushes; direct whole-preset writes are unnecessary.
+
+All toolbar, tab, and helper operations require `presets`. Revoking that
+permission immediately removes the extension's preset roots and subscriptions;
+previous scoped helper instances reject until the extension frontend is reloaded
+and registers again.
+
 ## Float Widgets (requires `ui_panels`)
 
 Create a small draggable widget overlaying the UI. Max 2 per extension, 8 global.

--- a/developer-docs/docs/frontend-api/ui-placement.md
+++ b/developer-docs/docs/frontend-api/ui-placement.md
@@ -222,6 +222,10 @@ semantics beneath its required `ariaLabel`.
 
 This additive helper is scoped to the calling extension's manifest identifier:
 
+The `extension` property is a read-only getter; each read acquires the current
+revocation-bound scoped helper.
+
+
 ```ts
 const editor = ctx.ui.presetEditor.extension
 const state = editor.getState()

--- a/developer-docs/docs/frontend-api/ui-placement.md
+++ b/developer-docs/docs/frontend-api/ui-placement.md
@@ -240,10 +240,12 @@ await editor.flush()
 ```
 
 `getState()` and `onChange()` expose structured clones of the active preset id,
-tab, Main blocks, prompt-variable values, and the raw value owned by the calling
-extension's namespace. `setMetadata()` accepts a JSON object; `updateMetadata()`
-receives that raw value and must return a JSON object. Both replace only the
-calling extension's namespace; the host keeps it separate from Loom-owned keys.
+tab, Main blocks, prompt-variable values, and the raw value at
+`metadata.<manifest identifier>`. `setMetadata()` accepts a JSON object;
+`updateMetadata()` receives that raw value and must return a JSON object. Both
+replace only the calling extension's top-level passthrough key. Manifest
+identifiers colliding with Loom-owned metadata keys, including `source` and
+`description`, are rejected rather than allowed to mutate Main-owned fields.
 `activateBuiltinTab('blocks')` selects the host's stable native Blocks tab.
 
 The helper is cooperative least-authority API design, **not** isolation against

--- a/developer-docs/docs/frontend-api/ui-placement.md
+++ b/developer-docs/docs/frontend-api/ui-placement.md
@@ -240,10 +240,10 @@ await editor.flush()
 ```
 
 `getState()` and `onChange()` expose structured clones of the active preset id,
-tab, Main blocks, prompt-variable values, and the raw value at
-`metadata[callingExtensionIdentifier]`. `setMetadata()` accepts a JSON object;
-`updateMetadata()` receives that raw value and must return a JSON object. Both
-replace only the calling extension's top-level metadata key.
+tab, Main blocks, prompt-variable values, and the raw value owned by the calling
+extension's namespace. `setMetadata()` accepts a JSON object; `updateMetadata()`
+receives that raw value and must return a JSON object. Both replace only the
+calling extension's namespace; the host keeps it separate from Loom-owned keys.
 `activateBuiltinTab('blocks')` selects the host's stable native Blocks tab.
 
 The helper is cooperative least-authority API design, **not** isolation against

--- a/developer-docs/docs/frontend-api/ui-placement.md
+++ b/developer-docs/docs/frontend-api/ui-placement.md
@@ -236,10 +236,11 @@ await editor.flush()
 ```
 
 `getState()` and `onChange()` expose structured clones of the active preset id,
-tab, Main blocks, prompt-variable values, and only
-`metadata[callingExtensionIdentifier]`. `setMetadata()` and `updateMetadata()`
-can replace only that top-level metadata key. `activateBuiltinTab('blocks')`
-selects the host's stable native Blocks tab.
+tab, Main blocks, prompt-variable values, and the raw value at
+`metadata[callingExtensionIdentifier]`. `setMetadata()` accepts a JSON object;
+`updateMetadata()` receives that raw value and must return a JSON object. Both
+replace only the calling extension's top-level metadata key.
+`activateBuiltinTab('blocks')` selects the host's stable native Blocks tab.
 
 The helper is cooperative least-authority API design, **not** isolation against
 hostile same-origin extension code. It shares Loom's one per-preset serialized
@@ -247,9 +248,9 @@ save coordinator with native edits, recovery, rename, duplicate, prompt-variable
 updates, and generation flushes; direct whole-preset writes are unnecessary.
 
 All toolbar, tab, and helper operations require `presets`. Revoking that
-permission immediately removes the extension's preset roots and subscriptions;
-previous scoped helper instances reject until the extension frontend is reloaded
-and registers again.
+permission immediately removes the extension's preset roots and subscriptions.
+Previously acquired scoped helpers stay revoked. After `presets` is regranted,
+read `ctx.ui.presetEditor.extension` again to acquire a fresh helper.
 
 ## Float Widgets (requires `ui_panels`)
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -29,7 +29,7 @@
         "i18next": "^26.2.0",
         "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "^0.468.0",
-        "lumiverse-spindle-types": "0.6.1",
+        "lumiverse-spindle-types": "0.6.2",
         "marked": "^15.0.4",
         "motion": "^12.0.0",
         "react": "^19.2.6",
@@ -754,7 +754,7 @@
 
     "lucide-react": ["lucide-react@0.468.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA=="],
 
-    "lumiverse-spindle-types": ["lumiverse-spindle-types@0.6.1", "", {}, "sha512-w9ckXsZDVe5cJS87Vuuo0Nw1imaU7IL/V4uVuoc6CeQOCCMViPa2E8zh3nu9DAtv8xj7vuDQG12KMEkWJpv54A=="],
+    "lumiverse-spindle-types": ["lumiverse-spindle-types@0.6.2", "", {}, "sha512-AGTdD3IPhr+oKkAYsSgG2/BG9k6TFCaLpcuTirpo1witAQfq8U2EX+QTwHxQxMvOU0d60E074FoHGSd+VsiVnw=="],
 
     "magic-string": ["magic-string@0.25.9", "", { "dependencies": { "sourcemap-codec": "^1.4.8" } }, "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ=="],
 

--- a/frontend/src/api/generate.ts
+++ b/frontend/src/api/generate.ts
@@ -1,5 +1,6 @@
 import { get, post, type RequestOptions } from './client'
 import { flushSettingsNow } from '@/store/slices/settings'
+import { flushPresetForGeneration } from '@/lib/loom/preset-save-coordinator'
 
 /** Generation requests go through prompt assembly + council + embedding calls
  *  which can legitimately take longer than the default 30s client timeout. */
@@ -307,6 +308,7 @@ export interface ActiveGenerationEntry {
 export const generateApi = {
   async start(request: GenerateRequest) {
     await flushSettingsNow()
+    await flushPresetForGeneration(request.preset_id)
     return post<GenerateResponse>('/generate', request, LONG)
   },
 
@@ -321,11 +323,13 @@ export const generateApi = {
 
   async regenerate(request: GenerateRequest) {
     await flushSettingsNow()
+    await flushPresetForGeneration(request.preset_id)
     return post<GenerateResponse>('/generate/regenerate', request, LONG)
   },
 
   async continueGeneration(request: GenerateRequest) {
     await flushSettingsNow()
+    await flushPresetForGeneration(request.preset_id)
     return post<GenerateResponse>('/generate/continue', request, LONG)
   },
 
@@ -360,6 +364,7 @@ export const generateApi = {
 
   async dryRun(request: GenerateRequest) {
     await flushSettingsNow()
+    await flushPresetForGeneration(request.preset_id)
     return post<DryRunResponse>('/generate/dry-run', request, LONG)
   },
 

--- a/frontend/src/components/chat/InputArea.tsx
+++ b/frontend/src/components/chat/InputArea.tsx
@@ -942,8 +942,10 @@ export default function InputArea({ chatId, onNavigateHome }: InputAreaProps) {
     setOpenPopover(null)
     setPromptVariablesLoading(true)
     try {
-      const hydration = presetSaveCoordinator.beginHydration(activeLoomPresetId)
-      const preset = await presetsApi.get(activeLoomPresetId)
+      const presetId = activeLoomPresetId
+      const hydration = presetSaveCoordinator.beginHydration(presetId)
+      const preset = await presetsApi.get(presetId)
+      if (useStore.getState().activeLoomPresetId !== presetId) return
       setPromptVariablesPreset(presetSaveCoordinator.hydrate(unmarshalPreset(preset), hydration))
       setPromptVariablesModalOpen(true)
     } catch (err) {
@@ -955,7 +957,11 @@ export default function InputArea({ chatId, onNavigateHome }: InputAreaProps) {
   }, [activeLoomPresetId, promptVariablesLoading, t])
 
   const savePromptVariableValues = useCallback(async (values: PromptVariableValues) => {
-    if (!promptVariablesPreset) return
+    if (!promptVariablesPreset || useStore.getState().activeLoomPresetId !== promptVariablesPreset.id) {
+      setPromptVariablesModalOpen(false)
+      setPromptVariablesPreset(null)
+      return
+    }
     const updated = presetSaveCoordinator.mutate(
       promptVariablesPreset.id,
       promptVariablesPreset,

--- a/frontend/src/components/chat/InputArea.tsx
+++ b/frontend/src/components/chat/InputArea.tsx
@@ -19,7 +19,7 @@ import { uuidv7 } from '@/lib/uuid'
 import { toast } from '@/lib/toast'
 import { shouldForceLoomRuntimePreset } from '@/lib/loom/runtimeProfile'
 import { unmarshalPreset } from '@/lib/loom/service'
-import { presetSaveCoordinator } from '@/lib/loom/preset-save-coordinator'
+import { presetSaveCoordinator, StalePresetHydrationError } from '@/lib/loom/preset-save-coordinator'
 import { resolveAutoPersonaBinding } from '@/store/slices/personas'
 import {
   CHAT_PERSONA_METADATA_KEY,
@@ -949,6 +949,7 @@ export default function InputArea({ chatId, onNavigateHome }: InputAreaProps) {
       setPromptVariablesPreset(presetSaveCoordinator.hydrate(unmarshalPreset(preset), hydration))
       setPromptVariablesModalOpen(true)
     } catch (err) {
+      if (err instanceof StalePresetHydrationError) return
       console.error('[InputArea] Failed to load prompt variables preset:', err)
       toast.error(t('toast.failedLoadPromptVariables'))
     } finally {

--- a/frontend/src/components/chat/InputArea.tsx
+++ b/frontend/src/components/chat/InputArea.tsx
@@ -941,14 +941,18 @@ export default function InputArea({ chatId, onNavigateHome }: InputAreaProps) {
     if (promptVariablesLoading) return
     setOpenPopover(null)
     setPromptVariablesLoading(true)
+    const presetId = activeLoomPresetId
+    const hydration = presetSaveCoordinator.beginHydration(presetId, 'prompt-variables')
     try {
-      const presetId = activeLoomPresetId
-      const hydration = presetSaveCoordinator.beginHydration(presetId)
       const preset = await presetsApi.get(presetId)
-      if (useStore.getState().activeLoomPresetId !== presetId) return
+      if (useStore.getState().activeLoomPresetId !== presetId) {
+        presetSaveCoordinator.cancelHydration(hydration)
+        return
+      }
       setPromptVariablesPreset(presetSaveCoordinator.hydrate(unmarshalPreset(preset), hydration))
       setPromptVariablesModalOpen(true)
     } catch (err) {
+      presetSaveCoordinator.cancelHydration(hydration)
       if (err instanceof StalePresetHydrationError) return
       console.error('[InputArea] Failed to load prompt variables preset:', err)
       toast.error(t('toast.failedLoadPromptVariables'))

--- a/frontend/src/components/chat/InputArea.tsx
+++ b/frontend/src/components/chat/InputArea.tsx
@@ -942,8 +942,9 @@ export default function InputArea({ chatId, onNavigateHome }: InputAreaProps) {
     setOpenPopover(null)
     setPromptVariablesLoading(true)
     try {
+      const hydration = presetSaveCoordinator.beginHydration(activeLoomPresetId)
       const preset = await presetsApi.get(activeLoomPresetId)
-      setPromptVariablesPreset(presetSaveCoordinator.hydrate(unmarshalPreset(preset)))
+      setPromptVariablesPreset(presetSaveCoordinator.hydrate(unmarshalPreset(preset), hydration))
       setPromptVariablesModalOpen(true)
     } catch (err) {
       console.error('[InputArea] Failed to load prompt variables preset:', err)

--- a/frontend/src/components/chat/InputArea.tsx
+++ b/frontend/src/components/chat/InputArea.tsx
@@ -18,7 +18,8 @@ import { getPersonaAvatarThumbUrl, getCharacterAvatarThumbUrl } from '@/lib/avat
 import { uuidv7 } from '@/lib/uuid'
 import { toast } from '@/lib/toast'
 import { shouldForceLoomRuntimePreset } from '@/lib/loom/runtimeProfile'
-import { marshalUpdate, unmarshalPreset } from '@/lib/loom/service'
+import { unmarshalPreset } from '@/lib/loom/service'
+import { presetSaveCoordinator } from '@/lib/loom/preset-save-coordinator'
 import { resolveAutoPersonaBinding } from '@/store/slices/personas'
 import {
   CHAT_PERSONA_METADATA_KEY,
@@ -942,7 +943,7 @@ export default function InputArea({ chatId, onNavigateHome }: InputAreaProps) {
     setPromptVariablesLoading(true)
     try {
       const preset = await presetsApi.get(activeLoomPresetId)
-      setPromptVariablesPreset(unmarshalPreset(preset))
+      setPromptVariablesPreset(presetSaveCoordinator.hydrate(unmarshalPreset(preset)))
       setPromptVariablesModalOpen(true)
     } catch (err) {
       console.error('[InputArea] Failed to load prompt variables preset:', err)
@@ -954,14 +955,15 @@ export default function InputArea({ chatId, onNavigateHome }: InputAreaProps) {
 
   const savePromptVariableValues = useCallback(async (values: PromptVariableValues) => {
     if (!promptVariablesPreset) return
-    const updated: LoomPreset = {
-      ...promptVariablesPreset,
-      promptVariables: values,
-      updatedAt: Date.now(),
-    }
+    const updated = presetSaveCoordinator.mutate(
+      promptVariablesPreset.id,
+      promptVariablesPreset,
+      (preset) => ({ ...preset, promptVariables: values }),
+      { immediate: true },
+    )
     try {
-      const saved = await presetsApi.update(updated.id, marshalUpdate(updated))
-      setPromptVariablesPreset(unmarshalPreset(saved))
+      const saved = await presetSaveCoordinator.flush(updated.id)
+      setPromptVariablesPreset(saved ?? updated)
     } catch (err) {
       console.warn('[InputArea] Failed to save prompt variable values:', err)
       toast.error(t('toast.failedSavePromptVariables'))

--- a/frontend/src/components/panels/LoomBuilder.module.css
+++ b/frontend/src/components/panels/LoomBuilder.module.css
@@ -50,6 +50,20 @@
   flex-wrap: wrap;
 }
 
+.extensionToolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 40px;
+  padding: 6px 14px;
+  border-bottom: 1px solid var(--lumiverse-border);
+  flex-shrink: 0;
+}
+
+.extensionToolbar > div {
+  min-width: 0;
+}
+
 .extensionTabBar {
   display: flex;
   gap: 4px;

--- a/frontend/src/components/panels/LoomBuilder.tsx
+++ b/frontend/src/components/panels/LoomBuilder.tsx
@@ -91,6 +91,7 @@ import { Button } from '@/components/shared/FormComponents'
 import { toast } from '@/lib/toast'
 import { markLoomRuntimeProfileContext } from '@/lib/loom/runtimeProfile'
 import SpindlePresetEditorTabContent from '@/components/spindle/SpindlePresetEditorTabContent'
+import SpindlePresetEditorToolbarItem from '@/components/spindle/SpindlePresetEditorToolbarItem'
 import { applyPresetEditorDraft, toPresetEditorDraft } from '@/lib/spindle/preset-editor-adapter'
 import { setPresetEditorController, syncPresetEditorState } from '@/lib/spindle/preset-editor-helper'
 import s from './LoomBuilder.module.css'
@@ -1528,6 +1529,7 @@ export default function LoomBuilder({
 
   const presetProfiles = usePresetProfiles(activePresetId, activePreset?.blocks)
   const presetEditorTabs = __contextMeterStore((state) => state.presetEditorTabs)
+  const presetEditorToolbarItems = __contextMeterStore((state) => state.presetEditorToolbarItems)
   const addToast = __contextMeterStore((s) => s.addToast)
   const activePresetRef = useRef(activePreset)
   const suppressNextProfileApplyRef = useRef<string | null>(null)
@@ -2126,6 +2128,14 @@ export default function LoomBuilder({
             </div>
           )}
         </div>
+
+        {presetEditorToolbarItems.some((item) => item.visible) && (
+          <div className={s.extensionToolbar}>
+            {presetEditorToolbarItems.filter((item) => item.visible).map((item) => (
+              <SpindlePresetEditorToolbarItem key={item.id} item={item} />
+            ))}
+          </div>
+        )}
 
         {presetEditorTabs.length > 0 && (
           <div className={s.extensionTabBar} role="tablist" aria-label="Preset editor tabs">

--- a/frontend/src/components/panels/LoomBuilder.tsx
+++ b/frontend/src/components/panels/LoomBuilder.tsx
@@ -2138,7 +2138,7 @@ export default function LoomBuilder({
         )}
 
         {presetEditorTabs.length > 0 && (
-          <div className={s.extensionTabBar} role="tablist" aria-label="Preset editor tabs">
+          <div className={s.extensionTabBar} role="tablist" aria-label={lb('editorTabs.ariaLabel')}>
             <button
               type="button"
               role="tab"
@@ -2146,7 +2146,7 @@ export default function LoomBuilder({
               className={clsx(s.extensionTab, activePresetEditorTab === 'preset' && s.extensionTabActive)}
               onClick={() => setActivePresetEditorTab('preset')}
             >
-              Preset
+              {lb('editorTabs.preset')}
             </button>
             {presetEditorTabs.map((tab) => (
               <button

--- a/frontend/src/components/panels/LoomBuilder.tsx
+++ b/frontend/src/components/panels/LoomBuilder.tsx
@@ -1649,12 +1649,23 @@ export default function LoomBuilder({
 
   useEffect(() => {
     setPresetEditorController({
-      getState: () => ({
-        open: true,
-        presetId: activePresetRef.current?.id ?? null,
-        activeTabId: activePresetEditorTabRef.current,
-        preset: activePresetRef.current ? toPresetEditorDraft(activePresetRef.current) : null,
-      }),
+      getState: () => {
+        const preset = activePresetRef.current
+        if (!preset || preset.id !== __contextMeterStore.getState().activeLoomPresetId) {
+          return {
+            open: false,
+            presetId: null,
+            activeTabId: activePresetEditorTabRef.current,
+            preset: null,
+          }
+        }
+        return {
+          open: true,
+          presetId: preset.id,
+          activeTabId: activePresetEditorTabRef.current,
+          preset: toPresetEditorDraft(preset),
+        }
+      },
       setActiveTab: (tabId) => {
         setView('list')
         setEditingBlock(null)
@@ -1671,13 +1682,22 @@ export default function LoomBuilder({
   }, [])
 
   useEffect(() => {
+    if (!activePreset || activePreset.id !== activePresetId) {
+      syncPresetEditorState({
+        open: false,
+        presetId: null,
+        activeTabId: activePresetEditorTab,
+        preset: null,
+      })
+      return
+    }
     syncPresetEditorState({
       open: true,
-      presetId: activePreset?.id ?? null,
+      presetId: activePreset.id,
       activeTabId: activePresetEditorTab,
-      preset: activePreset ? toPresetEditorDraft(activePreset) : null,
+      preset: toPresetEditorDraft(activePreset),
     })
-  }, [activePreset, activePresetEditorTab])
+  }, [activePreset, activePresetEditorTab, activePresetId])
 
   useEffect(() => {
     if (activePresetEditorTab === 'preset') return

--- a/frontend/src/components/panels/LoomBuilder.tsx
+++ b/frontend/src/components/panels/LoomBuilder.tsx
@@ -2051,19 +2051,30 @@ export default function LoomBuilder({
     e.target.value = ''
   }, [importFromFile, importFromST])
 
+  const presetEditorToolbar = presetEditorToolbarItems.some((item) => item.visible) ? (
+    <div className={s.extensionToolbar}>
+      {presetEditorToolbarItems.filter((item) => item.visible).map((item) => (
+        <SpindlePresetEditorToolbarItem key={item.id} item={item} />
+      ))}
+    </div>
+  ) : null
+
   // Edit view
   if (activePresetEditorTab === 'preset' && view === 'edit' && editingBlock) {
     return (
-      <BlockEditor
-        block={editingBlock}
-        blocks={activePreset?.blocks ?? []}
-        promptVariables={activePreset?.promptVariables ?? {}}
-        onSave={handleEditSave}
-        onBack={() => { setView('list'); setEditingBlock(null) }}
-        availableMacros={availableMacros}
-        refreshMacros={refreshMacros}
-        compact={compact}
-      />
+      <>
+        {presetEditorToolbar}
+        <BlockEditor
+          block={editingBlock}
+          blocks={activePreset?.blocks ?? []}
+          promptVariables={activePreset?.promptVariables ?? {}}
+          onSave={handleEditSave}
+          onBack={() => { setView('list'); setEditingBlock(null) }}
+          availableMacros={availableMacros}
+          refreshMacros={refreshMacros}
+          compact={compact}
+        />
+      </>
     )
   }
 
@@ -2129,13 +2140,7 @@ export default function LoomBuilder({
           )}
         </div>
 
-        {presetEditorToolbarItems.some((item) => item.visible) && (
-          <div className={s.extensionToolbar}>
-            {presetEditorToolbarItems.filter((item) => item.visible).map((item) => (
-              <SpindlePresetEditorToolbarItem key={item.id} item={item} />
-            ))}
-          </div>
-        )}
+        {presetEditorToolbar}
 
         {presetEditorTabs.length > 0 && (
           <div className={s.extensionTabBar} role="tablist" aria-label={lb('editorTabs.ariaLabel')}>

--- a/frontend/src/components/spindle/SpindlePresetEditorToolbarItem.tsx
+++ b/frontend/src/components/spindle/SpindlePresetEditorToolbarItem.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from 'react'
+import type { PresetEditorToolbarItemState } from '@/store/slices/spindle-placement'
+import { scheduleSpindleDomTask } from '@/lib/spindle/browser-scheduler'
+
+interface Props {
+  item: PresetEditorToolbarItemState
+}
+
+/** Mount one extension-owned preset toolbar root without sharing host DOM. */
+export default function SpindlePresetEditorToolbarItem({ item }: Props) {
+  const hostRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const host = hostRef.current
+    if (!host) return
+    return scheduleSpindleDomTask(() => {
+      if (!host.isConnected) return
+      if (!host.contains(item.root)) host.replaceChildren(item.root)
+    }, { phase: 'paint' })
+  }, [item.root])
+
+  return <div ref={hostRef} aria-label={item.ariaLabel} />
+}

--- a/frontend/src/components/spindle/SpindlePresetEditorToolbarItem.tsx
+++ b/frontend/src/components/spindle/SpindlePresetEditorToolbarItem.tsx
@@ -19,5 +19,5 @@ export default function SpindlePresetEditorToolbarItem({ item }: Props) {
     }, { phase: 'paint' })
   }, [item.root])
 
-  return <div ref={hostRef} aria-label={item.ariaLabel} />
+  return <div ref={hostRef} role="group" aria-label={item.ariaLabel} />
 }

--- a/frontend/src/hooks/preset-profile-mutation-coordinator.test.ts
+++ b/frontend/src/hooks/preset-profile-mutation-coordinator.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, test } from 'bun:test'
+import { createPresetProfileMutationCoordinator, runPresetProfileMutation } from './preset-profile-mutation-coordinator'
+
+function deferred<T>() {
+  return Promise.withResolvers<T>()
+}
+
+describe('preset profile mutation coordinator', () => {
+  test('serializes same-target bind and unbind operations in invocation order', async () => {
+    const coordinator = createPresetProfileMutationCoordinator()
+    const firstGate = deferred<void>()
+    const calls: string[] = []
+
+    const first = coordinator.enqueue('chat-binding:chat-a', async () => {
+      calls.push('bind-start')
+      await firstGate.promise
+      calls.push('bind-end')
+      return 'bound'
+    })
+    const second = coordinator.enqueue('chat-binding:chat-a', async () => {
+      calls.push('unbind')
+      return 'unbound'
+    })
+
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(calls).toEqual(['bind-start'])
+    firstGate.resolve()
+
+    expect(await first).toBe('bound')
+    expect(await second).toBe('unbound')
+    expect(calls).toEqual(['bind-start', 'bind-end', 'unbind'])
+  })
+
+  test('a successful mutation invalidates an in-flight GET while failed writes leave it recoverable', () => {
+    const coordinator = createPresetProfileMutationCoordinator()
+    const scope = 'chat-binding:chat-a'
+
+    const initialFetch = coordinator.beginFetch(scope)
+    const mutation = coordinator.beginMutation(scope)
+    expect(coordinator.isMutationCurrent(scope, mutation)).toBe(true)
+    expect(coordinator.isFetchCurrent(scope, initialFetch)).toBe(true)
+
+    coordinator.invalidateFetch(scope)
+    expect(coordinator.isFetchCurrent(scope, initialFetch)).toBe(false)
+
+    const retryFetch = coordinator.beginFetch(scope)
+    const failedMutation = coordinator.beginMutation(scope)
+    expect(coordinator.isFetchCurrent(scope, retryFetch)).toBe(true)
+    expect(coordinator.isMutationCurrent(scope, failedMutation)).toBe(true)
+  })
+
+  test('failed latest mutations leave the original GET token available for recovery', async () => {
+    const coordinator = createPresetProfileMutationCoordinator()
+    const scope = 'chat-binding:chat-a'
+    const fetchToken = coordinator.beginFetch(scope)
+    coordinator.beginMutation(scope)
+    const failure = coordinator.enqueue(scope, async () => {
+      throw new Error('write failed')
+    })
+
+    await expect(failure).rejects.toThrow('write failed')
+    expect(coordinator.isFetchCurrent(scope, fetchToken)).toBe(true)
+  })
+
+  test('older mutations cannot commit after a newer same-target mutation starts', async () => {
+    const coordinator = createPresetProfileMutationCoordinator()
+    const scope = 'chat-binding:chat-a'
+    const firstGate = deferred<void>()
+    const firstRevision = coordinator.beginMutation(scope)
+    const first = coordinator.enqueue(scope, async () => {
+      await firstGate.promise
+    })
+    const secondRevision = coordinator.beginMutation(scope)
+    const second = coordinator.enqueue(scope, async () => {})
+
+    expect(coordinator.isMutationCurrent(scope, firstRevision)).toBe(false)
+    expect(coordinator.isMutationCurrent(scope, secondRevision)).toBe(true)
+    firstGate.resolve()
+    await Promise.all([first, second])
+  })
+
+  test('recovers an earlier successful bind when a queued unbind fails', async () => {
+    const coordinator = createPresetProfileMutationCoordinator()
+    const scope = 'chat-binding:chat-a'
+    const bindGate = deferred<void>()
+    const binding = { preset_id: 'preset-bound', block_states: {}, captured_at: 1 }
+    let persisted = { preset_id: 'preset-old', block_states: {}, captured_at: 0 }
+    let visible = persisted
+
+    const bind = runPresetProfileMutation({
+      coordinator,
+      scope,
+      operation: async () => {
+        await bindGate.promise
+        persisted = binding
+        return binding
+      },
+      refresh: async () => persisted,
+      isCurrent: (revision) => coordinator.isMutationCurrent(scope, revision),
+      commit: (value) => { visible = value },
+      recover: (value) => { visible = value },
+    })
+    const unbind = runPresetProfileMutation({
+      coordinator,
+      scope,
+      operation: async () => { throw new Error('unbind failed') },
+      refresh: async () => persisted,
+      isCurrent: (revision) => coordinator.isMutationCurrent(scope, revision),
+      commit: () => { persisted = { preset_id: 'preset-old', block_states: {}, captured_at: 0 } },
+      recover: (value) => { visible = value },
+    })
+
+    bindGate.resolve()
+    expect(await bind).toBe('stale')
+    expect(await unbind).toBe('failed')
+    expect(persisted).toBe(binding)
+    expect(visible).toBe(binding)
+  })
+
+  test('recovers an absent binding after a queued duplicate delete', async () => {
+    const coordinator = createPresetProfileMutationCoordinator()
+    const scope = 'chat-binding:chat-a'
+    const deleteGate = deferred<void>()
+    const binding = { preset_id: 'preset-bound', block_states: {}, captured_at: 1 }
+    let persisted: typeof binding | null = binding
+    let visible: typeof binding | null = binding
+
+    const firstDelete = runPresetProfileMutation({
+      coordinator,
+      scope,
+      operation: async () => {
+        await deleteGate.promise
+        persisted = null
+      },
+      refresh: async () => persisted,
+      isCurrent: (revision) => coordinator.isMutationCurrent(scope, revision),
+      commit: () => { visible = null },
+      recover: (value) => { visible = value },
+    })
+    const secondDelete = runPresetProfileMutation({
+      coordinator,
+      scope,
+      operation: async () => { throw new Error('404 binding missing') },
+      refresh: async () => null,
+      isCurrent: (revision) => coordinator.isMutationCurrent(scope, revision),
+      commit: () => { visible = null },
+      recover: (value) => { visible = value },
+    })
+
+    deleteGate.resolve()
+    expect(await firstDelete).toBe('stale')
+    expect(await secondDelete).toBe('failed')
+    expect(persisted).toBeNull()
+    expect(visible).toBeNull()
+  })
+
+  test('recovery refresh supersedes a delayed initial GET', async () => {
+    const coordinator = createPresetProfileMutationCoordinator()
+    const scope = 'chat-binding:chat-a'
+    const initialFetchGate = deferred<{ preset_id: string }>()
+    const recoveryStarted = deferred<void>()
+    const recoveryGate = deferred<{ preset_id: string }>()
+    const initialBinding = { preset_id: 'preset-initial' }
+    const recoveredBinding = { preset_id: 'preset-recovered' }
+    const currentBinding = { preset_id: 'preset-current' }
+    const initialFetch = coordinator.beginFetch(scope)
+    let visible = currentBinding
+
+    const delayedInitialFetch = initialFetchGate.promise.then((value) => {
+      if (coordinator.isFetchCurrent(scope, initialFetch)) visible = value
+    })
+    const recovery = runPresetProfileMutation({
+      coordinator,
+      scope,
+      operation: async () => { throw new Error('write failed') },
+      refresh: async () => {
+        recoveryStarted.resolve()
+        return recoveryGate.promise
+      },
+      isCurrent: (revision) => coordinator.isMutationCurrent(scope, revision),
+      commit: (value) => { visible = value },
+      recover: (value) => { visible = value },
+    })
+
+    await recoveryStarted.promise
+    initialFetchGate.resolve(initialBinding)
+    await delayedInitialFetch
+    expect(visible).toBe(currentBinding)
+
+    recoveryGate.resolve(recoveredBinding)
+    expect(await recovery).toBe('failed')
+    expect(visible).toBe(recoveredBinding)
+  })
+
+  test('preserves the last visible binding when recovery GET fails', async () => {
+    const coordinator = createPresetProfileMutationCoordinator()
+    const scope = 'chat-binding:chat-a'
+    const visible = { preset_id: 'preset-old' }
+    const initialFetch = coordinator.beginFetch(scope)
+    let state = visible
+
+    const result = await runPresetProfileMutation({
+      coordinator,
+      scope,
+      operation: async () => { throw new Error('write failed') },
+      refresh: async () => { throw new Error('read failed') },
+      isCurrent: (revision) => coordinator.isMutationCurrent(scope, revision),
+      commit: (value) => { state = value },
+      recover: (value) => { state = value },
+    })
+
+    expect(result).toBe('failed')
+    expect(coordinator.isFetchCurrent(scope, initialFetch)).toBe(false)
+    expect(state).toBe(visible)
+  })
+
+  test('drops delayed recovery from an older mutation after a newer write commits', async () => {
+    const coordinator = createPresetProfileMutationCoordinator()
+    const scope = 'chat-binding:chat-a'
+    const refreshStarted = deferred<void>()
+    const refreshGate = deferred<{ preset_id: string }>()
+    const newerGate = deferred<void>()
+    const oldBinding = { preset_id: 'preset-old' }
+    const newBinding = { preset_id: 'preset-new' }
+    const currentBinding = { preset_id: 'preset-current' }
+    let visible = currentBinding
+
+    const recovery = runPresetProfileMutation({
+      coordinator,
+      scope,
+      operation: async () => { throw new Error('write failed') },
+      refresh: async () => {
+        refreshStarted.resolve()
+        return refreshGate.promise
+      },
+      isCurrent: (revision) => coordinator.isMutationCurrent(scope, revision),
+      commit: (value) => { visible = value },
+      recover: (value) => { visible = value },
+    })
+    await refreshStarted.promise
+
+    const newer = runPresetProfileMutation({
+      coordinator,
+      scope,
+      operation: async () => {
+        await newerGate.promise
+        return newBinding
+      },
+      refresh: async () => newBinding,
+      isCurrent: (revision) => coordinator.isMutationCurrent(scope, revision),
+      commit: (value) => { visible = value },
+      recover: (value) => { visible = value },
+    })
+    refreshGate.resolve(oldBinding)
+
+    expect(await recovery).toBe('stale')
+    expect(visible).toBe(currentBinding)
+    newerGate.resolve()
+    expect(await newer).toBe('committed')
+    expect(visible).toBe(newBinding)
+  })
+
+  test('target revisions remain independent when switching away and back', () => {
+    const coordinator = createPresetProfileMutationCoordinator()
+    const firstA = coordinator.beginMutation('chat-binding:chat-a')
+    const firstB = coordinator.beginMutation('chat-binding:chat-b')
+    coordinator.beginMutation('chat-binding:chat-a')
+
+    expect(coordinator.isMutationCurrent('chat-binding:chat-a', firstA)).toBe(false)
+    expect(coordinator.isMutationCurrent('chat-binding:chat-b', firstB)).toBe(true)
+  })
+
+  test('does not start queued writes after mutation scope invalidation', async () => {
+    const coordinator = createPresetProfileMutationCoordinator()
+    const scope = 'chat-binding:chat-a'
+    const firstGate = deferred<void>()
+    const calls: string[] = []
+
+    const first = runPresetProfileMutation({
+      coordinator,
+      scope,
+      operation: async () => {
+        calls.push('first')
+        await firstGate.promise
+        return 'first'
+      },
+      refresh: async () => null,
+      isCurrent: (revision) => coordinator.isMutationCurrent(scope, revision),
+      commit: () => {},
+      recover: () => {},
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+    const second = runPresetProfileMutation({
+      coordinator,
+      scope,
+      operation: async () => {
+        calls.push('second')
+        return 'second'
+      },
+      refresh: async () => null,
+      isCurrent: (revision) => coordinator.isMutationCurrent(scope, revision),
+      commit: () => {},
+      recover: () => {},
+    })
+
+    coordinator.invalidateMutations()
+    firstGate.resolve()
+    expect(await first).toBe('stale')
+    expect(await second).toBe('stale')
+    expect(calls).toEqual(['first'])
+  })
+})

--- a/frontend/src/hooks/preset-profile-mutation-coordinator.ts
+++ b/frontend/src/hooks/preset-profile-mutation-coordinator.ts
@@ -1,0 +1,139 @@
+export interface PresetProfileFetchToken {
+  fetchRevision: number
+}
+
+export interface PresetProfileMutationCoordinator {
+  beginFetch(scope: string): PresetProfileFetchToken
+  currentFetch(scope: string): PresetProfileFetchToken
+  beginMutation(scope: string): number
+  enqueue<T>(scope: string, operation: () => Promise<T>, canStart?: () => boolean): Promise<T>
+  invalidateFetch(scope: string): void
+  invalidateMutations(): void
+  mutationEpoch(scope: string): number
+  isMutationEpochCurrent(scope: string, epoch: number): boolean
+  isFetchCurrent(scope: string, token: PresetProfileFetchToken): boolean
+  isMutationCurrent(scope: string, revision: number): boolean
+}
+
+export type PresetProfileMutationResult = 'committed' | 'stale' | 'failed'
+
+export interface RunPresetProfileMutationOptions<TWrite, TRecovery> {
+  coordinator: PresetProfileMutationCoordinator
+  scope: string
+  operation: () => Promise<TWrite>
+  canStart?: () => boolean
+  refresh: () => Promise<TRecovery>
+  isCurrent: (revision: number) => boolean
+  commit: (value: TWrite) => void
+  recover: (value: TRecovery) => void
+}
+
+function bumpRevision(revisions: Map<string, number>, scope: string): number {
+  const revision = (revisions.get(scope) ?? 0) + 1
+  revisions.set(scope, revision)
+  return revision
+}
+
+function getRevision(revisions: Map<string, number>, scope: string): number {
+  return revisions.get(scope) ?? 0
+}
+
+export function createPresetProfileMutationCoordinator(): PresetProfileMutationCoordinator {
+  const mutationRevisions = new Map<string, number>()
+  const mutationEpochs = new Map<string, number>()
+  const fetchRevisions = new Map<string, number>()
+  const queues = new Map<string, Promise<unknown>>()
+
+  const beginFetch = (scope: string): PresetProfileFetchToken => ({
+    fetchRevision: bumpRevision(fetchRevisions, scope),
+  })
+
+  const currentFetch = (scope: string): PresetProfileFetchToken => ({
+    fetchRevision: getRevision(fetchRevisions, scope),
+  })
+
+  // Starting a mutation does not invalidate an existing GET. If the write
+  // fails, recovery starts a fresh fetch revision after the operation; a
+  // successful write invalidates fetches before committing its response.
+  // Keeping the initial GET alive until the outcome is known avoids losing
+  // the last authoritative recovery path.
+  const beginMutation = (scope: string): number => bumpRevision(mutationRevisions, scope)
+
+  const enqueue = <T,>(
+    scope: string,
+    operation: () => Promise<T>,
+    canStart?: () => boolean,
+  ): Promise<T> => {
+    const previous = queues.get(scope) ?? Promise.resolve()
+    const next = previous.catch(() => undefined).then(() => {
+      if (canStart && !canStart()) throw new Error('STALE_PRESET_PROFILE_MUTATION')
+      return operation()
+    })
+    queues.set(scope, next)
+    const cleanup = () => {
+      if (queues.get(scope) === next) queues.delete(scope)
+    }
+    void next.then(cleanup, cleanup)
+    return next
+  }
+
+  return {
+    beginFetch,
+    currentFetch,
+    beginMutation,
+    enqueue,
+    invalidateFetch: (scope) => { bumpRevision(fetchRevisions, scope) },
+    invalidateMutations: () => {
+      for (const scope of new Set([
+        ...mutationRevisions.keys(),
+        ...mutationEpochs.keys(),
+        ...fetchRevisions.keys(),
+        ...queues.keys(),
+      ])) {
+        bumpRevision(mutationRevisions, scope)
+        bumpRevision(mutationEpochs, scope)
+        bumpRevision(fetchRevisions, scope)
+      }
+    },
+    mutationEpoch: (scope) => getRevision(mutationEpochs, scope),
+    isMutationEpochCurrent: (scope, epoch) => getRevision(mutationEpochs, scope) === epoch,
+    isFetchCurrent: (scope, token) => getRevision(fetchRevisions, scope) === token.fetchRevision,
+    isMutationCurrent: (scope, revision) => getRevision(mutationRevisions, scope) === revision,
+  }
+}
+
+export async function runPresetProfileMutation<TWrite, TRecovery>({
+  coordinator,
+  scope,
+  operation,
+  canStart,
+  refresh,
+  isCurrent,
+  commit,
+  recover,
+}: RunPresetProfileMutationOptions<TWrite, TRecovery>): Promise<PresetProfileMutationResult> {
+  const revision = coordinator.beginMutation(scope)
+  const mutationEpoch = coordinator.mutationEpoch(scope)
+  try {
+    const value = await coordinator.enqueue(
+      scope,
+      operation,
+      () => coordinator.isMutationEpochCurrent(scope, mutationEpoch) && (canStart?.() ?? true),
+    )
+    coordinator.invalidateFetch(scope)
+    if (!isCurrent(revision)) return 'stale'
+    commit(value)
+    return 'committed'
+  } catch {
+    if (!isCurrent(revision)) return 'stale'
+    const fetchToken = coordinator.beginFetch(scope)
+    try {
+      const value = await refresh()
+      if (isCurrent(revision) && coordinator.isFetchCurrent(scope, fetchToken)) recover(value)
+    } catch {
+      // Preserve the last visible state when recovery itself fails. The
+      // mutation error still returns to the caller for user-facing feedback.
+    }
+    return isCurrent(revision) ? 'failed' : 'stale'
+  }
+}

--- a/frontend/src/hooks/useAppInit.ts
+++ b/frontend/src/hooks/useAppInit.ts
@@ -10,6 +10,7 @@ import { personasApi } from '@/api/personas'
 import { packsApi } from '@/api/packs'
 import { resetUserScopedStoreState } from '@/store/user-scoped-reset'
 import { setSettingsPersistenceScope } from '@/store/slices/settings'
+import { setPresetSaveCoordinatorScope } from '@/lib/loom/preset-save-coordinator'
 import { listAllConnections } from '@/api/listAllConnections'
 
 let appInitGeneration = 0
@@ -40,6 +41,7 @@ export function useAppInit() {
       initializedUserId.current = null
       appInitGeneration += 1
       setSettingsPersistenceScope(null)
+      setPresetSaveCoordinatorScope(null)
       return
     }
 
@@ -48,6 +50,7 @@ export function useAppInit() {
       resetUserScopedStoreState()
     }
     setSettingsPersistenceScope(userId)
+    setPresetSaveCoordinatorScope(userId)
     initializedUserId.current = userId
     const generation = ++appInitGeneration
     const isCurrent = () => (

--- a/frontend/src/hooks/useBoundPresetSelection.ts
+++ b/frontend/src/hooks/useBoundPresetSelection.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { presetProfilesApi } from '@/api/preset-profiles'
 import { useStore } from '@/store'
-import { transitionActiveLoomPreset } from '@/lib/loom/preset-selection-coordinator'
+import { beginActiveLoomPresetSelection } from '@/lib/loom/preset-selection-coordinator'
 
 export function useBoundPresetSelection() {
   const isAuthenticated = useStore((s) => s.isAuthenticated)
@@ -16,21 +16,35 @@ export function useBoundPresetSelection() {
 
     let cancelled = false
     const selectionAbort = new AbortController()
+    const selection = beginActiveLoomPresetSelection({ signal: selectionAbort.signal })
     const fallbackPresetId = useStore.getState().activeLoomPresetId
 
     presetProfilesApi.resolve(activeChatId, fallbackPresetId, activeProfileId)
       .then((resolved) => {
         if (cancelled) return
-        if (resolved.source !== 'chat' && resolved.source !== 'character' && resolved.source !== 'connection') return
-        if (!resolved.preset_id) return
-        if (useStore.getState().activeChatId !== activeChatId) return
-        if (activeLoomPresetId === resolved.preset_id) return
-        void transitionActiveLoomPreset(resolved.preset_id, { signal: selectionAbort.signal }).catch(() => {})
+        if (
+          resolved.source !== 'chat'
+          && resolved.source !== 'character'
+          && resolved.source !== 'connection'
+        ) {
+          selection.cancel()
+          return
+        }
+        if (!resolved.preset_id || useStore.getState().activeChatId !== activeChatId) {
+          selection.cancel()
+          return
+        }
+        if (useStore.getState().activeLoomPresetId === resolved.preset_id) {
+          selection.cancel()
+          return
+        }
+        void selection.transition(resolved.preset_id).catch(() => {})
       })
-      .catch(() => {})
+      .catch(() => { selection.cancel() })
 
     return () => {
       cancelled = true
+      selection.cancel()
       selectionAbort.abort()
     }
   }, [activeChatId, activeCharacterId, activeLoomPresetId, activeProfileId, isAuthenticated, settingsLoaded])

--- a/frontend/src/hooks/useBoundPresetSelection.ts
+++ b/frontend/src/hooks/useBoundPresetSelection.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { presetProfilesApi } from '@/api/preset-profiles'
 import { useStore } from '@/store'
+import { transitionActiveLoomPreset } from '@/lib/loom/preset-selection-coordinator'
 
 export function useBoundPresetSelection() {
   const isAuthenticated = useStore((s) => s.isAuthenticated)
@@ -8,12 +9,13 @@ export function useBoundPresetSelection() {
   const activeChatId = useStore((s) => s.activeChatId)
   const activeCharacterId = useStore((s) => s.activeCharacterId)
   const activeProfileId = useStore((s) => s.activeProfileId)
-  const setActiveLoomPreset = useStore((s) => s.setActiveLoomPreset)
+  const activeLoomPresetId = useStore((s) => s.activeLoomPresetId)
 
   useEffect(() => {
     if (!isAuthenticated || !settingsLoaded || !activeChatId) return
 
     let cancelled = false
+    const selectionAbort = new AbortController()
     const fallbackPresetId = useStore.getState().activeLoomPresetId
 
     presetProfilesApi.resolve(activeChatId, fallbackPresetId, activeProfileId)
@@ -22,11 +24,14 @@ export function useBoundPresetSelection() {
         if (resolved.source !== 'chat' && resolved.source !== 'character' && resolved.source !== 'connection') return
         if (!resolved.preset_id) return
         if (useStore.getState().activeChatId !== activeChatId) return
-        if (useStore.getState().activeLoomPresetId === resolved.preset_id) return
-        setActiveLoomPreset(resolved.preset_id)
+        if (activeLoomPresetId === resolved.preset_id) return
+        void transitionActiveLoomPreset(resolved.preset_id, { signal: selectionAbort.signal }).catch(() => {})
       })
       .catch(() => {})
 
-    return () => { cancelled = true }
-  }, [activeChatId, activeCharacterId, activeProfileId, isAuthenticated, settingsLoaded, setActiveLoomPreset])
+    return () => {
+      cancelled = true
+      selectionAbort.abort()
+    }
+  }, [activeChatId, activeCharacterId, activeLoomPresetId, activeProfileId, isAuthenticated, settingsLoaded])
 }

--- a/frontend/src/hooks/useLoomBuilder.ts
+++ b/frontend/src/hooks/useLoomBuilder.ts
@@ -7,7 +7,7 @@ import { regexApi } from '@/api/regex'
 import { toast } from '@/lib/toast'
 import i18n from '@/i18n'
 import { enqueuePresetRegexOperation } from '@/lib/presetRegexQueue'
-import { presetSaveCoordinator } from '@/lib/loom/preset-save-coordinator'
+import { flushPresetForGeneration, presetSaveCoordinator } from '@/lib/loom/preset-save-coordinator'
 import { getMacroCatalog } from '@/api/macros'
 import type { LoomPreset, PromptBlock, LoomConnectionProfile, MacroGroup, PromptVariableValues } from '@/lib/loom/types'
 import {
@@ -122,13 +122,13 @@ export function useLoomBuilder() {
   const createPreset = useCallback(async (name: string, description?: string) => {
     setIsLoading(true)
     try {
-      const previousPresetId = activePresetRef.current?.id
-      if (previousPresetId) await presetSaveCoordinator.flush(previousPresetId)
+      const previousPresetId = activePresetRef.current?.id ?? activeLoomPresetId
+      if (previousPresetId) await flushPresetForGeneration(previousPresetId)
       const loom = createNewLoomPreset(name, description)
       const created = await presetsApi.create(marshalPreset(loom))
       const newLoom = presetSaveCoordinator.hydrate(unmarshalPreset(created))
       await refreshRegistry()
-      if (previousPresetId) await presetSaveCoordinator.flush(previousPresetId)
+      if (previousPresetId) await flushPresetForGeneration(previousPresetId)
       setActiveLoomPreset(created.id)
       activePresetRef.current = newLoom
       setActivePreset(newLoom)
@@ -139,13 +139,13 @@ export function useLoomBuilder() {
     } finally {
       setIsLoading(false)
     }
-  }, [refreshRegistry, setActiveLoomPreset])
+  }, [activeLoomPresetId, refreshRegistry, setActiveLoomPreset])
 
   const flushPendingPreset = useCallback(async (): Promise<void> => {
-    const presetId = activePresetRef.current?.id
+    const presetId = activePresetRef.current?.id ?? activeLoomPresetId
     if (!presetId) return
-    await presetSaveCoordinator.flush(presetId)
-  }, [])
+    await flushPresetForGeneration(presetId)
+  }, [activeLoomPresetId])
 
   // Keep this mounted editor synchronized when another owner (the prompt
   // variable modal or a Spindle scoped helper) updates the shared draft.
@@ -288,7 +288,7 @@ export function useLoomBuilder() {
 
   // Delete a preset
   const deletePreset = useCallback(async (presetId: string) => {
-    await presetSaveCoordinator.flush(presetId)
+    await flushPresetForGeneration(presetId)
     await presetsApi.delete(presetId)
     presetSaveCoordinator.remove(presetId)
     await refreshRegistry()
@@ -311,10 +311,10 @@ export function useLoomBuilder() {
   const duplicatePreset = useCallback(async (presetId: string, newName: string) => {
     setIsLoading(true)
     try {
-      await presetSaveCoordinator.flush(presetId)
+      await flushPresetForGeneration(presetId)
       const hydration = presetSaveCoordinator.beginHydration(presetId)
       presetSaveCoordinator.hydrate(unmarshalPreset(await presetsApi.get(presetId)), hydration)
-      await presetSaveCoordinator.flush(presetId)
+      await flushPresetForGeneration(presetId)
       const source = presetSaveCoordinator.getDraft(presetId)
       if (!source) throw new Error('Preset disappeared while preparing its duplicate')
       const copy = createNewLoomPreset(newName)
@@ -334,7 +334,7 @@ export function useLoomBuilder() {
       const created = await presetsApi.create(marshalPreset(copy))
       const newLoom = presetSaveCoordinator.hydrate(unmarshalPreset(created))
       await refreshRegistry()
-      await presetSaveCoordinator.flush(presetId)
+      await flushPresetForGeneration(presetId)
       setActiveLoomPreset(created.id)
       activePresetRef.current = newLoom
       setActivePreset(newLoom)
@@ -454,14 +454,14 @@ export function useLoomBuilder() {
   const persistImportedPreset = useCallback(async (payload: any, fileName?: string) => {
     setIsLoading(true)
     try {
-      const previousPresetId = activePresetRef.current?.id
-      if (previousPresetId) await presetSaveCoordinator.flush(previousPresetId)
+      const previousPresetId = activePresetRef.current?.id ?? activeLoomPresetId
+      if (previousPresetId) await flushPresetForGeneration(previousPresetId)
       const fallbackName = fileName?.replace(/\.json$/i, '') || 'Imported Preset'
       const loom = coerceImportedLoomPreset(payload, fallbackName)
       const created = await presetsApi.create(marshalPreset(loom))
       const newLoom = presetSaveCoordinator.hydrate(unmarshalPreset(created))
       await refreshRegistry()
-      if (previousPresetId) await presetSaveCoordinator.flush(previousPresetId)
+      if (previousPresetId) await flushPresetForGeneration(previousPresetId)
       setActiveLoomPreset(created.id)
       activePresetRef.current = newLoom
       setActivePreset(newLoom)
@@ -497,7 +497,7 @@ export function useLoomBuilder() {
     } finally {
       setIsLoading(false)
     }
-  }, [refreshRegistry, setActiveLoomPreset])
+  }, [activeLoomPresetId, refreshRegistry, setActiveLoomPreset])
 
   // Import from legacy preset JSON
   const importFromST = useCallback(async (stData: any, fileName: string) => {

--- a/frontend/src/hooks/useLoomBuilder.ts
+++ b/frontend/src/hooks/useLoomBuilder.ts
@@ -61,9 +61,10 @@ export function useLoomBuilder() {
 
     let cancelled = false
     setIsLoading(true)
+    const hydration = presetSaveCoordinator.beginHydration(activeLoomPresetId)
     presetsApi.get(activeLoomPresetId).then((preset) => {
       if (cancelled) return
-      const loadedPreset = presetSaveCoordinator.hydrate(unmarshalPreset(preset))
+      const loadedPreset = presetSaveCoordinator.hydrate(unmarshalPreset(preset), hydration)
       activePresetRef.current = loadedPreset
       setActivePreset(loadedPreset)
       setIsLoading(false)
@@ -121,10 +122,13 @@ export function useLoomBuilder() {
   const createPreset = useCallback(async (name: string, description?: string) => {
     setIsLoading(true)
     try {
+      const previousPresetId = activePresetRef.current?.id
+      if (previousPresetId) await presetSaveCoordinator.flush(previousPresetId)
       const loom = createNewLoomPreset(name, description)
       const created = await presetsApi.create(marshalPreset(loom))
       const newLoom = presetSaveCoordinator.hydrate(unmarshalPreset(created))
       await refreshRegistry()
+      if (previousPresetId) await presetSaveCoordinator.flush(previousPresetId)
       setActiveLoomPreset(created.id)
       activePresetRef.current = newLoom
       setActivePreset(newLoom)
@@ -184,8 +188,9 @@ export function useLoomBuilder() {
       if (!event.persisted) return
       const presetId = activePresetRef.current?.id
       if (!presetId) return
+      const hydration = presetSaveCoordinator.beginHydration(presetId)
       void presetsApi.get(presetId).then((preset) => {
-        const restored = presetSaveCoordinator.hydrate(unmarshalPreset(preset))
+        const restored = presetSaveCoordinator.hydrate(unmarshalPreset(preset), hydration)
         if (activePresetRef.current?.id !== restored.id) return
         activePresetRef.current = restored
         setActivePreset(restored)
@@ -263,9 +268,10 @@ export function useLoomBuilder() {
 
   // Rename a preset
   const renamePreset = useCallback(async (presetId: string, newName: string) => {
+    const hydration = presetSaveCoordinator.beginHydration(presetId)
     const current = presetId === activePresetRef.current?.id
       ? activePresetRef.current
-      : presetSaveCoordinator.hydrate(unmarshalPreset(await presetsApi.get(presetId)))
+      : presetSaveCoordinator.hydrate(unmarshalPreset(await presetsApi.get(presetId)), hydration)
     const updated = presetSaveCoordinator.mutate(
       presetId,
       current,
@@ -306,7 +312,11 @@ export function useLoomBuilder() {
     setIsLoading(true)
     try {
       await presetSaveCoordinator.flush(presetId)
-      const source = presetSaveCoordinator.hydrate(unmarshalPreset(await presetsApi.get(presetId)))
+      const hydration = presetSaveCoordinator.beginHydration(presetId)
+      presetSaveCoordinator.hydrate(unmarshalPreset(await presetsApi.get(presetId)), hydration)
+      await presetSaveCoordinator.flush(presetId)
+      const source = presetSaveCoordinator.getDraft(presetId)
+      if (!source) throw new Error('Preset disappeared while preparing its duplicate')
       const copy = createNewLoomPreset(newName)
       // Copy all content from the coordinator-confirmed persisted source.
       copy.blocks = JSON.parse(JSON.stringify(source.blocks))
@@ -324,6 +334,7 @@ export function useLoomBuilder() {
       const created = await presetsApi.create(marshalPreset(copy))
       const newLoom = presetSaveCoordinator.hydrate(unmarshalPreset(created))
       await refreshRegistry()
+      await presetSaveCoordinator.flush(presetId)
       setActiveLoomPreset(created.id)
       activePresetRef.current = newLoom
       setActivePreset(newLoom)
@@ -443,11 +454,14 @@ export function useLoomBuilder() {
   const persistImportedPreset = useCallback(async (payload: any, fileName?: string) => {
     setIsLoading(true)
     try {
+      const previousPresetId = activePresetRef.current?.id
+      if (previousPresetId) await presetSaveCoordinator.flush(previousPresetId)
       const fallbackName = fileName?.replace(/\.json$/i, '') || 'Imported Preset'
       const loom = coerceImportedLoomPreset(payload, fallbackName)
       const created = await presetsApi.create(marshalPreset(loom))
       const newLoom = presetSaveCoordinator.hydrate(unmarshalPreset(created))
       await refreshRegistry()
+      if (previousPresetId) await presetSaveCoordinator.flush(previousPresetId)
       setActiveLoomPreset(created.id)
       activePresetRef.current = newLoom
       setActivePreset(newLoom)

--- a/frontend/src/hooks/useLoomBuilder.ts
+++ b/frontend/src/hooks/useLoomBuilder.ts
@@ -2,11 +2,12 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useStore } from '@/store'
 import { presetsApi } from '@/api/presets'
 import { connectionsApi } from '@/api/connections'
-import { ApiError, BASE_URL } from '@/api/client'
+import { ApiError } from '@/api/client'
 import { regexApi } from '@/api/regex'
 import { toast } from '@/lib/toast'
 import i18n from '@/i18n'
 import { enqueuePresetRegexOperation } from '@/lib/presetRegexQueue'
+import { presetSaveCoordinator } from '@/lib/loom/preset-save-coordinator'
 import { getMacroCatalog } from '@/api/macros'
 import type { LoomPreset, PromptBlock, LoomConnectionProfile, MacroGroup, PromptVariableValues } from '@/lib/loom/types'
 import {
@@ -32,49 +33,6 @@ import {
   detectImportedPresetKind,
 } from '@/lib/loom/service'
 
-const PENDING_LOOM_PRESETS_KEY = '__lumiverse_pending_loom_presets'
-
-function readPendingLoomPresets(): Record<string, LoomPreset> {
-  if (typeof window === 'undefined') return {}
-  try {
-    const raw = localStorage.getItem(PENDING_LOOM_PRESETS_KEY)
-    if (!raw) return {}
-    const parsed = JSON.parse(raw)
-    return parsed && typeof parsed === 'object' ? parsed : {}
-  } catch {
-    return {}
-  }
-}
-
-function writePendingLoomPresets(presets: Record<string, LoomPreset>) {
-  if (typeof window === 'undefined') return
-  try {
-    if (Object.keys(presets).length === 0) {
-      localStorage.removeItem(PENDING_LOOM_PRESETS_KEY)
-      return
-    }
-    localStorage.setItem(PENDING_LOOM_PRESETS_KEY, JSON.stringify(presets))
-  } catch {}
-}
-
-function getPendingLoomPreset(id: string): LoomPreset | null {
-  const pending = readPendingLoomPresets()[id]
-  return pending && typeof pending === 'object' ? pending : null
-}
-
-function setPendingLoomPreset(preset: LoomPreset) {
-  const pending = readPendingLoomPresets()
-  pending[preset.id] = preset
-  writePendingLoomPresets(pending)
-}
-
-function clearPendingLoomPreset(id: string, expected?: LoomPreset) {
-  const pending = readPendingLoomPresets()
-  if (!(id in pending)) return
-  if (expected && JSON.stringify(pending[id]) !== JSON.stringify(expected)) return
-  delete pending[id]
-  writePendingLoomPresets(pending)
-}
 
 export function useLoomBuilder() {
   const activeLoomPresetId = useStore((s) => s.activeLoomPresetId)
@@ -88,40 +46,35 @@ export function useLoomBuilder() {
   const [activePreset, setActivePreset] = useState<LoomPreset | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const activePresetRef = useRef<LoomPreset | null>(null)
 
-  // Load active preset when activeLoomPresetId changes
+  // Load active preset when activeLoomPresetId changes. Durable recovery is
+  // rebased through the process-wide coordinator so an old local snapshot
+  // cannot overwrite unrelated prompt-variable or extension metadata changes.
   useEffect(() => {
     if (!activeLoomPresetId) {
+      activePresetRef.current = null
       setActivePreset(null)
       return
     }
-    if (activePreset?.id === activeLoomPresetId) {
-      return
-    }
+    if (activePresetRef.current?.id === activeLoomPresetId) return
+
     let cancelled = false
     setIsLoading(true)
     presetsApi.get(activeLoomPresetId).then((preset) => {
-      if (!cancelled) {
-        const loadedPreset = unmarshalPreset(preset)
-        const pendingPreset = getPendingLoomPreset(activeLoomPresetId)
-
-        if (pendingPreset && JSON.stringify(marshalUpdate(pendingPreset)) !== JSON.stringify(marshalUpdate(loadedPreset))) {
-          setActivePreset(pendingPreset)
-          void presetsApi.update(pendingPreset.id, marshalUpdate(pendingPreset))
-            .then(() => clearPendingLoomPreset(pendingPreset.id))
-            .catch(() => {})
-        } else {
-          if (pendingPreset) clearPendingLoomPreset(activeLoomPresetId)
-          setActivePreset(loadedPreset)
-        }
-        setIsLoading(false)
-      }
+      if (cancelled) return
+      const loadedPreset = presetSaveCoordinator.hydrate(unmarshalPreset(preset))
+      activePresetRef.current = loadedPreset
+      setActivePreset(loadedPreset)
+      setIsLoading(false)
     }).catch((err) => {
       if (cancelled) return
       // Retroactive cleanup: if the persisted active preset id points at a row
       // that no longer exists (legacy deletions that didn't cascade), clear it
       // so generation doesn't keep 400ing on a ghost id.
       if (err instanceof ApiError && err.status === 404) {
+        presetSaveCoordinator.remove(activeLoomPresetId)
+        activePresetRef.current = null
         setActiveLoomPreset(null)
         setActivePreset(null)
         setIsLoading(false)
@@ -132,7 +85,7 @@ export function useLoomBuilder() {
       setIsLoading(false)
     })
     return () => { cancelled = true }
-  }, [activeLoomPresetId, activePreset?.id, setActiveLoomPreset])
+  }, [activeLoomPresetId, setActiveLoomPreset])
 
   // Refresh registry from API
   const refreshRegistry = useCallback(async () => {
@@ -170,9 +123,10 @@ export function useLoomBuilder() {
     try {
       const loom = createNewLoomPreset(name, description)
       const created = await presetsApi.create(marshalPreset(loom))
-      const newLoom = unmarshalPreset(created)
+      const newLoom = presetSaveCoordinator.hydrate(unmarshalPreset(created))
       await refreshRegistry()
       setActiveLoomPreset(created.id)
+      activePresetRef.current = newLoom
       setActivePreset(newLoom)
       return newLoom
     } catch (err: any) {
@@ -183,70 +137,24 @@ export function useLoomBuilder() {
     }
   }, [refreshRegistry, setActiveLoomPreset])
 
-  // Debounced preset save
-  const pendingSaveRef = useRef<LoomPreset | null>(null)
-  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const persistChainRef = useRef<Promise<void>>(Promise.resolve())
-
-  const persistPreset = useCallback((preset: LoomPreset): Promise<void> => {
-    setPendingLoomPreset(preset)
-    const operation = persistChainRef.current
-      .catch(() => {})
-      .then(async () => {
-        await presetsApi.update(preset.id, marshalUpdate(preset))
-        clearPendingLoomPreset(preset.id, preset)
-      })
-    persistChainRef.current = operation
-    return operation
+  const flushPendingPreset = useCallback(async (): Promise<void> => {
+    const presetId = activePresetRef.current?.id
+    if (!presetId) return
+    await presetSaveCoordinator.flush(presetId)
   }, [])
 
-  const persistPresetKeepalive = useCallback((preset: LoomPreset) => {
-    setPendingLoomPreset(preset)
-    fetch(`${BASE_URL}/presets/${encodeURIComponent(preset.id)}`, {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json',
-      },
-      credentials: 'include',
-      body: JSON.stringify(marshalUpdate(preset)),
-      keepalive: true,
-    }).catch(() => {})
-  }, [])
+  // Keep this mounted editor synchronized when another owner (the prompt
+  // variable modal or a Spindle scoped helper) updates the shared draft.
+  useEffect(() => {
+    if (!activeLoomPresetId) return
+    return presetSaveCoordinator.subscribe(activeLoomPresetId, (preset) => {
+      if (activePresetRef.current?.id !== preset.id) return
+      activePresetRef.current = preset
+      setActivePreset(preset)
+    })
+  }, [activeLoomPresetId])
 
-  const debouncedSavePreset = useCallback((preset: LoomPreset) => {
-    pendingSaveRef.current = preset
-    setPendingLoomPreset(preset)
-    if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
-    saveTimerRef.current = setTimeout(async () => {
-      const toSave = pendingSaveRef.current
-      if (toSave) {
-        pendingSaveRef.current = null
-        try {
-          await persistPreset(toSave)
-        } catch (err) {
-          console.warn('[LoomBuilder] Debounced save failed:', err)
-        }
-      }
-    }, 400)
-  }, [persistPreset])
-
-  const flushPendingPreset = useCallback(async (mode: 'default' | 'keepalive' = 'default'): Promise<void> => {
-    const pending = pendingSaveRef.current
-    if (saveTimerRef.current) {
-      clearTimeout(saveTimerRef.current)
-      saveTimerRef.current = null
-    }
-    pendingSaveRef.current = null
-    if (mode === 'keepalive') {
-      if (pending) persistPresetKeepalive(pending)
-      return
-    }
-    if (pending) await persistPreset(pending)
-    await persistChainRef.current
-  }, [persistPreset, persistPresetKeepalive])
-
-  // Flush pending save on unmount
+  // Flush pending save on unmount.
   useEffect(() => () => {
     void flushPendingPreset()
   }, [flushPendingPreset])
@@ -254,7 +162,10 @@ export function useLoomBuilder() {
   useEffect(() => {
     if (typeof window === 'undefined') return
 
-    const handlePageExit = () => { void flushPendingPreset('keepalive') }
+    const handlePageExit = () => {
+      const presetId = activePresetRef.current?.id
+      if (presetId) presetSaveCoordinator.flushBestEffort(presetId)
+    }
     window.addEventListener('beforeunload', handlePageExit)
     window.addEventListener('pagehide', handlePageExit)
 
@@ -262,20 +173,28 @@ export function useLoomBuilder() {
       window.removeEventListener('beforeunload', handlePageExit)
       window.removeEventListener('pagehide', handlePageExit)
     }
-  }, [flushPendingPreset])
+  }, [])
 
-  const takePendingPreset = useCallback((presetId: string): LoomPreset | null => {
-    if (saveTimerRef.current) {
-      clearTimeout(saveTimerRef.current)
-      saveTimerRef.current = null
+  // BFCache restoration keeps React mounted, so re-read and field-rebase the
+  // active preset instead of replaying a stale full-document snapshot.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (!event.persisted) return
+      const presetId = activePresetRef.current?.id
+      if (!presetId) return
+      void presetsApi.get(presetId).then((preset) => {
+        const restored = presetSaveCoordinator.hydrate(unmarshalPreset(preset))
+        if (activePresetRef.current?.id !== restored.id) return
+        activePresetRef.current = restored
+        setActivePreset(restored)
+      }).catch((err) => {
+        console.warn('[LoomBuilder] Failed to rebase restored preset:', err)
+      })
     }
-
-    const pending = pendingSaveRef.current?.id === presetId
-      ? pendingSaveRef.current
-      : null
-
-    pendingSaveRef.current = null
-    return pending
+    window.addEventListener('pageshow', handlePageShow)
+    return () => { window.removeEventListener('pageshow', handlePageShow) }
   }, [])
 
   // Flush the prior draft before changing the editor target so extension and
@@ -291,10 +210,7 @@ export function useLoomBuilder() {
   }, [flushPendingPreset, setActiveLoomPreset])
 
   // Read activePreset through a ref so saveStructure stays reference-stable
-  // across renders. When saveBlocks is captured by downstream effects, a
-  // changing reference would either cause runaway effect loops or leak stale
-  // activePreset into the callback — the ref avoids both.
-  const activePresetRef = useRef(activePreset)
+  // across renders. The coordinator remains the authoritative draft owner.
   activePresetRef.current = activePreset
 
   const updateActivePreset = useCallback((
@@ -303,40 +219,42 @@ export function useLoomBuilder() {
   ) => {
     const current = activePresetRef.current
     if (!current) return
-    const updated = updater(current)
+    const updated = presetSaveCoordinator.mutate(
+      current.id,
+      current,
+      updater,
+      { immediate },
+    )
     activePresetRef.current = updated
     setActivePreset(updated)
     if (immediate) {
-      takePendingPreset(updated.id)
-      void persistPreset(updated).catch((err) => {
+      void presetSaveCoordinator.flush(updated.id).catch((err) => {
         console.warn('[LoomBuilder] Immediate preset save failed:', err)
       })
-    } else {
-      debouncedSavePreset(updated)
     }
-  }, [debouncedSavePreset, persistPreset, takePendingPreset])
+  }, [])
 
   const saveStructure = useCallback(async (
     blocks: PromptBlock[],
   ) => {
     const current = activePresetRef.current
     if (!current) return
-    const base = takePendingPreset(current.id) ?? current
     const normalizedBlocks = normalizeCategoryBlockState(blocks)
-    const updated = {
-      ...base,
-      blocks: normalizedBlocks,
-      updatedAt: Date.now(),
-    }
+    const updated = presetSaveCoordinator.mutate(
+      current.id,
+      current,
+      (draft) => ({ ...draft, blocks: normalizedBlocks }),
+      { immediate: true },
+    )
     activePresetRef.current = updated
     setActivePreset(updated)
     try {
-      await persistPreset(updated)
+      await presetSaveCoordinator.flush(updated.id)
       refreshRegistry()
     } catch (err) {
       console.warn('[LoomBuilder] Failed to save preset structure:', err)
     }
-  }, [persistPreset, refreshRegistry, takePendingPreset])
+  }, [refreshRegistry])
 
   // Save blocks
   const saveBlocks = useCallback(async (blocks: PromptBlock[]) => {
@@ -345,21 +263,31 @@ export function useLoomBuilder() {
 
   // Rename a preset
   const renamePreset = useCallback(async (presetId: string, newName: string) => {
-    if (presetId === activePresetRef.current?.id) {
-      updateActivePreset((current) => ({ ...current, name: newName, updatedAt: Date.now() }), true)
-      await flushPendingPreset()
-    } else {
-      await presetsApi.update(presetId, { name: newName })
+    const current = presetId === activePresetRef.current?.id
+      ? activePresetRef.current
+      : presetSaveCoordinator.hydrate(unmarshalPreset(await presetsApi.get(presetId)))
+    const updated = presetSaveCoordinator.mutate(
+      presetId,
+      current,
+      (draft) => ({ ...draft, name: newName }),
+      { immediate: true },
+    )
+    if (updated.id === activePresetRef.current?.id) {
+      activePresetRef.current = updated
+      setActivePreset(updated)
     }
+    await presetSaveCoordinator.flush(presetId)
     await refreshRegistry()
-  }, [flushPendingPreset, refreshRegistry, updateActivePreset])
+  }, [refreshRegistry])
 
   // Delete a preset
   const deletePreset = useCallback(async (presetId: string) => {
-    await flushPendingPreset()
+    await presetSaveCoordinator.flush(presetId)
     await presetsApi.delete(presetId)
+    presetSaveCoordinator.remove(presetId)
     await refreshRegistry()
     if (presetId === activeLoomPresetId) {
+      activePresetRef.current = null
       setActiveLoomPreset(null)
       setActivePreset(null)
     }
@@ -371,33 +299,33 @@ export function useLoomBuilder() {
     } catch {
       // non-fatal — store just keeps the previous profile list
     }
-  }, [activeLoomPresetId, flushPendingPreset, refreshRegistry, setActiveLoomPreset])
+  }, [activeLoomPresetId, refreshRegistry, setActiveLoomPreset])
 
   // Duplicate a preset
   const duplicatePreset = useCallback(async (presetId: string, newName: string) => {
     setIsLoading(true)
     try {
-      await flushPendingPreset()
-      const original = await presetsApi.get(presetId)
-      const loom = unmarshalPreset(original)
+      await presetSaveCoordinator.flush(presetId)
+      const source = presetSaveCoordinator.hydrate(unmarshalPreset(await presetsApi.get(presetId)))
       const copy = createNewLoomPreset(newName)
-      // Copy all content from original
-      copy.blocks = JSON.parse(JSON.stringify(loom.blocks))
-      copy.samplerOverrides = { ...loom.samplerOverrides }
-      copy.customBody = { ...loom.customBody }
-      copy.promptBehavior = { ...loom.promptBehavior }
-      copy.completionSettings = { ...loom.completionSettings }
-      copy.advancedSettings = { ...loom.advancedSettings }
-      copy.modelProfiles = { ...loom.modelProfiles }
-      copy.passthroughMetadata = JSON.parse(JSON.stringify(loom.passthroughMetadata || {}))
-      copy.promptVariables = JSON.parse(JSON.stringify(loom.promptVariables || {}))
-      copy.source = loom.source ? { ...loom.source } : null
-      copy.coverUrl = loom.coverUrl
+      // Copy all content from the coordinator-confirmed persisted source.
+      copy.blocks = JSON.parse(JSON.stringify(source.blocks))
+      copy.samplerOverrides = { ...source.samplerOverrides }
+      copy.customBody = { ...source.customBody }
+      copy.promptBehavior = { ...source.promptBehavior }
+      copy.completionSettings = { ...source.completionSettings }
+      copy.advancedSettings = { ...source.advancedSettings }
+      copy.modelProfiles = { ...source.modelProfiles }
+      copy.passthroughMetadata = JSON.parse(JSON.stringify(source.passthroughMetadata))
+      copy.promptVariables = JSON.parse(JSON.stringify(source.promptVariables))
+      copy.source = source.source ? { ...source.source } : null
+      copy.coverUrl = source.coverUrl
 
       const created = await presetsApi.create(marshalPreset(copy))
-      const newLoom = unmarshalPreset(created)
+      const newLoom = presetSaveCoordinator.hydrate(unmarshalPreset(created))
       await refreshRegistry()
       setActiveLoomPreset(created.id)
+      activePresetRef.current = newLoom
       setActivePreset(newLoom)
       return newLoom
     } catch (err: any) {
@@ -406,7 +334,7 @@ export function useLoomBuilder() {
     } finally {
       setIsLoading(false)
     }
-  }, [flushPendingPreset, refreshRegistry, setActiveLoomPreset])
+  }, [refreshRegistry, setActiveLoomPreset])
 
   // Block manipulation helpers
   const addBlock = useCallback((block: PromptBlock, index?: number) => {
@@ -494,18 +422,23 @@ export function useLoomBuilder() {
   // so we bypass the debouncer and wait for the network round-trip so errors
   // surface immediately.
   const savePromptVariableValues = useCallback(async (values: PromptVariableValues) => {
-    if (!activePreset) return
-    const base = takePendingPreset(activePreset.id) ?? activePreset
-    const updated = { ...base, promptVariables: values, updatedAt: Date.now() }
+    const current = activePresetRef.current
+    if (!current) return
+    const updated = presetSaveCoordinator.mutate(
+      current.id,
+      current,
+      (draft) => ({ ...draft, promptVariables: values }),
+      { immediate: true },
+    )
     activePresetRef.current = updated
     setActivePreset(updated)
     try {
-      await persistPreset(updated)
+      await presetSaveCoordinator.flush(updated.id)
     } catch (err) {
       console.warn('[LoomBuilder] Failed to save prompt variable values:', err)
       throw err
     }
-  }, [activePreset, persistPreset, takePendingPreset])
+  }, [])
 
   const persistImportedPreset = useCallback(async (payload: any, fileName?: string) => {
     setIsLoading(true)
@@ -513,9 +446,10 @@ export function useLoomBuilder() {
       const fallbackName = fileName?.replace(/\.json$/i, '') || 'Imported Preset'
       const loom = coerceImportedLoomPreset(payload, fallbackName)
       const created = await presetsApi.create(marshalPreset(loom))
-      const newLoom = unmarshalPreset(created)
+      const newLoom = presetSaveCoordinator.hydrate(unmarshalPreset(created))
       await refreshRegistry()
       setActiveLoomPreset(created.id)
+      activePresetRef.current = newLoom
       setActivePreset(newLoom)
 
       const embeddedRegex = Array.isArray(payload?.extensions?.regex_scripts)

--- a/frontend/src/hooks/useLoomBuilder.ts
+++ b/frontend/src/hooks/useLoomBuilder.ts
@@ -8,7 +8,7 @@ import { toast } from '@/lib/toast'
 import i18n from '@/i18n'
 import { enqueuePresetRegexOperation } from '@/lib/presetRegexQueue'
 import { flushPresetForGeneration, presetSaveCoordinator, StalePresetHydrationError } from '@/lib/loom/preset-save-coordinator'
-import { transitionActiveLoomPreset } from '@/lib/loom/preset-selection-coordinator'
+import { beginActiveLoomPresetSelection, transitionActiveLoomPreset } from '@/lib/loom/preset-selection-coordinator'
 import { getMacroCatalog } from '@/api/macros'
 import type { LoomPreset, PromptBlock, LoomConnectionProfile, MacroGroup, PromptVariableValues } from '@/lib/loom/types'
 import {
@@ -61,14 +61,18 @@ export function useLoomBuilder() {
 
     let cancelled = false
     setIsLoading(true)
-    const hydration = presetSaveCoordinator.beginHydration(activeLoomPresetId)
+    const hydration = presetSaveCoordinator.beginHydration(activeLoomPresetId, 'loom-editor')
     presetsApi.get(activeLoomPresetId).then((preset) => {
-      if (cancelled) return
+      if (cancelled) {
+        presetSaveCoordinator.cancelHydration(hydration)
+        return
+      }
       const loadedPreset = presetSaveCoordinator.hydrate(unmarshalPreset(preset), hydration)
       activePresetRef.current = loadedPreset
       setActivePreset(loadedPreset)
       setIsLoading(false)
     }).catch((err) => {
+      presetSaveCoordinator.cancelHydration(hydration)
       if (cancelled) return
       if (err instanceof StalePresetHydrationError) {
         setIsLoading(false)
@@ -79,9 +83,11 @@ export function useLoomBuilder() {
       // so generation doesn't keep 400ing on a ghost id.
       if (err instanceof ApiError && err.status === 404) {
         presetSaveCoordinator.remove(activeLoomPresetId)
-        activePresetRef.current = null
-        setActiveLoomPreset(null)
-        setActivePreset(null)
+        if (useStore.getState().activeLoomPresetId === activeLoomPresetId) {
+          activePresetRef.current = null
+          useStore.getState().setActiveLoomPreset(null)
+          setActivePreset(null)
+        }
         setIsLoading(false)
         return
       }
@@ -89,8 +95,12 @@ export function useLoomBuilder() {
       setError(err.message)
       setIsLoading(false)
     })
-    return () => { cancelled = true }
-  }, [activeLoomPresetId, setActiveLoomPreset])
+    return () => {
+      cancelled = true
+      presetSaveCoordinator.cancelHydration(hydration)
+    }
+  }, [activeLoomPresetId])
+
 
   // Refresh registry from API
   const refreshRegistry = useCallback(async () => {
@@ -124,17 +134,20 @@ export function useLoomBuilder() {
 
   // Create a new preset
   const createPreset = useCallback(async (name: string, description?: string) => {
+    const selection = beginActiveLoomPresetSelection()
     setIsLoading(true)
     try {
       const loom = createNewLoomPreset(name, description)
       const created = await presetsApi.create(marshalPreset(loom))
       const newLoom = presetSaveCoordinator.hydrate(unmarshalPreset(created))
       await refreshRegistry()
-      await transitionActiveLoomPreset(created.id)
-      activePresetRef.current = newLoom
-      setActivePreset(newLoom)
+      if (await selection.transition(created.id)) {
+        activePresetRef.current = newLoom
+        setActivePreset(newLoom)
+      }
       return newLoom
     } catch (err: any) {
+      selection.cancel()
       setError(err.message)
       throw err
     } finally {
@@ -190,13 +203,18 @@ export function useLoomBuilder() {
       if (!event.persisted) return
       const presetId = activePresetRef.current?.id
       if (!presetId) return
-      const hydration = presetSaveCoordinator.beginHydration(presetId)
+      const hydration = presetSaveCoordinator.beginHydration(presetId, 'loom-editor')
       void presetsApi.get(presetId).then((preset) => {
+        if (useStore.getState().activeLoomPresetId !== presetId) {
+          presetSaveCoordinator.cancelHydration(hydration)
+          return
+        }
         const restored = presetSaveCoordinator.hydrate(unmarshalPreset(preset), hydration)
         if (activePresetRef.current?.id !== restored.id) return
         activePresetRef.current = restored
         setActivePreset(restored)
       }).catch((err) => {
+        presetSaveCoordinator.cancelHydration(hydration)
         if (err instanceof StalePresetHydrationError) return
         console.warn('[LoomBuilder] Failed to rebase restored preset:', err)
       })
@@ -267,10 +285,16 @@ export function useLoomBuilder() {
 
   // Rename a preset
   const renamePreset = useCallback(async (presetId: string, newName: string) => {
-    const hydration = presetSaveCoordinator.beginHydration(presetId)
-    const current = presetId === activePresetRef.current?.id
-      ? activePresetRef.current
-      : presetSaveCoordinator.hydrate(unmarshalPreset(await presetsApi.get(presetId)), hydration)
+    let current = presetId === activePresetRef.current?.id ? activePresetRef.current : null
+    if (!current) {
+      const hydration = presetSaveCoordinator.beginHydration(presetId, 'preset-rename')
+      try {
+        current = presetSaveCoordinator.hydrate(unmarshalPreset(await presetsApi.get(presetId)), hydration)
+      } catch (error) {
+        presetSaveCoordinator.cancelHydration(hydration)
+        throw error
+      }
+    }
     const updated = presetSaveCoordinator.mutate(
       presetId,
       current,
@@ -291,9 +315,11 @@ export function useLoomBuilder() {
     await presetsApi.delete(presetId)
     presetSaveCoordinator.remove(presetId)
     await refreshRegistry()
-    if (presetId === activeLoomPresetId) {
+    // A later coordinated selection may have committed while deletion was in
+    // flight. Only clear the live selection when it still names this row.
+    if (useStore.getState().activeLoomPresetId === presetId) {
       activePresetRef.current = null
-      setActiveLoomPreset(null)
+      useStore.getState().setActiveLoomPreset(null)
       setActivePreset(null)
     }
     // Refresh connection profiles so any stale preset_id references (the
@@ -304,18 +330,26 @@ export function useLoomBuilder() {
     } catch {
       // non-fatal — store just keeps the previous profile list
     }
-  }, [activeLoomPresetId, refreshRegistry, setActiveLoomPreset])
+  }, [refreshRegistry])
 
   // Duplicate a preset
   const duplicatePreset = useCallback(async (presetId: string, newName: string) => {
+    const selection = beginActiveLoomPresetSelection()
     setIsLoading(true)
     try {
       await flushPresetForGeneration(presetId)
-      const hydration = presetSaveCoordinator.beginHydration(presetId)
-      presetSaveCoordinator.hydrate(unmarshalPreset(await presetsApi.get(presetId)), hydration)
-      await flushPresetForGeneration(presetId)
-      const source = presetSaveCoordinator.getDraft(presetId)
-      if (!source) throw new Error('Preset disappeared while preparing its duplicate')
+      const hydration = presetSaveCoordinator.beginHydration(presetId, 'preset-duplicate')
+      let hydratedSource: LoomPreset
+      try {
+        hydratedSource = presetSaveCoordinator.hydrate(
+          unmarshalPreset(await presetsApi.get(presetId)),
+          hydration,
+        )
+      } catch (error) {
+        presetSaveCoordinator.cancelHydration(hydration)
+        throw error
+      }
+      const source = await presetSaveCoordinator.flush(presetId) ?? hydratedSource
       const copy = createNewLoomPreset(newName)
       // Copy all content from the coordinator-confirmed persisted source.
       copy.blocks = JSON.parse(JSON.stringify(source.blocks))
@@ -334,11 +368,13 @@ export function useLoomBuilder() {
       const newLoom = presetSaveCoordinator.hydrate(unmarshalPreset(created))
       await refreshRegistry()
       await flushPresetForGeneration(presetId)
-      await transitionActiveLoomPreset(created.id)
-      activePresetRef.current = newLoom
-      setActivePreset(newLoom)
+      if (await selection.transition(created.id)) {
+        activePresetRef.current = newLoom
+        setActivePreset(newLoom)
+      }
       return newLoom
     } catch (err: any) {
+      selection.cancel()
       setError(err.message)
       throw err
     } finally {
@@ -451,6 +487,7 @@ export function useLoomBuilder() {
   }, [])
 
   const persistImportedPreset = useCallback(async (payload: any, fileName?: string) => {
+    const selection = beginActiveLoomPresetSelection()
     setIsLoading(true)
     try {
       const fallbackName = fileName?.replace(/\.json$/i, '') || 'Imported Preset'
@@ -458,9 +495,10 @@ export function useLoomBuilder() {
       const created = await presetsApi.create(marshalPreset(loom))
       const newLoom = presetSaveCoordinator.hydrate(unmarshalPreset(created))
       await refreshRegistry()
-      await transitionActiveLoomPreset(created.id)
-      activePresetRef.current = newLoom
-      setActivePreset(newLoom)
+      if (await selection.transition(created.id)) {
+        activePresetRef.current = newLoom
+        setActivePreset(newLoom)
+      }
 
       const embeddedRegex = Array.isArray(payload?.extensions?.regex_scripts)
         ? payload.extensions.regex_scripts
@@ -488,6 +526,7 @@ export function useLoomBuilder() {
 
       return newLoom
     } catch (err: any) {
+      selection.cancel()
       setError(err.message)
       throw err
     } finally {

--- a/frontend/src/hooks/useLoomBuilder.ts
+++ b/frontend/src/hooks/useLoomBuilder.ts
@@ -7,7 +7,8 @@ import { regexApi } from '@/api/regex'
 import { toast } from '@/lib/toast'
 import i18n from '@/i18n'
 import { enqueuePresetRegexOperation } from '@/lib/presetRegexQueue'
-import { flushPresetForGeneration, presetSaveCoordinator } from '@/lib/loom/preset-save-coordinator'
+import { flushPresetForGeneration, presetSaveCoordinator, StalePresetHydrationError } from '@/lib/loom/preset-save-coordinator'
+import { transitionActiveLoomPreset } from '@/lib/loom/preset-selection-coordinator'
 import { getMacroCatalog } from '@/api/macros'
 import type { LoomPreset, PromptBlock, LoomConnectionProfile, MacroGroup, PromptVariableValues } from '@/lib/loom/types'
 import {
@@ -21,7 +22,6 @@ import {
 import {
   createNewLoomPreset,
   marshalPreset,
-  marshalUpdate,
   unmarshalPreset,
   detectSupportedParamsFromProviders,
   getAvailableMacros,
@@ -70,6 +70,10 @@ export function useLoomBuilder() {
       setIsLoading(false)
     }).catch((err) => {
       if (cancelled) return
+      if (err instanceof StalePresetHydrationError) {
+        setIsLoading(false)
+        return
+      }
       // Retroactive cleanup: if the persisted active preset id points at a row
       // that no longer exists (legacy deletions that didn't cascade), clear it
       // so generation doesn't keep 400ing on a ghost id.
@@ -122,14 +126,11 @@ export function useLoomBuilder() {
   const createPreset = useCallback(async (name: string, description?: string) => {
     setIsLoading(true)
     try {
-      const previousPresetId = activePresetRef.current?.id ?? activeLoomPresetId
-      if (previousPresetId) await flushPresetForGeneration(previousPresetId)
       const loom = createNewLoomPreset(name, description)
       const created = await presetsApi.create(marshalPreset(loom))
       const newLoom = presetSaveCoordinator.hydrate(unmarshalPreset(created))
       await refreshRegistry()
-      if (previousPresetId) await flushPresetForGeneration(previousPresetId)
-      setActiveLoomPreset(created.id)
+      await transitionActiveLoomPreset(created.id)
       activePresetRef.current = newLoom
       setActivePreset(newLoom)
       return newLoom
@@ -139,7 +140,7 @@ export function useLoomBuilder() {
     } finally {
       setIsLoading(false)
     }
-  }, [activeLoomPresetId, refreshRegistry, setActiveLoomPreset])
+  }, [refreshRegistry])
 
   const flushPendingPreset = useCallback(async (): Promise<void> => {
     const presetId = activePresetRef.current?.id ?? activeLoomPresetId
@@ -152,9 +153,10 @@ export function useLoomBuilder() {
   useEffect(() => {
     if (!activeLoomPresetId) return
     return presetSaveCoordinator.subscribe(activeLoomPresetId, (preset) => {
-      if (activePresetRef.current?.id !== preset.id) return
+      if (useStore.getState().activeLoomPresetId !== preset.id) return
       activePresetRef.current = preset
       setActivePreset(preset)
+      setIsLoading(false)
     })
   }, [activeLoomPresetId])
 
@@ -195,6 +197,7 @@ export function useLoomBuilder() {
         activePresetRef.current = restored
         setActivePreset(restored)
       }).catch((err) => {
+        if (err instanceof StalePresetHydrationError) return
         console.warn('[LoomBuilder] Failed to rebase restored preset:', err)
       })
     }
@@ -204,26 +207,22 @@ export function useLoomBuilder() {
 
   // Flush the prior draft before changing the editor target so extension and
   // native edits cannot be delivered to the wrong preset or lost on unmount.
+  // All supported manual and automatic selection paths use the same
+  // coordinator so the departing draft is flushed before a new id is exposed.
   const selectPreset = useCallback(async (presetId: string | null) => {
-    await flushPendingPreset()
-    if (!presetId) {
-      setActiveLoomPreset(null)
-      setActivePreset(null)
-      return
-    }
-    setActiveLoomPreset(presetId)
-  }, [flushPendingPreset, setActiveLoomPreset])
+    await transitionActiveLoomPreset(presetId)
+  }, [])
 
   // Read activePreset through a ref so saveStructure stays reference-stable
   // across renders. The coordinator remains the authoritative draft owner.
-  activePresetRef.current = activePreset
+  activePresetRef.current = activePreset?.id === activeLoomPresetId ? activePreset : null
 
   const updateActivePreset = useCallback((
     updater: (current: LoomPreset) => LoomPreset,
     immediate = false,
   ) => {
     const current = activePresetRef.current
-    if (!current) return
+    if (!current || useStore.getState().activeLoomPresetId !== current.id) return
     const updated = presetSaveCoordinator.mutate(
       current.id,
       current,
@@ -243,7 +242,7 @@ export function useLoomBuilder() {
     blocks: PromptBlock[],
   ) => {
     const current = activePresetRef.current
-    if (!current) return
+    if (!current || useStore.getState().activeLoomPresetId !== current.id) return
     const normalizedBlocks = normalizeCategoryBlockState(blocks)
     const updated = presetSaveCoordinator.mutate(
       current.id,
@@ -335,7 +334,7 @@ export function useLoomBuilder() {
       const newLoom = presetSaveCoordinator.hydrate(unmarshalPreset(created))
       await refreshRegistry()
       await flushPresetForGeneration(presetId)
-      setActiveLoomPreset(created.id)
+      await transitionActiveLoomPreset(created.id)
       activePresetRef.current = newLoom
       setActivePreset(newLoom)
       return newLoom
@@ -345,7 +344,7 @@ export function useLoomBuilder() {
     } finally {
       setIsLoading(false)
     }
-  }, [refreshRegistry, setActiveLoomPreset])
+  }, [refreshRegistry])
 
   // Block manipulation helpers
   const addBlock = useCallback((block: PromptBlock, index?: number) => {
@@ -434,7 +433,7 @@ export function useLoomBuilder() {
   // surface immediately.
   const savePromptVariableValues = useCallback(async (values: PromptVariableValues) => {
     const current = activePresetRef.current
-    if (!current) return
+    if (!current || useStore.getState().activeLoomPresetId !== current.id) return
     const updated = presetSaveCoordinator.mutate(
       current.id,
       current,
@@ -454,15 +453,12 @@ export function useLoomBuilder() {
   const persistImportedPreset = useCallback(async (payload: any, fileName?: string) => {
     setIsLoading(true)
     try {
-      const previousPresetId = activePresetRef.current?.id ?? activeLoomPresetId
-      if (previousPresetId) await flushPresetForGeneration(previousPresetId)
       const fallbackName = fileName?.replace(/\.json$/i, '') || 'Imported Preset'
       const loom = coerceImportedLoomPreset(payload, fallbackName)
       const created = await presetsApi.create(marshalPreset(loom))
       const newLoom = presetSaveCoordinator.hydrate(unmarshalPreset(created))
       await refreshRegistry()
-      if (previousPresetId) await flushPresetForGeneration(previousPresetId)
-      setActiveLoomPreset(created.id)
+      await transitionActiveLoomPreset(created.id)
       activePresetRef.current = newLoom
       setActivePreset(newLoom)
 
@@ -497,7 +493,7 @@ export function useLoomBuilder() {
     } finally {
       setIsLoading(false)
     }
-  }, [activeLoomPresetId, refreshRegistry, setActiveLoomPreset])
+  }, [refreshRegistry])
 
   // Import from legacy preset JSON
   const importFromST = useCallback(async (stData: any, fileName: string) => {
@@ -593,7 +589,7 @@ export function useLoomBuilder() {
     // State
     registry: loomRegistry,
     activePresetId: activeLoomPresetId,
-    activePreset,
+    activePreset: activePreset?.id === activeLoomPresetId ? activePreset : null,
     isLoading,
     error,
     availableMacros,

--- a/frontend/src/hooks/usePresetProfiles-selection.test.ts
+++ b/frontend/src/hooks/usePresetProfiles-selection.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, test } from 'bun:test'
+import { createPresetSelectionCoordinator } from '@/lib/loom/preset-selection-coordinator-core'
+import { createPresetProfileSelectionController } from './usePresetProfiles-selection'
+
+function deferred<T>() {
+  const gate = Promise.withResolvers<T>()
+  return { promise: gate.promise, resolve: gate.resolve }
+}
+
+describe('preset profile selection controller', () => {
+  test('does not supersede an unrelated settings request without a target', async () => {
+    let activePresetId: string | null = 'preset-a'
+    let beginCalls = 0
+    const coordinator = createPresetSelectionCoordinator({
+      getActivePresetId: () => activePresetId,
+      setActivePresetId: (presetId) => { activePresetId = presetId },
+      flushPreset: async () => {},
+    })
+    const profiles = createPresetProfileSelectionController(() => {
+      beginCalls += 1
+      return coordinator.begin()
+    })
+    const settingsRequest = coordinator.begin()
+
+    profiles.select(null, 'preset-a')
+    profiles.select('preset-a', 'preset-a')
+    profiles.cancel()
+
+    expect(beginCalls).toBe(0)
+    expect(await settingsRequest.transition('preset-settings')).toBe(true)
+    expect(activePresetId).toBe('preset-settings')
+  })
+
+  test('cancels a resolved binding transition when its context changes', async () => {
+    let activePresetId: string | null = 'preset-a'
+    let beginCalls = 0
+    const flushStarted = deferred<void>()
+    const pendingFlush = deferred<void>()
+    const coordinator = createPresetSelectionCoordinator({
+      getActivePresetId: () => activePresetId,
+      setActivePresetId: (presetId) => { activePresetId = presetId },
+      flushPreset: async () => {
+        flushStarted.resolve()
+        await pendingFlush.promise
+      },
+    })
+    const profiles = createPresetProfileSelectionController(() => {
+      beginCalls += 1
+      return coordinator.begin()
+    })
+
+    const transition = profiles.select('preset-binding', 'preset-a')
+    await flushStarted.promise
+    profiles.cancel()
+    pendingFlush.resolve()
+
+    expect(beginCalls).toBe(1)
+    expect(await transition).toBe(false)
+    expect(activePresetId).toBe('preset-a')
+  })
+
+  test('allows a fresh request after the previous transition settles', async () => {
+    let beginCalls = 0
+    const transitions: Array<Promise<boolean>> = []
+    const profiles = createPresetProfileSelectionController(() => {
+      beginCalls += 1
+      const transition = Promise.resolve(beginCalls === 2)
+      transitions.push(transition)
+      return {
+        transition: async () => transition,
+        cancel: () => {},
+      }
+    })
+
+    expect(await profiles.select('preset-binding', 'preset-a')).toBe(false)
+    expect(await profiles.select('preset-binding', 'preset-a')).toBe(true)
+    expect(beginCalls).toBe(2)
+  })
+  test('cancels an obsolete binding when the resolved target returns to current', async () => {
+    let activePresetId: string | null = 'preset-a'
+    const flushStarted = deferred<void>()
+    const pendingFlush = deferred<void>()
+    const coordinator = createPresetSelectionCoordinator({
+      getActivePresetId: () => activePresetId,
+      setActivePresetId: (presetId) => { activePresetId = presetId },
+      flushPreset: async () => {
+        flushStarted.resolve()
+        await pendingFlush.promise
+      },
+    })
+    const profiles = createPresetProfileSelectionController(() => coordinator.begin())
+
+    const transition = profiles.select('preset-binding', 'preset-a')
+    await flushStarted.promise
+    expect(profiles.select('preset-a', 'preset-a')).toBeNull()
+    pendingFlush.resolve()
+
+    expect(await transition).toBe(false)
+    expect(activePresetId).toBe('preset-a')
+  })
+
+  test('cancels an obsolete binding when no target remains', async () => {
+    let activePresetId: string | null = 'preset-a'
+    const flushStarted = deferred<void>()
+    const pendingFlush = deferred<void>()
+    const coordinator = createPresetSelectionCoordinator({
+      getActivePresetId: () => activePresetId,
+      setActivePresetId: (presetId) => { activePresetId = presetId },
+      flushPreset: async () => {
+        flushStarted.resolve()
+        await pendingFlush.promise
+      },
+    })
+    const profiles = createPresetProfileSelectionController(() => coordinator.begin())
+
+    const transition = profiles.select('preset-binding', 'preset-a')
+    await flushStarted.promise
+    expect(profiles.select(null, 'preset-a')).toBeNull()
+    pendingFlush.resolve()
+
+    expect(await transition).toBe(false)
+    expect(activePresetId).toBe('preset-a')
+  })
+
+  test('supersedes a pending binding transition when a newer target resolves', async () => {
+    let activePresetId: string | null = 'preset-a'
+    let flushCount = 0
+    const firstFlushStarted = deferred<void>()
+    const firstFlush = deferred<void>()
+    const flushed: string[] = []
+    const coordinator = createPresetSelectionCoordinator({
+      getActivePresetId: () => activePresetId,
+      setActivePresetId: (presetId) => { activePresetId = presetId },
+      flushPreset: async (presetId) => {
+        flushed.push(presetId)
+        flushCount += 1
+        if (flushCount === 1) {
+          firstFlushStarted.resolve()
+          await firstFlush.promise
+        }
+      },
+    })
+    const profiles = createPresetProfileSelectionController(() => coordinator.begin())
+
+    const first = profiles.select('preset-b', 'preset-a')
+    await firstFlushStarted.promise
+    const second = profiles.select('preset-c', 'preset-a')
+    firstFlush.resolve()
+
+    expect(await first).toBe(false)
+    expect(await second).toBe(true)
+    expect(flushed).toEqual(['preset-a', 'preset-a'])
+    expect(activePresetId).toBe('preset-c')
+  })
+
+  test('does not restart selection for repeated calls of the same pending target', async () => {
+    let activePresetId: string | null = 'preset-a'
+    let beginCalls = 0
+    let flushes = 0
+    const flushStarted = deferred<void>()
+    const pendingFlush = deferred<void>()
+    const coordinator = createPresetSelectionCoordinator({
+      getActivePresetId: () => activePresetId,
+      setActivePresetId: (presetId) => { activePresetId = presetId },
+      flushPreset: async () => {
+        flushes += 1
+        flushStarted.resolve()
+        await pendingFlush.promise
+      },
+    })
+    const profiles = createPresetProfileSelectionController(() => {
+      beginCalls += 1
+      return coordinator.begin()
+    })
+
+    const first = profiles.select('preset-binding', 'preset-a')
+    await flushStarted.promise
+    const second = profiles.select('preset-binding', 'preset-a')
+    pendingFlush.resolve()
+
+    expect(first).toBe(second)
+    expect(beginCalls).toBe(1)
+    expect(flushes).toBe(1)
+    expect(await first).toBe(true)
+    expect(activePresetId).toBe('preset-binding')
+  })
+
+  test('transitions to a later target in the same stable context after the prior one committed', async () => {
+    let activePresetId: string | null = 'preset-a'
+    let beginCalls = 0
+    const flushed: string[] = []
+    const coordinator = createPresetSelectionCoordinator({
+      getActivePresetId: () => activePresetId,
+      setActivePresetId: (presetId) => { activePresetId = presetId },
+      flushPreset: async (presetId) => { flushed.push(presetId) },
+    })
+    const profiles = createPresetProfileSelectionController(() => {
+      beginCalls += 1
+      return coordinator.begin()
+    })
+
+    expect(await profiles.select('preset-b', 'preset-a')).toBe(true)
+    expect(await profiles.select('preset-c', 'preset-b')).toBe(true)
+
+    expect(beginCalls).toBe(2)
+    expect(flushed).toEqual(['preset-a', 'preset-b'])
+    expect(activePresetId).toBe('preset-c')
+  })
+})

--- a/frontend/src/hooks/usePresetProfiles-selection.ts
+++ b/frontend/src/hooks/usePresetProfiles-selection.ts
@@ -1,0 +1,59 @@
+import {
+  beginActiveLoomPresetSelection,
+  type PresetSelectionRequest,
+} from '@/lib/loom/preset-selection-coordinator'
+
+export type BeginPresetSelection = () => PresetSelectionRequest
+
+export interface PresetProfileSelectionController {
+  select(resolvedPresetId: string | null, currentPresetId: string | null): Promise<boolean> | null
+  cancel(): void
+}
+
+/**
+ * Owns the selection request created by a resolved profile binding.
+ *
+ * A request is reserved only when a binding resolves to a different preset;
+ * callers can cancel that request when the profile context changes or unmounts.
+ */
+export function createPresetProfileSelectionController(
+  beginSelection: BeginPresetSelection = beginActiveLoomPresetSelection,
+): PresetProfileSelectionController {
+  let selection: {
+    target: string
+    request: PresetSelectionRequest
+    transition: Promise<boolean>
+  } | null = null
+
+  const cancel = () => {
+    selection?.request.cancel()
+    selection = null
+  }
+
+  const select = (resolvedPresetId: string | null, currentPresetId: string | null) => {
+    if (!resolvedPresetId || resolvedPresetId === currentPresetId) {
+      // A removed binding must retire its prior transition, but with no owned
+      // request this is a no-op and cannot invalidate unrelated global work.
+      cancel()
+      return null
+    }
+
+    if (selection?.target === resolvedPresetId) {
+      return selection.transition
+    }
+
+    // A changed binding result supersedes any transition started for the
+    // previous result before reserving the new latest intent.
+    cancel()
+    const request = beginSelection()
+    const transition = request.transition(resolvedPresetId)
+      .catch(() => false)
+      .finally(() => {
+        if (selection?.request === request) selection = null
+      })
+    selection = { target: resolvedPresetId, request, transition }
+    return transition
+  }
+
+  return { select, cancel }
+}

--- a/frontend/src/hooks/usePresetProfiles.ts
+++ b/frontend/src/hooks/usePresetProfiles.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStore } from '@/store'
 import { presetProfilesApi, type PresetProfileBinding } from '@/api/preset-profiles'
+import { transitionActiveLoomPreset } from '@/lib/loom/preset-selection-coordinator'
 import type { PromptBlock } from '@/lib/loom/types'
 
 /**
@@ -35,7 +36,6 @@ export function usePresetProfiles(
   const activeChatId = useStore((s) => s.activeChatId)
   const activeCharacterId = useStore((s) => s.activeCharacterId)
   const activeProfileId = useStore((s) => s.activeProfileId)
-  const setActiveLoomPreset = useStore((s) => s.setActiveLoomPreset)
   const isGroupChat = useStore((s) => s.isGroupChat)
   const addToast = useStore((s) => s.addToast)
 
@@ -281,8 +281,8 @@ export function usePresetProfiles(
 
   const selectResolvedPreset = useCallback(() => {
     if (!resolvedPresetId || resolvedPresetId === presetId) return
-    setActiveLoomPreset(resolvedPresetId)
-  }, [resolvedPresetId, presetId, setActiveLoomPreset])
+    void transitionActiveLoomPreset(resolvedPresetId).catch(() => {})
+  }, [resolvedPresetId, presetId])
 
   return {
     // State

--- a/frontend/src/hooks/usePresetProfiles.ts
+++ b/frontend/src/hooks/usePresetProfiles.ts
@@ -1,8 +1,8 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStore } from '@/store'
 import { presetProfilesApi, type PresetProfileBinding } from '@/api/preset-profiles'
-import { transitionActiveLoomPreset } from '@/lib/loom/preset-selection-coordinator'
+import { beginActiveLoomPresetSelection, type PresetSelectionRequest } from '@/lib/loom/preset-selection-coordinator'
 import type { PromptBlock } from '@/lib/loom/types'
 
 /**
@@ -44,6 +44,20 @@ export function usePresetProfiles(
   const [charSlot, setCharSlot] = useState<CharSlot>(EMPTY_CHAR_SLOT)
   const [connectionSlot, setConnectionSlot] = useState<ConnectionSlot>(EMPTY_CONNECTION_SLOT)
   const [isLoading, setIsLoading] = useState(false)
+  const selectionIntentRef = useRef<PresetSelectionRequest | null>(null)
+
+  useEffect(() => {
+    selectionIntentRef.current?.cancel()
+    const selectionIntent = beginActiveLoomPresetSelection()
+    selectionIntentRef.current = selectionIntent
+    return () => {
+      selectionIntent.cancel()
+      if (selectionIntentRef.current === selectionIntent) {
+        selectionIntentRef.current = null
+      }
+    }
+  }, [activeChatId, activeCharacterId, activeProfileId, presetId])
+
 
   // Load defaults for the currently selected preset. Defaults are stored per
   // preset, so switching presets should load a different default snapshot.
@@ -281,7 +295,15 @@ export function usePresetProfiles(
 
   const selectResolvedPreset = useCallback(() => {
     if (!resolvedPresetId || resolvedPresetId === presetId) return
-    void transitionActiveLoomPreset(resolvedPresetId).catch(() => {})
+    const selection = selectionIntentRef.current ?? beginActiveLoomPresetSelection()
+    selectionIntentRef.current = selection
+    void selection.transition(resolvedPresetId)
+      .catch(() => {})
+      .finally(() => {
+        if (selectionIntentRef.current === selection) {
+          selectionIntentRef.current = null
+        }
+      })
   }, [resolvedPresetId, presetId])
 
   return {

--- a/frontend/src/hooks/usePresetProfiles.ts
+++ b/frontend/src/hooks/usePresetProfiles.ts
@@ -1,8 +1,10 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStore } from '@/store'
+import { ApiError } from '@/api/client'
 import { presetProfilesApi, type PresetProfileBinding } from '@/api/preset-profiles'
-import { beginActiveLoomPresetSelection, type PresetSelectionRequest } from '@/lib/loom/preset-selection-coordinator'
+import { createPresetProfileSelectionController, type PresetProfileSelectionController } from './usePresetProfiles-selection'
+import { createPresetProfileMutationCoordinator, runPresetProfileMutation, type PresetProfileMutationCoordinator } from './preset-profile-mutation-coordinator'
 import type { PromptBlock } from '@/lib/loom/types'
 
 /**
@@ -16,6 +18,15 @@ function snapshotBlockStates(blocks: PromptBlock[]): Record<string, boolean> {
   return states
 }
 
+function refreshProfileBinding(
+  request: Promise<PresetProfileBinding>,
+): Promise<PresetProfileBinding | null> {
+  return request.catch((error: unknown) => {
+    if (error instanceof ApiError && error.status === 404) return null
+    throw error
+  })
+}
+
 // Bindings are cached with the chat/character id they were fetched for so
 // stale fetches (e.g. left over from the previous chat) can't leak into the
 // current context. The `for` field holds the id the binding was fetched
@@ -27,6 +38,12 @@ type ConnectionSlot = { for: string | null; binding: PresetProfileBinding | null
 const EMPTY_CHAT_SLOT: ChatSlot = { for: null, binding: null }
 const EMPTY_CHAR_SLOT: CharSlot = { for: null, binding: null }
 const EMPTY_CONNECTION_SLOT: ConnectionSlot = { for: null, binding: null }
+const profileScopes = {
+  defaults: (id: string) => `defaults:${id}`,
+  chat: (id: string) => `chat-binding:${id}`,
+  character: (id: string) => `character-binding:${id}`,
+  connection: (id: string) => `connection-binding:${id}`,
+}
 
 export function usePresetProfiles(
   presetId: string | null,
@@ -39,88 +56,151 @@ export function usePresetProfiles(
   const isGroupChat = useStore((s) => s.isGroupChat)
   const addToast = useStore((s) => s.addToast)
 
+  const authUserId = useStore((s) => s.user?.id ?? null)
   const [defaults, setDefaults] = useState<PresetProfileBinding | null>(null)
+  const [defaultsFor, setDefaultsFor] = useState<string | null>(null)
   const [chatSlot, setChatSlot] = useState<ChatSlot>(EMPTY_CHAT_SLOT)
   const [charSlot, setCharSlot] = useState<CharSlot>(EMPTY_CHAR_SLOT)
   const [connectionSlot, setConnectionSlot] = useState<ConnectionSlot>(EMPTY_CONNECTION_SLOT)
+  const presetIdRef = useRef(presetId)
+  const authUserIdRef = useRef(authUserId)
+  presetIdRef.current = presetId
+  authUserIdRef.current = authUserId
+  const activeChatIdRef = useRef(activeChatId)
+  const activeCharacterIdRef = useRef(activeCharacterId)
+  const activeProfileIdRef = useRef(activeProfileId)
+  activeChatIdRef.current = activeChatId
+  activeCharacterIdRef.current = activeCharacterId
+  activeProfileIdRef.current = activeProfileId
+  const mutationCoordinatorRef = useRef<PresetProfileMutationCoordinator | null>(null)
+  if (!mutationCoordinatorRef.current) {
+    mutationCoordinatorRef.current = createPresetProfileMutationCoordinator()
+  }
+  const mutationCoordinator = mutationCoordinatorRef.current!
   const [isLoading, setIsLoading] = useState(false)
-  const selectionIntentRef = useRef<PresetSelectionRequest | null>(null)
+  const mutationCountRef = useRef(0)
+  const beginMutation = useCallback(() => {
+    mutationCountRef.current += 1
+    setIsLoading(true)
+  }, [])
+  const endMutation = useCallback(() => {
+    mutationCountRef.current = Math.max(0, mutationCountRef.current - 1)
+    setIsLoading(mutationCountRef.current > 0)
+  }, [])
+  const selectionControllerRef = useRef<PresetProfileSelectionController | null>(null)
+  if (!selectionControllerRef.current) {
+    selectionControllerRef.current = createPresetProfileSelectionController()
+  }
 
   useEffect(() => {
-    selectionIntentRef.current?.cancel()
-    const selectionIntent = beginActiveLoomPresetSelection()
-    selectionIntentRef.current = selectionIntent
     return () => {
-      selectionIntent.cancel()
-      if (selectionIntentRef.current === selectionIntent) {
-        selectionIntentRef.current = null
-      }
+      selectionControllerRef.current?.cancel()
+      mutationCoordinator.invalidateMutations()
     }
-  }, [activeChatId, activeCharacterId, activeProfileId, presetId])
-
+  }, [activeChatId, activeCharacterId, activeProfileId, presetId, authUserId, mutationCoordinator])
 
   // Load defaults for the currently selected preset. Defaults are stored per
   // preset, so switching presets should load a different default snapshot.
   useEffect(() => {
-    if (!presetId) { setDefaults(null); return }
+    const targetPresetId = presetId
+    const scope = targetPresetId ? profileScopes.defaults(targetPresetId) : null
+    const fetchToken = scope ? mutationCoordinator.beginFetch(scope) : null
+    setDefaults(null)
+    setDefaultsFor(null)
+    if (!targetPresetId || !scope || !fetchToken) return
     let cancelled = false
-    presetProfilesApi.getDefaults(presetId)
-      .then((d) => { if (!cancelled) setDefaults(d) })
-      .catch(() => { if (!cancelled) setDefaults(null) })
+    presetProfilesApi.getDefaults(targetPresetId)
+      .then((d) => {
+        if (cancelled || !mutationCoordinator.isFetchCurrent(scope, fetchToken)) return
+        setDefaults(d)
+        setDefaultsFor(targetPresetId)
+      })
+      .catch(() => {
+        if (cancelled || !mutationCoordinator.isFetchCurrent(scope, fetchToken)) return
+        setDefaults(null)
+        setDefaultsFor(targetPresetId)
+      })
     return () => { cancelled = true }
-  }, [presetId])
+  }, [presetId, mutationCoordinator])
 
   // Load chat binding when chat changes. Stale fetches are discarded by the
   // cancelled flag, and the slot is keyed by the chat id it was fetched for so
   // downstream consumers can tell whether it's fresh for the current chat.
   useEffect(() => {
-    if (!activeChatId) {
+    const target = activeChatId
+    const scope = target ? profileScopes.chat(target) : null
+    const fetchToken = scope ? mutationCoordinator.beginFetch(scope) : null
+    if (!target) {
       setChatSlot(EMPTY_CHAT_SLOT)
       return
     }
-    const target = activeChatId
     let cancelled = false
-    // Drop any previous slot whose id doesn't match the new target so the
-    // consumer doesn't observe a stale X-binding during the fetch window.
     setChatSlot((prev) => (prev.for === target ? prev : EMPTY_CHAT_SLOT))
     presetProfilesApi.getChatBinding(target)
-      .then((b) => { if (!cancelled) setChatSlot({ for: target, binding: b }) })
-      .catch(() => { if (!cancelled) setChatSlot({ for: target, binding: null }) })
+      .then((b) => {
+        if (!cancelled && scope && fetchToken && mutationCoordinator.isFetchCurrent(scope, fetchToken)) {
+          setChatSlot({ for: target, binding: b })
+        }
+      })
+      .catch(() => {
+        if (!cancelled && scope && fetchToken && mutationCoordinator.isFetchCurrent(scope, fetchToken)) {
+          setChatSlot({ for: target, binding: null })
+        }
+      })
     return () => { cancelled = true }
-  }, [activeChatId])
+  }, [activeChatId, mutationCoordinator])
 
   // Load character binding when character changes (same pattern as chat).
   useEffect(() => {
-    if (!activeCharacterId) {
+    const target = activeCharacterId
+    const scope = target ? profileScopes.character(target) : null
+    const fetchToken = scope ? mutationCoordinator.beginFetch(scope) : null
+    if (!target) {
       setCharSlot(EMPTY_CHAR_SLOT)
       return
     }
-    const target = activeCharacterId
     let cancelled = false
     setCharSlot((prev) => (prev.for === target ? prev : EMPTY_CHAR_SLOT))
     presetProfilesApi.getCharacterBinding(target)
-      .then((b) => { if (!cancelled) setCharSlot({ for: target, binding: b }) })
-      .catch(() => { if (!cancelled) setCharSlot({ for: target, binding: null }) })
+      .then((b) => {
+        if (!cancelled && scope && fetchToken && mutationCoordinator.isFetchCurrent(scope, fetchToken)) {
+          setCharSlot({ for: target, binding: b })
+        }
+      })
+      .catch(() => {
+        if (!cancelled && scope && fetchToken && mutationCoordinator.isFetchCurrent(scope, fetchToken)) {
+          setCharSlot({ for: target, binding: null })
+        }
+      })
     return () => { cancelled = true }
-  }, [activeCharacterId])
+  }, [activeCharacterId, mutationCoordinator])
 
   // Load connection profile binding when active connection changes.
   useEffect(() => {
-    if (!activeProfileId) {
+    const target = activeProfileId
+    const scope = target ? profileScopes.connection(target) : null
+    const fetchToken = scope ? mutationCoordinator.beginFetch(scope) : null
+    if (!target) {
       setConnectionSlot(EMPTY_CONNECTION_SLOT)
       return
     }
-    const target = activeProfileId
     let cancelled = false
     setConnectionSlot((prev) => (prev.for === target ? prev : EMPTY_CONNECTION_SLOT))
     presetProfilesApi.getConnectionBinding(target)
-      .then((b) => { if (!cancelled) setConnectionSlot({ for: target, binding: b }) })
-      .catch(() => { if (!cancelled) setConnectionSlot({ for: target, binding: null }) })
+      .then((b) => {
+        if (!cancelled && scope && fetchToken && mutationCoordinator.isFetchCurrent(scope, fetchToken)) {
+          setConnectionSlot({ for: target, binding: b })
+        }
+      })
+      .catch(() => {
+        if (!cancelled && scope && fetchToken && mutationCoordinator.isFetchCurrent(scope, fetchToken)) {
+          setConnectionSlot({ for: target, binding: null })
+        }
+      })
     return () => { cancelled = true }
-  }, [activeProfileId])
+  }, [activeProfileId, mutationCoordinator])
 
-  // A binding is only considered "for" the current context if its `for` id
-  // still matches the store's active id. Anything else is stale.
+  // A binding is only considered current when it was fetched for the active id.
   const chatBinding = chatSlot.for === activeChatId ? chatSlot.binding : null
   const characterBinding = charSlot.for === activeCharacterId ? charSlot.binding : null
   const connectionBinding = connectionSlot.for === activeProfileId ? connectionSlot.binding : null
@@ -131,129 +211,240 @@ export function usePresetProfiles(
   const chatResolved = !activeChatId || chatSlot.for === activeChatId
   const characterResolved = !activeCharacterId || charSlot.for === activeCharacterId
   const connectionResolved = !activeProfileId || connectionSlot.for === activeProfileId
-  const isResolved = chatResolved && characterResolved && connectionResolved
+  const defaultsResolved = !presetId || defaultsFor === presetId
+  const isResolved = chatResolved && characterResolved && connectionResolved && defaultsResolved
 
-  const hasDefaults = defaults !== null
+  const hasDefaults = defaultsFor === presetId && defaults !== null
 
   // Capture defaults
   const captureDefaults = useCallback(async () => {
-    if (!presetId || !blocks) return
-    setIsLoading(true)
+    const targetPresetId = presetId
+    if (!targetPresetId || !blocks) return
+    const snapshot = snapshotBlockStates(blocks)
+    const scope = profileScopes.defaults(targetPresetId)
+    beginMutation()
     try {
-      const binding = await presetProfilesApi.captureDefaults(presetId, snapshotBlockStates(blocks))
-      setDefaults(binding)
-      addToast({ type: 'success', message: t('defaultsCaptured') })
-    } catch {
-      addToast({ type: 'error', message: t('captureDefaultsFailed') })
+      const result = await runPresetProfileMutation({
+        coordinator: mutationCoordinator,
+        scope,
+        operation: () => presetProfilesApi.captureDefaults(targetPresetId, snapshot),
+        canStart: () => authUserIdRef.current === authUserId && presetIdRef.current === targetPresetId,
+        refresh: () => refreshProfileBinding(presetProfilesApi.getDefaults(targetPresetId)),
+        isCurrent: (revision) => presetIdRef.current === targetPresetId && mutationCoordinator.isMutationCurrent(scope, revision),
+        commit: (binding) => {
+          setDefaults(binding)
+          setDefaultsFor(targetPresetId)
+        },
+        recover: (binding) => {
+          if (presetIdRef.current === targetPresetId) {
+            setDefaults(binding)
+            setDefaultsFor(targetPresetId)
+          }
+        },
+      })
+      if (result === 'committed') addToast({ type: 'success', message: t('defaultsCaptured') })
+      if (result === 'failed') addToast({ type: 'error', message: t('captureDefaultsFailed') })
     } finally {
-      setIsLoading(false)
+      endMutation()
     }
-  }, [presetId, blocks, addToast])
+  }, [presetId, blocks, addToast, mutationCoordinator, authUserId])
 
   // Clear defaults
   const clearDefaults = useCallback(async () => {
-    if (!presetId) return
-    setIsLoading(true)
+    const targetPresetId = presetId
+    if (!targetPresetId) return
+    const scope = profileScopes.defaults(targetPresetId)
+    beginMutation()
     try {
-      await presetProfilesApi.deleteDefaults(presetId)
-      setDefaults(null)
-      addToast({ type: 'info', message: t('defaultsCleared') })
-    } catch {
-      addToast({ type: 'error', message: t('clearDefaultsFailed') })
+      const result = await runPresetProfileMutation({
+        coordinator: mutationCoordinator,
+        scope,
+        operation: () => presetProfilesApi.deleteDefaults(targetPresetId),
+        canStart: () => authUserIdRef.current === authUserId && presetIdRef.current === targetPresetId,
+        refresh: () => refreshProfileBinding(presetProfilesApi.getDefaults(targetPresetId)),
+        isCurrent: (revision) => presetIdRef.current === targetPresetId && mutationCoordinator.isMutationCurrent(scope, revision),
+        commit: () => {
+          setDefaults(null)
+          setDefaultsFor(targetPresetId)
+        },
+        recover: (binding) => {
+          if (presetIdRef.current === targetPresetId) {
+            setDefaults(binding)
+            setDefaultsFor(targetPresetId)
+          }
+        },
+      })
+      if (result === 'committed') addToast({ type: 'info', message: t('defaultsCleared') })
+      if (result === 'failed') addToast({ type: 'error', message: t('clearDefaultsFailed') })
     } finally {
-      setIsLoading(false)
+      endMutation()
     }
-  }, [presetId, addToast])
+  }, [presetId, addToast, mutationCoordinator, authUserId])
 
   // Bind to current chat
   const bindToChat = useCallback(async () => {
-    if (!presetId || !blocks || !activeChatId) return
-    setIsLoading(true)
+    const targetPresetId = presetId
+    const targetChatId = activeChatId
+    if (!targetPresetId || !blocks || !targetChatId) return
+    const snapshot = snapshotBlockStates(blocks)
+    const scope = profileScopes.chat(targetChatId)
+    beginMutation()
     try {
-      const binding = await presetProfilesApi.setChatBinding(activeChatId, presetId, snapshotBlockStates(blocks))
-      setChatSlot({ for: activeChatId, binding })
-      addToast({ type: 'success', message: t('boundToChat') })
-    } catch {
-      addToast({ type: 'error', message: t('bindChatFailed') })
+      const result = await runPresetProfileMutation({
+        coordinator: mutationCoordinator,
+        scope,
+        operation: () => presetProfilesApi.setChatBinding(targetChatId, targetPresetId, snapshot),
+        canStart: () => authUserIdRef.current === authUserId
+          && presetIdRef.current === targetPresetId
+          && activeChatIdRef.current === targetChatId,
+        refresh: () => refreshProfileBinding(presetProfilesApi.getChatBinding(targetChatId)),
+        isCurrent: (revision) => activeChatIdRef.current === targetChatId && mutationCoordinator.isMutationCurrent(scope, revision),
+        commit: (binding) => setChatSlot({ for: targetChatId, binding }),
+        recover: (binding) => {
+          if (activeChatIdRef.current === targetChatId) setChatSlot({ for: targetChatId, binding })
+        },
+      })
+      if (result === 'committed') addToast({ type: 'success', message: t('boundToChat') })
+      if (result === 'failed') addToast({ type: 'error', message: t('bindChatFailed') })
     } finally {
-      setIsLoading(false)
+      endMutation()
     }
-  }, [presetId, blocks, activeChatId, addToast])
+  }, [presetId, blocks, activeChatId, addToast, mutationCoordinator, authUserId])
 
   // Unbind from current chat
   const unbindChat = useCallback(async () => {
-    if (!activeChatId) return
-    setIsLoading(true)
+    const targetChatId = activeChatId
+    if (!targetChatId) return
+    const scope = profileScopes.chat(targetChatId)
+    beginMutation()
     try {
-      await presetProfilesApi.deleteChatBinding(activeChatId)
-      setChatSlot({ for: activeChatId, binding: null })
-      addToast({ type: 'info', message: t('chatBindingRemoved') })
-    } catch {
-      addToast({ type: 'error', message: t('removeChatBindingFailed') })
+      const result = await runPresetProfileMutation({
+        coordinator: mutationCoordinator,
+        scope,
+        operation: () => presetProfilesApi.deleteChatBinding(targetChatId),
+        canStart: () => authUserIdRef.current === authUserId && activeChatIdRef.current === targetChatId,
+        refresh: () => refreshProfileBinding(presetProfilesApi.getChatBinding(targetChatId)),
+        isCurrent: (revision) => activeChatIdRef.current === targetChatId && mutationCoordinator.isMutationCurrent(scope, revision),
+        commit: () => setChatSlot({ for: targetChatId, binding: null }),
+        recover: (binding) => {
+          if (activeChatIdRef.current === targetChatId) setChatSlot({ for: targetChatId, binding })
+        },
+      })
+      if (result === 'committed') addToast({ type: 'info', message: t('chatBindingRemoved') })
+      if (result === 'failed') addToast({ type: 'error', message: t('removeChatBindingFailed') })
     } finally {
-      setIsLoading(false)
+      endMutation()
     }
-  }, [activeChatId, addToast])
-
-  // Bind to current character
+  }, [activeChatId, addToast, mutationCoordinator, authUserId])
   const bindToCharacter = useCallback(async () => {
-    if (!presetId || !blocks || !activeCharacterId || isGroupChat) return
-    setIsLoading(true)
+    const targetPresetId = presetId
+    const targetCharacterId = activeCharacterId
+    if (!targetPresetId || !blocks || !targetCharacterId || isGroupChat) return
+    const snapshot = snapshotBlockStates(blocks)
+    const scope = profileScopes.character(targetCharacterId)
+    beginMutation()
     try {
-      const binding = await presetProfilesApi.setCharacterBinding(activeCharacterId, presetId, snapshotBlockStates(blocks))
-      setCharSlot({ for: activeCharacterId, binding })
-      addToast({ type: 'success', message: t('boundToCharacter') })
-    } catch {
-      addToast({ type: 'error', message: t('bindCharacterFailed') })
+      const result = await runPresetProfileMutation({
+        coordinator: mutationCoordinator,
+        scope,
+        operation: () => presetProfilesApi.setCharacterBinding(targetCharacterId, targetPresetId, snapshot),
+        canStart: () => authUserIdRef.current === authUserId
+          && presetIdRef.current === targetPresetId
+          && activeCharacterIdRef.current === targetCharacterId,
+        refresh: () => refreshProfileBinding(presetProfilesApi.getCharacterBinding(targetCharacterId)),
+        isCurrent: (revision) => activeCharacterIdRef.current === targetCharacterId && mutationCoordinator.isMutationCurrent(scope, revision),
+        commit: (binding) => setCharSlot({ for: targetCharacterId, binding }),
+        recover: (binding) => {
+          if (activeCharacterIdRef.current === targetCharacterId) setCharSlot({ for: targetCharacterId, binding })
+        },
+      })
+      if (result === 'committed') addToast({ type: 'success', message: t('boundToCharacter') })
+      if (result === 'failed') addToast({ type: 'error', message: t('bindCharacterFailed') })
     } finally {
-      setIsLoading(false)
+      endMutation()
     }
-  }, [presetId, blocks, activeCharacterId, isGroupChat, addToast])
+  }, [presetId, blocks, activeCharacterId, isGroupChat, addToast, mutationCoordinator, authUserId])
 
   // Unbind from current character
   const unbindCharacter = useCallback(async () => {
-    if (!activeCharacterId || isGroupChat) return
-    setIsLoading(true)
+    const targetCharacterId = activeCharacterId
+    if (!targetCharacterId || isGroupChat) return
+    const scope = profileScopes.character(targetCharacterId)
+    beginMutation()
     try {
-      await presetProfilesApi.deleteCharacterBinding(activeCharacterId)
-      setCharSlot({ for: activeCharacterId, binding: null })
-      addToast({ type: 'info', message: t('characterBindingRemoved') })
-    } catch {
-      addToast({ type: 'error', message: t('removeCharacterBindingFailed') })
+      const result = await runPresetProfileMutation({
+        coordinator: mutationCoordinator,
+        scope,
+        operation: () => presetProfilesApi.deleteCharacterBinding(targetCharacterId),
+        canStart: () => authUserIdRef.current === authUserId && activeCharacterIdRef.current === targetCharacterId,
+        refresh: () => refreshProfileBinding(presetProfilesApi.getCharacterBinding(targetCharacterId)),
+        isCurrent: (revision) => activeCharacterIdRef.current === targetCharacterId && mutationCoordinator.isMutationCurrent(scope, revision),
+        commit: () => setCharSlot({ for: targetCharacterId, binding: null }),
+        recover: (binding) => {
+          if (activeCharacterIdRef.current === targetCharacterId) setCharSlot({ for: targetCharacterId, binding })
+        },
+      })
+      if (result === 'committed') addToast({ type: 'info', message: t('characterBindingRemoved') })
+      if (result === 'failed') addToast({ type: 'error', message: t('removeCharacterBindingFailed') })
     } finally {
-      setIsLoading(false)
+      endMutation()
     }
-  }, [activeCharacterId, isGroupChat, addToast])
-
+  }, [activeCharacterId, isGroupChat, addToast, mutationCoordinator, authUserId])
   // Bind to current connection profile
   const bindToConnection = useCallback(async () => {
-    if (!presetId || !blocks || !activeProfileId) return
-    setIsLoading(true)
+    const targetPresetId = presetId
+    const targetProfileId = activeProfileId
+    if (!targetPresetId || !blocks || !targetProfileId) return
+    const snapshot = snapshotBlockStates(blocks)
+    const scope = profileScopes.connection(targetProfileId)
+    beginMutation()
     try {
-      const binding = await presetProfilesApi.setConnectionBinding(activeProfileId, presetId, snapshotBlockStates(blocks))
-      setConnectionSlot({ for: activeProfileId, binding })
-      addToast({ type: 'success', message: t('boundToConnection') })
-    } catch {
-      addToast({ type: 'error', message: t('bindConnectionFailed') })
+      const result = await runPresetProfileMutation({
+        coordinator: mutationCoordinator,
+        scope,
+        operation: () => presetProfilesApi.setConnectionBinding(targetProfileId, targetPresetId, snapshot),
+        canStart: () => authUserIdRef.current === authUserId
+          && presetIdRef.current === targetPresetId
+          && activeProfileIdRef.current === targetProfileId,
+        refresh: () => refreshProfileBinding(presetProfilesApi.getConnectionBinding(targetProfileId)),
+        isCurrent: (revision) => activeProfileIdRef.current === targetProfileId && mutationCoordinator.isMutationCurrent(scope, revision),
+        commit: (binding) => setConnectionSlot({ for: targetProfileId, binding }),
+        recover: (binding) => {
+          if (activeProfileIdRef.current === targetProfileId) setConnectionSlot({ for: targetProfileId, binding })
+        },
+      })
+      if (result === 'committed') addToast({ type: 'success', message: t('boundToConnection') })
+      if (result === 'failed') addToast({ type: 'error', message: t('bindConnectionFailed') })
     } finally {
-      setIsLoading(false)
+      endMutation()
     }
-  }, [presetId, blocks, activeProfileId, addToast])
+  }, [presetId, blocks, activeProfileId, addToast, mutationCoordinator, authUserId])
 
   // Unbind from current connection profile
   const unbindConnection = useCallback(async () => {
-    if (!activeProfileId) return
-    setIsLoading(true)
+    const targetProfileId = activeProfileId
+    if (!targetProfileId) return
+    const scope = profileScopes.connection(targetProfileId)
+    beginMutation()
     try {
-      await presetProfilesApi.deleteConnectionBinding(activeProfileId)
-      setConnectionSlot({ for: activeProfileId, binding: null })
-      addToast({ type: 'info', message: t('connectionBindingRemoved') })
-    } catch {
-      addToast({ type: 'error', message: t('removeConnectionBindingFailed') })
+      const result = await runPresetProfileMutation({
+        coordinator: mutationCoordinator,
+        scope,
+        operation: () => presetProfilesApi.deleteConnectionBinding(targetProfileId),
+        canStart: () => authUserIdRef.current === authUserId && activeProfileIdRef.current === targetProfileId,
+        refresh: () => refreshProfileBinding(presetProfilesApi.getConnectionBinding(targetProfileId)),
+        isCurrent: (revision) => activeProfileIdRef.current === targetProfileId && mutationCoordinator.isMutationCurrent(scope, revision),
+        commit: () => setConnectionSlot({ for: targetProfileId, binding: null }),
+        recover: (binding) => {
+          if (activeProfileIdRef.current === targetProfileId) setConnectionSlot({ for: targetProfileId, binding })
+        },
+      })
+      if (result === 'committed') addToast({ type: 'info', message: t('connectionBindingRemoved') })
+      if (result === 'failed') addToast({ type: 'error', message: t('removeConnectionBindingFailed') })
     } finally {
-      setIsLoading(false)
+      endMutation()
     }
-  }, [activeProfileId, addToast])
+  }, [activeProfileId, addToast, mutationCoordinator, authUserId])
 
   // Character bindings are skipped in group chats (per-member bindings are
   // ambiguous — backend resolveProfile applies the same gate).
@@ -266,26 +457,37 @@ export function usePresetProfiles(
     return presetId
   }, [chatBinding, characterBinding, characterBindingEnabled, connectionBinding, presetId])
 
+  // A binding can disappear or fall back to the current preset without
+  // changing the surrounding context ids. Retire an owned transition in that
+  // no-op case; the controller does nothing when no profile transition exists,
+  // so unrelated global selection requests remain untouched.
+  useEffect(() => {
+    if (!resolvedPresetId || resolvedPresetId === presetId) {
+      selectionControllerRef.current?.select(resolvedPresetId, presetId)
+    }
+  }, [resolvedPresetId, presetId])
+
   // Resolved active binding (chat > character > connection > defaults > none)
   const activeBinding = useMemo(() => {
+    const currentDefaults = defaultsFor === presetId ? defaults : null
     if (chatBinding) {
       if (chatBinding.linked_to_defaults) {
-        return defaults && defaults.preset_id === chatBinding.preset_id ? defaults : null
+        return currentDefaults && currentDefaults.preset_id === chatBinding.preset_id ? currentDefaults : null
       }
       return chatBinding
     }
     if (characterBindingEnabled && characterBinding) return characterBinding
     if (connectionBinding) return connectionBinding
-    if (defaults) return defaults
+    if (currentDefaults) return currentDefaults
     return null
-  }, [chatBinding, characterBinding, connectionBinding, defaults, characterBindingEnabled])
+  }, [chatBinding, characterBinding, connectionBinding, defaults, defaultsFor, presetId, characterBindingEnabled])
 
   // Determine active source
   const activeSource: 'chat' | 'character' | 'connection' | 'defaults' | 'none' = (() => {
     if (chatBinding) return 'chat'
     if (characterBindingEnabled && characterBinding) return 'character'
     if (connectionBinding) return 'connection'
-    if (defaults) return 'defaults'
+    if (defaultsFor === presetId && defaults) return 'defaults'
     return 'none'
   })()
 
@@ -294,16 +496,7 @@ export function usePresetProfiles(
   const hasConnectionBinding = connectionBinding !== null
 
   const selectResolvedPreset = useCallback(() => {
-    if (!resolvedPresetId || resolvedPresetId === presetId) return
-    const selection = selectionIntentRef.current ?? beginActiveLoomPresetSelection()
-    selectionIntentRef.current = selection
-    void selection.transition(resolvedPresetId)
-      .catch(() => {})
-      .finally(() => {
-        if (selectionIntentRef.current === selection) {
-          selectionIntentRef.current = null
-        }
-      })
+    return selectionControllerRef.current?.select(resolvedPresetId, presetId) ?? null
   }, [resolvedPresetId, presetId])
 
   return {

--- a/frontend/src/i18n/locales/en/panels.json
+++ b/frontend/src/i18n/locales/en/panels.json
@@ -3091,6 +3091,10 @@
   "panel": "Panel",
   "loomBuilder": {
     "unknownProvider": "Unknown",
+    "editorTabs": {
+      "ariaLabel": "Preset editor tabs",
+      "preset": "Preset"
+    },
     "tokens": " tokens",
     "category": {
       "dragDisabledSearch": "Reordering disabled while searching",

--- a/frontend/src/i18n/locales/fr/panels.json
+++ b/frontend/src/i18n/locales/fr/panels.json
@@ -2952,6 +2952,10 @@
   "panel": "Panneau",
   "loomBuilder": {
     "unknownProvider": "Inconnu",
+    "editorTabs": {
+      "ariaLabel": "Onglets de l’éditeur de préréglages",
+      "preset": "Préréglage"
+    },
     "tokens": " jetons",
     "category": {
       "dragDisabledSearch": "Réorganisation désactivée lors de la recherche",

--- a/frontend/src/i18n/locales/it/panels.json
+++ b/frontend/src/i18n/locales/it/panels.json
@@ -2960,6 +2960,10 @@
   "panel": "Pannello",
   "loomBuilder": {
     "unknownProvider": "Sconosciuto",
+    "editorTabs": {
+      "ariaLabel": "Schede dell'editor dei preset",
+      "preset": "Preset"
+    },
     "tokens": " token",
     "category": {
       "dragDisabledSearch": "Riordinamento disabilitato durante la ricerca",

--- a/frontend/src/i18n/locales/ja/panels.json
+++ b/frontend/src/i18n/locales/ja/panels.json
@@ -2952,6 +2952,10 @@
   "panel": "パネル",
   "loomBuilder": {
     "unknownProvider": "不明",
+    "editorTabs": {
+      "ariaLabel": "プリセットエディターのタブ",
+      "preset": "プリセット"
+    },
     "tokens": " トークン",
     "category": {
       "dragDisabledSearch": "検索中の並べ替えは無効です",

--- a/frontend/src/i18n/locales/zh-TW/panels.json
+++ b/frontend/src/i18n/locales/zh-TW/panels.json
@@ -2952,6 +2952,10 @@
   "panel": "面板",
   "loomBuilder": {
     "unknownProvider": "未知",
+    "editorTabs": {
+      "ariaLabel": "預設編輯器分頁",
+      "preset": "預設"
+    },
     "tokens": " 詞元",
     "category": {
       "dragDisabledSearch": "搜索時無法排序",

--- a/frontend/src/i18n/locales/zh/panels.json
+++ b/frontend/src/i18n/locales/zh/panels.json
@@ -2952,6 +2952,10 @@
   "panel": "面板",
   "loomBuilder": {
     "unknownProvider": "未知",
+    "editorTabs": {
+      "ariaLabel": "预设编辑器标签",
+      "preset": "预设"
+    },
     "tokens": " 词元",
     "category": {
       "dragDisabledSearch": "搜索时无法排序",

--- a/frontend/src/lib/loom/preset-save-coordinator.response.test.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.response.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import type { Preset, UpdatePresetInput } from '@/types/api'
+import { createPresetSaveCoordinator, type PresetSaveAdapter } from './preset-save-coordinator'
+import { unmarshalPreset } from './service'
+
+function rawPreset(metadata: Record<string, unknown>, cacheRevision?: number): Preset {
+  return {
+    id: 'preset-response-1',
+    name: 'Coordinator response test',
+    provider: 'loom',
+    parameters: {},
+    prompt_order: [],
+    prompts: {},
+    metadata,
+    created_at: 1,
+    updated_at: 2,
+    ...(cacheRevision === undefined ? {} : { cache_revision: cacheRevision }),
+  }
+}
+
+afterEach(() => localStorage.clear())
+
+describe('preset save coordinator response preservation', () => {
+  test('keeps passthrough siblings when an update response omits them', async () => {
+    let sent: UpdatePresetInput | null = null
+    const adapter: PresetSaveAdapter = {
+      async update(_presetId, input) {
+        sent = structuredClone(input)
+        return rawPreset({
+          description: input.metadata?.description ?? '',
+        })
+      },
+    }
+    const coordinator = createPresetSaveCoordinator(adapter)
+    const unsubscribe = coordinator.subscribe('preset-response-1', () => {})
+    const base = unmarshalPreset(rawPreset({
+      agentic_preset_composer: { mode: 'parallel' },
+      unrelated_extension: { enabled: true },
+    }))
+    coordinator.hydrate(base)
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({ ...preset, description: 'Updated description' }),
+      { immediate: true },
+    )
+
+    await coordinator.flush(base.id)
+
+    expect(sent?.metadata?.agentic_preset_composer).toEqual({ mode: 'parallel' })
+    expect(coordinator.getDraft(base.id)?.passthroughMetadata).toEqual({
+      agentic_preset_composer: { mode: 'parallel' },
+      unrelated_extension: { enabled: true },
+    })
+    unsubscribe()
+  })
+
+  test('does not requeue an in-flight save when its normalized websocket echo arrives first', async () => {
+    let resolveUpdate!: (preset: Preset) => void
+    const updateGate = new Promise<Preset>((resolve) => { resolveUpdate = resolve })
+    let updateCalls = 0
+    let response: Preset | null = null
+    const adapter: PresetSaveAdapter = {
+      async update(presetId, input) {
+        updateCalls += 1
+        const reorderedMetadata = Object.fromEntries(Object.entries(input.metadata ?? {}).reverse())
+        response = {
+          ...rawPreset(reorderedMetadata, 3),
+          id: presetId,
+          name: input.name ?? '',
+          parameters: structuredClone(input.parameters ?? {}),
+          prompt_order: structuredClone(input.prompt_order ?? []),
+          prompts: structuredClone(input.prompts ?? {}),
+        }
+        return updateGate
+      },
+    }
+    const coordinator = createPresetSaveCoordinator(adapter)
+    const base = unmarshalPreset(rawPreset({
+      promptVariables: { orphan: 'pruned before persistence' },
+    }, 2))
+    const unsubscribe = coordinator.subscribe(base.id, () => {})
+    expect(base.cacheRevision).toBe(2)
+    coordinator.hydrate(base)
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({ ...preset, description: 'Updated description' }),
+      { immediate: true },
+    )
+    const flush = coordinator.flush(base.id)
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(updateCalls).toBe(1)
+    expect(response).not.toBeNull()
+    coordinator.hydrate(unmarshalPreset(response!))
+    expect(updateCalls).toBe(1)
+    expect(coordinator.getDraft(base.id)?.cacheRevision).toBe(3)
+
+    const partialResponse = { ...response! }
+    delete partialResponse.cache_revision
+    resolveUpdate(partialResponse)
+    const saved = await flush
+    expect(updateCalls).toBe(1)
+    expect(saved.cacheRevision).toBe(3)
+    expect(coordinator.getDraft(base.id)?.cacheRevision).toBe(3)
+    unsubscribe()
+  })
+  test('preserves omitted first-class fields in a partial update response', async () => {
+    const baseSource = {
+      type: 'import',
+      slug: 'source-slug',
+      importedVersion: 'v1',
+      importedName: 'Imported preset',
+      importedAt: 10,
+    }
+    const baseRaw: Preset = {
+      ...rawPreset({
+        source: baseSource,
+        modelProfiles: { primary: { model: 'one' } },
+        schemaVersion: 9,
+        description: 'Original description',
+        coverUrl: 'original-cover',
+        isDefault: true,
+        lastProfileKey: 'primary',
+        promptVariables: { block: { tone: 'warm' } },
+        _lumiverse_preset_version: 'v1',
+        _lumiverse_provenance: { hub: 'source-hub' },
+        extension: { enabled: true },
+      }, 7),
+      parameters: {
+        samplerOverrides: { temperature: 0.7 },
+        customBody: { prefix: 'prefix' },
+      },
+      prompts: {
+        promptBehavior: { mode: 'custom' },
+        completionSettings: { mode: 'complete' },
+        advancedSettings: { mode: 'advanced' },
+      },
+    }
+    const adapter: PresetSaveAdapter = {
+      async update(_presetId, input) {
+        return rawPreset({
+          description: input.metadata?.description ?? '',
+        })
+      },
+    }
+    const coordinator = createPresetSaveCoordinator(adapter)
+    const unsubscribe = coordinator.subscribe(baseRaw.id, () => {})
+    const base = unmarshalPreset(baseRaw)
+    coordinator.hydrate(base)
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({ ...preset, description: 'Updated description' }),
+      { immediate: true },
+    )
+
+    const saved = await coordinator.flush(base.id)
+
+    expect(saved?.description).toBe('Updated description')
+    expect(saved?.source).toEqual(baseSource)
+    expect(saved?.modelProfiles).toEqual({ primary: { model: 'one' } })
+    expect(saved?.schemaVersion).toBe(9)
+    expect(saved?.coverUrl).toBe('original-cover')
+    expect(saved?.isDefault).toBe(true)
+    expect(saved?.lastProfileKey).toBe('primary')
+    expect(saved?.promptVariables).toEqual({ block: { tone: 'warm' } })
+    expect(saved?.presetVersion).toBe('v1')
+    expect(saved?.lumihubMeta).toEqual({ _lumiverse_provenance: { hub: 'source-hub' } })
+    expect(saved?.passthroughMetadata).toEqual({ extension: { enabled: true } })
+    expect(saved?.samplerOverrides).toEqual(base.samplerOverrides)
+    expect(saved?.customBody).toEqual(base.customBody)
+    expect(saved?.promptBehavior).toEqual(base.promptBehavior)
+    expect(saved?.completionSettings).toEqual(base.completionSettings)
+    expect(saved?.advancedSettings).toEqual(base.advancedSettings)
+    expect(saved?.cacheRevision).toBe(7)
+    unsubscribe()
+  })
+})

--- a/frontend/src/lib/loom/preset-save-coordinator.test.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.test.ts
@@ -1044,6 +1044,7 @@ describe('preset save coordinator', () => {
       },
     })
     coordinator.hydrate(base)
+    const unsubscribe = coordinator.subscribe(base.id, () => {})
     coordinator.mutate(
       base.id,
       base,
@@ -1070,6 +1071,9 @@ describe('preset save coordinator', () => {
     expect(writes).toHaveLength(3)
     expect(writes.map((input) => input.expected_cache_revision)).toEqual([1, 2, 2])
     expect(writes[2].prompt_order?.[0]?.content).toBe('second')
+    expect(() => coordinator.hydrate(unmarshalPreset(firstSaved))).not.toThrow()
+    expect(coordinator.getDraft(base.id)?.blocks[0]?.content).toBe('second')
+    unsubscribe()
     localStorage.clear()
   })
 

--- a/frontend/src/lib/loom/preset-save-coordinator.test.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.test.ts
@@ -1064,6 +1064,7 @@ describe('preset save coordinator', () => {
       { immediate: true },
     )
     resolveFirst(firstSaved)
+    expect(() => coordinator.hydrate(unmarshalPreset(firstSaved))).not.toThrow()
 
     await coordinator.flush(base.id)
     expect(writes).toHaveLength(3)

--- a/frontend/src/lib/loom/preset-save-coordinator.test.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import type { Preset, UpdatePresetInput } from '@/types/api'
 import type { LoomPreset } from './types'
 import { createPresetSaveCoordinator, type PresetSaveAdapter } from './preset-save-coordinator'
-import { unmarshalPreset } from './service'
+import { SPINDLE_EXTENSION_METADATA_KEY, unmarshalPreset } from './service'
 
 function rawPreset(overrides: Partial<Preset> = {}): Preset {
   return {
@@ -87,6 +87,54 @@ describe('preset save coordinator', () => {
     expect(writes).toHaveLength(2)
     expect(writes[1].prompt_order).toHaveLength(1)
     expect(writes[1].metadata?.promptVariables).toEqual({ 'block-1': { tone: 'warm' } })
+  })
+
+  test('flush waits for a mutation queued while an earlier write is in flight', async () => {
+    const writes: UpdatePresetInput[] = []
+    let resolveFirst!: (preset: Preset) => void
+    let resolveSecond!: (preset: Preset) => void
+    let markFirstStarted!: () => void
+    let markSecondStarted!: () => void
+    const firstStarted = new Promise<void>((resolve) => { markFirstStarted = resolve })
+    const secondStarted = new Promise<void>((resolve) => { markSecondStarted = resolve })
+    let callCount = 0
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        writes.push(structuredClone(input))
+        callCount += 1
+        if (callCount === 1) {
+          markFirstStarted()
+          return new Promise<Preset>((resolve) => { resolveFirst = resolve })
+        }
+        markSecondStarted()
+        return new Promise<Preset>((resolve) => { resolveSecond = resolve })
+      },
+    })
+    const base = unmarshalPreset(rawPreset())
+    coordinator.hydrate(base)
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({ ...preset, name: 'First write' }),
+      { immediate: true },
+    )
+    await firstStarted
+    let flushed = false
+    const flushing = coordinator.flush(base.id).then(() => { flushed = true })
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({ ...preset, description: 'Second write' }),
+      { immediate: true },
+    )
+    resolveFirst(persistedFromUpdate(base.id, writes[0]))
+    await secondStarted
+    expect(flushed).toBe(false)
+    resolveSecond(persistedFromUpdate(base.id, writes[1]))
+    await flushing
+    expect(writes).toHaveLength(2)
+    expect(writes[1].name).toBe('First write')
+    expect(writes[1].metadata?.description).toBe('Second write')
   })
 
   test('rebases only locally-owned dirty fields over a fresh persisted row', async () => {
@@ -227,6 +275,149 @@ describe('preset save coordinator', () => {
     expect(rebased.name).toBe('Unsaved editor name')
     expect(rebased.promptVariables).toEqual({ 'block-1': { tone: 'fresh' } })
     expect(rebased.passthroughMetadata.agentic_preset_composer).toEqual({ mode: 'parallel' })
+    localStorage.clear()
+  })
+
+  test('rebases a durable protected Spindle namespace over fresh sibling namespaces', async () => {
+    localStorage.clear()
+    const writes: UpdatePresetInput[] = []
+    const persisted = unmarshalPreset(rawPreset({
+      metadata: {
+        [SPINDLE_EXTENSION_METADATA_KEY]: {
+          first_extension: { mode: 'old' },
+          second_extension: { revision: 2 },
+        },
+      },
+    }))
+    const pending = {
+      ...persisted,
+      passthroughMetadata: {
+        ...persisted.passthroughMetadata,
+        [SPINDLE_EXTENSION_METADATA_KEY]: {
+          first_extension: { mode: 'new' },
+          second_extension: { revision: 1 },
+        },
+      },
+    }
+    localStorage.setItem('__lumiverse_pending_loom_presets', JSON.stringify({
+      [persisted.id]: {
+        __lumiverse_pending_loom_preset_v2: 2,
+        preset: pending,
+        dirty: {
+          fields: [],
+          passthroughKeys: [],
+          spindleMetadataKeys: ['first_extension'],
+        },
+        revision: 1,
+      },
+    }))
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        writes.push(structuredClone(input))
+        return persistedFromUpdate(presetId, input)
+      },
+    })
+
+    expect(coordinator.hasDurablePendingRecovery(persisted.id)).toBe(true)
+    const rebased = coordinator.hydrate(persisted)
+    expect(coordinator.hasDurablePendingRecovery(persisted.id)).toBe(false)
+    expect(rebased.passthroughMetadata[SPINDLE_EXTENSION_METADATA_KEY]).toEqual({
+      first_extension: { mode: 'new' },
+      second_extension: { revision: 2 },
+    })
+    await coordinator.flush(persisted.id)
+    expect(writes[0].metadata?.[SPINDLE_EXTENSION_METADATA_KEY]).toEqual({
+      first_extension: { mode: 'new' },
+      second_extension: { revision: 2 },
+    })
+    localStorage.clear()
+  })
+
+  test('rebases only a dirty protected Spindle namespace over fresh sibling namespaces', async () => {
+    const writes: UpdatePresetInput[] = []
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        writes.push(structuredClone(input))
+        return persistedFromUpdate(presetId, input)
+      },
+    })
+    const base = unmarshalPreset(rawPreset({
+      metadata: {
+        [SPINDLE_EXTENSION_METADATA_KEY]: {
+          first_extension: { mode: 'old' },
+          second_extension: { revision: 1 },
+        },
+      },
+    }))
+    coordinator.hydrate(base)
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({
+        ...preset,
+        passthroughMetadata: {
+          ...preset.passthroughMetadata,
+          [SPINDLE_EXTENSION_METADATA_KEY]: {
+            first_extension: { mode: 'new' },
+            second_extension: { revision: 1 },
+          },
+        },
+      }),
+    )
+
+    const rebased = coordinator.hydrate(unmarshalPreset(rawPreset({
+      metadata: {
+        [SPINDLE_EXTENSION_METADATA_KEY]: {
+          first_extension: { mode: 'old' },
+          second_extension: { revision: 2 },
+        },
+      },
+    })))
+    expect(rebased.passthroughMetadata[SPINDLE_EXTENSION_METADATA_KEY]).toEqual({
+      first_extension: { mode: 'new' },
+      second_extension: { revision: 2 },
+    })
+    await coordinator.flush(base.id)
+    expect(writes[0].metadata?.[SPINDLE_EXTENSION_METADATA_KEY]).toEqual({
+      first_extension: { mode: 'new' },
+      second_extension: { revision: 2 },
+    })
+  })
+
+  test('rejects a delayed persisted read after a newer write was confirmed', async () => {
+    localStorage.clear()
+    const writes: UpdatePresetInput[] = []
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        writes.push(structuredClone(input))
+        return persistedFromUpdate(presetId, input)
+      },
+    })
+    const base = unmarshalPreset(rawPreset({ name: 'Before delayed read' }))
+    coordinator.hydrate(base)
+
+    const delayedRead = coordinator.beginHydration(base.id)
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({ ...preset, name: 'Saved before delayed read resolves' }),
+      { immediate: true },
+    )
+    await coordinator.flush(base.id)
+
+    const afterDelayedRead = coordinator.hydrate(base, delayedRead)
+    expect(afterDelayedRead.name).toBe('Saved before delayed read resolves')
+
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({ ...preset, promptVariables: { 'block-1': { tone: 'warm' } } }),
+      { immediate: true },
+    )
+    await coordinator.flush(base.id)
+
+    expect(writes).toHaveLength(2)
+    expect(writes[1].name).toBe('Saved before delayed read resolves')
     localStorage.clear()
   })
 

--- a/frontend/src/lib/loom/preset-save-coordinator.test.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.test.ts
@@ -1,11 +1,13 @@
-import { describe, expect, test } from 'bun:test'
+import { describe, expect, test, vi } from 'bun:test'
 import type { Preset, UpdatePresetInput } from '@/types/api'
 import type { LoomPreset } from './types'
 import {
   createPresetSaveCoordinator,
   flushPresetForGeneration,
+  setPresetSaveCoordinatorScope,
   presetSaveCoordinator,
   StalePresetHydrationError,
+  PresetScopeChangedError,
   type PresetSaveAdapter,
 } from './preset-save-coordinator'
 import { unmarshalPreset } from './service'
@@ -94,6 +96,60 @@ describe('preset save coordinator', () => {
     expect(writes).toHaveLength(2)
     expect(writes[1].prompt_order).toHaveLength(1)
     expect(writes[1].metadata?.promptVariables).toEqual({ 'block-1': { tone: 'warm' } })
+  })
+  test('retains same-tick functional block updates over the coordinator draft', async () => {
+    const writes: UpdatePresetInput[] = []
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        writes.push(structuredClone(input))
+        return persistedFromUpdate(presetId, input)
+      },
+    })
+    const base = unmarshalPreset(rawPreset())
+    coordinator.hydrate(base)
+    const firstBlock: LoomPreset['blocks'][number] = {
+      id: 'block-1',
+      name: 'Added block',
+      content: 'initial content',
+      role: 'system',
+      enabled: true,
+      position: 'pre_history',
+      depth: 0,
+      marker: null,
+      isLocked: false,
+      color: null,
+      injectionTrigger: [],
+    }
+
+    const added = coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({ ...preset, blocks: [...preset.blocks, firstBlock] }),
+      { immediate: true },
+    )
+    const updated = coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({
+        ...preset,
+        blocks: preset.blocks.map((block) => (
+          block.id === firstBlock.id ? { ...block, name: 'Updated block' } : block
+        )),
+      }),
+      { immediate: true },
+    )
+
+    expect(added.blocks).toEqual([firstBlock])
+    expect(updated.blocks).toEqual([{ ...firstBlock, name: 'Updated block' }])
+    expect(coordinator.getDraft(base.id)?.blocks).toEqual(updated.blocks)
+
+    await coordinator.flush(base.id)
+
+    expect(writes).toHaveLength(2)
+    expect(writes[1].prompt_order?.[0]).toMatchObject({
+      id: firstBlock.id,
+      name: 'Updated block',
+    })
   })
 
   test('flush waits for a mutation queued while an earlier write is in flight', async () => {
@@ -282,6 +338,34 @@ describe('preset save coordinator', () => {
     expect(rebased.name).toBe('Unsaved editor name')
     expect(rebased.promptVariables).toEqual({ 'block-1': { tone: 'fresh' } })
     expect(rebased.passthroughMetadata.agentic_preset_composer).toEqual({ mode: 'parallel' })
+    localStorage.clear()
+  })
+
+  test('migrates an unscoped legacy draft after selecting the authenticated scope', () => {
+    localStorage.clear()
+    const persisted = unmarshalPreset(rawPreset({
+      name: 'Persisted name',
+      cache_revision: 2,
+    }))
+    const legacy = {
+      ...persisted,
+      name: 'Legacy unsaved name',
+    }
+    localStorage.setItem('__lumiverse_pending_loom_presets', JSON.stringify({
+      [persisted.id]: legacy,
+    }))
+
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        return persistedFromUpdate(presetId, input)
+      },
+    })
+    coordinator.setScope('legacy-user')
+
+    expect(coordinator.hydrate(persisted).name).toBe('Legacy unsaved name')
+    expect(localStorage.getItem('__lumiverse_pending_loom_presets:legacy-user')).not.toBeNull()
+    expect(localStorage.getItem('__lumiverse_pending_loom_presets')).toBeNull()
+    coordinator.setScope(null)
     localStorage.clear()
   })
 
@@ -650,6 +734,518 @@ describe('preset save coordinator', () => {
       ;(presetsApi as any).update = originalUpdate
       presetSaveCoordinator.remove(presetId)
       localStorage.removeItem('__lumiverse_pending_loom_presets')
+    }
+  })
+  test('rejects generation flush when the user scope switches mid-write', async () => {
+    const presetId = 'scope-generation-preset'
+    const persisted = rawPreset({ id: presetId })
+    const originalUpdate = presetsApi.update
+    let resolveUpdate!: (preset: Preset) => void
+    const pendingUpdate = new Promise<Preset>((resolve) => { resolveUpdate = resolve })
+
+    presetSaveCoordinator.setScope('generation-user-a')
+    presetSaveCoordinator.hydrate(unmarshalPreset(persisted))
+    ;(presetsApi as any).update = async () => pendingUpdate
+
+    try {
+      presetSaveCoordinator.mutate(
+        presetId,
+        unmarshalPreset(persisted),
+        (preset) => ({ ...preset, description: 'pending generation write' }),
+        { immediate: true },
+      )
+      const flush = flushPresetForGeneration(presetId)
+      await Promise.resolve()
+      presetSaveCoordinator.setScope('generation-user-b')
+      resolveUpdate(persisted)
+      await expect(flush).rejects.toBeInstanceOf(PresetScopeChangedError)
+    } finally {
+      ;(presetsApi as any).update = originalUpdate
+      presetSaveCoordinator.setScope(null)
+      presetSaveCoordinator.remove(presetId)
+      localStorage.clear()
+    }
+  })
+  test('scopes recovery and drops deferred writes across user changes', () => {
+    localStorage.clear()
+    vi.useFakeTimers()
+    let updates = 0
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        updates += 1
+        return persistedFromUpdate(presetId, input)
+      },
+    })
+    const base = unmarshalPreset(rawPreset())
+
+    try {
+      coordinator.setScope('user-a')
+      coordinator.mutate(base.id, base, (preset) => ({
+        ...preset,
+        description: 'private to user A',
+      }))
+
+      expect(localStorage.getItem('__lumiverse_pending_loom_presets:user-a')).not.toBeNull()
+      coordinator.setScope('user-b')
+      expect(coordinator.getDraft(base.id)).toBeNull()
+      expect(coordinator.hasDurablePendingRecovery(base.id)).toBe(false)
+      expect(localStorage.getItem('__lumiverse_pending_loom_presets:user-a')).not.toBeNull()
+      expect(localStorage.getItem('__lumiverse_pending_loom_presets:user-b')).toBeNull()
+      vi.advanceTimersByTime(401)
+      expect(updates).toBe(0)
+
+      coordinator.setScope('user-a')
+      expect(coordinator.hasDurablePendingRecovery(base.id)).toBe(true)
+    } finally {
+      coordinator.setScope(null)
+      localStorage.clear()
+      vi.useRealTimers()
+    }
+  })
+  test('rebases local edits after a revision conflict before retrying', async () => {
+    localStorage.clear()
+    const base = unmarshalPreset(rawPreset({
+      name: 'Base name',
+      metadata: { external: { value: 'base' } },
+      cache_revision: 3,
+    }))
+    const latestPersisted = rawPreset({
+      name: 'Remote name',
+      metadata: {
+        external: { value: 'remote' },
+        remoteOnly: { enabled: true },
+      },
+      cache_revision: 4,
+      updated_at: 5,
+    })
+    const writes: UpdatePresetInput[] = []
+    let updateCalls = 0
+    let getCalls = 0
+    const conflict = Object.assign(new Error('preset revision conflict'), {
+      status: 409,
+      body: { code: 'PRESET_REVISION_CONFLICT' },
+    })
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        writes.push(structuredClone(input))
+        updateCalls += 1
+        if (updateCalls === 1) throw conflict
+        return rawPreset({
+          ...latestPersisted,
+          id: presetId,
+          name: input.name ?? latestPersisted.name,
+          parameters: input.parameters ?? latestPersisted.parameters,
+          prompt_order: input.prompt_order ?? latestPersisted.prompt_order,
+          prompts: input.prompts ?? latestPersisted.prompts,
+          metadata: input.metadata ?? latestPersisted.metadata,
+          cache_revision: 5,
+        })
+      },
+      async get(presetId) {
+        getCalls += 1
+        expect(presetId).toBe(base.id)
+        return latestPersisted
+      },
+    })
+
+    const unsubscribe = coordinator.subscribe(base.id, () => {})
+    coordinator.hydrate(base)
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({ ...preset, name: 'Local name' }),
+      { immediate: true },
+    )
+
+    const saved = await coordinator.flush(base.id)
+    const draft = coordinator.getDraft(base.id)
+
+    expect(getCalls).toBe(1)
+    expect(writes).toHaveLength(2)
+    expect(writes.map((input) => input.expected_cache_revision)).toEqual([3, 4])
+    expect(saved?.name).toBe('Local name')
+    expect(saved?.cacheRevision).toBe(5)
+    expect(draft?.name).toBe('Local name')
+    expect(draft?.passthroughMetadata.external).toEqual({ value: 'remote' })
+    expect(draft?.passthroughMetadata.remoteOnly).toEqual({ enabled: true })
+    unsubscribe()
+    localStorage.clear()
+  })
+
+  test('retries block edits when a revision conflict changed unrelated fields only', async () => {
+    localStorage.clear()
+    const block = {
+      id: 'block-a',
+      name: 'Block A',
+      content: 'base',
+      role: 'system' as const,
+      enabled: true,
+      position: 'pre_history' as const,
+      depth: 0,
+      marker: null,
+      isLocked: false,
+      color: null,
+      injectionTrigger: [],
+    }
+    const base = unmarshalPreset(rawPreset({
+      prompt_order: [block],
+      cache_revision: 1,
+    }))
+    const latest = rawPreset({
+      name: 'Remote name',
+      prompt_order: [block],
+      cache_revision: 2,
+    })
+    const conflict = Object.assign(new Error('preset revision conflict'), {
+      status: 409,
+      body: { code: 'PRESET_REVISION_CONFLICT' },
+    })
+    const writes: UpdatePresetInput[] = []
+    let updateCalls = 0
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        writes.push(structuredClone(input))
+        updateCalls += 1
+        if (updateCalls === 1) throw conflict
+        return rawPreset({
+          ...latest,
+          id: presetId,
+          prompt_order: input.prompt_order ?? latest.prompt_order,
+          cache_revision: 3,
+        })
+      },
+      async get() {
+        return latest
+      },
+    })
+    coordinator.hydrate(base)
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({
+        ...preset,
+        blocks: preset.blocks.map((candidate) => ({ ...candidate, content: 'local' })),
+      }),
+      { immediate: true },
+    )
+
+    await coordinator.flush(base.id)
+    expect(writes).toHaveLength(2)
+    expect(writes[1].prompt_order?.[0]?.content).toBe('local')
+    localStorage.clear()
+  })
+
+  test('surfaces a block conflict instead of replaying a stale array', async () => {
+    localStorage.clear()
+    const baseBlock = {
+      id: 'block-a',
+      name: 'Block A',
+      content: 'base',
+      role: 'system' as const,
+      enabled: true,
+      position: 'pre_history' as const,
+      depth: 0,
+      marker: null,
+      isLocked: false,
+      color: null,
+      injectionTrigger: [],
+    }
+    const remoteBlock = { ...baseBlock, content: 'remote' }
+    const base = unmarshalPreset(rawPreset({
+      prompt_order: [baseBlock],
+      cache_revision: 1,
+    }))
+    const latest = rawPreset({
+      prompt_order: [remoteBlock],
+      cache_revision: 2,
+    })
+    const conflict = Object.assign(new Error('preset revision conflict'), {
+      status: 409,
+      body: { code: 'PRESET_REVISION_CONFLICT' },
+    })
+    const writes: UpdatePresetInput[] = []
+    const coordinator = createPresetSaveCoordinator({
+      async update(_presetId, input) {
+        writes.push(structuredClone(input))
+        throw conflict
+      },
+      async get() {
+        return latest
+      },
+    })
+    coordinator.hydrate(base)
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({
+        ...preset,
+        blocks: preset.blocks.map((candidate) => ({ ...candidate, content: 'local' })),
+      }),
+      { immediate: true },
+    )
+
+    await expect(coordinator.flush(base.id)).rejects.toBe(conflict)
+    expect(writes).toHaveLength(1)
+    localStorage.clear()
+  })
+
+  test('confirms persisted dirty paths individually while retaining newer edits', async () => {
+    localStorage.clear()
+    const base = unmarshalPreset(rawPreset({
+      name: 'Base name',
+      metadata: {
+        description: 'Base description',
+        extension: { value: 'base' },
+      },
+      cache_revision: 1,
+    }))
+    const ownEvent = rawPreset({
+      name: 'Local name',
+      metadata: {
+        description: 'Remote description',
+        extension: { value: 'remote' },
+      },
+      cache_revision: 2,
+      updated_at: 3,
+    })
+    const writes: UpdatePresetInput[] = []
+    let updateCalls = 0
+    let markFirstStarted!: () => void
+    let resolveFirst!: (preset: Preset) => void
+    const firstStarted = new Promise<void>((resolve) => { markFirstStarted = resolve })
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        writes.push(structuredClone(input))
+        updateCalls += 1
+        if (updateCalls === 1) {
+          markFirstStarted()
+          return new Promise<Preset>((resolve) => { resolveFirst = resolve })
+        }
+        return rawPreset({
+          ...ownEvent,
+          id: presetId,
+          name: input.name ?? ownEvent.name,
+          parameters: input.parameters ?? ownEvent.parameters,
+          prompt_order: input.prompt_order ?? ownEvent.prompt_order,
+          prompts: input.prompts ?? ownEvent.prompts,
+          metadata: input.metadata ?? ownEvent.metadata,
+          cache_revision: 3,
+        })
+      },
+    })
+
+    coordinator.hydrate(base)
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({
+        ...preset,
+        name: 'Local name',
+        description: 'Local description',
+      }),
+      { immediate: true },
+    )
+    await firstStarted
+
+    const rebased = coordinator.hydrate(unmarshalPreset(ownEvent))
+    expect(rebased.name).toBe('Local name')
+    expect(rebased.description).toBe('Local description')
+    expect(rebased.passthroughMetadata.extension).toEqual({ value: 'remote' })
+    expect(coordinator.hasPendingChanges(base.id)).toBe(true)
+
+    resolveFirst(ownEvent)
+    await coordinator.flush(base.id)
+
+    expect(writes).toHaveLength(2)
+    expect(writes[1].expected_cache_revision).toBe(2)
+    expect(writes[1].name).toBe('Local name')
+    expect(writes[1].metadata?.description).toBe('Local description')
+    expect(writes[1].metadata?.extension).toEqual({ value: 'remote' })
+    localStorage.clear()
+  })
+
+  test('does not mutate a recreated entry after an in-flight conflict read', async () => {
+    localStorage.clear()
+    const base = unmarshalPreset(rawPreset({ cache_revision: 1 }))
+    const latest = rawPreset({ name: 'Latest persisted', cache_revision: 2 })
+    const replacement = unmarshalPreset(rawPreset({ name: 'Replacement', cache_revision: 9 }))
+    const conflict = Object.assign(new Error('preset revision conflict'), {
+      status: 409,
+      body: { code: 'PRESET_REVISION_CONFLICT' },
+    })
+    let updateCalls = 0
+    let getCalls = 0
+    let markUpdateStarted!: () => void
+    let markGetStarted!: () => void
+    let resolveGet!: (preset: Preset) => void
+    let resolveGetRow!: (preset: Preset) => void
+    const updateStarted = new Promise<void>((resolve) => { markUpdateStarted = resolve })
+    const getStarted = new Promise<void>((resolve) => { markGetStarted = resolve })
+    const getFinished = new Promise<void>((resolve) => {
+      resolveGet = (preset) => { resolveGetRow(preset); resolve() }
+    })
+    const coordinator = createPresetSaveCoordinator({
+      async update() {
+        updateCalls += 1
+        markUpdateStarted()
+        throw conflict
+      },
+      async get() {
+        getCalls += 1
+        markGetStarted()
+        return new Promise<Preset>((resolve) => { resolveGetRow = resolve })
+      },
+    })
+
+    coordinator.hydrate(base)
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({ ...preset, name: 'Local name' }),
+      { immediate: true },
+    )
+    await updateStarted
+    await getStarted
+
+    coordinator.remove(base.id)
+    coordinator.subscribe(base.id, () => {})
+    coordinator.hydrate(replacement)
+    resolveGet(latest)
+    await getFinished
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(updateCalls).toBe(1)
+    expect(getCalls).toBe(1)
+    expect(coordinator.getDraft(base.id)?.name).toBe('Replacement')
+    localStorage.clear()
+  })
+  test('bounds recoverable revision conflict retries', async () => {
+    localStorage.clear()
+    const base = unmarshalPreset(rawPreset({ cache_revision: 1 }))
+    const latest = rawPreset({ cache_revision: 2 })
+    const conflict = Object.assign(new Error('preset revision conflict'), {
+      status: 409,
+      body: { code: 'PRESET_REVISION_CONFLICT' },
+    })
+    let updateCalls = 0
+    let getCalls = 0
+    const coordinator = createPresetSaveCoordinator({
+      async update() {
+        updateCalls += 1
+        throw conflict
+      },
+      async get() {
+        getCalls += 1
+        return latest
+      },
+    })
+
+    coordinator.hydrate(base)
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({ ...preset, name: 'Local name' }),
+      { immediate: true },
+    )
+
+    await expect(coordinator.flush(base.id)).rejects.toBe(conflict)
+    expect(updateCalls).toBe(4)
+    expect(getCalls).toBe(3)
+    localStorage.clear()
+  })
+  test('isolates durable storage scopes per coordinator instance', () => {
+    localStorage.clear()
+    const first = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        return persistedFromUpdate(presetId, input)
+      },
+    })
+    const second = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        return persistedFromUpdate(presetId, input)
+      },
+    })
+    const base = unmarshalPreset(rawPreset())
+
+    try {
+      first.setScope('first-user')
+      first.mutate(base.id, base, (preset) => ({
+        ...preset,
+        description: 'private to first user',
+      }))
+      second.setScope('second-user')
+      second.mutate(base.id, base, (preset) => ({
+        ...preset,
+        description: 'private to second user',
+      }))
+
+      expect(localStorage.getItem('__lumiverse_pending_loom_presets:first-user')).not.toBeNull()
+      expect(localStorage.getItem('__lumiverse_pending_loom_presets:second-user')).not.toBeNull()
+
+      first.remove(base.id)
+      expect(localStorage.getItem('__lumiverse_pending_loom_presets:first-user')).toBeNull()
+      expect(localStorage.getItem('__lumiverse_pending_loom_presets:second-user')).not.toBeNull()
+    } finally {
+      first.setScope(null)
+      second.setScope(null)
+      localStorage.clear()
+    }
+  })
+
+  test('rejects hydration tokens from a previous user scope', () => {
+    localStorage.clear()
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        return persistedFromUpdate(presetId, input)
+      },
+    })
+    const base = unmarshalPreset(rawPreset())
+
+    coordinator.setScope('hydration-user-a')
+    const token = coordinator.beginHydration(base.id)
+    coordinator.setScope('hydration-user-b')
+
+    expect(() => coordinator.hydrate(base, token)).toThrow(PresetScopeChangedError)
+    coordinator.setScope(null)
+    localStorage.clear()
+  })
+
+  test('rejects durable recovery with scope error when the persisted read fails late', async () => {
+    localStorage.clear()
+    const presetId = 'scope-rejected-recovery'
+    const persisted = rawPreset({ id: presetId })
+    const originalGet = presetsApi.get
+    let rejectGet!: (error: Error) => void
+    let markGetStarted!: () => void
+    const getStarted = new Promise<void>((resolve) => { markGetStarted = resolve })
+    const pendingGet = new Promise<Preset>((_resolve, reject) => { rejectGet = reject })
+
+    presetSaveCoordinator.setScope('recovery-user-a')
+    presetSaveCoordinator.remove(presetId)
+    localStorage.setItem('__lumiverse_pending_loom_presets:recovery-user-a', JSON.stringify({
+      [presetId]: {
+        __lumiverse_pending_loom_preset_v2: 2,
+        preset: unmarshalPreset(persisted),
+        dirty: { fields: ['description'], passthroughKeys: [] },
+        revision: 0,
+      },
+    }))
+    presetsApi.get = async (_presetId: string) => {
+      markGetStarted()
+      return pendingGet
+    }
+
+    try {
+      const flush = flushPresetForGeneration(presetId)
+      await getStarted
+      presetSaveCoordinator.setScope('recovery-user-b')
+      rejectGet(new Error('late persisted read failure'))
+      await expect(flush).rejects.toBeInstanceOf(PresetScopeChangedError)
+    } finally {
+      presetsApi.get = originalGet
+      presetSaveCoordinator.setScope(null)
+      localStorage.clear()
     }
   })
 })

--- a/frontend/src/lib/loom/preset-save-coordinator.test.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.test.ts
@@ -391,6 +391,28 @@ describe('preset save coordinator', () => {
     })
   })
 
+  test('evicts a clean no-subscriber entry after persistence completes', async () => {
+    localStorage.clear()
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        return persistedFromUpdate(presetId, input)
+      },
+    })
+    const base = unmarshalPreset(rawPreset())
+    coordinator.hydrate(base)
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({ ...preset, description: 'Saved without a subscriber' }),
+      { immediate: true },
+    )
+
+    await coordinator.flush(base.id)
+    await Promise.resolve()
+    expect(coordinator.getDraft(base.id)).toBeNull()
+    localStorage.clear()
+  })
+
   test('rejects a delayed persisted read after a newer write was confirmed', async () => {
     localStorage.clear()
     const writes: UpdatePresetInput[] = []
@@ -417,7 +439,7 @@ describe('preset save coordinator', () => {
 
     coordinator.mutate(
       base.id,
-      base,
+      afterDelayedRead,
       (preset) => ({ ...preset, promptVariables: { 'block-1': { tone: 'warm' } } }),
       { immediate: true },
     )

--- a/frontend/src/lib/loom/preset-save-coordinator.test.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import type { Preset, UpdatePresetInput } from '@/types/api'
+import type { LoomPreset } from './types'
 import { createPresetSaveCoordinator, type PresetSaveAdapter } from './preset-save-coordinator'
 import { unmarshalPreset } from './service'
 
@@ -226,6 +227,62 @@ describe('preset save coordinator', () => {
     expect(rebased.name).toBe('Unsaved editor name')
     expect(rebased.promptVariables).toEqual({ 'block-1': { tone: 'fresh' } })
     expect(rebased.passthroughMetadata.agentic_preset_composer).toEqual({ mode: 'parallel' })
+    localStorage.clear()
+  })
+
+  test('notifies a subscription registered before the first hydration', () => {
+    localStorage.clear()
+    const base = unmarshalPreset(rawPreset())
+    const observed: LoomPreset[] = []
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        return persistedFromUpdate(presetId, input)
+      },
+    })
+
+    const unsubscribe = coordinator.subscribe(base.id, (preset) => observed.push(preset))
+    coordinator.hydrate(base)
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({
+        ...preset,
+        promptVariables: { 'block-1': { tone: 'warm' } },
+      }),
+      { immediate: true },
+    )
+
+    expect(observed).toHaveLength(1)
+    expect(observed[0].promptVariables).toEqual({ 'block-1': { tone: 'warm' } })
+    unsubscribe()
+    localStorage.clear()
+  })
+
+  test('does not let a stale cleanup erase a replacement pre-hydration listener', () => {
+    localStorage.clear()
+    const base = unmarshalPreset(rawPreset())
+    const received: LoomPreset[] = []
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        return persistedFromUpdate(presetId, input)
+      },
+    })
+
+    const staleUnsubscribe = coordinator.subscribe(base.id, () => {})
+    coordinator.remove(base.id)
+    const currentUnsubscribe = coordinator.subscribe(base.id, (preset) => received.push(preset))
+    staleUnsubscribe()
+    coordinator.hydrate(base)
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({ ...preset, name: 'Current subscriber receives this' }),
+      { immediate: true },
+    )
+
+    expect(received).toHaveLength(1)
+    expect(received[0].name).toBe('Current subscriber receives this')
+    currentUnsubscribe()
     localStorage.clear()
   })
 })

--- a/frontend/src/lib/loom/preset-save-coordinator.test.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.test.ts
@@ -1071,7 +1071,15 @@ describe('preset save coordinator', () => {
     expect(writes).toHaveLength(3)
     expect(writes.map((input) => input.expected_cache_revision)).toEqual([1, 2, 2])
     expect(writes[2].prompt_order?.[0]?.content).toBe('second')
+    const hydrationToken = coordinator.beginHydration(base.id)
     expect(() => coordinator.hydrate(unmarshalPreset(firstSaved))).not.toThrow()
+    const newerPersisted = unmarshalPreset(rawPreset({
+      ...firstSaved,
+      name: 'newer',
+      cache_revision: 4,
+      prompt_order: firstSaved.prompt_order?.map((candidate) => ({ ...candidate, content: 'second' })),
+    }))
+    expect(coordinator.hydrate(newerPersisted, hydrationToken).name).toBe('newer')
     expect(coordinator.getDraft(base.id)?.blocks[0]?.content).toBe('second')
     unsubscribe()
     localStorage.clear()

--- a/frontend/src/lib/loom/preset-save-coordinator.test.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.test.ts
@@ -1309,6 +1309,53 @@ describe('preset save coordinator', () => {
     expect(coordinator.getDraft(base.id)?.name).toBe('Replacement')
     localStorage.clear()
   })
+  test('keeps conflict-recovered fields against an older tokenless echo', async () => {
+    localStorage.clear()
+    const base = unmarshalPreset(rawPreset({
+      cache_revision: 1,
+      metadata: { description: 'Base description' },
+    }))
+    const latest = rawPreset({
+      cache_revision: 3,
+      metadata: { description: 'Remote description' },
+    })
+    const stale = unmarshalPreset(rawPreset({
+      cache_revision: 2,
+      metadata: { description: 'Stale description' },
+    }))
+    const conflict = Object.assign(new Error('preset revision conflict'), {
+      status: 409,
+      body: { code: 'PRESET_REVISION_CONFLICT' },
+    })
+    let updateCalls = 0
+    let markRetryStarted!: () => void
+    let rejectRetry!: (error: Error) => void
+    const retryStarted = new Promise<void>((resolve) => { markRetryStarted = resolve })
+    const coordinator = createPresetSaveCoordinator({
+      async update() {
+        updateCalls += 1
+        if (updateCalls === 1) throw conflict
+        markRetryStarted()
+        return new Promise<Preset>((_resolve, reject) => { rejectRetry = reject })
+      },
+      async get() {
+        return latest
+      },
+    })
+
+    coordinator.hydrate(base)
+    coordinator.mutate(base.id, base, (preset) => ({ ...preset, name: 'Local name' }), { immediate: true })
+    await retryStarted
+
+    const echoed = coordinator.hydrate(stale)
+    expect(echoed.name).toBe('Local name')
+    expect(echoed.description).toBe('Remote description')
+    const retryFailure = new Error('retry failed')
+    rejectRetry(retryFailure)
+    await expect(coordinator.flush(base.id)).rejects.toThrow('retry failed')
+    localStorage.clear()
+  })
+
   test('bounds recoverable revision conflict retries', async () => {
     localStorage.clear()
     const base = unmarshalPreset(rawPreset({ cache_revision: 1 }))

--- a/frontend/src/lib/loom/preset-save-coordinator.test.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, test } from 'bun:test'
 import type { Preset, UpdatePresetInput } from '@/types/api'
 import type { LoomPreset } from './types'
-import { createPresetSaveCoordinator, type PresetSaveAdapter } from './preset-save-coordinator'
+import {
+  createPresetSaveCoordinator,
+  flushPresetForGeneration,
+  presetSaveCoordinator,
+  StalePresetHydrationError,
+  type PresetSaveAdapter,
+} from './preset-save-coordinator'
 import { SPINDLE_EXTENSION_METADATA_KEY, unmarshalPreset } from './service'
+import { presetsApi } from '@/api/presets'
 
 function rawPreset(overrides: Partial<Preset> = {}): Preset {
   return {
@@ -421,6 +428,90 @@ describe('preset save coordinator', () => {
     localStorage.clear()
   })
 
+  test('allows only the latest concurrently started hydration to establish a draft', async () => {
+    localStorage.clear()
+    const writes: UpdatePresetInput[] = []
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        writes.push(structuredClone(input))
+        return persistedFromUpdate(presetId, input)
+      },
+    })
+    const stale = unmarshalPreset(rawPreset({ name: 'Stale read', updated_at: 1 }))
+    const fresh = unmarshalPreset(rawPreset({ name: 'Fresh read', updated_at: 2 }))
+
+    const firstRead = coordinator.beginHydration(stale.id)
+    const secondRead = coordinator.beginHydration(fresh.id)
+    expect(() => coordinator.hydrate(stale, firstRead)).toThrow(StalePresetHydrationError)
+
+    const loaded = coordinator.hydrate(fresh, secondRead)
+    const edited = coordinator.mutate(
+      loaded.id,
+      loaded,
+      (preset) => ({ ...preset, description: 'Locally edited after the fresh read' }),
+      { immediate: true },
+    )
+    await coordinator.flush(edited.id)
+
+    expect(writes).toHaveLength(1)
+    expect(writes[0].name).toBe('Fresh read')
+    expect(writes[0].metadata?.description).toBe('Locally edited after the fresh read')
+    localStorage.clear()
+  })
+
+  test('rebases a local dirty mutation over the latest in-flight persisted read', async () => {
+    localStorage.clear()
+    const writes: UpdatePresetInput[] = []
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        writes.push(structuredClone(input))
+        return persistedFromUpdate(presetId, input)
+      },
+    })
+    const base = unmarshalPreset(rawPreset({ name: 'Base', updated_at: 1 }))
+    coordinator.hydrate(base)
+    const read = coordinator.beginHydration(base.id)
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({ ...preset, promptVariables: { 'block-1': { tone: 'warm' } } }),
+    )
+
+    const rebased = coordinator.hydrate(
+      unmarshalPreset(rawPreset({ name: 'Fresh base', updated_at: 2 })),
+      read,
+    )
+    await coordinator.flush(base.id)
+
+    expect(rebased.name).toBe('Fresh base')
+    expect(rebased.promptVariables).toEqual({ 'block-1': { tone: 'warm' } })
+    expect(writes).toHaveLength(1)
+    expect(writes[0].name).toBe('Fresh base')
+    localStorage.clear()
+  })
+
+  test('rejects a delayed read after a direct authoritative hydration', () => {
+    localStorage.clear()
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        return persistedFromUpdate(presetId, input)
+      },
+    })
+    const old = unmarshalPreset(rawPreset({ name: 'Old row', updated_at: 1 }))
+    coordinator.hydrate(old)
+    const delayedRead = coordinator.beginHydration(old.id)
+
+    const current = coordinator.hydrate(unmarshalPreset(rawPreset({
+      name: 'Authoritative row',
+      updated_at: 2,
+    })))
+    const afterDelayedRead = coordinator.hydrate(old, delayedRead)
+
+    expect(current.name).toBe('Authoritative row')
+    expect(afterDelayedRead.name).toBe('Authoritative row')
+    localStorage.clear()
+  })
+
   test('notifies a subscription registered before the first hydration', () => {
     localStorage.clear()
     const base = unmarshalPreset(rawPreset())
@@ -443,8 +534,8 @@ describe('preset save coordinator', () => {
       { immediate: true },
     )
 
-    expect(observed).toHaveLength(1)
-    expect(observed[0].promptVariables).toEqual({ 'block-1': { tone: 'warm' } })
+    expect(observed).toHaveLength(2)
+    expect(observed[1].promptVariables).toEqual({ 'block-1': { tone: 'warm' } })
     unsubscribe()
     localStorage.clear()
   })
@@ -471,9 +562,48 @@ describe('preset save coordinator', () => {
       { immediate: true },
     )
 
-    expect(received).toHaveLength(1)
-    expect(received[0].name).toBe('Current subscriber receives this')
+    expect(received).toHaveLength(2)
+    expect(received[1].name).toBe('Current subscriber receives this')
     currentUnsubscribe()
     localStorage.clear()
+  })
+
+  test('single-flights concurrent durable recovery before generation', async () => {
+    const presetId = 'single-flight-recovery'
+    const persisted = rawPreset({ id: presetId })
+    const originalGet = presetsApi.get
+    const originalUpdate = presetsApi.update
+    let getCalls = 0
+    let resolveGet!: (preset: Preset) => void
+    const pendingGet = new Promise<Preset>((resolve) => { resolveGet = resolve })
+    presetSaveCoordinator.remove(presetId)
+    localStorage.setItem('__lumiverse_pending_loom_presets', JSON.stringify({
+      [presetId]: {
+        __lumiverse_pending_loom_preset_v2: 2,
+        preset: unmarshalPreset(persisted),
+        dirty: { fields: ['description'], passthroughKeys: [], spindleMetadataKeys: [] },
+        revision: 0,
+      },
+    }))
+    ;(presetsApi as any).get = async () => {
+      getCalls += 1
+      return pendingGet
+    }
+    ;(presetsApi as any).update = async (id: string, input: UpdatePresetInput) => persistedFromUpdate(id, input)
+
+    try {
+      const first = flushPresetForGeneration(presetId)
+      const second = flushPresetForGeneration(presetId)
+      await Promise.resolve()
+      expect(getCalls).toBe(1)
+
+      resolveGet(persisted)
+      await Promise.all([first, second])
+    } finally {
+      ;(presetsApi as any).get = originalGet
+      ;(presetsApi as any).update = originalUpdate
+      presetSaveCoordinator.remove(presetId)
+      localStorage.removeItem('__lumiverse_pending_loom_presets')
+    }
   })
 })

--- a/frontend/src/lib/loom/preset-save-coordinator.test.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, test } from 'bun:test'
+import type { Preset, UpdatePresetInput } from '@/types/api'
+import { createPresetSaveCoordinator, type PresetSaveAdapter } from './preset-save-coordinator'
+import { unmarshalPreset } from './service'
+
+function rawPreset(overrides: Partial<Preset> = {}): Preset {
+  return {
+    id: 'preset-1',
+    name: 'Coordinator test',
+    provider: 'loom',
+    parameters: {},
+    prompt_order: [],
+    prompts: {},
+    metadata: {},
+    created_at: 1,
+    updated_at: 2,
+    ...overrides,
+  }
+}
+
+function persistedFromUpdate(presetId: string, input: UpdatePresetInput): Preset {
+  return rawPreset({
+    id: presetId,
+    name: input.name ?? 'Coordinator test',
+    parameters: input.parameters ?? {},
+    prompt_order: input.prompt_order ?? [],
+    prompts: input.prompts ?? {},
+    metadata: input.metadata ?? {},
+    updated_at: Date.now(),
+  })
+}
+
+describe('preset save coordinator', () => {
+  test('serializes a stale editor writer and a later prompt-variable writer', async () => {
+    const writes: UpdatePresetInput[] = []
+    const adapter: PresetSaveAdapter = {
+      async update(presetId, input) {
+        writes.push(structuredClone(input))
+        return persistedFromUpdate(presetId, input)
+      },
+    }
+    const coordinator = createPresetSaveCoordinator(adapter)
+    const base = unmarshalPreset(rawPreset())
+    coordinator.hydrate(base)
+
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({
+        ...preset,
+        blocks: [{
+          id: 'block-1',
+          name: 'Editor block',
+          content: 'editor update',
+          role: 'system',
+          enabled: true,
+          position: 'pre_history',
+          depth: 0,
+          marker: null,
+          isLocked: false,
+          color: null,
+          injectionTrigger: [],
+          variables: [{
+            id: 'tone',
+            name: 'tone',
+            label: 'Tone',
+            type: 'text',
+            defaultValue: '',
+          }],
+        }],
+      }),
+      { immediate: true },
+    )
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({
+        ...preset,
+        promptVariables: { 'block-1': { tone: 'warm' } },
+      }),
+      { immediate: true },
+    )
+
+    await coordinator.flush(base.id)
+
+    expect(writes).toHaveLength(2)
+    expect(writes[1].prompt_order).toHaveLength(1)
+    expect(writes[1].metadata?.promptVariables).toEqual({ 'block-1': { tone: 'warm' } })
+  })
+
+  test('rebases only locally-owned dirty fields over a fresh persisted row', async () => {
+    const adapter: PresetSaveAdapter = {
+      async update(presetId, input) {
+        return persistedFromUpdate(presetId, input)
+      },
+    }
+    const coordinator = createPresetSaveCoordinator(adapter)
+    const base = unmarshalPreset(rawPreset({
+      metadata: { agentic_preset_composer: { mode: 'single' } },
+    }))
+    coordinator.hydrate(base)
+
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({
+        ...preset,
+        promptVariables: { 'block-1': { tone: 'warm' } },
+      }),
+      { immediate: true },
+    )
+
+    const rebased = coordinator.hydrate(unmarshalPreset(rawPreset({
+      metadata: { agentic_preset_composer: { mode: 'parallel' } },
+      updated_at: 3,
+    })))
+
+    expect(rebased.promptVariables).toEqual({ 'block-1': { tone: 'warm' } })
+    expect(rebased.passthroughMetadata.agentic_preset_composer).toEqual({ mode: 'parallel' })
+    await coordinator.flush(base.id)
+  })
+
+  test('preserves independent passthrough namespaces during a scoped rebase', async () => {
+    const adapter: PresetSaveAdapter = {
+      async update(presetId, input) {
+        return persistedFromUpdate(presetId, input)
+      },
+    }
+    const coordinator = createPresetSaveCoordinator(adapter)
+    const base = unmarshalPreset(rawPreset({
+      metadata: {
+        first_extension: { enabled: false },
+        second_extension: { revision: 1 },
+      },
+    }))
+    coordinator.hydrate(base)
+
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({
+        ...preset,
+        passthroughMetadata: {
+          ...preset.passthroughMetadata,
+          first_extension: { enabled: true },
+        },
+      }),
+      { immediate: true },
+    )
+
+    const rebased = coordinator.hydrate(unmarshalPreset(rawPreset({
+      metadata: {
+        first_extension: { enabled: false },
+        second_extension: { revision: 2 },
+      },
+      updated_at: 4,
+    })))
+
+    expect(rebased.passthroughMetadata).toEqual({
+      first_extension: { enabled: true },
+
+      second_extension: { revision: 2 },
+    })
+    await coordinator.flush(base.id)
+  })
+
+  test('rebases a durable prompt-only envelope over the fresh persisted row', () => {
+    localStorage.clear()
+    const base = unmarshalPreset(rawPreset({
+      metadata: { agentic_preset_composer: { mode: 'single' } },
+    }))
+    const pending = {
+      ...base,
+      promptVariables: { 'block-1': { tone: 'warm' } },
+    }
+    localStorage.setItem('__lumiverse_pending_loom_presets', JSON.stringify({
+      [base.id]: {
+        __lumiverse_pending_loom_preset_v2: 2,
+        preset: pending,
+        dirty: { fields: ['promptVariables'], passthroughKeys: [] },
+        revision: 1,
+      },
+    }))
+
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        return persistedFromUpdate(presetId, input)
+      },
+    })
+    const rebased = coordinator.hydrate(unmarshalPreset(rawPreset({
+      metadata: { agentic_preset_composer: { mode: 'parallel' } },
+      updated_at: 5,
+    })))
+
+    expect(rebased.promptVariables).toEqual({ 'block-1': { tone: 'warm' } })
+    expect(rebased.passthroughMetadata.agentic_preset_composer).toEqual({ mode: 'parallel' })
+    localStorage.clear()
+  })
+
+  test('migrates a legacy raw snapshot without replaying prompt or extension state', () => {
+    localStorage.clear()
+    const persisted = unmarshalPreset(rawPreset({
+      metadata: {
+        agentic_preset_composer: { mode: 'parallel' },
+        promptVariables: { 'block-1': { tone: 'fresh' } },
+      },
+      updated_at: 6,
+    }))
+    const legacy = {
+      ...persisted,
+      name: 'Unsaved editor name',
+      promptVariables: { 'block-1': { tone: 'stale' } },
+      passthroughMetadata: { agentic_preset_composer: { mode: 'single' } },
+    }
+    localStorage.setItem('__lumiverse_pending_loom_presets', JSON.stringify({
+      [persisted.id]: legacy,
+    }))
+
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        return persistedFromUpdate(presetId, input)
+      },
+    })
+    const rebased = coordinator.hydrate(persisted)
+
+    expect(rebased.name).toBe('Unsaved editor name')
+    expect(rebased.promptVariables).toEqual({ 'block-1': { tone: 'fresh' } })
+    expect(rebased.passthroughMetadata.agentic_preset_composer).toEqual({ mode: 'parallel' })
+    localStorage.clear()
+  })
+})

--- a/frontend/src/lib/loom/preset-save-coordinator.test.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.test.ts
@@ -8,7 +8,7 @@ import {
   StalePresetHydrationError,
   type PresetSaveAdapter,
 } from './preset-save-coordinator'
-import { SPINDLE_EXTENSION_METADATA_KEY, unmarshalPreset } from './service'
+import { unmarshalPreset } from './service'
 import { presetsApi } from '@/api/presets'
 
 function rawPreset(overrides: Partial<Preset> = {}): Preset {
@@ -285,25 +285,21 @@ describe('preset save coordinator', () => {
     localStorage.clear()
   })
 
-  test('rebases a durable protected Spindle namespace over fresh sibling namespaces', async () => {
+  test('rebases a durable extension key over fresh sibling extension keys', async () => {
     localStorage.clear()
     const writes: UpdatePresetInput[] = []
     const persisted = unmarshalPreset(rawPreset({
       metadata: {
-        [SPINDLE_EXTENSION_METADATA_KEY]: {
-          first_extension: { mode: 'old' },
-          second_extension: { revision: 2 },
-        },
+        first_extension: { mode: 'old' },
+        second_extension: { revision: 2 },
       },
     }))
     const pending = {
       ...persisted,
       passthroughMetadata: {
         ...persisted.passthroughMetadata,
-        [SPINDLE_EXTENSION_METADATA_KEY]: {
-          first_extension: { mode: 'new' },
-          second_extension: { revision: 1 },
-        },
+        first_extension: { mode: 'new' },
+        second_extension: { revision: 1 },
       },
     }
     localStorage.setItem('__lumiverse_pending_loom_presets', JSON.stringify({
@@ -312,8 +308,7 @@ describe('preset save coordinator', () => {
         preset: pending,
         dirty: {
           fields: [],
-          passthroughKeys: [],
-          spindleMetadataKeys: ['first_extension'],
+          passthroughKeys: ['first_extension'],
         },
         revision: 1,
       },
@@ -328,19 +323,15 @@ describe('preset save coordinator', () => {
     expect(coordinator.hasDurablePendingRecovery(persisted.id)).toBe(true)
     const rebased = coordinator.hydrate(persisted)
     expect(coordinator.hasDurablePendingRecovery(persisted.id)).toBe(false)
-    expect(rebased.passthroughMetadata[SPINDLE_EXTENSION_METADATA_KEY]).toEqual({
-      first_extension: { mode: 'new' },
-      second_extension: { revision: 2 },
-    })
+    expect(rebased.passthroughMetadata.first_extension).toEqual({ mode: 'new' })
+    expect(rebased.passthroughMetadata.second_extension).toEqual({ revision: 2 })
     await coordinator.flush(persisted.id)
-    expect(writes[0].metadata?.[SPINDLE_EXTENSION_METADATA_KEY]).toEqual({
-      first_extension: { mode: 'new' },
-      second_extension: { revision: 2 },
-    })
+    expect(writes[0].metadata?.first_extension).toEqual({ mode: 'new' })
+    expect(writes[0].metadata?.second_extension).toEqual({ revision: 2 })
     localStorage.clear()
   })
 
-  test('rebases only a dirty protected Spindle namespace over fresh sibling namespaces', async () => {
+  test('rebases only a dirty extension key over fresh sibling extension keys', async () => {
     const writes: UpdatePresetInput[] = []
     const coordinator = createPresetSaveCoordinator({
       async update(presetId, input) {
@@ -350,10 +341,8 @@ describe('preset save coordinator', () => {
     })
     const base = unmarshalPreset(rawPreset({
       metadata: {
-        [SPINDLE_EXTENSION_METADATA_KEY]: {
-          first_extension: { mode: 'old' },
-          second_extension: { revision: 1 },
-        },
+        first_extension: { mode: 'old' },
+        second_extension: { revision: 1 },
       },
     }))
     coordinator.hydrate(base)
@@ -364,31 +353,23 @@ describe('preset save coordinator', () => {
         ...preset,
         passthroughMetadata: {
           ...preset.passthroughMetadata,
-          [SPINDLE_EXTENSION_METADATA_KEY]: {
-            first_extension: { mode: 'new' },
-            second_extension: { revision: 1 },
-          },
+          first_extension: { mode: 'new' },
+          second_extension: { revision: 1 },
         },
       }),
     )
 
     const rebased = coordinator.hydrate(unmarshalPreset(rawPreset({
       metadata: {
-        [SPINDLE_EXTENSION_METADATA_KEY]: {
-          first_extension: { mode: 'old' },
-          second_extension: { revision: 2 },
-        },
+        first_extension: { mode: 'old' },
+        second_extension: { revision: 2 },
       },
     })))
-    expect(rebased.passthroughMetadata[SPINDLE_EXTENSION_METADATA_KEY]).toEqual({
-      first_extension: { mode: 'new' },
-      second_extension: { revision: 2 },
-    })
+    expect(rebased.passthroughMetadata.first_extension).toEqual({ mode: 'new' })
+    expect(rebased.passthroughMetadata.second_extension).toEqual({ revision: 2 })
     await coordinator.flush(base.id)
-    expect(writes[0].metadata?.[SPINDLE_EXTENSION_METADATA_KEY]).toEqual({
-      first_extension: { mode: 'new' },
-      second_extension: { revision: 2 },
-    })
+    expect(writes[0].metadata?.first_extension).toEqual({ mode: 'new' })
+    expect(writes[0].metadata?.second_extension).toEqual({ revision: 2 })
   })
 
   test('evicts a clean no-subscriber entry after persistence completes', async () => {
@@ -646,7 +627,7 @@ describe('preset save coordinator', () => {
       [presetId]: {
         __lumiverse_pending_loom_preset_v2: 2,
         preset: unmarshalPreset(persisted),
-        dirty: { fields: ['description'], passthroughKeys: [], spindleMetadataKeys: [] },
+        dirty: { fields: ['description'], passthroughKeys: [] },
         revision: 0,
       },
     }))

--- a/frontend/src/lib/loom/preset-save-coordinator.test.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.test.ts
@@ -1044,7 +1044,6 @@ describe('preset save coordinator', () => {
       },
     })
     coordinator.hydrate(base)
-    const unsubscribe = coordinator.subscribe(base.id, () => {})
     coordinator.mutate(
       base.id,
       base,
@@ -1072,17 +1071,72 @@ describe('preset save coordinator', () => {
     expect(writes.map((input) => input.expected_cache_revision)).toEqual([1, 2, 2])
     expect(writes[2].prompt_order?.[0]?.content).toBe('second')
     const hydrationToken = coordinator.beginHydration(base.id)
-    expect(() => coordinator.hydrate(unmarshalPreset(firstSaved))).not.toThrow()
+    expect(coordinator.hydrate(unmarshalPreset(firstSaved)).blocks[0]?.content).toBe('second')
     const newerPersisted = unmarshalPreset(rawPreset({
       ...firstSaved,
       name: 'newer',
       cache_revision: 4,
       prompt_order: firstSaved.prompt_order?.map((candidate) => ({ ...candidate, content: 'second' })),
     }))
-    expect(coordinator.hydrate(newerPersisted, hydrationToken).name).toBe('newer')
-    expect(coordinator.getDraft(base.id)?.blocks[0]?.content).toBe('second')
-    unsubscribe()
+    const hydratedNewer = coordinator.hydrate(newerPersisted, hydrationToken)
+    expect(hydratedNewer.name).toBe('newer')
+    expect(hydratedNewer.blocks[0]?.content).toBe('second')
     localStorage.clear()
+  })
+
+  test('rebases local edits when a stale echo follows clean eviction', () => {
+    localStorage.clear()
+    const block = {
+      id: 'base-block',
+      name: 'Base block',
+      content: 'base',
+      role: 'system' as const,
+      enabled: true,
+      position: 'pre_history' as const,
+      depth: 0,
+      marker: null,
+      isLocked: false,
+      color: null,
+      injectionTrigger: [],
+    }
+    const base = unmarshalPreset(rawPreset({ prompt_order: [block], cache_revision: 2 }))
+    const remoteBlock = { ...base.blocks[0], id: 'remote-block', content: 'remote' }
+    const persisted = {
+      ...base,
+      cacheRevision: 3,
+      name: 'Persisted',
+      blocks: [...base.blocks, remoteBlock],
+    }
+    const coordinator = createPresetSaveCoordinator({
+      async update() {
+        return rawPreset({ cache_revision: 3 })
+      },
+    })
+    coordinator.hydrate(persisted)
+    coordinator.mutate(
+      persisted.id,
+      base,
+      (preset) => ({
+        ...preset,
+        blocks: [
+          ...preset.blocks,
+          { ...preset.blocks[0], id: 'local-block', content: 'local' },
+        ],
+      }),
+    )
+
+    const draftBeforeEcho = coordinator.getDraft(persisted.id)
+    expect(draftBeforeEcho?.blocks.map((block) => block.id)).toEqual([
+      base.blocks[0].id,
+      'remote-block',
+      'local-block',
+    ])
+    const hydrated = coordinator.hydrate(base)
+    expect(hydrated.blocks.map((block) => block.id)).toEqual([
+      base.blocks[0].id,
+      'remote-block',
+      'local-block',
+    ])
   })
 
   test('surfaces remote block changes during hydration', () => {

--- a/frontend/src/lib/loom/preset-save-coordinator.test.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.test.ts
@@ -459,6 +459,32 @@ describe('preset save coordinator', () => {
     localStorage.clear()
   })
 
+  test('keeps an editor hydration usable when a later auxiliary read fails', () => {
+    localStorage.clear()
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        return persistedFromUpdate(presetId, input)
+      },
+    })
+    const editorRow = unmarshalPreset(rawPreset({ name: 'Editor row', updated_at: 1 }))
+    const unsubscribe = coordinator.subscribe(editorRow.id, () => {})
+    const editorRead = coordinator.beginHydration(editorRow.id, 'loom-editor')
+    const promptRead = coordinator.beginHydration(editorRow.id, 'prompt-variables')
+
+    const editorDraft = coordinator.hydrate(editorRow, editorRead)
+    expect(editorDraft.name).toBe('Editor row')
+    // The prompt-variable request intentionally never resolves. The selected
+    // editor still owns a usable persisted draft rather than remaining blank.
+    expect(coordinator.getDraft(editorRow.id)?.name).toBe('Editor row')
+
+    const freshPromptRow = unmarshalPreset(rawPreset({ name: 'Fresh prompt row', updated_at: 2 }))
+    const promptDraft = coordinator.hydrate(freshPromptRow, promptRead)
+    expect(promptDraft.name).toBe('Fresh prompt row')
+    expect(coordinator.hydrate(editorRow, editorRead).name).toBe('Fresh prompt row')
+    unsubscribe()
+    localStorage.clear()
+  })
+
   test('rebases a local dirty mutation over the latest in-flight persisted read', async () => {
     localStorage.clear()
     const writes: UpdatePresetInput[] = []
@@ -565,6 +591,23 @@ describe('preset save coordinator', () => {
     expect(received).toHaveLength(2)
     expect(received[1].name).toBe('Current subscriber receives this')
     currentUnsubscribe()
+    localStorage.clear()
+  })
+
+  test('evicts a clean preset once its final listener unsubscribes', () => {
+    localStorage.clear()
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        return persistedFromUpdate(presetId, input)
+      },
+    })
+    const base = unmarshalPreset(rawPreset())
+    const unsubscribe = coordinator.subscribe(base.id, () => {})
+    coordinator.hydrate(base)
+    expect(coordinator.getDraft(base.id)).not.toBeNull()
+
+    unsubscribe()
+    expect(coordinator.getDraft(base.id)).toBeNull()
     localStorage.clear()
   })
 

--- a/frontend/src/lib/loom/preset-save-coordinator.test.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.test.ts
@@ -989,6 +989,88 @@ describe('preset save coordinator', () => {
     localStorage.clear()
   })
 
+  test('uses the post-queue block revision as the retry base', async () => {
+    localStorage.clear()
+    const block = {
+      id: 'block-a',
+      name: 'Block A',
+      content: 'base',
+      role: 'system' as const,
+      enabled: true,
+      position: 'pre_history' as const,
+      depth: 0,
+      marker: null,
+      isLocked: false,
+      color: null,
+      injectionTrigger: [],
+    }
+    const base = unmarshalPreset(rawPreset({
+      prompt_order: [block],
+      cache_revision: 1,
+    }))
+    const firstSaved = rawPreset({
+      ...base,
+      prompt_order: [{ ...block, content: 'first' }],
+      cache_revision: 2,
+    })
+    const conflict = Object.assign(new Error('preset revision conflict'), {
+      status: 409,
+      body: { code: 'PRESET_REVISION_CONFLICT' },
+    })
+    const writes: UpdatePresetInput[] = []
+    let updateCalls = 0
+    let markFirstStarted!: () => void
+    let resolveFirst!: (preset: Preset) => void
+    const firstStarted = new Promise<void>((resolve) => { markFirstStarted = resolve })
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        writes.push(structuredClone(input))
+        updateCalls += 1
+        if (updateCalls === 1) {
+          markFirstStarted()
+          return new Promise<Preset>((resolve) => { resolveFirst = resolve })
+        }
+        if (updateCalls === 2) throw conflict
+        return rawPreset({
+          ...firstSaved,
+          id: presetId,
+          prompt_order: input.prompt_order ?? firstSaved.prompt_order,
+          cache_revision: 3,
+        })
+      },
+      async get() {
+        return firstSaved
+      },
+    })
+    coordinator.hydrate(base)
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({
+        ...preset,
+        blocks: preset.blocks.map((candidate) => ({ ...candidate, content: 'first' })),
+      }),
+      { immediate: true },
+    )
+    await firstStarted
+    coordinator.mutate(
+      base.id,
+      base,
+      (preset) => ({
+        ...preset,
+        blocks: preset.blocks.map((candidate) => ({ ...candidate, content: 'second' })),
+      }),
+      { immediate: true },
+    )
+    resolveFirst(firstSaved)
+
+    await coordinator.flush(base.id)
+    expect(writes).toHaveLength(3)
+    expect(writes.map((input) => input.expected_cache_revision)).toEqual([1, 2, 2])
+    expect(writes[2].prompt_order?.[0]?.content).toBe('second')
+    localStorage.clear()
+  })
+
   test('confirms persisted dirty paths individually while retaining newer edits', async () => {
     localStorage.clear()
     const base = unmarshalPreset(rawPreset({

--- a/frontend/src/lib/loom/preset-save-coordinator.test.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.test.ts
@@ -8,6 +8,7 @@ import {
   presetSaveCoordinator,
   StalePresetHydrationError,
   PresetScopeChangedError,
+  PresetBlockConflictError,
   type PresetSaveAdapter,
 } from './preset-save-coordinator'
 import { unmarshalPreset } from './service'
@@ -1068,6 +1069,45 @@ describe('preset save coordinator', () => {
     expect(writes).toHaveLength(3)
     expect(writes.map((input) => input.expected_cache_revision)).toEqual([1, 2, 2])
     expect(writes[2].prompt_order?.[0]?.content).toBe('second')
+    localStorage.clear()
+  })
+
+  test('surfaces remote block changes during hydration', () => {
+    localStorage.clear()
+    const block = {
+      id: 'block-a',
+      name: 'Block A',
+      content: 'base',
+      role: 'system' as const,
+      enabled: true,
+      position: 'pre_history' as const,
+      depth: 0,
+      marker: null,
+      isLocked: false,
+      color: null,
+      injectionTrigger: [],
+    }
+    const base = unmarshalPreset(rawPreset({
+      prompt_order: [block],
+      cache_revision: 1,
+    }))
+    const coordinator = createPresetSaveCoordinator({
+      async update(presetId, input) {
+        return persistedFromUpdate(presetId, input)
+      },
+    })
+    coordinator.hydrate(base)
+    coordinator.mutate(base.id, base, (preset) => ({
+      ...preset,
+      blocks: preset.blocks.map((candidate) => ({ ...candidate, content: 'local' })),
+    }))
+
+    const remote = unmarshalPreset(rawPreset({
+      prompt_order: [{ ...block, content: 'remote' }],
+      cache_revision: 2,
+    }))
+    expect(() => coordinator.hydrate(remote)).toThrow(PresetBlockConflictError)
+    expect(coordinator.getDraft(base.id)?.blocks[0]?.content).toBe('local')
     localStorage.clear()
   })
 

--- a/frontend/src/lib/loom/preset-save-coordinator.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.ts
@@ -1,6 +1,6 @@
 import { presetsApi } from '@/api/presets'
 import type { Preset, UpdatePresetInput } from '@/types/api'
-import { looksLikeLoomPresetData, marshalUpdate, unmarshalPreset } from './service'
+import { looksLikeLoomPresetData, marshalUpdate, SPINDLE_EXTENSION_METADATA_KEY, unmarshalPreset } from './service'
 import type { LoomPreset } from './types'
 
 const PENDING_LOOM_PRESETS_KEY = '__lumiverse_pending_loom_presets'
@@ -31,6 +31,7 @@ type DraftField = (typeof DRAFT_FIELDS)[number]
 interface DirtyPresetPaths {
   fields: DraftField[]
   passthroughKeys: string[]
+  spindleMetadataKeys: string[]
 }
 
 interface PendingLoomPresetEnvelope {
@@ -60,16 +61,36 @@ export interface PresetMutationOptions {
   debounceMs?: number
 }
 
+export interface PresetHydrationToken {
+  readonly presetId: string
+  readonly epoch: number
+}
+
+export class StalePresetHydrationError extends Error {
+  constructor(presetId: string) {
+    super(`Stale preset hydration: ${presetId}`)
+    this.name = 'StalePresetHydrationError'
+  }
+}
+
 export interface PresetSaveCoordinator {
+  /**
+   * Capture the coordinator state before beginning an asynchronous persisted-row read.
+   * Pass this token to `hydrate()` when the read resolves so stale responses cannot
+   * replace a newer local mutation or persistence confirmation.
+   */
+  beginHydration(presetId: string): PresetHydrationToken
   /**
    * Incorporate a freshly read persisted row. Any durable or in-memory dirty
    * paths are rebased over that row; untouched paths always come from the row.
    */
-  hydrate(preset: LoomPreset): LoomPreset
+  hydrate(preset: LoomPreset, token?: PresetHydrationToken): LoomPreset
   /** Return the current per-preset draft, if this coordinator owns one. */
   getDraft(presetId: string): LoomPreset | null
   /** True when the preset has unsaved local changes. */
   hasPendingChanges(presetId: string): boolean
+  /** True when only durable recovery state exists and a persisted read is required before flushing. */
+  hasDurablePendingRecovery(presetId: string): boolean
   /**
    * Atomically derive a draft from the coordinator's current value. A fallback
    * is used only on the first writer for a preset, preventing a stale caller
@@ -113,25 +134,35 @@ function isDraftField(value: unknown): value is DraftField {
 
 function normalizeDirtyPaths(value: unknown): DirtyPresetPaths | null {
   if (!isRecord(value) || !Array.isArray(value.fields) || !Array.isArray(value.passthroughKeys)) return null
-  if (!value.fields.every(isDraftField) || !value.passthroughKeys.every((key) => typeof key === 'string')) return null
+  const spindleMetadataKeys = value.spindleMetadataKeys === undefined
+    ? []
+    : value.spindleMetadataKeys
+  if (
+    !value.fields.every(isDraftField)
+    || !value.passthroughKeys.every((key) => typeof key === 'string')
+    || !Array.isArray(spindleMetadataKeys)
+    || !spindleMetadataKeys.every((key) => typeof key === 'string')
+  ) return null
   return {
     fields: [...new Set(value.fields)],
     passthroughKeys: [...new Set(value.passthroughKeys)],
+    spindleMetadataKeys: [...new Set(spindleMetadataKeys)],
   }
 }
 
 function isDirty(dirty: DirtyPresetPaths): boolean {
-  return dirty.fields.length > 0 || dirty.passthroughKeys.length > 0
+  return dirty.fields.length > 0 || dirty.passthroughKeys.length > 0 || dirty.spindleMetadataKeys.length > 0
 }
 
 function emptyDirtyPaths(): DirtyPresetPaths {
-  return { fields: [], passthroughKeys: [] }
+  return { fields: [], passthroughKeys: [], spindleMetadataKeys: [] }
 }
 
 function mergeDirtyPaths(previous: DirtyPresetPaths, next: DirtyPresetPaths): DirtyPresetPaths {
   return {
     fields: [...new Set([...previous.fields, ...next.fields])],
     passthroughKeys: [...new Set([...previous.passthroughKeys, ...next.passthroughKeys])],
+    spindleMetadataKeys: [...new Set([...previous.spindleMetadataKeys, ...next.spindleMetadataKeys])],
   }
 }
 
@@ -139,12 +170,22 @@ function getChangedPaths(before: LoomPreset, after: LoomPreset): DirtyPresetPath
   const fields = DRAFT_FIELDS.filter((field) => !sameJson(before[field], after[field]))
   const beforeMetadata = before.passthroughMetadata ?? {}
   const afterMetadata = after.passthroughMetadata ?? {}
+  const beforeNamespaces = isRecord(beforeMetadata[SPINDLE_EXTENSION_METADATA_KEY])
+    ? beforeMetadata[SPINDLE_EXTENSION_METADATA_KEY]
+    : {}
+  const afterNamespaces = isRecord(afterMetadata[SPINDLE_EXTENSION_METADATA_KEY])
+    ? afterMetadata[SPINDLE_EXTENSION_METADATA_KEY]
+    : {}
+  const spindleMetadataKeys = [...new Set([
+    ...Object.keys(beforeNamespaces),
+    ...Object.keys(afterNamespaces),
+  ])].filter((key) => !sameJson(beforeNamespaces[key], afterNamespaces[key]))
   const passthroughKeys = [...new Set([
     ...Object.keys(beforeMetadata),
     ...Object.keys(afterMetadata),
-  ])].filter((key) => !sameJson(beforeMetadata[key], afterMetadata[key]))
+  ])].filter((key) => key !== SPINDLE_EXTENSION_METADATA_KEY && !sameJson(beforeMetadata[key], afterMetadata[key]))
 
-  return { fields, passthroughKeys }
+  return { fields, passthroughKeys, spindleMetadataKeys }
 }
 
 function rebaseDirtyPaths(
@@ -158,7 +199,7 @@ function rebaseDirtyPaths(
     rebased[field] = clone(draft[field]) as never
   }
 
-  if (dirty.passthroughKeys.length > 0) {
+  if (dirty.passthroughKeys.length > 0 || dirty.spindleMetadataKeys.length > 0) {
     const metadata = clone(persisted.passthroughMetadata ?? {})
     for (const key of dirty.passthroughKeys) {
       if (Object.hasOwn(draft.passthroughMetadata, key)) {
@@ -171,6 +212,33 @@ function rebaseDirtyPaths(
       } else {
         delete metadata[key]
       }
+    }
+
+    if (dirty.spindleMetadataKeys.length > 0) {
+      const namespaces = isRecord(metadata[SPINDLE_EXTENSION_METADATA_KEY])
+        ? clone(metadata[SPINDLE_EXTENSION_METADATA_KEY])
+        : {}
+      const draftNamespaces = isRecord(draft.passthroughMetadata[SPINDLE_EXTENSION_METADATA_KEY])
+        ? draft.passthroughMetadata[SPINDLE_EXTENSION_METADATA_KEY]
+        : {}
+      for (const extensionId of dirty.spindleMetadataKeys) {
+        if (Object.hasOwn(draftNamespaces, extensionId)) {
+          Object.defineProperty(namespaces, extensionId, {
+            value: clone(draftNamespaces[extensionId]),
+            enumerable: true,
+            writable: true,
+            configurable: true,
+          })
+        } else {
+          delete namespaces[extensionId]
+        }
+      }
+      Object.defineProperty(metadata, SPINDLE_EXTENSION_METADATA_KEY, {
+        value: namespaces,
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      })
     }
     rebased.passthroughMetadata = metadata
   }
@@ -211,7 +279,7 @@ function legacyDirtyPaths(includePromptVariables: boolean): DirtyPresetPaths {
     && field !== 'presetVersion'
   ))
   if (includePromptVariables) fields.push('promptVariables')
-  return { fields, passthroughKeys: [] }
+  return { fields, passthroughKeys: [], spindleMetadataKeys: [] }
 }
 function readPendingEnvelope(presetId: string): PendingLoomPresetEnvelope | null {
   const entry = readPendingEntries()[presetId]
@@ -242,7 +310,7 @@ function readPendingEnvelope(presetId: string): PendingLoomPresetEnvelope | null
       preset: entry.preset,
       dirty: includeEditorContent
         ? legacyDirtyPaths(includePromptVariables)
-        : { fields: includePromptVariables ? ['promptVariables'] : [], passthroughKeys: [] },
+        : { fields: includePromptVariables ? ['promptVariables'] : [], passthroughKeys: [], spindleMetadataKeys: [] },
       revision: typeof entry.revision === 'number' && Number.isSafeInteger(entry.revision)
         ? entry.revision
         : 0,
@@ -306,6 +374,12 @@ function createEntry(preset: LoomPreset): PresetSaveEntry {
 export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetSaveCoordinator {
   const entries = new Map<string, PresetSaveEntry>()
   const listenersByPreset = new Map<string, Set<(preset: LoomPreset) => void>>()
+  const hydrationEpochs = new Map<string, number>()
+
+  const getHydrationEpoch = (presetId: string): number => hydrationEpochs.get(presetId) ?? 0
+  const advanceHydrationEpoch = (presetId: string): void => {
+    hydrationEpochs.set(presetId, getHydrationEpoch(presetId) + 1)
+  }
 
   function publish(entry: PresetSaveEntry): void {
     const snapshot = clone(entry.draft)
@@ -352,6 +426,7 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
       } else {
         current.draft = rebaseDirtyPaths(saved, current.draft, current.dirty)
       }
+      advanceHydrationEpoch(presetId)
       writePendingEnvelope(presetId, current)
       publish(current)
       return saved
@@ -380,10 +455,21 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
   }
 
   return {
-    hydrate(preset: LoomPreset): LoomPreset {
+    beginHydration(presetId): PresetHydrationToken {
+      return { presetId, epoch: getHydrationEpoch(presetId) }
+    },
+
+    hydrate(preset, token): LoomPreset {
+      if (token && (token.presetId !== preset.id || token.epoch !== getHydrationEpoch(preset.id))) {
+        const current = entries.get(preset.id)
+        if (current) return clone(current.draft)
+        throw new StalePresetHydrationError(preset.id)
+      }
+
       const entry = entries.get(preset.id)
       if (!entry) {
         const created = ensure(preset.id, preset)
+        advanceHydrationEpoch(preset.id)
         if (isDirty(created.dirty)) void enqueuePersist(preset.id, created).catch(() => {})
         return clone(created.draft)
       }
@@ -396,6 +482,7 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
       if (isDirty(entry.dirty) && persistedChanged) {
         entry.revision += 1
       }
+      advanceHydrationEpoch(preset.id)
       writePendingEnvelope(preset.id, entry)
       publish(entry)
       if (isDirty(entry.dirty) && persistedChanged) {
@@ -413,6 +500,10 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
       return Boolean(entries.get(presetId) && isDirty(entries.get(presetId)!.dirty))
     },
 
+    hasDurablePendingRecovery(presetId: string): boolean {
+      return !entries.has(presetId) && readPendingEnvelope(presetId) !== null
+    },
+
     mutate(presetId, fallback, mutator, options = {}): LoomPreset {
       const entry = ensure(presetId, fallback)
       const before = entry.draft
@@ -425,6 +516,7 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
       entry.draft = clone({ ...after, updatedAt: Date.now() })
       entry.dirty = mergeDirtyPaths(entry.dirty, changed)
       entry.revision += 1
+      advanceHydrationEpoch(presetId)
       writePendingEnvelope(presetId, entry)
       publish(entry)
 
@@ -437,14 +529,23 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
     },
 
     async flush(presetId: string): Promise<LoomPreset | null> {
-      const entry = entries.get(presetId)
-      if (!entry) return null
-      if (entry.timer) {
-        clearTimeout(entry.timer)
-        entry.timer = null
+      while (true) {
+        const entry = entries.get(presetId)
+        if (!entry) return null
+        if (entry.timer) {
+          clearTimeout(entry.timer)
+          entry.timer = null
+        }
+
+        const revision = entry.revision
+        const chain = isDirty(entry.dirty) ? enqueuePersist(presetId, entry) : entry.chain
+        const saved = await chain
+        const current = entries.get(presetId)
+        if (!current) return saved
+        if (current.revision === revision && !isDirty(current.dirty) && current.chain === chain) {
+          return saved
+        }
       }
-      if (isDirty(entry.dirty)) return enqueuePersist(presetId, entry)
-      return entry.chain
     },
 
     flushBestEffort(presetId: string): void {
@@ -467,6 +568,7 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
       const entry = entries.get(presetId)
       clearTimeout(entry?.timer)
       entries.delete(presetId)
+      advanceHydrationEpoch(presetId)
       listenersByPreset.delete(presetId)
       removePendingEnvelope(presetId)
     },
@@ -477,8 +579,20 @@ export const presetSaveCoordinator = createPresetSaveCoordinator({
   update: (presetId, input) => presetsApi.update(presetId, input),
 })
 
-/** Await the active preset's latest draft before a generation endpoint reads it. */
+/**
+ * Await the selected preset's latest draft before generation reads it. When
+ * Loom has not mounted yet, hydrate durable recovery state over a fresh row
+ * first so prompt-only or scoped writes cannot be skipped.
+ */
 export async function flushPresetForGeneration(presetId: string | undefined): Promise<void> {
   if (!presetId) return
+  if (!presetSaveCoordinator.hasDurablePendingRecovery(presetId)) {
+    await presetSaveCoordinator.flush(presetId)
+    return
+  }
+
+  const hydration = presetSaveCoordinator.beginHydration(presetId)
+  const persisted = unmarshalPreset(await presetsApi.get(presetId))
+  presetSaveCoordinator.hydrate(persisted, hydration)
   await presetSaveCoordinator.flush(presetId)
 }

--- a/frontend/src/lib/loom/preset-save-coordinator.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.ts
@@ -513,6 +513,16 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
   const hydrationReadEpochs = new Map<string, Map<string, number>>()
   const latestHydrationReadEpochs = new Map<string, number>()
   const confirmedEpochs = new Map<string, number>()
+  const confirmedCacheRevisions = new Map<string, number>()
+  const confirmedSnapshots = new Map<string, LoomPreset>()
+  const rememberConfirmedCacheRevision = (presetId: string, preset: LoomPreset): void => {
+    if (typeof preset.cacheRevision !== 'number') return
+    const previous = confirmedCacheRevisions.get(presetId)
+    if (previous === undefined || preset.cacheRevision > previous) {
+      confirmedCacheRevisions.set(presetId, preset.cacheRevision)
+      confirmedSnapshots.set(presetId, clone(preset))
+    }
+  }
   const pendingHydrations = new Set<PresetHydrationToken>()
   let scopeEpoch = 0
   let pendingStorageScope: string | null = null
@@ -526,6 +536,8 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
     hydrationReadEpochs.clear()
     latestHydrationReadEpochs.clear()
     confirmedEpochs.clear()
+    confirmedCacheRevisions.clear()
+    confirmedSnapshots.clear()
     pendingHydrations.clear()
   }
 
@@ -567,13 +579,20 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
     const existing = entries.get(presetId)
     if (existing) return existing
     if (fallback.id !== presetId) throw new Error('Preset coordinator fallback id mismatch')
-
-    const entry = createEntry(fallback)
+    const remembered = confirmedSnapshots.get(presetId)
+    const initial = remembered
+      && typeof fallback.cacheRevision === 'number'
+      && typeof remembered.cacheRevision === 'number'
+      && remembered.cacheRevision > fallback.cacheRevision
+      ? remembered
+      : fallback
+    const entry = createEntry(initial)
+    rememberConfirmedCacheRevision(presetId, entry.confirmed)
     entry.listeners = listenersByPreset.get(presetId) ?? new Set()
     listenersByPreset.set(presetId, entry.listeners)
     const pending = readPendingEnvelope(presetId, pendingStorageScope)
     if (pending) {
-      entry.draft = rebaseDirtyPaths(fallback, pending.preset, pending.dirty)
+      entry.draft = rebaseDirtyPaths(initial, pending.preset, pending.dirty)
       entry.dirty = pending.dirty
       entry.revision = pending.revision
     }
@@ -641,6 +660,7 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
           )
 
           current.confirmed = clone(saved)
+          rememberConfirmedCacheRevision(presetId, saved)
           if (current.revision === revision) {
             current.draft = clone(saved)
             current.dirty = emptyDirtyPaths()
@@ -783,14 +803,40 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
       }
       if (!entries.has(preset.id)) migrateLegacyPendingEnvelope(preset.id, pendingStorageScope)
       const existingEntry = entries.get(preset.id)
-      if (
-        !token
-        && existingEntry
+      const residentCacheRevision = existingEntry?.confirmed.cacheRevision
+      const rememberedCacheRevision = confirmedCacheRevisions.get(preset.id)
+      const confirmedCacheRevision = residentCacheRevision === undefined
+        ? rememberedCacheRevision
+        : rememberedCacheRevision === undefined
+          ? residentCacheRevision
+          : Math.max(residentCacheRevision, rememberedCacheRevision)
+      const staleTokenlessEcho = !token
         && typeof preset.cacheRevision === 'number'
-        && typeof existingEntry.confirmed.cacheRevision === 'number'
-        && preset.cacheRevision < existingEntry.confirmed.cacheRevision
-      ) {
-        return clone(existingEntry.draft)
+        && typeof confirmedCacheRevision === 'number'
+        && preset.cacheRevision < confirmedCacheRevision
+      if (staleTokenlessEcho) {
+        if (
+          existingEntry
+          && (rememberedCacheRevision === undefined
+            || residentCacheRevision === rememberedCacheRevision)
+        ) {
+          return clone(existingEntry.draft)
+        }
+        const confirmedSnapshot = confirmedSnapshots.get(preset.id)
+        if (confirmedSnapshot) {
+          if (existingEntry) {
+            existingEntry.confirmed = clone(confirmedSnapshot)
+            existingEntry.draft = isDirty(existingEntry.dirty)
+              ? rebaseDirtyPaths(confirmedSnapshot, existingEntry.draft, existingEntry.dirty)
+              : clone(confirmedSnapshot)
+            writePendingEnvelope(preset.id, existingEntry, pendingStorageScope)
+            publish(existingEntry)
+            return clone(existingEntry.draft)
+          }
+          return clone(confirmedSnapshot)
+        }
+        if (existingEntry) return clone(existingEntry.draft)
+        throw new StalePresetHydrationError(preset.id)
       }
       if (!token) advanceConfirmedEpoch(preset.id)
       const isAuthoritativeRead = !token
@@ -820,6 +866,7 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
         ))
       ) {
         entry.confirmed = clone(preset)
+        rememberConfirmedCacheRevision(preset.id, preset)
         entry.draft = isDirty(entry.dirty)
           ? rebaseDirtyPaths(preset, entry.draft, entry.dirty)
           : clone(preset)
@@ -840,6 +887,7 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
         ? confirmPersistedDirtyPaths(preset, entry.draft, entry.dirty)
         : { draft: clone(preset), dirty: emptyDirtyPaths() }
       entry.confirmed = clone(preset)
+      rememberConfirmedCacheRevision(preset.id, preset)
       entry.draft = rebased.draft
       entry.dirty = rebased.dirty
       if (isDirty(entry.dirty) && persistedChanged) {
@@ -946,6 +994,8 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
     remove(presetId: string): void {
       const entry = entries.get(presetId)
       clearTimeout(entry?.timer)
+      confirmedCacheRevisions.delete(presetId)
+      confirmedSnapshots.delete(presetId)
       entries.delete(presetId)
       advanceConfirmedEpoch(presetId)
       listenersByPreset.delete(presetId)

--- a/frontend/src/lib/loom/preset-save-coordinator.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.ts
@@ -85,6 +85,12 @@ export class PresetScopeChangedError extends Error {
     this.name = 'PresetScopeChangedError'
   }
 }
+export class PresetBlockConflictError extends Error {
+  constructor(presetId: string) {
+    super(`Preset block changes conflict with a newer persisted revision: ${presetId}`)
+    this.name = 'PresetBlockConflictError'
+  }
+}
 
 export interface PresetSaveCoordinator {
   /** Replace the authenticated-user scope and discard in-memory work from the previous scope. */
@@ -793,6 +799,12 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
         writePendingEnvelope(preset.id, entry, pendingStorageScope)
         publish(entry)
         return clone(entry.draft)
+      }
+      if (
+        entry.dirty.fields.includes('blocks')
+        && !sameJson(preset.blocks, entry.confirmed.blocks)
+      ) {
+        throw new PresetBlockConflictError(preset.id)
       }
       const persistedChanged = !sameJson(entry.confirmed, preset)
       const rebased = isDirty(entry.dirty)

--- a/frontend/src/lib/loom/preset-save-coordinator.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.ts
@@ -1,6 +1,6 @@
 import { presetsApi } from '@/api/presets'
 import type { Preset, UpdatePresetInput } from '@/types/api'
-import { looksLikeLoomPresetData, marshalUpdate, SPINDLE_EXTENSION_METADATA_KEY, unmarshalPreset } from './service'
+import { looksLikeLoomPresetData, marshalUpdate, unmarshalPreset } from './service'
 import type { LoomPreset } from './types'
 
 const PENDING_LOOM_PRESETS_KEY = '__lumiverse_pending_loom_presets'
@@ -31,7 +31,6 @@ type DraftField = (typeof DRAFT_FIELDS)[number]
 interface DirtyPresetPaths {
   fields: DraftField[]
   passthroughKeys: string[]
-  spindleMetadataKeys: string[]
 }
 
 interface PendingLoomPresetEnvelope {
@@ -139,35 +138,28 @@ function isDraftField(value: unknown): value is DraftField {
 
 function normalizeDirtyPaths(value: unknown): DirtyPresetPaths | null {
   if (!isRecord(value) || !Array.isArray(value.fields) || !Array.isArray(value.passthroughKeys)) return null
-  const spindleMetadataKeys = value.spindleMetadataKeys === undefined
-    ? []
-    : value.spindleMetadataKeys
   if (
     !value.fields.every(isDraftField)
     || !value.passthroughKeys.every((key) => typeof key === 'string')
-    || !Array.isArray(spindleMetadataKeys)
-    || !spindleMetadataKeys.every((key) => typeof key === 'string')
   ) return null
   return {
     fields: [...new Set(value.fields)],
     passthroughKeys: [...new Set(value.passthroughKeys)],
-    spindleMetadataKeys: [...new Set(spindleMetadataKeys)],
   }
 }
 
 function isDirty(dirty: DirtyPresetPaths): boolean {
-  return dirty.fields.length > 0 || dirty.passthroughKeys.length > 0 || dirty.spindleMetadataKeys.length > 0
+  return dirty.fields.length > 0 || dirty.passthroughKeys.length > 0
 }
 
 function emptyDirtyPaths(): DirtyPresetPaths {
-  return { fields: [], passthroughKeys: [], spindleMetadataKeys: [] }
+  return { fields: [], passthroughKeys: [] }
 }
 
 function mergeDirtyPaths(previous: DirtyPresetPaths, next: DirtyPresetPaths): DirtyPresetPaths {
   return {
     fields: [...new Set([...previous.fields, ...next.fields])],
     passthroughKeys: [...new Set([...previous.passthroughKeys, ...next.passthroughKeys])],
-    spindleMetadataKeys: [...new Set([...previous.spindleMetadataKeys, ...next.spindleMetadataKeys])],
   }
 }
 
@@ -175,22 +167,12 @@ function getChangedPaths(before: LoomPreset, after: LoomPreset): DirtyPresetPath
   const fields = DRAFT_FIELDS.filter((field) => !sameJson(before[field], after[field]))
   const beforeMetadata = before.passthroughMetadata ?? {}
   const afterMetadata = after.passthroughMetadata ?? {}
-  const beforeNamespaces = isRecord(beforeMetadata[SPINDLE_EXTENSION_METADATA_KEY])
-    ? beforeMetadata[SPINDLE_EXTENSION_METADATA_KEY]
-    : {}
-  const afterNamespaces = isRecord(afterMetadata[SPINDLE_EXTENSION_METADATA_KEY])
-    ? afterMetadata[SPINDLE_EXTENSION_METADATA_KEY]
-    : {}
-  const spindleMetadataKeys = [...new Set([
-    ...Object.keys(beforeNamespaces),
-    ...Object.keys(afterNamespaces),
-  ])].filter((key) => !sameJson(beforeNamespaces[key], afterNamespaces[key]))
   const passthroughKeys = [...new Set([
     ...Object.keys(beforeMetadata),
     ...Object.keys(afterMetadata),
-  ])].filter((key) => key !== SPINDLE_EXTENSION_METADATA_KEY && !sameJson(beforeMetadata[key], afterMetadata[key]))
+  ])].filter((key) => !sameJson(beforeMetadata[key], afterMetadata[key]))
 
-  return { fields, passthroughKeys, spindleMetadataKeys }
+  return { fields, passthroughKeys }
 }
 
 function rebaseDirtyPaths(
@@ -204,7 +186,7 @@ function rebaseDirtyPaths(
     rebased[field] = clone(draft[field]) as never
   }
 
-  if (dirty.passthroughKeys.length > 0 || dirty.spindleMetadataKeys.length > 0) {
+  if (dirty.passthroughKeys.length > 0) {
     const metadata = clone(persisted.passthroughMetadata ?? {})
     for (const key of dirty.passthroughKeys) {
       if (Object.hasOwn(draft.passthroughMetadata, key)) {
@@ -217,33 +199,6 @@ function rebaseDirtyPaths(
       } else {
         delete metadata[key]
       }
-    }
-
-    if (dirty.spindleMetadataKeys.length > 0) {
-      const namespaces = isRecord(metadata[SPINDLE_EXTENSION_METADATA_KEY])
-        ? clone(metadata[SPINDLE_EXTENSION_METADATA_KEY])
-        : {}
-      const draftNamespaces = isRecord(draft.passthroughMetadata[SPINDLE_EXTENSION_METADATA_KEY])
-        ? draft.passthroughMetadata[SPINDLE_EXTENSION_METADATA_KEY]
-        : {}
-      for (const extensionId of dirty.spindleMetadataKeys) {
-        if (Object.hasOwn(draftNamespaces, extensionId)) {
-          Object.defineProperty(namespaces, extensionId, {
-            value: clone(draftNamespaces[extensionId]),
-            enumerable: true,
-            writable: true,
-            configurable: true,
-          })
-        } else {
-          delete namespaces[extensionId]
-        }
-      }
-      Object.defineProperty(metadata, SPINDLE_EXTENSION_METADATA_KEY, {
-        value: namespaces,
-        enumerable: true,
-        writable: true,
-        configurable: true,
-      })
     }
     rebased.passthroughMetadata = metadata
   }
@@ -284,7 +239,7 @@ function legacyDirtyPaths(includePromptVariables: boolean): DirtyPresetPaths {
     && field !== 'presetVersion'
   ))
   if (includePromptVariables) fields.push('promptVariables')
-  return { fields, passthroughKeys: [], spindleMetadataKeys: [] }
+  return { fields, passthroughKeys: [] }
 }
 function readPendingEnvelope(presetId: string): PendingLoomPresetEnvelope | null {
   const entry = readPendingEntries()[presetId]
@@ -315,7 +270,7 @@ function readPendingEnvelope(presetId: string): PendingLoomPresetEnvelope | null
       preset: entry.preset,
       dirty: includeEditorContent
         ? legacyDirtyPaths(includePromptVariables)
-        : { fields: includePromptVariables ? ['promptVariables'] : [], passthroughKeys: [], spindleMetadataKeys: [] },
+        : { fields: includePromptVariables ? ['promptVariables'] : [], passthroughKeys: [] },
       revision: typeof entry.revision === 'number' && Number.isSafeInteger(entry.revision)
         ? entry.revision
         : 0,

--- a/frontend/src/lib/loom/preset-save-coordinator.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.ts
@@ -50,6 +50,7 @@ interface PresetSaveEntry {
   chain: Promise<LoomPreset>
   queuedRevision: number | null
   queuedSnapshot: LoomPreset | null
+  queuedSnapshots: LoomPreset[]
   listeners: Set<(preset: LoomPreset) => void>
 }
 
@@ -497,6 +498,7 @@ function createEntry(preset: LoomPreset): PresetSaveEntry {
     chain: Promise.resolve(clone(preset)),
     queuedRevision: null,
     queuedSnapshot: null,
+    queuedSnapshots: [],
     listeners: new Set(),
   }
 }
@@ -620,6 +622,11 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
             return clone(entry.confirmed)
           }
           pendingSnapshot = rebaseDirtyPaths(entry.confirmed, pendingSnapshot, entry.dirty)
+          if (!entry.queuedSnapshots.some((queued) => (
+            sameJson(canonicalPersistedPayload(queued), canonicalPersistedPayload(pendingSnapshot))
+          ))) {
+            entry.queuedSnapshots.push(clone(pendingSnapshot))
+          }
           conflictBase = clone(entry.confirmed)
           const savedRow = await adapter.update(presetId, marshalUpdate(pendingSnapshot))
           const current = entries.get(presetId)
@@ -700,6 +707,7 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
         if (scopeEpoch === enqueueEpoch && current === entry && current.queuedRevision === revision) {
           current.queuedRevision = null
           current.queuedSnapshot = null
+          current.queuedSnapshots = []
           evictCleanEntry(presetId)
         }
       },
@@ -708,6 +716,7 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
         if (scopeEpoch === enqueueEpoch && current === entry && current.queuedRevision === revision) {
           current.queuedRevision = null
           current.queuedSnapshot = null
+          current.queuedSnapshots = []
           evictCleanEntry(presetId)
         }
       },
@@ -787,8 +796,9 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
 
       if (
         entry.queuedRevision !== null
-        && entry.queuedSnapshot
-        && sameJson(canonicalPersistedPayload(entry.queuedSnapshot), canonicalPersistedPayload(preset))
+        && entry.queuedSnapshots.some((queued) => (
+          sameJson(canonicalPersistedPayload(queued), canonicalPersistedPayload(preset))
+        ))
       ) {
         entry.confirmed = clone(preset)
         entry.draft = isDirty(entry.dirty)

--- a/frontend/src/lib/loom/preset-save-coordinator.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.ts
@@ -795,6 +795,15 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
       }
 
       if (
+        typeof preset.cacheRevision === 'number'
+        && typeof entry.confirmed.cacheRevision === 'number'
+        && preset.cacheRevision < entry.confirmed.cacheRevision
+      ) {
+        // A late echo for an older queued write cannot regress the confirmed
+        // revision while a newer dispatch is still in flight.
+        return clone(entry.draft)
+      }
+      if (
         entry.queuedRevision !== null
         && entry.queuedSnapshots.some((queued) => (
           sameJson(canonicalPersistedPayload(queued), canonicalPersistedPayload(preset))

--- a/frontend/src/lib/loom/preset-save-coordinator.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.ts
@@ -63,7 +63,8 @@ export interface PresetMutationOptions {
 
 export interface PresetHydrationToken {
   readonly presetId: string
-  readonly epoch: number
+  readonly readEpoch: number
+  readonly confirmedEpoch: number
 }
 
 export class StalePresetHydrationError extends Error {
@@ -75,9 +76,9 @@ export class StalePresetHydrationError extends Error {
 
 export interface PresetSaveCoordinator {
   /**
-   * Capture the coordinator state before beginning an asynchronous persisted-row read.
-   * Pass this token to `hydrate()` when the read resolves so stale responses cannot
-   * replace a newer local mutation or persistence confirmation.
+   * Reserve the latest hydration generation before beginning an asynchronous
+   * persisted-row read. Pass this token to `hydrate()` when it resolves; only
+   * the most recently begun read can replace coordinator state.
    */
   beginHydration(presetId: string): PresetHydrationToken
   /**
@@ -374,11 +375,18 @@ function createEntry(preset: LoomPreset): PresetSaveEntry {
 export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetSaveCoordinator {
   const entries = new Map<string, PresetSaveEntry>()
   const listenersByPreset = new Map<string, Set<(preset: LoomPreset) => void>>()
-  const hydrationEpochs = new Map<string, number>()
+  const hydrationReadEpochs = new Map<string, number>()
+  const confirmedEpochs = new Map<string, number>()
 
-  const getHydrationEpoch = (presetId: string): number => hydrationEpochs.get(presetId) ?? 0
-  const advanceHydrationEpoch = (presetId: string): void => {
-    hydrationEpochs.set(presetId, getHydrationEpoch(presetId) + 1)
+  const getHydrationReadEpoch = (presetId: string): number => hydrationReadEpochs.get(presetId) ?? 0
+  const reserveHydrationRead = (presetId: string): number => {
+    const next = getHydrationReadEpoch(presetId) + 1
+    hydrationReadEpochs.set(presetId, next)
+    return next
+  }
+  const getConfirmedEpoch = (presetId: string): number => confirmedEpochs.get(presetId) ?? 0
+  const advanceConfirmedEpoch = (presetId: string): void => {
+    confirmedEpochs.set(presetId, getConfirmedEpoch(presetId) + 1)
   }
 
   function publish(entry: PresetSaveEntry): void {
@@ -426,7 +434,7 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
       } else {
         current.draft = rebaseDirtyPaths(saved, current.draft, current.dirty)
       }
-      advanceHydrationEpoch(presetId)
+      advanceConfirmedEpoch(presetId)
       writePendingEnvelope(presetId, current)
       publish(current)
       return saved
@@ -456,11 +464,23 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
 
   return {
     beginHydration(presetId): PresetHydrationToken {
-      return { presetId, epoch: getHydrationEpoch(presetId) }
+      return {
+        presetId,
+        readEpoch: reserveHydrationRead(presetId),
+        confirmedEpoch: getConfirmedEpoch(presetId),
+      }
     },
 
     hydrate(preset, token): LoomPreset {
-      if (token && (token.presetId !== preset.id || token.epoch !== getHydrationEpoch(preset.id))) {
+      // Read ordering and confirmed persistence are independent: a local dirty
+      // mutation may rebase over the newest read, but an older read cannot
+      // replace a subsequently confirmed persisted row.
+      if (!token) advanceConfirmedEpoch(preset.id)
+      if (token && (
+        token.presetId !== preset.id
+        || token.readEpoch !== getHydrationReadEpoch(preset.id)
+        || token.confirmedEpoch !== getConfirmedEpoch(preset.id)
+      )) {
         const current = entries.get(preset.id)
         if (current) return clone(current.draft)
         throw new StalePresetHydrationError(preset.id)
@@ -469,7 +489,7 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
       const entry = entries.get(preset.id)
       if (!entry) {
         const created = ensure(preset.id, preset)
-        advanceHydrationEpoch(preset.id)
+        publish(created)
         if (isDirty(created.dirty)) void enqueuePersist(preset.id, created).catch(() => {})
         return clone(created.draft)
       }
@@ -482,7 +502,6 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
       if (isDirty(entry.dirty) && persistedChanged) {
         entry.revision += 1
       }
-      advanceHydrationEpoch(preset.id)
       writePendingEnvelope(preset.id, entry)
       publish(entry)
       if (isDirty(entry.dirty) && persistedChanged) {
@@ -516,7 +535,8 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
       entry.draft = clone({ ...after, updatedAt: Date.now() })
       entry.dirty = mergeDirtyPaths(entry.dirty, changed)
       entry.revision += 1
-      advanceHydrationEpoch(presetId)
+      // Dirty local paths intentionally remain compatible with an in-flight
+      // latest read; hydrate() rebases them over its fresh persisted base.
       writePendingEnvelope(presetId, entry)
       publish(entry)
 
@@ -568,7 +588,7 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
       const entry = entries.get(presetId)
       clearTimeout(entry?.timer)
       entries.delete(presetId)
-      advanceHydrationEpoch(presetId)
+      advanceConfirmedEpoch(presetId)
       listenersByPreset.delete(presetId)
       removePendingEnvelope(presetId)
     },
@@ -578,6 +598,8 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
 export const presetSaveCoordinator = createPresetSaveCoordinator({
   update: (presetId, input) => presetsApi.update(presetId, input),
 })
+
+const durableRecoveryFlushes = new Map<string, Promise<void>>()
 
 /**
  * Await the selected preset's latest draft before generation reads it. When
@@ -591,8 +613,31 @@ export async function flushPresetForGeneration(presetId: string | undefined): Pr
     return
   }
 
-  const hydration = presetSaveCoordinator.beginHydration(presetId)
-  const persisted = unmarshalPreset(await presetsApi.get(presetId))
-  presetSaveCoordinator.hydrate(persisted, hydration)
-  await presetSaveCoordinator.flush(presetId)
+  const existingRecovery = durableRecoveryFlushes.get(presetId)
+  if (existingRecovery) {
+    await existingRecovery
+    return
+  }
+
+  const recovery = (async () => {
+    while (true) {
+      const hydration = presetSaveCoordinator.beginHydration(presetId)
+      const persisted = unmarshalPreset(await presetsApi.get(presetId))
+      try {
+        presetSaveCoordinator.hydrate(persisted, hydration)
+        break
+      } catch (error) {
+        if (!(error instanceof StalePresetHydrationError)) throw error
+      }
+    }
+    await presetSaveCoordinator.flush(presetId)
+  })()
+  durableRecoveryFlushes.set(presetId, recovery)
+  try {
+    await recovery
+  } finally {
+    if (durableRecoveryFlushes.get(presetId) === recovery) {
+      durableRecoveryFlushes.delete(presetId)
+    }
+  }
 }

--- a/frontend/src/lib/loom/preset-save-coordinator.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.ts
@@ -63,7 +63,9 @@ export interface PresetMutationOptions {
 
 export interface PresetHydrationToken {
   readonly presetId: string
+  readonly owner: string
   readonly readEpoch: number
+  readonly globalReadEpoch: number
   readonly confirmedEpoch: number
 }
 
@@ -76,11 +78,13 @@ export class StalePresetHydrationError extends Error {
 
 export interface PresetSaveCoordinator {
   /**
-   * Reserve the latest hydration generation before beginning an asynchronous
-   * persisted-row read. Pass this token to `hydrate()` when it resolves; only
-   * the most recently begun read can replace coordinator state.
+   * Reserve this consumer's next persisted-row read. A later read by the same
+   * consumer supersedes it; another consumer cannot strand this reader if its
+   * own request fails.
    */
-  beginHydration(presetId: string): PresetHydrationToken
+  beginHydration(presetId: string, owner?: string): PresetHydrationToken
+  /** Release a hydration token whose persisted-row request did not resolve. */
+  cancelHydration(token: PresetHydrationToken): void
   /**
    * Incorporate a freshly read persisted row. Any durable or in-memory dirty
    * paths are rebased over that row; untouched paths always come from the row.
@@ -375,18 +379,36 @@ function createEntry(preset: LoomPreset): PresetSaveEntry {
 export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetSaveCoordinator {
   const entries = new Map<string, PresetSaveEntry>()
   const listenersByPreset = new Map<string, Set<(preset: LoomPreset) => void>>()
-  const hydrationReadEpochs = new Map<string, number>()
+  const hydrationReadEpochs = new Map<string, Map<string, number>>()
+  const latestHydrationReadEpochs = new Map<string, number>()
   const confirmedEpochs = new Map<string, number>()
+  const pendingHydrations = new Set<PresetHydrationToken>()
 
-  const getHydrationReadEpoch = (presetId: string): number => hydrationReadEpochs.get(presetId) ?? 0
-  const reserveHydrationRead = (presetId: string): number => {
-    const next = getHydrationReadEpoch(presetId) + 1
-    hydrationReadEpochs.set(presetId, next)
-    return next
+  const getHydrationReadEpoch = (presetId: string, owner: string): number => (
+    hydrationReadEpochs.get(presetId)?.get(owner) ?? 0
+  )
+  const reserveHydrationRead = (presetId: string, owner: string): {
+    readEpoch: number
+    globalReadEpoch: number
+  } => {
+    const owners = hydrationReadEpochs.get(presetId) ?? new Map<string, number>()
+    const readEpoch = getHydrationReadEpoch(presetId, owner) + 1
+    owners.set(owner, readEpoch)
+    hydrationReadEpochs.set(presetId, owners)
+    const globalReadEpoch = (latestHydrationReadEpochs.get(presetId) ?? 0) + 1
+    latestHydrationReadEpochs.set(presetId, globalReadEpoch)
+    return { readEpoch, globalReadEpoch }
   }
   const getConfirmedEpoch = (presetId: string): number => confirmedEpochs.get(presetId) ?? 0
   const advanceConfirmedEpoch = (presetId: string): void => {
     confirmedEpochs.set(presetId, getConfirmedEpoch(presetId) + 1)
+  }
+
+  const hasPendingHydration = (presetId: string): boolean => {
+    for (const token of pendingHydrations) {
+      if (token.presetId === presetId) return true
+    }
+    return false
   }
 
   function publish(entry: PresetSaveEntry): void {
@@ -412,6 +434,22 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
     }
     entries.set(presetId, entry)
     return entry
+  }
+
+  function evictCleanEntry(presetId: string): void {
+    const entry = entries.get(presetId)
+    if (
+      !entry
+      || entry.listeners.size > 0
+      || entry.timer !== null
+      || entry.queuedRevision !== null
+      || isDirty(entry.dirty)
+      || hasPendingHydration(presetId)
+    ) return
+    entries.delete(presetId)
+    if (listenersByPreset.get(presetId) === entry.listeners) {
+      listenersByPreset.delete(presetId)
+    }
   }
 
   function enqueuePersist(presetId: string, entry: PresetSaveEntry): Promise<LoomPreset> {
@@ -443,11 +481,15 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
     link.then(
       () => {
         const current = entries.get(presetId)
-        if (current?.queuedRevision === revision) current.queuedRevision = null
+        if (current?.queuedRevision === revision) {
+          current.queuedRevision = null
+        }
       },
       () => {
         const current = entries.get(presetId)
-        if (current?.queuedRevision === revision) current.queuedRevision = null
+        if (current?.queuedRevision === revision) {
+          current.queuedRevision = null
+        }
       },
     )
     link.catch(() => {})
@@ -463,34 +505,49 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
   }
 
   return {
-    beginHydration(presetId): PresetHydrationToken {
-      return {
+    beginHydration(presetId, owner = 'default'): PresetHydrationToken {
+      const reservation = reserveHydrationRead(presetId, owner)
+      const token = {
         presetId,
-        readEpoch: reserveHydrationRead(presetId),
+        owner,
+        readEpoch: reservation.readEpoch,
+        globalReadEpoch: reservation.globalReadEpoch,
         confirmedEpoch: getConfirmedEpoch(presetId),
       }
+      pendingHydrations.add(token)
+      return token
+    },
+
+    cancelHydration(token): void {
+      if (pendingHydrations.delete(token)) evictCleanEntry(token.presetId)
     },
 
     hydrate(preset, token): LoomPreset {
+      let isStaleHydration = false
+      try {
       // Read ordering and confirmed persistence are independent: a local dirty
       // mutation may rebase over the newest read, but an older read cannot
-      // replace a subsequently confirmed persisted row.
+      // replace a subsequently confirmed persisted row. A non-authoritative
+      // consumer read remains a valid fallback until the latest consumer read
+      // succeeds, so one failed auxiliary load cannot blank the active editor.
       if (!token) advanceConfirmedEpoch(preset.id)
       if (token && (
         token.presetId !== preset.id
-        || token.readEpoch !== getHydrationReadEpoch(preset.id)
+        || token.readEpoch !== getHydrationReadEpoch(preset.id, token.owner)
         || token.confirmedEpoch !== getConfirmedEpoch(preset.id)
       )) {
+        isStaleHydration = true
         const current = entries.get(preset.id)
         if (current) return clone(current.draft)
         throw new StalePresetHydrationError(preset.id)
       }
-
+      const isAuthoritativeRead = !token
+        || token.globalReadEpoch === (latestHydrationReadEpochs.get(preset.id) ?? 0)
       const entry = entries.get(preset.id)
       if (!entry) {
         const created = ensure(preset.id, preset)
+        if (token && isAuthoritativeRead) advanceConfirmedEpoch(preset.id)
         publish(created)
-        if (isDirty(created.dirty)) void enqueuePersist(preset.id, created).catch(() => {})
         return clone(created.draft)
       }
 
@@ -502,12 +559,18 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
       if (isDirty(entry.dirty) && persistedChanged) {
         entry.revision += 1
       }
+      if (token && isAuthoritativeRead) advanceConfirmedEpoch(preset.id)
       writePendingEnvelope(preset.id, entry)
       publish(entry)
       if (isDirty(entry.dirty) && persistedChanged) {
         void enqueuePersist(preset.id, entry).catch(() => {})
       }
       return clone(entry.draft)
+      } finally {
+        if (token && pendingHydrations.delete(token) && !isStaleHydration) {
+          evictCleanEntry(token.presetId)
+        }
+      }
     },
 
     getDraft(presetId: string): LoomPreset | null {
@@ -580,7 +643,9 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
         if (!listeners.delete(listener) || listeners.size > 0) return
         if (!entries.has(presetId) && listenersByPreset.get(presetId) === listeners) {
           listenersByPreset.delete(presetId)
+          return
         }
+        evictCleanEntry(presetId)
       }
     },
 
@@ -621,12 +686,13 @@ export async function flushPresetForGeneration(presetId: string | undefined): Pr
 
   const recovery = (async () => {
     while (true) {
-      const hydration = presetSaveCoordinator.beginHydration(presetId)
-      const persisted = unmarshalPreset(await presetsApi.get(presetId))
+      const hydration = presetSaveCoordinator.beginHydration(presetId, 'durable-recovery')
       try {
+        const persisted = unmarshalPreset(await presetsApi.get(presetId))
         presetSaveCoordinator.hydrate(persisted, hydration)
         break
       } catch (error) {
+        presetSaveCoordinator.cancelHydration(hydration)
         if (!(error instanceof StalePresetHydrationError)) throw error
       }
     }

--- a/frontend/src/lib/loom/preset-save-coordinator.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.ts
@@ -710,6 +710,7 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
           }
 
           current.confirmed = clone(latest)
+          rememberConfirmedCacheRevision(presetId, latest)
           const rebased = rebaseDirtyPaths(latest, current.draft, current.dirty)
           current.draft = rebased
           advanceConfirmedEpoch(presetId)
@@ -817,8 +818,9 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
       if (staleTokenlessEcho) {
         if (
           existingEntry
+          && residentCacheRevision !== undefined
           && (rememberedCacheRevision === undefined
-            || residentCacheRevision === rememberedCacheRevision)
+            || residentCacheRevision >= rememberedCacheRevision)
         ) {
           return clone(existingEntry.draft)
         }

--- a/frontend/src/lib/loom/preset-save-coordinator.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.ts
@@ -305,6 +305,7 @@ function createEntry(preset: LoomPreset): PresetSaveEntry {
  */
 export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetSaveCoordinator {
   const entries = new Map<string, PresetSaveEntry>()
+  const listenersByPreset = new Map<string, Set<(preset: LoomPreset) => void>>()
 
   function publish(entry: PresetSaveEntry): void {
     const snapshot = clone(entry.draft)
@@ -319,6 +320,8 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
     if (fallback.id !== presetId) throw new Error('Preset coordinator fallback id mismatch')
 
     const entry = createEntry(fallback)
+    entry.listeners = listenersByPreset.get(presetId) ?? new Set()
+    listenersByPreset.set(presetId, entry.listeners)
     const pending = readPendingEnvelope(presetId)
     if (pending) {
       entry.draft = rebaseDirtyPaths(fallback, pending.preset, pending.dirty)
@@ -449,16 +452,22 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
     },
 
     subscribe(presetId, listener): () => void {
-      const entry = entries.get(presetId)
-      if (!entry) return () => {}
-      entry.listeners.add(listener)
-      return () => { entry.listeners.delete(listener) }
+      const listeners = listenersByPreset.get(presetId) ?? new Set<(preset: LoomPreset) => void>()
+      listenersByPreset.set(presetId, listeners)
+      listeners.add(listener)
+      return () => {
+        if (!listeners.delete(listener) || listeners.size > 0) return
+        if (!entries.has(presetId) && listenersByPreset.get(presetId) === listeners) {
+          listenersByPreset.delete(presetId)
+        }
+      }
     },
 
     remove(presetId: string): void {
       const entry = entries.get(presetId)
       clearTimeout(entry?.timer)
       entries.delete(presetId)
+      listenersByPreset.delete(presetId)
       removePendingEnvelope(presetId)
     },
   }

--- a/frontend/src/lib/loom/preset-save-coordinator.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.ts
@@ -595,7 +595,6 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
 
     const revision = entry.revision
     const snapshot = clone(entry.draft)
-    const conflictBase = clone(entry.confirmed)
     entry.queuedRevision = revision
     entry.queuedSnapshot = clone(snapshot)
     const enqueueEpoch = scopeEpoch
@@ -603,6 +602,7 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
     const link = previous.then(async () => {
       let pendingSnapshot = snapshot
       let conflictRetries = 0
+      let conflictBase: LoomPreset | null = null
 
       while (true) {
         if (scopeEpoch !== enqueueEpoch || entries.get(presetId) !== entry) {
@@ -613,6 +613,8 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
           if (scopeEpoch !== enqueueEpoch || entries.get(presetId) !== entry) {
             return clone(entry.confirmed)
           }
+          pendingSnapshot = rebaseDirtyPaths(entry.confirmed, pendingSnapshot, entry.dirty)
+          conflictBase = clone(entry.confirmed)
           const savedRow = await adapter.update(presetId, marshalUpdate(pendingSnapshot))
           const current = entries.get(presetId)
           if (scopeEpoch !== enqueueEpoch || current !== entry) {
@@ -663,7 +665,7 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
           const current = entries.get(presetId)
           if (
             entry.dirty.fields.includes('blocks')
-            && !sameJson(latest.blocks, conflictBase.blocks)
+            && !sameJson(latest.blocks, conflictBase!.blocks)
           ) {
             // Block arrays need block-id/property-aware merging. Until that
             // merge exists, surface only conflicts that changed blocks

--- a/frontend/src/lib/loom/preset-save-coordinator.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.ts
@@ -769,7 +769,6 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
       // replace a subsequently confirmed persisted row. A non-authoritative
       // consumer read remains a valid fallback until the latest consumer read
       // succeeds, so one failed auxiliary load cannot blank the active editor.
-      if (!token) advanceConfirmedEpoch(preset.id)
       if (token && token.scopeEpoch !== scopeEpoch) {
         throw new PresetScopeChangedError()
       }
@@ -783,6 +782,17 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
         throw new StalePresetHydrationError(preset.id)
       }
       if (!entries.has(preset.id)) migrateLegacyPendingEnvelope(preset.id, pendingStorageScope)
+      const existingEntry = entries.get(preset.id)
+      if (
+        !token
+        && existingEntry
+        && typeof preset.cacheRevision === 'number'
+        && typeof existingEntry.confirmed.cacheRevision === 'number'
+        && preset.cacheRevision < existingEntry.confirmed.cacheRevision
+      ) {
+        return clone(existingEntry.draft)
+      }
+      if (!token) advanceConfirmedEpoch(preset.id)
       const isAuthoritativeRead = !token
         || token.globalReadEpoch === (latestHydrationReadEpochs.get(preset.id) ?? 0)
       const entry = entries.get(preset.id)

--- a/frontend/src/lib/loom/preset-save-coordinator.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.ts
@@ -483,12 +483,14 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
         const current = entries.get(presetId)
         if (current?.queuedRevision === revision) {
           current.queuedRevision = null
+          evictCleanEntry(presetId)
         }
       },
       () => {
         const current = entries.get(presetId)
         if (current?.queuedRevision === revision) {
           current.queuedRevision = null
+          evictCleanEntry(presetId)
         }
       },
     )
@@ -523,7 +525,6 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
     },
 
     hydrate(preset, token): LoomPreset {
-      let isStaleHydration = false
       try {
       // Read ordering and confirmed persistence are independent: a local dirty
       // mutation may rebase over the newest read, but an older read cannot
@@ -536,7 +537,6 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
         || token.readEpoch !== getHydrationReadEpoch(preset.id, token.owner)
         || token.confirmedEpoch !== getConfirmedEpoch(preset.id)
       )) {
-        isStaleHydration = true
         const current = entries.get(preset.id)
         if (current) return clone(current.draft)
         throw new StalePresetHydrationError(preset.id)
@@ -548,6 +548,7 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
         const created = ensure(preset.id, preset)
         if (token && isAuthoritativeRead) advanceConfirmedEpoch(preset.id)
         publish(created)
+        if (!token) evictCleanEntry(preset.id)
         return clone(created.draft)
       }
 
@@ -565,9 +566,10 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
       if (isDirty(entry.dirty) && persistedChanged) {
         void enqueuePersist(preset.id, entry).catch(() => {})
       }
+      if (!token && !isDirty(entry.dirty)) evictCleanEntry(preset.id)
       return clone(entry.draft)
       } finally {
-        if (token && pendingHydrations.delete(token) && !isStaleHydration) {
+        if (token && pendingHydrations.delete(token)) {
           evictCleanEntry(token.presetId)
         }
       }

--- a/frontend/src/lib/loom/preset-save-coordinator.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.ts
@@ -1,0 +1,475 @@
+import { presetsApi } from '@/api/presets'
+import type { Preset, UpdatePresetInput } from '@/types/api'
+import { looksLikeLoomPresetData, marshalUpdate, unmarshalPreset } from './service'
+import type { LoomPreset } from './types'
+
+const PENDING_LOOM_PRESETS_KEY = '__lumiverse_pending_loom_presets'
+const PENDING_LOOM_PRESET_ENVELOPE_KEY = '__lumiverse_pending_loom_preset_v2'
+
+const DRAFT_FIELDS = [
+  'name',
+  'description',
+  'coverUrl',
+  'presetVersion',
+  'lumihubMeta',
+  'schemaVersion',
+  'blocks',
+  'source',
+  'isDefault',
+  'samplerOverrides',
+  'customBody',
+  'promptBehavior',
+  'completionSettings',
+  'advancedSettings',
+  'modelProfiles',
+  'lastProfileKey',
+  'promptVariables',
+] as const satisfies readonly (keyof LoomPreset)[]
+
+type DraftField = (typeof DRAFT_FIELDS)[number]
+
+interface DirtyPresetPaths {
+  fields: DraftField[]
+  passthroughKeys: string[]
+}
+
+interface PendingLoomPresetEnvelope {
+  [PENDING_LOOM_PRESET_ENVELOPE_KEY]: 2
+  preset: LoomPreset
+  dirty: DirtyPresetPaths
+  revision: number
+}
+
+interface PresetSaveEntry {
+  confirmed: LoomPreset
+  draft: LoomPreset
+  dirty: DirtyPresetPaths
+  revision: number
+  timer: ReturnType<typeof globalThis.setTimeout> | null
+  chain: Promise<LoomPreset>
+  queuedRevision: number | null
+  listeners: Set<(preset: LoomPreset) => void>
+}
+
+export interface PresetSaveAdapter {
+  update(presetId: string, input: UpdatePresetInput): Promise<Preset>
+}
+
+export interface PresetMutationOptions {
+  immediate?: boolean
+  debounceMs?: number
+}
+
+export interface PresetSaveCoordinator {
+  /**
+   * Incorporate a freshly read persisted row. Any durable or in-memory dirty
+   * paths are rebased over that row; untouched paths always come from the row.
+   */
+  hydrate(preset: LoomPreset): LoomPreset
+  /** Return the current per-preset draft, if this coordinator owns one. */
+  getDraft(presetId: string): LoomPreset | null
+  /** True when the preset has unsaved local changes. */
+  hasPendingChanges(presetId: string): boolean
+  /**
+   * Atomically derive a draft from the coordinator's current value. A fallback
+   * is used only on the first writer for a preset, preventing a stale caller
+   * snapshot from replacing an already-known newer draft.
+   */
+  mutate(
+    presetId: string,
+    fallback: LoomPreset,
+    mutator: (current: LoomPreset) => LoomPreset,
+    options?: PresetMutationOptions,
+  ): LoomPreset
+  /** Await all pending work and persist the current draft when it is dirty. */
+  flush(presetId: string): Promise<LoomPreset | null>
+  /** Queue a best-effort save without waiting; retained recovery handles exit failures. */
+  flushBestEffort(presetId: string): void
+  /** Subscribe to draft, rebase, and persistence transitions for one preset. */
+  subscribe(presetId: string, listener: (preset: LoomPreset) => void): () => void
+  /** Forget all in-memory and durable state after a confirmed deletion. */
+  remove(presetId: string): void
+}
+
+function clone<T>(value: T): T {
+  try {
+    return structuredClone(value)
+  } catch {
+    return JSON.parse(JSON.stringify(value)) as T
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function sameJson(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right)
+}
+
+function isDraftField(value: unknown): value is DraftField {
+  return typeof value === 'string' && (DRAFT_FIELDS as readonly string[]).includes(value)
+}
+
+function normalizeDirtyPaths(value: unknown): DirtyPresetPaths | null {
+  if (!isRecord(value) || !Array.isArray(value.fields) || !Array.isArray(value.passthroughKeys)) return null
+  if (!value.fields.every(isDraftField) || !value.passthroughKeys.every((key) => typeof key === 'string')) return null
+  return {
+    fields: [...new Set(value.fields)],
+    passthroughKeys: [...new Set(value.passthroughKeys)],
+  }
+}
+
+function isDirty(dirty: DirtyPresetPaths): boolean {
+  return dirty.fields.length > 0 || dirty.passthroughKeys.length > 0
+}
+
+function emptyDirtyPaths(): DirtyPresetPaths {
+  return { fields: [], passthroughKeys: [] }
+}
+
+function mergeDirtyPaths(previous: DirtyPresetPaths, next: DirtyPresetPaths): DirtyPresetPaths {
+  return {
+    fields: [...new Set([...previous.fields, ...next.fields])],
+    passthroughKeys: [...new Set([...previous.passthroughKeys, ...next.passthroughKeys])],
+  }
+}
+
+function getChangedPaths(before: LoomPreset, after: LoomPreset): DirtyPresetPaths {
+  const fields = DRAFT_FIELDS.filter((field) => !sameJson(before[field], after[field]))
+  const beforeMetadata = before.passthroughMetadata ?? {}
+  const afterMetadata = after.passthroughMetadata ?? {}
+  const passthroughKeys = [...new Set([
+    ...Object.keys(beforeMetadata),
+    ...Object.keys(afterMetadata),
+  ])].filter((key) => !sameJson(beforeMetadata[key], afterMetadata[key]))
+
+  return { fields, passthroughKeys }
+}
+
+function rebaseDirtyPaths(
+  persisted: LoomPreset,
+  draft: LoomPreset,
+  dirty: DirtyPresetPaths,
+): LoomPreset {
+  const rebased = clone(persisted)
+
+  for (const field of dirty.fields) {
+    rebased[field] = clone(draft[field]) as never
+  }
+
+  if (dirty.passthroughKeys.length > 0) {
+    const metadata = clone(persisted.passthroughMetadata ?? {})
+    for (const key of dirty.passthroughKeys) {
+      if (Object.hasOwn(draft.passthroughMetadata, key)) {
+        Object.defineProperty(metadata, key, {
+          value: clone(draft.passthroughMetadata[key]),
+          enumerable: true,
+          writable: true,
+          configurable: true,
+        })
+      } else {
+        delete metadata[key]
+      }
+    }
+    rebased.passthroughMetadata = metadata
+  }
+
+  return rebased
+}
+
+function readPendingEntries(): Record<string, unknown> {
+  if (typeof window === 'undefined') return {}
+  try {
+    const raw = globalThis.localStorage.getItem(PENDING_LOOM_PRESETS_KEY)
+    if (!raw) return {}
+    const parsed: unknown = JSON.parse(raw)
+    return isRecord(parsed) ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+function writePendingEntries(entries: Record<string, unknown>): void {
+  if (typeof window === 'undefined') return
+  try {
+    if (Object.keys(entries).length === 0) {
+      globalThis.localStorage.removeItem(PENDING_LOOM_PRESETS_KEY)
+      return
+    }
+    globalThis.localStorage.setItem(PENDING_LOOM_PRESETS_KEY, JSON.stringify(entries))
+  } catch {
+    // Recovery is best-effort; the in-memory coordinator still serializes work.
+  }
+}
+
+
+function legacyDirtyPaths(includePromptVariables: boolean): DirtyPresetPaths {
+  const fields: DraftField[] = DRAFT_FIELDS.filter((field) => (
+    field !== 'promptVariables'
+    && field !== 'lumihubMeta'
+    && field !== 'presetVersion'
+  ))
+  if (includePromptVariables) fields.push('promptVariables')
+  return { fields, passthroughKeys: [] }
+}
+function readPendingEnvelope(presetId: string): PendingLoomPresetEnvelope | null {
+  const entry = readPendingEntries()[presetId]
+  if (!isRecord(entry)) return null
+
+  if (entry[PENDING_LOOM_PRESET_ENVELOPE_KEY] === 2) {
+    if (!looksLikeLoomPresetData(entry.preset) || entry.preset.id !== presetId) return null
+    const dirty = normalizeDirtyPaths(entry.dirty)
+    if (!dirty || !isDirty(dirty) || typeof entry.revision !== 'number' || !Number.isSafeInteger(entry.revision)) {
+      return null
+    }
+    return {
+      [PENDING_LOOM_PRESET_ENVELOPE_KEY]: 2,
+      preset: entry.preset,
+      dirty,
+      revision: entry.revision,
+    }
+  }
+
+  // v1 envelopes tracked prompt ownership but did not track individual fields.
+  // Retain their editor intent while inheriting fresh extension/LumiHub metadata.
+  if (entry.__lumiverse_pending_loom_preset_v1 === 1) {
+    if (!looksLikeLoomPresetData(entry.preset) || entry.preset.id !== presetId) return null
+    const includeEditorContent = entry.includeEditorContent !== false
+    const includePromptVariables = entry.includePromptVariables === true
+    return {
+      [PENDING_LOOM_PRESET_ENVELOPE_KEY]: 2,
+      preset: entry.preset,
+      dirty: includeEditorContent
+        ? legacyDirtyPaths(includePromptVariables)
+        : { fields: includePromptVariables ? ['promptVariables'] : [], passthroughKeys: [] },
+      revision: typeof entry.revision === 'number' && Number.isSafeInteger(entry.revision)
+        ? entry.revision
+        : 0,
+    }
+  }
+
+  // The original Loom editor stored a raw full snapshot. It cannot identify a
+  // prompt-variable or extension owner, so recovery deliberately replays only
+  // ordinary editor fields over the fresh persisted row.
+  if (!looksLikeLoomPresetData(entry) || entry.id !== presetId) return null
+  return {
+    [PENDING_LOOM_PRESET_ENVELOPE_KEY]: 2,
+    preset: entry,
+    dirty: legacyDirtyPaths(false),
+    revision: 0,
+  }
+}
+
+function writePendingEnvelope(presetId: string, entry: PresetSaveEntry): void {
+  const all = readPendingEntries()
+  if (!isDirty(entry.dirty)) {
+    delete all[presetId]
+    writePendingEntries(all)
+    return
+  }
+
+  const envelope: PendingLoomPresetEnvelope = {
+    [PENDING_LOOM_PRESET_ENVELOPE_KEY]: 2,
+    preset: entry.draft,
+    dirty: entry.dirty,
+    revision: entry.revision,
+  }
+  all[presetId] = envelope
+  writePendingEntries(all)
+}
+
+function removePendingEnvelope(presetId: string): void {
+  const all = readPendingEntries()
+  if (!(presetId in all)) return
+  delete all[presetId]
+  writePendingEntries(all)
+}
+
+function createEntry(preset: LoomPreset): PresetSaveEntry {
+  return {
+    confirmed: clone(preset),
+    draft: clone(preset),
+    dirty: emptyDirtyPaths(),
+    revision: 0,
+    timer: null,
+    chain: Promise.resolve(clone(preset)),
+    queuedRevision: null,
+    listeners: new Set(),
+  }
+}
+
+/**
+ * Create an isolated coordinator. Tests and alternate hosts provide their own
+ * adapter; the application-wide coordinator below uses the regular preset API.
+ */
+export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetSaveCoordinator {
+  const entries = new Map<string, PresetSaveEntry>()
+
+  function publish(entry: PresetSaveEntry): void {
+    const snapshot = clone(entry.draft)
+    for (const listener of entry.listeners) {
+      try { listener(clone(snapshot)) } catch { /* one subscriber cannot break saves */ }
+    }
+  }
+
+  function ensure(presetId: string, fallback: LoomPreset): PresetSaveEntry {
+    const existing = entries.get(presetId)
+    if (existing) return existing
+    if (fallback.id !== presetId) throw new Error('Preset coordinator fallback id mismatch')
+
+    const entry = createEntry(fallback)
+    const pending = readPendingEnvelope(presetId)
+    if (pending) {
+      entry.draft = rebaseDirtyPaths(fallback, pending.preset, pending.dirty)
+      entry.dirty = pending.dirty
+      entry.revision = pending.revision
+    }
+    entries.set(presetId, entry)
+    return entry
+  }
+
+  function enqueuePersist(presetId: string, entry: PresetSaveEntry): Promise<LoomPreset> {
+    if (!isDirty(entry.dirty)) return entry.chain
+    if (entry.queuedRevision === entry.revision) return entry.chain
+
+    const revision = entry.revision
+    const snapshot = clone(entry.draft)
+    entry.queuedRevision = revision
+    const previous = entry.chain.catch(() => entry.confirmed)
+    const link = previous.then(async () => {
+      const saved = unmarshalPreset(await adapter.update(presetId, marshalUpdate(snapshot)))
+      const current = entries.get(presetId)
+      if (!current) return saved
+
+      current.confirmed = clone(saved)
+      if (current.revision === revision) {
+        current.draft = clone(saved)
+        current.dirty = emptyDirtyPaths()
+      } else {
+        current.draft = rebaseDirtyPaths(saved, current.draft, current.dirty)
+      }
+      writePendingEnvelope(presetId, current)
+      publish(current)
+      return saved
+    })
+    entry.chain = link
+    link.then(
+      () => {
+        const current = entries.get(presetId)
+        if (current?.queuedRevision === revision) current.queuedRevision = null
+      },
+      () => {
+        const current = entries.get(presetId)
+        if (current?.queuedRevision === revision) current.queuedRevision = null
+      },
+    )
+    link.catch(() => {})
+    return link
+  }
+
+  function queueDebouncedSave(presetId: string, entry: PresetSaveEntry, debounceMs: number): void {
+    clearTimeout(entry.timer)
+    entry.timer = globalThis.setTimeout(() => {
+      entry.timer = null
+      void enqueuePersist(presetId, entry).catch(() => {})
+    }, debounceMs)
+  }
+
+  return {
+    hydrate(preset: LoomPreset): LoomPreset {
+      const entry = entries.get(preset.id)
+      if (!entry) {
+        const created = ensure(preset.id, preset)
+        if (isDirty(created.dirty)) void enqueuePersist(preset.id, created).catch(() => {})
+        return clone(created.draft)
+      }
+
+      const persistedChanged = !sameJson(entry.confirmed, preset)
+      entry.confirmed = clone(preset)
+      entry.draft = isDirty(entry.dirty)
+        ? rebaseDirtyPaths(preset, entry.draft, entry.dirty)
+        : clone(preset)
+      if (isDirty(entry.dirty) && persistedChanged) {
+        entry.revision += 1
+      }
+      writePendingEnvelope(preset.id, entry)
+      publish(entry)
+      if (isDirty(entry.dirty) && persistedChanged) {
+        void enqueuePersist(preset.id, entry).catch(() => {})
+      }
+      return clone(entry.draft)
+    },
+
+    getDraft(presetId: string): LoomPreset | null {
+      const entry = entries.get(presetId)
+      return entry ? clone(entry.draft) : null
+    },
+
+    hasPendingChanges(presetId: string): boolean {
+      return Boolean(entries.get(presetId) && isDirty(entries.get(presetId)!.dirty))
+    },
+
+    mutate(presetId, fallback, mutator, options = {}): LoomPreset {
+      const entry = ensure(presetId, fallback)
+      const before = entry.draft
+      const after = mutator(clone(before))
+      if (!after || after.id !== presetId) throw new Error('Preset mutations must preserve the active preset id')
+
+      const changed = getChangedPaths(before, after)
+      if (!isDirty(changed)) return clone(before)
+
+      entry.draft = clone({ ...after, updatedAt: Date.now() })
+      entry.dirty = mergeDirtyPaths(entry.dirty, changed)
+      entry.revision += 1
+      writePendingEnvelope(presetId, entry)
+      publish(entry)
+
+      if (options.immediate) {
+        void enqueuePersist(presetId, entry).catch(() => {})
+      } else {
+        queueDebouncedSave(presetId, entry, options.debounceMs ?? 400)
+      }
+      return clone(entry.draft)
+    },
+
+    async flush(presetId: string): Promise<LoomPreset | null> {
+      const entry = entries.get(presetId)
+      if (!entry) return null
+      if (entry.timer) {
+        clearTimeout(entry.timer)
+        entry.timer = null
+      }
+      if (isDirty(entry.dirty)) return enqueuePersist(presetId, entry)
+      return entry.chain
+    },
+
+    flushBestEffort(presetId: string): void {
+      void this.flush(presetId).catch(() => {})
+    },
+
+    subscribe(presetId, listener): () => void {
+      const entry = entries.get(presetId)
+      if (!entry) return () => {}
+      entry.listeners.add(listener)
+      return () => { entry.listeners.delete(listener) }
+    },
+
+    remove(presetId: string): void {
+      const entry = entries.get(presetId)
+      clearTimeout(entry?.timer)
+      entries.delete(presetId)
+      removePendingEnvelope(presetId)
+    },
+  }
+}
+
+export const presetSaveCoordinator = createPresetSaveCoordinator({
+  update: (presetId, input) => presetsApi.update(presetId, input),
+})
+
+/** Await the active preset's latest draft before a generation endpoint reads it. */
+export async function flushPresetForGeneration(presetId: string | undefined): Promise<void> {
+  if (!presetId) return
+  await presetSaveCoordinator.flush(presetId)
+}

--- a/frontend/src/lib/loom/preset-save-coordinator.ts
+++ b/frontend/src/lib/loom/preset-save-coordinator.ts
@@ -5,6 +5,7 @@ import type { LoomPreset } from './types'
 
 const PENDING_LOOM_PRESETS_KEY = '__lumiverse_pending_loom_presets'
 const PENDING_LOOM_PRESET_ENVELOPE_KEY = '__lumiverse_pending_loom_preset_v2'
+const MAX_REVISION_CONFLICT_RETRIES = 3
 
 const DRAFT_FIELDS = [
   'name',
@@ -48,11 +49,14 @@ interface PresetSaveEntry {
   timer: ReturnType<typeof globalThis.setTimeout> | null
   chain: Promise<LoomPreset>
   queuedRevision: number | null
+  queuedSnapshot: LoomPreset | null
   listeners: Set<(preset: LoomPreset) => void>
 }
 
 export interface PresetSaveAdapter {
   update(presetId: string, input: UpdatePresetInput): Promise<Preset>
+  /** Read the latest persisted row when a conditional update detects a conflict. */
+  get?: (presetId: string) => Promise<Preset>
 }
 
 export interface PresetMutationOptions {
@@ -66,6 +70,7 @@ export interface PresetHydrationToken {
   readonly readEpoch: number
   readonly globalReadEpoch: number
   readonly confirmedEpoch: number
+  readonly scopeEpoch: number
 }
 
 export class StalePresetHydrationError extends Error {
@@ -74,8 +79,18 @@ export class StalePresetHydrationError extends Error {
     this.name = 'StalePresetHydrationError'
   }
 }
+export class PresetScopeChangedError extends Error {
+  constructor() {
+    super('Preset save scope changed during generation flush')
+    this.name = 'PresetScopeChangedError'
+  }
+}
 
 export interface PresetSaveCoordinator {
+  /** Replace the authenticated-user scope and discard in-memory work from the previous scope. */
+  setScope(scope: string | null): void
+  /** Identify the current scope for guarding in-flight recovery work. */
+  getScopeEpoch(): number
   /**
    * Reserve this consumer's next persisted-row read. A later read by the same
    * consumer supersedes it; another consumer cannot strand this reader if its
@@ -127,9 +142,33 @@ function clone<T>(value: T): T {
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value)
 }
+function isRevisionConflict(error: unknown): boolean {
+  if (!isRecord(error) || error.status !== 409 || !isRecord(error.body)) return false
+  return error.body.code === 'PRESET_REVISION_CONFLICT'
+}
 
 function sameJson(left: unknown, right: unknown): boolean {
-  return JSON.stringify(left) === JSON.stringify(right)
+  if (Object.is(left, right)) return true
+  if (
+    typeof left !== 'object'
+    || left === null
+    || typeof right !== 'object'
+    || right === null
+  ) return false
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false
+    return left.every((value, index) => sameJson(value, right[index]))
+  }
+  if (!isRecord(left) || !isRecord(right)) return false
+  const leftKeys = Object.keys(left)
+  const rightKeys = Object.keys(right)
+  if (leftKeys.length !== rightKeys.length) return false
+  return leftKeys.every((key) => Object.hasOwn(right, key) && sameJson(left[key], right[key]))
+}
+
+function canonicalPersistedPayload(preset: LoomPreset): unknown {
+  const { expected_cache_revision: _expectedCacheRevision, ...payload } = marshalUpdate(preset)
+  return payload
 }
 
 function isDraftField(value: unknown): value is DraftField {
@@ -174,6 +213,93 @@ function getChangedPaths(before: LoomPreset, after: LoomPreset): DirtyPresetPath
 
   return { fields, passthroughKeys }
 }
+function preserveResponseState(
+  saved: LoomPreset,
+  source: LoomPreset,
+  response: Preset,
+): LoomPreset {
+  const responseMetadata = isRecord(response.metadata) ? response.metadata : {}
+  const responseParameters = isRecord(response.parameters) ? response.parameters : {}
+  const responsePrompts = isRecord(response.prompts) ? response.prompts : {}
+  const preserved = clone(saved)
+
+  if (!Object.hasOwn(response, 'name')) preserved.name = source.name
+  if (!Object.hasOwn(response, 'created_at')) preserved.createdAt = source.createdAt
+  if (!Object.hasOwn(response, 'updated_at')) preserved.updatedAt = source.updatedAt
+  if (!Object.hasOwn(response, 'prompt_order')) preserved.blocks = clone(source.blocks)
+  if (!Object.hasOwn(response, 'cache_revision') && typeof source.cacheRevision === 'number') {
+    preserved.cacheRevision = source.cacheRevision
+  } else if (typeof response.cache_revision !== 'number' && typeof source.cacheRevision === 'number') {
+    preserved.cacheRevision = source.cacheRevision
+  }
+
+  if (!Object.hasOwn(responseParameters, 'samplerOverrides')) {
+    preserved.samplerOverrides = clone(source.samplerOverrides)
+  }
+  if (!Object.hasOwn(responseParameters, 'customBody')) {
+    preserved.customBody = clone(source.customBody)
+  }
+  if (!Object.hasOwn(responsePrompts, 'promptBehavior')) {
+    preserved.promptBehavior = clone(source.promptBehavior)
+  }
+  if (!Object.hasOwn(responsePrompts, 'completionSettings')) {
+    preserved.completionSettings = clone(source.completionSettings)
+  }
+  if (!Object.hasOwn(responsePrompts, 'advancedSettings')) {
+    preserved.advancedSettings = clone(source.advancedSettings)
+  }
+
+  if (!Object.hasOwn(responseMetadata, 'source')) preserved.source = clone(source.source)
+  if (!Object.hasOwn(responseMetadata, 'modelProfiles')) {
+    preserved.modelProfiles = clone(source.modelProfiles)
+  }
+  if (!Object.hasOwn(responseMetadata, 'schemaVersion')) {
+    preserved.schemaVersion = source.schemaVersion
+  }
+  if (!Object.hasOwn(responseMetadata, 'description')) {
+    preserved.description = source.description
+  }
+  if (!Object.hasOwn(responseMetadata, 'coverUrl') && !Object.hasOwn(responseMetadata, 'cover_url')) {
+    preserved.coverUrl = source.coverUrl
+  }
+  if (!Object.hasOwn(responseMetadata, 'isDefault')) {
+    preserved.isDefault = source.isDefault
+  }
+  if (!Object.hasOwn(responseMetadata, 'lastProfileKey')) {
+    preserved.lastProfileKey = source.lastProfileKey
+  }
+  if (!Object.hasOwn(responseMetadata, 'promptVariables')) {
+    preserved.promptVariables = clone(source.promptVariables)
+  }
+  if (!Object.hasOwn(responseMetadata, '_lumiverse_preset_version')) {
+    preserved.presetVersion = source.presetVersion
+  }
+
+  const savedMetadata = saved.passthroughMetadata ?? {}
+  const sourceMetadata = source.passthroughMetadata ?? {}
+  const missingPassthroughKeys = Object.keys(sourceMetadata).filter((key) => (
+    !Object.hasOwn(responseMetadata, key)
+  ))
+  if (missingPassthroughKeys.length > 0) {
+    preserved.passthroughMetadata = {
+      ...clone(sourceMetadata),
+      ...clone(savedMetadata),
+    }
+  }
+
+  const savedLumihubMeta = saved.lumihubMeta ?? {}
+  const sourceLumihubMeta = source.lumihubMeta ?? {}
+  const missingLumihubKeys = Object.keys(sourceLumihubMeta).filter((key) => (
+    !Object.hasOwn(responseMetadata, key)
+  ))
+  if (missingLumihubKeys.length > 0) {
+    preserved.lumihubMeta = {
+      ...clone(sourceLumihubMeta),
+      ...clone(savedLumihubMeta),
+    }
+  }
+  return preserved
+}
 
 function rebaseDirtyPaths(
   persisted: LoomPreset,
@@ -205,11 +331,32 @@ function rebaseDirtyPaths(
 
   return rebased
 }
+function confirmPersistedDirtyPaths(
+  persisted: LoomPreset,
+  draft: LoomPreset,
+  dirty: DirtyPresetPaths,
+): { draft: LoomPreset; dirty: DirtyPresetPaths } {
+  const fields = dirty.fields.filter((field) => !sameJson(persisted[field], draft[field]))
+  const persistedMetadata = persisted.passthroughMetadata ?? {}
+  const draftMetadata = draft.passthroughMetadata ?? {}
+  const passthroughKeys = dirty.passthroughKeys.filter((key) => (
+    !sameJson(persistedMetadata[key], draftMetadata[key])
+  ))
+  const remaining = { fields, passthroughKeys }
+  return {
+    draft: rebaseDirtyPaths(persisted, draft, remaining),
+    dirty: remaining,
+  }
+}
 
-function readPendingEntries(): Record<string, unknown> {
+function pendingStorageKey(scope: string | null): string {
+  return scope ? `${PENDING_LOOM_PRESETS_KEY}:${scope}` : PENDING_LOOM_PRESETS_KEY
+}
+
+function readPendingEntries(scope: string | null): Record<string, unknown> {
   if (typeof window === 'undefined') return {}
   try {
-    const raw = globalThis.localStorage.getItem(PENDING_LOOM_PRESETS_KEY)
+    const raw = globalThis.localStorage.getItem(pendingStorageKey(scope))
     if (!raw) return {}
     const parsed: unknown = JSON.parse(raw)
     return isRecord(parsed) ? parsed : {}
@@ -218,16 +365,18 @@ function readPendingEntries(): Record<string, unknown> {
   }
 }
 
-function writePendingEntries(entries: Record<string, unknown>): void {
-  if (typeof window === 'undefined') return
+function writePendingEntries(scope: string | null, entries: Record<string, unknown>): boolean {
+  if (typeof window === 'undefined') return false
   try {
     if (Object.keys(entries).length === 0) {
-      globalThis.localStorage.removeItem(PENDING_LOOM_PRESETS_KEY)
-      return
+      globalThis.localStorage.removeItem(pendingStorageKey(scope))
+      return true
     }
-    globalThis.localStorage.setItem(PENDING_LOOM_PRESETS_KEY, JSON.stringify(entries))
+    globalThis.localStorage.setItem(pendingStorageKey(scope), JSON.stringify(entries))
+    return true
   } catch {
     // Recovery is best-effort; the in-memory coordinator still serializes work.
+    return false
   }
 }
 
@@ -241,8 +390,8 @@ function legacyDirtyPaths(includePromptVariables: boolean): DirtyPresetPaths {
   if (includePromptVariables) fields.push('promptVariables')
   return { fields, passthroughKeys: [] }
 }
-function readPendingEnvelope(presetId: string): PendingLoomPresetEnvelope | null {
-  const entry = readPendingEntries()[presetId]
+function readPendingEnvelope(presetId: string, scope: string | null): PendingLoomPresetEnvelope | null {
+  const entry = readPendingEntries(scope)[presetId]
   if (!isRecord(entry)) return null
 
   if (entry[PENDING_LOOM_PRESET_ENVELOPE_KEY] === 2) {
@@ -288,12 +437,30 @@ function readPendingEnvelope(presetId: string): PendingLoomPresetEnvelope | null
     revision: 0,
   }
 }
+function migrateLegacyPendingEnvelope(presetId: string, scope: string | null): void {
+  if (!scope || readPendingEnvelope(presetId, scope)) return
+  const legacy = readPendingEnvelope(presetId, null)
+  if (!legacy) return
 
-function writePendingEnvelope(presetId: string, entry: PresetSaveEntry): void {
-  const all = readPendingEntries()
+  const scopedEntries = readPendingEntries(scope)
+  scopedEntries[presetId] = legacy
+  if (!writePendingEntries(scope, scopedEntries)) return
+
+  const legacyEntries = readPendingEntries(null)
+  if (!(presetId in legacyEntries)) return
+  delete legacyEntries[presetId]
+  writePendingEntries(null, legacyEntries)
+}
+
+function writePendingEnvelope(
+  presetId: string,
+  entry: PresetSaveEntry,
+  scope: string | null,
+): void {
+  const all = readPendingEntries(scope)
   if (!isDirty(entry.dirty)) {
     delete all[presetId]
-    writePendingEntries(all)
+    writePendingEntries(scope, all)
     return
   }
 
@@ -304,14 +471,14 @@ function writePendingEnvelope(presetId: string, entry: PresetSaveEntry): void {
     revision: entry.revision,
   }
   all[presetId] = envelope
-  writePendingEntries(all)
+  writePendingEntries(scope, all)
 }
 
-function removePendingEnvelope(presetId: string): void {
-  const all = readPendingEntries()
+function removePendingEnvelope(presetId: string, scope: string | null): void {
+  const all = readPendingEntries(scope)
   if (!(presetId in all)) return
   delete all[presetId]
-  writePendingEntries(all)
+  writePendingEntries(scope, all)
 }
 
 function createEntry(preset: LoomPreset): PresetSaveEntry {
@@ -323,6 +490,7 @@ function createEntry(preset: LoomPreset): PresetSaveEntry {
     timer: null,
     chain: Promise.resolve(clone(preset)),
     queuedRevision: null,
+    queuedSnapshot: null,
     listeners: new Set(),
   }
 }
@@ -338,6 +506,20 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
   const latestHydrationReadEpochs = new Map<string, number>()
   const confirmedEpochs = new Map<string, number>()
   const pendingHydrations = new Set<PresetHydrationToken>()
+  let scopeEpoch = 0
+  let pendingStorageScope: string | null = null
+
+  const discardScopeState = (): void => {
+    for (const entry of entries.values()) {
+      if (entry.timer !== null) globalThis.clearTimeout(entry.timer)
+    }
+    entries.clear()
+    listenersByPreset.clear()
+    hydrationReadEpochs.clear()
+    latestHydrationReadEpochs.clear()
+    confirmedEpochs.clear()
+    pendingHydrations.clear()
+  }
 
   const getHydrationReadEpoch = (presetId: string, owner: string): number => (
     hydrationReadEpochs.get(presetId)?.get(owner) ?? 0
@@ -381,7 +563,7 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
     const entry = createEntry(fallback)
     entry.listeners = listenersByPreset.get(presetId) ?? new Set()
     listenersByPreset.set(presetId, entry.listeners)
-    const pending = readPendingEnvelope(presetId)
+    const pending = readPendingEnvelope(presetId, pendingStorageScope)
     if (pending) {
       entry.draft = rebaseDirtyPaths(fallback, pending.preset, pending.dirty)
       entry.dirty = pending.dirty
@@ -413,38 +595,111 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
 
     const revision = entry.revision
     const snapshot = clone(entry.draft)
+    const conflictBase = clone(entry.confirmed)
     entry.queuedRevision = revision
+    entry.queuedSnapshot = clone(snapshot)
+    const enqueueEpoch = scopeEpoch
     const previous = entry.chain.catch(() => entry.confirmed)
     const link = previous.then(async () => {
-      const saved = unmarshalPreset(await adapter.update(presetId, marshalUpdate(snapshot)))
-      const current = entries.get(presetId)
-      if (!current) return saved
+      let pendingSnapshot = snapshot
+      let conflictRetries = 0
 
-      current.confirmed = clone(saved)
-      if (current.revision === revision) {
-        current.draft = clone(saved)
-        current.dirty = emptyDirtyPaths()
-      } else {
-        current.draft = rebaseDirtyPaths(saved, current.draft, current.dirty)
+      while (true) {
+        if (scopeEpoch !== enqueueEpoch || entries.get(presetId) !== entry) {
+          return clone(entry.confirmed)
+        }
+
+        try {
+          if (scopeEpoch !== enqueueEpoch || entries.get(presetId) !== entry) {
+            return clone(entry.confirmed)
+          }
+          const savedRow = await adapter.update(presetId, marshalUpdate(pendingSnapshot))
+          const current = entries.get(presetId)
+          if (scopeEpoch !== enqueueEpoch || current !== entry) {
+            return clone(entry.confirmed)
+          }
+          const responseSource = current.queuedSnapshot ?? pendingSnapshot
+          const saved = preserveResponseState(
+            unmarshalPreset(savedRow),
+            responseSource,
+            savedRow,
+          )
+
+          current.confirmed = clone(saved)
+          if (current.revision === revision) {
+            current.draft = clone(saved)
+            current.dirty = emptyDirtyPaths()
+          } else {
+            const rebased = confirmPersistedDirtyPaths(saved, current.draft, current.dirty)
+            current.draft = rebased.draft
+            current.dirty = rebased.dirty
+          }
+          advanceConfirmedEpoch(presetId)
+          writePendingEnvelope(presetId, current, pendingStorageScope)
+          publish(current)
+          return saved
+        } catch (error) {
+          if (scopeEpoch !== enqueueEpoch || entries.get(presetId) !== entry) {
+            return clone(entry.confirmed)
+          }
+          if (!isRevisionConflict(error) || !adapter.get || conflictRetries >= MAX_REVISION_CONFLICT_RETRIES) {
+            throw error
+          }
+
+          conflictRetries += 1
+          let latestRow: Preset
+          try {
+            latestRow = await adapter.get(presetId)
+          } catch (readError) {
+            if (scopeEpoch !== enqueueEpoch || entries.get(presetId) !== entry) {
+              return clone(entry.confirmed)
+            }
+            throw readError
+          }
+          if (scopeEpoch !== enqueueEpoch || entries.get(presetId) !== entry) {
+            return clone(entry.confirmed)
+          }
+          const latest = unmarshalPreset(latestRow)
+          const current = entries.get(presetId)
+          if (
+            entry.dirty.fields.includes('blocks')
+            && !sameJson(latest.blocks, conflictBase.blocks)
+          ) {
+            // Block arrays need block-id/property-aware merging. Until that
+            // merge exists, surface only conflicts that changed blocks
+            // remotely; unrelated persisted fields can still be rebased.
+            throw error
+          }
+          if (scopeEpoch !== enqueueEpoch || current !== entry) {
+            return clone(entry.confirmed)
+          }
+
+          current.confirmed = clone(latest)
+          const rebased = rebaseDirtyPaths(latest, current.draft, current.dirty)
+          current.draft = rebased
+          advanceConfirmedEpoch(presetId)
+          writePendingEnvelope(presetId, current, pendingStorageScope)
+          publish(current)
+          pendingSnapshot = clone(current.draft)
+          current.queuedSnapshot = clone(pendingSnapshot)
+        }
       }
-      advanceConfirmedEpoch(presetId)
-      writePendingEnvelope(presetId, current)
-      publish(current)
-      return saved
     })
     entry.chain = link
     link.then(
       () => {
         const current = entries.get(presetId)
-        if (current?.queuedRevision === revision) {
+        if (scopeEpoch === enqueueEpoch && current === entry && current.queuedRevision === revision) {
           current.queuedRevision = null
+          current.queuedSnapshot = null
           evictCleanEntry(presetId)
         }
       },
       () => {
         const current = entries.get(presetId)
-        if (current?.queuedRevision === revision) {
+        if (scopeEpoch === enqueueEpoch && current === entry && current.queuedRevision === revision) {
           current.queuedRevision = null
+          current.queuedSnapshot = null
           evictCleanEntry(presetId)
         }
       },
@@ -462,6 +717,16 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
   }
 
   return {
+    setScope(nextScope: string | null): void {
+      if (pendingStorageScope === nextScope) return
+      pendingStorageScope = nextScope
+      scopeEpoch += 1
+      discardScopeState()
+    },
+
+    getScopeEpoch(): number {
+      return scopeEpoch
+    },
     beginHydration(presetId, owner = 'default'): PresetHydrationToken {
       const reservation = reserveHydrationRead(presetId, owner)
       const token = {
@@ -470,6 +735,7 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
         readEpoch: reservation.readEpoch,
         globalReadEpoch: reservation.globalReadEpoch,
         confirmedEpoch: getConfirmedEpoch(presetId),
+        scopeEpoch,
       }
       pendingHydrations.add(token)
       return token
@@ -487,6 +753,9 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
       // consumer read remains a valid fallback until the latest consumer read
       // succeeds, so one failed auxiliary load cannot blank the active editor.
       if (!token) advanceConfirmedEpoch(preset.id)
+      if (token && token.scopeEpoch !== scopeEpoch) {
+        throw new PresetScopeChangedError()
+      }
       if (token && (
         token.presetId !== preset.id
         || token.readEpoch !== getHydrationReadEpoch(preset.id, token.owner)
@@ -496,6 +765,7 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
         if (current) return clone(current.draft)
         throw new StalePresetHydrationError(preset.id)
       }
+      if (!entries.has(preset.id)) migrateLegacyPendingEnvelope(preset.id, pendingStorageScope)
       const isAuthoritativeRead = !token
         || token.globalReadEpoch === (latestHydrationReadEpochs.get(preset.id) ?? 0)
       const entry = entries.get(preset.id)
@@ -507,16 +777,33 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
         return clone(created.draft)
       }
 
+      if (
+        entry.queuedRevision !== null
+        && entry.queuedSnapshot
+        && sameJson(canonicalPersistedPayload(entry.queuedSnapshot), canonicalPersistedPayload(preset))
+      ) {
+        entry.confirmed = clone(preset)
+        entry.draft = isDirty(entry.dirty)
+          ? rebaseDirtyPaths(preset, entry.draft, entry.dirty)
+          : clone(preset)
+        entry.queuedSnapshot = clone(entry.draft)
+        if (token && isAuthoritativeRead) advanceConfirmedEpoch(preset.id)
+        writePendingEnvelope(preset.id, entry, pendingStorageScope)
+        publish(entry)
+        return clone(entry.draft)
+      }
       const persistedChanged = !sameJson(entry.confirmed, preset)
+      const rebased = isDirty(entry.dirty)
+        ? confirmPersistedDirtyPaths(preset, entry.draft, entry.dirty)
+        : { draft: clone(preset), dirty: emptyDirtyPaths() }
       entry.confirmed = clone(preset)
-      entry.draft = isDirty(entry.dirty)
-        ? rebaseDirtyPaths(preset, entry.draft, entry.dirty)
-        : clone(preset)
+      entry.draft = rebased.draft
+      entry.dirty = rebased.dirty
       if (isDirty(entry.dirty) && persistedChanged) {
         entry.revision += 1
       }
       if (token && isAuthoritativeRead) advanceConfirmedEpoch(preset.id)
-      writePendingEnvelope(preset.id, entry)
+      writePendingEnvelope(preset.id, entry, pendingStorageScope)
       publish(entry)
       if (isDirty(entry.dirty) && persistedChanged) {
         void enqueuePersist(preset.id, entry).catch(() => {})
@@ -540,7 +827,7 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
     },
 
     hasDurablePendingRecovery(presetId: string): boolean {
-      return !entries.has(presetId) && readPendingEnvelope(presetId) !== null
+      return !entries.has(presetId) && readPendingEnvelope(presetId, pendingStorageScope) !== null
     },
 
     mutate(presetId, fallback, mutator, options = {}): LoomPreset {
@@ -552,12 +839,19 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
       const changed = getChangedPaths(before, after)
       if (!isDirty(changed)) return clone(before)
 
-      entry.draft = clone({ ...after, updatedAt: Date.now() })
+      const confirmedCacheRevision = before.cacheRevision
+      entry.draft = clone({
+        ...after,
+        updatedAt: Date.now(),
+        ...(typeof confirmedCacheRevision === 'number'
+          ? { cacheRevision: confirmedCacheRevision }
+          : {}),
+      })
       entry.dirty = mergeDirtyPaths(entry.dirty, changed)
       entry.revision += 1
       // Dirty local paths intentionally remain compatible with an in-flight
       // latest read; hydrate() rebases them over its fresh persisted base.
-      writePendingEnvelope(presetId, entry)
+      writePendingEnvelope(presetId, entry, pendingStorageScope)
       publish(entry)
 
       if (options.immediate) {
@@ -612,48 +906,62 @@ export function createPresetSaveCoordinator(adapter: PresetSaveAdapter): PresetS
       entries.delete(presetId)
       advanceConfirmedEpoch(presetId)
       listenersByPreset.delete(presetId)
-      removePendingEnvelope(presetId)
+      removePendingEnvelope(presetId, pendingStorageScope)
     },
   }
 }
 
 export const presetSaveCoordinator = createPresetSaveCoordinator({
   update: (presetId, input) => presetsApi.update(presetId, input),
+  get: (presetId) => presetsApi.get(presetId),
 })
 
 const durableRecoveryFlushes = new Map<string, Promise<void>>()
-
-/**
- * Await the selected preset's latest draft before generation reads it. When
- * Loom has not mounted yet, hydrate durable recovery state over a fresh row
- * first so prompt-only or scoped writes cannot be skipped.
- */
+export function setPresetSaveCoordinatorScope(scope: string | null): void {
+  const previousScopeEpoch = presetSaveCoordinator.getScopeEpoch()
+  presetSaveCoordinator.setScope(scope)
+  if (presetSaveCoordinator.getScopeEpoch() !== previousScopeEpoch) {
+    durableRecoveryFlushes.clear()
+  }
+}
 export async function flushPresetForGeneration(presetId: string | undefined): Promise<void> {
   if (!presetId) return
+  const scopeEpoch = presetSaveCoordinator.getScopeEpoch()
+  const assertScope = (): void => {
+    if (presetSaveCoordinator.getScopeEpoch() !== scopeEpoch) {
+      throw new PresetScopeChangedError()
+    }
+  }
   if (!presetSaveCoordinator.hasDurablePendingRecovery(presetId)) {
     await presetSaveCoordinator.flush(presetId)
+    assertScope()
     return
   }
 
   const existingRecovery = durableRecoveryFlushes.get(presetId)
   if (existingRecovery) {
     await existingRecovery
+    assertScope()
     return
   }
 
   const recovery = (async () => {
     while (true) {
+      assertScope()
       const hydration = presetSaveCoordinator.beginHydration(presetId, 'durable-recovery')
       try {
         const persisted = unmarshalPreset(await presetsApi.get(presetId))
+        assertScope()
         presetSaveCoordinator.hydrate(persisted, hydration)
         break
       } catch (error) {
         presetSaveCoordinator.cancelHydration(hydration)
+        assertScope()
         if (!(error instanceof StalePresetHydrationError)) throw error
       }
     }
     await presetSaveCoordinator.flush(presetId)
+    assertScope()
   })()
   durableRecoveryFlushes.set(presetId, recovery)
   try {

--- a/frontend/src/lib/loom/preset-selection-coordinator-core.ts
+++ b/frontend/src/lib/loom/preset-selection-coordinator-core.ts
@@ -9,8 +9,14 @@ export interface PresetSelectionTransitionOptions {
   signal?: AbortSignal
 }
 
+export interface PresetSelectionRequest {
+  transition(presetId: string | null): Promise<boolean>
+  cancel(): void
+}
+
 export interface PresetSelectionCoordinator {
-  transition(presetId: string | null, options?: PresetSelectionTransitionOptions): Promise<void>
+  begin(options?: PresetSelectionTransitionOptions): PresetSelectionRequest
+  transition(presetId: string | null, options?: PresetSelectionTransitionOptions): Promise<boolean>
 }
 
 /**
@@ -22,33 +28,64 @@ export function createPresetSelectionCoordinator(adapter: PresetSelectionAdapter
   let chain: Promise<void> = Promise.resolve()
   let latestRequest = 0
 
-  return {
-    transition(presetId, options = {}) {
-      const request = ++latestRequest
-      const invalidate = () => {
-        if (latestRequest === request) latestRequest += 1
+  const begin = (options: PresetSelectionTransitionOptions = {}): PresetSelectionRequest => {
+    if (options.signal?.aborted) {
+      return {
+        transition: async () => false,
+        cancel() {},
       }
-      options.signal?.addEventListener('abort', invalidate, { once: true })
-      const isStale = () => options.signal?.aborted === true || request !== latestRequest
-      const transition = chain.catch(() => {}).then(async () => {
-        if (isStale()) return
-        while (true) {
-          const currentPresetId = adapter.getActivePresetId()
-          if (currentPresetId === presetId) return
-          if (currentPresetId) await adapter.flushPreset(currentPresetId)
-          if (isStale()) return
+    }
 
-          // An external lifecycle transition changed the source while this
-          // transition was flushing. Rebase that source before continuing.
-          if (adapter.getActivePresetId() !== currentPresetId) continue
-          adapter.setActivePresetId(presetId)
-          return
+    const request = ++latestRequest
+    let closed = false
+    const invalidate = () => {
+      if (latestRequest === request) latestRequest += 1
+    }
+    const cleanup = () => {
+      options.signal?.removeEventListener('abort', invalidate)
+    }
+    const cancel = () => {
+      if (closed) return
+      invalidate()
+      closed = true
+      cleanup()
+    }
+    options.signal?.addEventListener('abort', cancel, { once: true })
+    const isStale = () => closed || options.signal?.aborted === true || request !== latestRequest
+
+    return {
+      transition(presetId) {
+        if (isStale()) {
+          cleanup()
+          return Promise.resolve(false)
         }
-      }).finally(() => {
-        options.signal?.removeEventListener('abort', invalidate)
-      })
-      chain = transition.catch(() => {})
-      return transition
-    },
+        const transition = chain.catch(() => {}).then(async (): Promise<boolean> => {
+          if (isStale()) return false
+          while (true) {
+            const currentPresetId = adapter.getActivePresetId()
+            if (currentPresetId === presetId) return true
+            if (currentPresetId) await adapter.flushPreset(currentPresetId)
+            if (isStale()) return false
+
+            // An external lifecycle transition changed the source while this
+            // transition was flushing. Rebase that source before continuing.
+            if (adapter.getActivePresetId() !== currentPresetId) continue
+            adapter.setActivePresetId(presetId)
+            return true
+          }
+        }).finally(() => {
+          closed = true
+          cleanup()
+        })
+        chain = transition.then(() => {}, () => {})
+        return transition
+      },
+      cancel,
+    }
+  }
+
+  return {
+    begin,
+    transition: (presetId, options) => begin(options).transition(presetId),
   }
 }

--- a/frontend/src/lib/loom/preset-selection-coordinator-core.ts
+++ b/frontend/src/lib/loom/preset-selection-coordinator-core.ts
@@ -1,0 +1,54 @@
+export interface PresetSelectionAdapter {
+  getActivePresetId(): string | null
+  setActivePresetId(presetId: string | null): void
+  flushPreset(presetId: string): Promise<void>
+}
+
+
+export interface PresetSelectionTransitionOptions {
+  signal?: AbortSignal
+}
+
+export interface PresetSelectionCoordinator {
+  transition(presetId: string | null, options?: PresetSelectionTransitionOptions): Promise<void>
+}
+
+/**
+ * Serializes active-preset changes. The departing preset is durably rebased and
+ * flushed before the store exposes the next id. A later request or lifecycle
+ * cancellation wins before an obsolete intermediate target becomes visible.
+ */
+export function createPresetSelectionCoordinator(adapter: PresetSelectionAdapter): PresetSelectionCoordinator {
+  let chain: Promise<void> = Promise.resolve()
+  let latestRequest = 0
+
+  return {
+    transition(presetId, options = {}) {
+      const request = ++latestRequest
+      const invalidate = () => {
+        if (latestRequest === request) latestRequest += 1
+      }
+      options.signal?.addEventListener('abort', invalidate, { once: true })
+      const isStale = () => options.signal?.aborted === true || request !== latestRequest
+      const transition = chain.catch(() => {}).then(async () => {
+        if (isStale()) return
+        while (true) {
+          const currentPresetId = adapter.getActivePresetId()
+          if (currentPresetId === presetId) return
+          if (currentPresetId) await adapter.flushPreset(currentPresetId)
+          if (isStale()) return
+
+          // An external lifecycle transition changed the source while this
+          // transition was flushing. Rebase that source before continuing.
+          if (adapter.getActivePresetId() !== currentPresetId) continue
+          adapter.setActivePresetId(presetId)
+          return
+        }
+      }).finally(() => {
+        options.signal?.removeEventListener('abort', invalidate)
+      })
+      chain = transition.catch(() => {})
+      return transition
+    },
+  }
+}

--- a/frontend/src/lib/loom/preset-selection-coordinator.test.ts
+++ b/frontend/src/lib/loom/preset-selection-coordinator.test.ts
@@ -82,6 +82,33 @@ describe('preset selection coordinator', () => {
     expect(activePresetId).toBe('preset-b')
   })
 
+  test('keeps a manual selection authoritative when a delayed settings read resolves later', async () => {
+    let activePresetId: string | null = 'preset-a'
+    const pendingManualFlush = deferred<void>()
+    const manualFlushStarted = deferred<void>()
+    const coordinator = createPresetSelectionCoordinator({
+      getActivePresetId: () => activePresetId,
+      setActivePresetId: (presetId) => { activePresetId = presetId },
+      flushPreset: async () => {
+        manualFlushStarted.resolve()
+        await pendingManualFlush.promise
+      },
+    })
+    const pendingSettingsRead = deferred<string>()
+    const settingsSelection = coordinator.begin()
+    const delayedSettingsSelection = pendingSettingsRead.promise.then((presetId) => settingsSelection.transition(presetId))
+    const manualSelection = coordinator.transition('preset-c')
+
+    await manualFlushStarted.promise
+    pendingSettingsRead.resolve('preset-a')
+    expect(await delayedSettingsSelection).toBe(false)
+    pendingManualFlush.resolve()
+    await manualSelection
+
+    expect(activePresetId).toBe('preset-c')
+  })
+
+
   test('does not expose a stale intermediate target after a later switch request', async () => {
     let activePresetId: string | null = 'preset-a'
     const exposed: (string | null)[] = []

--- a/frontend/src/lib/loom/preset-selection-coordinator.test.ts
+++ b/frontend/src/lib/loom/preset-selection-coordinator.test.ts
@@ -32,6 +32,56 @@ describe('preset selection coordinator', () => {
     expect(activePresetId).toBe('preset-b')
   })
 
+  test('does not expose an aborted lifecycle selection after its flush completes', async () => {
+    let activePresetId: string | null = 'preset-a'
+    const pendingFlush = deferred<void>()
+    const coordinator = createPresetSelectionCoordinator({
+      getActivePresetId: () => activePresetId,
+      setActivePresetId: (presetId) => { activePresetId = presetId },
+      flushPreset: async () => { await pendingFlush.promise },
+    })
+    const abort = new AbortController()
+    const transition = coordinator.transition('preset-b', { signal: abort.signal })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    abort.abort()
+    pendingFlush.resolve()
+    await transition
+
+    expect(activePresetId).toBe('preset-a')
+  })
+
+  test('ignores a request whose lifecycle was cancelled before it reached selection', async () => {
+    let activePresetId: string | null = 'preset-a'
+    let flushes = 0
+    const coordinator = createPresetSelectionCoordinator({
+      getActivePresetId: () => activePresetId,
+      setActivePresetId: (presetId) => { activePresetId = presetId },
+      flushPreset: async () => { flushes += 1 },
+    })
+    const abort = new AbortController()
+    abort.abort()
+
+    await coordinator.transition('preset-b', { signal: abort.signal })
+    expect(activePresetId).toBe('preset-a')
+    expect(flushes).toBe(0)
+  })
+
+  test('rejects an older asynchronous intent after a later manual selection commits', async () => {
+    let activePresetId: string | null = 'preset-a'
+    const coordinator = createPresetSelectionCoordinator({
+      getActivePresetId: () => activePresetId,
+      setActivePresetId: (presetId) => { activePresetId = presetId },
+      flushPreset: async () => {},
+    })
+
+    const createIntent = coordinator.begin()
+    expect(await coordinator.transition('preset-b')).toBe(true)
+    expect(await createIntent.transition('preset-c')).toBe(false)
+    expect(activePresetId).toBe('preset-b')
+  })
+
   test('does not expose a stale intermediate target after a later switch request', async () => {
     let activePresetId: string | null = 'preset-a'
     const exposed: (string | null)[] = []

--- a/frontend/src/lib/loom/preset-selection-coordinator.test.ts
+++ b/frontend/src/lib/loom/preset-selection-coordinator.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test'
+import { createPresetSelectionCoordinator } from './preset-selection-coordinator-core'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((complete) => { resolve = complete })
+  return { promise, resolve }
+}
+
+describe('preset selection coordinator', () => {
+  test('flushes the departing preset before exposing the next one', async () => {
+    let activePresetId: string | null = 'preset-a'
+    const flushed: string[] = []
+    const pendingFlush = deferred<void>()
+    const coordinator = createPresetSelectionCoordinator({
+      getActivePresetId: () => activePresetId,
+      setActivePresetId: (presetId) => { activePresetId = presetId },
+      flushPreset: async (presetId) => {
+        flushed.push(presetId)
+        await pendingFlush.promise
+      },
+    })
+
+    const transition = coordinator.transition('preset-b')
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(activePresetId).toBe('preset-a')
+    expect(flushed).toEqual(['preset-a'])
+
+    pendingFlush.resolve()
+    await transition
+    expect(activePresetId).toBe('preset-b')
+  })
+
+  test('does not expose a stale intermediate target after a later switch request', async () => {
+    let activePresetId: string | null = 'preset-a'
+    const exposed: (string | null)[] = []
+    const firstFlush = deferred<void>()
+    let flushes = 0
+    const coordinator = createPresetSelectionCoordinator({
+      getActivePresetId: () => activePresetId,
+      setActivePresetId: (presetId) => {
+        exposed.push(presetId)
+        activePresetId = presetId
+      },
+      flushPreset: async () => {
+        flushes += 1
+        if (flushes === 1) await firstFlush.promise
+      },
+    })
+
+    const staleTransition = coordinator.transition('preset-b')
+    await Promise.resolve()
+    await Promise.resolve()
+    const currentTransition = coordinator.transition('preset-c')
+    firstFlush.resolve()
+    await Promise.all([staleTransition, currentTransition])
+
+    expect(exposed).toEqual(['preset-c'])
+    expect(activePresetId).toBe('preset-c')
+  })
+})

--- a/frontend/src/lib/loom/preset-selection-coordinator.ts
+++ b/frontend/src/lib/loom/preset-selection-coordinator.ts
@@ -1,7 +1,8 @@
-import { useStore } from '@/store'
-import { flushPresetForGeneration } from './preset-save-coordinator'
 import {
   createPresetSelectionCoordinator,
+  type PresetSelectionAdapter,
+  type PresetSelectionCoordinator,
+  type PresetSelectionRequest,
   type PresetSelectionTransitionOptions,
 } from './preset-selection-coordinator-core'
 
@@ -10,17 +11,31 @@ export {
   type PresetSelectionAdapter,
   type PresetSelectionCoordinator,
   type PresetSelectionTransitionOptions,
+  type PresetSelectionRequest,
 } from './preset-selection-coordinator-core'
 
-const presetSelectionCoordinator = createPresetSelectionCoordinator({
-  getActivePresetId: () => useStore.getState().activeLoomPresetId,
-  setActivePresetId: (presetId) => useStore.getState().setActiveLoomPreset(presetId),
-  flushPreset: flushPresetForGeneration,
-})
+let presetSelectionCoordinator: PresetSelectionCoordinator | null = null
+
+export function configurePresetSelectionCoordinator(adapter: PresetSelectionAdapter): void {
+  presetSelectionCoordinator = createPresetSelectionCoordinator(adapter)
+}
+
+function getPresetSelectionCoordinator(): PresetSelectionCoordinator {
+  if (!presetSelectionCoordinator) {
+    throw new Error('PRESET_SELECTION_UNAVAILABLE: Preset selection coordinator is not initialized')
+  }
+  return presetSelectionCoordinator
+}
+
+export function beginActiveLoomPresetSelection(
+  options?: PresetSelectionTransitionOptions,
+): PresetSelectionRequest {
+  return getPresetSelectionCoordinator().begin(options)
+}
 
 export function transitionActiveLoomPreset(
   presetId: string | null,
   options?: PresetSelectionTransitionOptions,
-): Promise<void> {
-  return presetSelectionCoordinator.transition(presetId, options)
+): Promise<boolean> {
+  return getPresetSelectionCoordinator().transition(presetId, options)
 }

--- a/frontend/src/lib/loom/preset-selection-coordinator.ts
+++ b/frontend/src/lib/loom/preset-selection-coordinator.ts
@@ -1,0 +1,26 @@
+import { useStore } from '@/store'
+import { flushPresetForGeneration } from './preset-save-coordinator'
+import {
+  createPresetSelectionCoordinator,
+  type PresetSelectionTransitionOptions,
+} from './preset-selection-coordinator-core'
+
+export {
+  createPresetSelectionCoordinator,
+  type PresetSelectionAdapter,
+  type PresetSelectionCoordinator,
+  type PresetSelectionTransitionOptions,
+} from './preset-selection-coordinator-core'
+
+const presetSelectionCoordinator = createPresetSelectionCoordinator({
+  getActivePresetId: () => useStore.getState().activeLoomPresetId,
+  setActivePresetId: (presetId) => useStore.getState().setActiveLoomPreset(presetId),
+  flushPreset: flushPresetForGeneration,
+})
+
+export function transitionActiveLoomPreset(
+  presetId: string | null,
+  options?: PresetSelectionTransitionOptions,
+): Promise<void> {
+  return presetSelectionCoordinator.transition(presetId, options)
+}

--- a/frontend/src/lib/loom/service.metadata.test.ts
+++ b/frontend/src/lib/loom/service.metadata.test.ts
@@ -6,7 +6,6 @@ import {
   marshalUpdate,
   unmarshalPreset,
 } from './service'
-import { SPINDLE_EXTENSION_METADATA_KEY } from './service'
 
 function rawPreset(metadata: Record<string, unknown>): Preset {
   return {
@@ -54,36 +53,4 @@ describe('Loom extension metadata preservation', () => {
     })
   })
 
-  test('preserves colliding extension namespaces in the protected Spindle envelope', () => {
-    const nativeSource = {
-      type: 'native-source',
-      slug: null,
-      importedVersion: null,
-      importedName: null,
-      importedAt: 1,
-    }
-    const loom = unmarshalPreset(rawPreset({
-      source: nativeSource,
-      description: 'Native description',
-      [SPINDLE_EXTENSION_METADATA_KEY]: {
-        source: { mode: 'parallel' },
-        description: { mode: 'single' },
-      },
-    }))
-
-    expect(loom.source).toEqual(nativeSource)
-    expect(loom.description).toBe('Native description')
-    expect(loom.passthroughMetadata[SPINDLE_EXTENSION_METADATA_KEY]).toEqual({
-      source: { mode: 'parallel' },
-      description: { mode: 'single' },
-    })
-
-    const metadata = marshalUpdate(loom).metadata!
-    expect(metadata.source).toEqual(nativeSource)
-    expect(metadata.description).toBe('Native description')
-    expect(metadata[SPINDLE_EXTENSION_METADATA_KEY]).toEqual({
-      source: { mode: 'parallel' },
-      description: { mode: 'single' },
-    })
-  })
 })

--- a/frontend/src/lib/loom/service.metadata.test.ts
+++ b/frontend/src/lib/loom/service.metadata.test.ts
@@ -6,6 +6,7 @@ import {
   marshalUpdate,
   unmarshalPreset,
 } from './service'
+import { SPINDLE_EXTENSION_METADATA_KEY } from './service'
 
 function rawPreset(metadata: Record<string, unknown>): Preset {
   return {
@@ -50,6 +51,39 @@ describe('Loom extension metadata preservation', () => {
     expect(marshalPreset(imported).metadata?.agentic_preset_composer).toEqual({
       version: 1,
       pipelines: [{ id: 'main' }],
+    })
+  })
+
+  test('preserves colliding extension namespaces in the protected Spindle envelope', () => {
+    const nativeSource = {
+      type: 'native-source',
+      slug: null,
+      importedVersion: null,
+      importedName: null,
+      importedAt: 1,
+    }
+    const loom = unmarshalPreset(rawPreset({
+      source: nativeSource,
+      description: 'Native description',
+      [SPINDLE_EXTENSION_METADATA_KEY]: {
+        source: { mode: 'parallel' },
+        description: { mode: 'single' },
+      },
+    }))
+
+    expect(loom.source).toEqual(nativeSource)
+    expect(loom.description).toBe('Native description')
+    expect(loom.passthroughMetadata[SPINDLE_EXTENSION_METADATA_KEY]).toEqual({
+      source: { mode: 'parallel' },
+      description: { mode: 'single' },
+    })
+
+    const metadata = marshalUpdate(loom).metadata!
+    expect(metadata.source).toEqual(nativeSource)
+    expect(metadata.description).toBe('Native description')
+    expect(metadata[SPINDLE_EXTENSION_METADATA_KEY]).toEqual({
+      source: { mode: 'parallel' },
+      description: { mode: 'single' },
     })
   })
 })

--- a/frontend/src/lib/loom/service.ts
+++ b/frontend/src/lib/loom/service.ts
@@ -118,8 +118,6 @@ function isRecord(value: unknown): value is Record<string, any> {
 
 /** Version key is surfaced separately as `presetVersion`; the rest of the bag round-trips verbatim. */
 const LUMIHUB_VERSION_META_KEY = '_lumiverse_preset_version'
-/** Internal metadata envelope for Spindle namespaces, kept separate from Loom-owned keys. */
-export const SPINDLE_EXTENSION_METADATA_KEY = '_lumiverse_spindle_extensions'
 const LOOM_OWNED_META_KEYS = new Set([
   'source',
   'modelProfiles',
@@ -132,6 +130,10 @@ const LOOM_OWNED_META_KEYS = new Set([
   'promptVariables',
 ])
 
+export function isLoomOwnedPresetMetadataKey(key: string): boolean {
+  return LOOM_OWNED_META_KEYS.has(key) || key.startsWith('_lumiverse_')
+}
+
 /**
  * Pull the LumiHub provenance bag (install source, hub id, slug, creator) out of a stored
  * preset's metadata so it survives the marshal/unmarshal round-trip. `marshalUpdate` rewrites
@@ -142,7 +144,7 @@ const LOOM_OWNED_META_KEYS = new Set([
 function extractLumihubMeta(meta: Record<string, any>): Record<string, unknown> | null {
   const bag: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(meta)) {
-    if (key.startsWith('_lumiverse_') && key !== LUMIHUB_VERSION_META_KEY && key !== SPINDLE_EXTENSION_METADATA_KEY) {
+    if (key.startsWith('_lumiverse_') && key !== LUMIHUB_VERSION_META_KEY) {
       bag[key] = value
     }
   }
@@ -152,7 +154,7 @@ function extractLumihubMeta(meta: Record<string, any>): Record<string, unknown> 
 function extractPassthroughMetadata(meta: Record<string, any>): Record<string, unknown> {
   const bag: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(meta)) {
-    if (LOOM_OWNED_META_KEYS.has(key) || (key.startsWith('_lumiverse_') && key !== SPINDLE_EXTENSION_METADATA_KEY)) continue
+    if (isLoomOwnedPresetMetadataKey(key)) continue
     bag[key] = value
   }
   return bag

--- a/frontend/src/lib/loom/service.ts
+++ b/frontend/src/lib/loom/service.ts
@@ -366,6 +366,7 @@ export function unmarshalPreset(preset: Preset): LoomPreset {
     schemaVersion: meta.schemaVersion || 1,
     createdAt: preset.created_at,
     updatedAt: preset.updated_at,
+    ...(typeof preset.cache_revision === 'number' ? { cacheRevision: preset.cache_revision } : {}),
     blocks: (preset.prompt_order || []) as PromptBlock[],
     source: meta.source || null,
     isDefault: meta.isDefault || false,
@@ -388,6 +389,9 @@ export function marshalUpdate(loom: LoomPreset): UpdatePresetInput {
   const blocks = normalizeCategoryBlockState(loom.blocks)
   return {
     name: loom.name,
+    ...(typeof loom.cacheRevision === 'number'
+      ? { expected_cache_revision: loom.cacheRevision }
+      : {}),
     parameters: {
       samplerOverrides: loom.samplerOverrides,
       customBody: loom.customBody,

--- a/frontend/src/lib/loom/service.ts
+++ b/frontend/src/lib/loom/service.ts
@@ -118,6 +118,8 @@ function isRecord(value: unknown): value is Record<string, any> {
 
 /** Version key is surfaced separately as `presetVersion`; the rest of the bag round-trips verbatim. */
 const LUMIHUB_VERSION_META_KEY = '_lumiverse_preset_version'
+/** Internal metadata envelope for Spindle namespaces, kept separate from Loom-owned keys. */
+export const SPINDLE_EXTENSION_METADATA_KEY = '_lumiverse_spindle_extensions'
 const LOOM_OWNED_META_KEYS = new Set([
   'source',
   'modelProfiles',
@@ -140,7 +142,7 @@ const LOOM_OWNED_META_KEYS = new Set([
 function extractLumihubMeta(meta: Record<string, any>): Record<string, unknown> | null {
   const bag: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(meta)) {
-    if (key.startsWith('_lumiverse_') && key !== LUMIHUB_VERSION_META_KEY) {
+    if (key.startsWith('_lumiverse_') && key !== LUMIHUB_VERSION_META_KEY && key !== SPINDLE_EXTENSION_METADATA_KEY) {
       bag[key] = value
     }
   }
@@ -150,7 +152,7 @@ function extractLumihubMeta(meta: Record<string, any>): Record<string, unknown> 
 function extractPassthroughMetadata(meta: Record<string, any>): Record<string, unknown> {
   const bag: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(meta)) {
-    if (LOOM_OWNED_META_KEYS.has(key) || key.startsWith('_lumiverse_')) continue
+    if (LOOM_OWNED_META_KEYS.has(key) || (key.startsWith('_lumiverse_') && key !== SPINDLE_EXTENSION_METADATA_KEY)) continue
     bag[key] = value
   }
   return bag

--- a/frontend/src/lib/loom/types.ts
+++ b/frontend/src/lib/loom/types.ts
@@ -175,6 +175,8 @@ export interface LoomPreset {
   schemaVersion: number
   createdAt: number
   updatedAt: number
+  /** Monotonic persisted revision for conditional coordinator updates. Omitted for raw imports. */
+  cacheRevision?: number
   blocks: PromptBlock[]
   source: PresetSource | null
   isDefault: boolean

--- a/frontend/src/lib/spindle/frontend-extension-cleanup.ts
+++ b/frontend/src/lib/spindle/frontend-extension-cleanup.ts
@@ -1,0 +1,87 @@
+export interface FrontendExtensionCleanupResources {
+  deactivatePresetEditor(): void
+  clearPresetEditorSubscriptions(): void
+  destroyPlacements(): void
+  cleanupProcesses(): void
+  teardown?(): void
+  reportTeardownError?(error: unknown): void
+  drainEventSubscriptions(): void
+  cleanupDomAndMounts(): void
+  cleanupRegistries(): void
+}
+
+/**
+ * Coordinates one extension's teardown lifecycle. The loader supplies the
+ * concrete resource callbacks; the seam keeps ordering and idempotence
+ * testable without loading a real extension.
+ */
+export function createFrontendExtensionCleanup(
+  resources: FrontendExtensionCleanupResources,
+): (reportTeardownError?: boolean) => void {
+  let cleanupComplete = false
+  let teardownInvoked = false
+  return (reportTeardownError = false): void => {
+    if (cleanupComplete) return
+    cleanupComplete = true
+
+    resources.deactivatePresetEditor()
+    try {
+      resources.clearPresetEditorSubscriptions()
+    } catch {
+      // no-op
+    }
+    try {
+      resources.destroyPlacements()
+    } catch {
+      // no-op
+    }
+    resources.cleanupProcesses()
+
+    if (!teardownInvoked) {
+      teardownInvoked = true
+      try {
+        resources.teardown?.()
+      } catch (error) {
+        if (reportTeardownError) resources.reportTeardownError?.(error)
+      }
+    }
+
+    resources.drainEventSubscriptions()
+    resources.cleanupDomAndMounts()
+    resources.cleanupRegistries()
+  }
+}
+
+/**
+ * Shared branch finalization for setup failures and superseded generations.
+ * A synchronous stale setup return becomes the teardown exactly once before
+ * the idempotent cleanup routine runs.
+ */
+export function finalizeFrontendLoadFailure(
+  cleanup: ((reportTeardownError?: boolean) => void) | undefined,
+  loaded: { teardown?: () => void },
+  options: { superseded: boolean; teardownResult?: unknown },
+): void {
+  if (options.superseded && typeof options.teardownResult === 'function') {
+    loaded.teardown = options.teardownResult as () => void
+  }
+  cleanup?.()
+}
+
+export function adoptFrontendSetupTeardown(
+  loaded: { teardown?: () => void },
+  resolved: unknown,
+  isCurrent: boolean,
+  reportError?: (error: unknown) => void,
+): void {
+  if (typeof resolved !== 'function') return
+  if (isCurrent) {
+    loaded.teardown = resolved as () => void
+    return
+  }
+  try {
+    ;(resolved as () => void)()
+  } catch (error) {
+    reportError?.(error)
+  }
+}

--- a/frontend/src/lib/spindle/frontend-extension-cleanup.ts
+++ b/frontend/src/lib/spindle/frontend-extension-cleanup.ts
@@ -59,29 +59,78 @@ export function createFrontendExtensionCleanup(
  */
 export function finalizeFrontendLoadFailure(
   cleanup: ((reportTeardownError?: boolean) => void) | undefined,
-  loaded: { teardown?: () => void },
+  loaded: { teardown?: () => void; teardownClaimed?: boolean; staleTeardowns?: Set<() => void> },
   options: { superseded: boolean; teardownResult?: unknown },
 ): void {
   if (options.superseded && typeof options.teardownResult === 'function') {
-    loaded.teardown = options.teardownResult as () => void
+    const teardown = options.teardownResult as () => void
+    if (loaded.teardownClaimed) {
+      invokeStaleTeardown(loaded, teardown)
+    } else {
+      loaded.teardown = teardown
+    }
   }
   cleanup?.()
 }
 
+function invokeStaleTeardown(
+  loaded: { teardown?: () => void; teardownClaimed?: boolean; staleTeardowns?: Set<() => void> },
+  teardown: () => void,
+  reportError?: (error: unknown) => void,
+): void {
+  if (loaded.teardownClaimed && loaded.teardown === teardown) return
+  const staleTeardowns = loaded.staleTeardowns ??= new Set<() => void>()
+  if (staleTeardowns.has(teardown)) return
+  // Claim before invocation so a re-entrant or repeated resolution cannot run
+  // the same stale teardown twice.
+  staleTeardowns.add(teardown)
+  try {
+    teardown()
+  } catch (error) {
+    reportError?.(error)
+  }
+}
+
 export function adoptFrontendSetupTeardown(
-  loaded: { teardown?: () => void },
+  loaded: { teardown?: () => void; teardownClaimed?: boolean; staleTeardowns?: Set<() => void> },
   resolved: unknown,
   isCurrent: boolean,
   reportError?: (error: unknown) => void,
 ): void {
   if (typeof resolved !== 'function') return
-  if (isCurrent) {
-    loaded.teardown = resolved as () => void
+  const teardown = resolved as () => void
+  if (isCurrent && !loaded.teardownClaimed) {
+    loaded.teardown = teardown
     return
   }
-  try {
-    ;(resolved as () => void)()
-  } catch (error) {
-    reportError?.(error)
-  }
+  invokeStaleTeardown(loaded, teardown, reportError)
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return !!value && typeof value === 'object' && typeof (value as PromiseLike<unknown>).then === 'function'
+}
+
+export function observeFrontendSetupTeardown(
+  result: unknown,
+  loaded: { teardown?: () => void; teardownClaimed?: boolean; staleTeardowns?: Set<() => void> },
+  isCurrent: () => boolean,
+  onCurrentError: (error: unknown) => void,
+  reportStaleTeardownError?: (error: unknown) => void,
+): void {
+  if (!isPromiseLike(result)) return
+  void Promise.resolve(result)
+    .then((resolved) => {
+      adoptFrontendSetupTeardown(loaded, resolved, isCurrent(), reportStaleTeardownError)
+    })
+    .catch((error) => {
+      if (isCurrent()) onCurrentError(error)
+    })
+}
+
+/**
+ * An initial permission response may only be adopted when no permission
+ * change event was observed after that request started.
+ */
+export function isPermissionBootstrapCurrent(readVersion: number, eventVersion: number): boolean {
+  return readVersion === eventVersion
 }

--- a/frontend/src/lib/spindle/loader.lifecycle.test.ts
+++ b/frontend/src/lib/spindle/loader.lifecycle.test.ts
@@ -1,0 +1,398 @@
+import { afterEach, beforeAll, describe, expect, mock, test } from 'bun:test'
+import type { SpindleManifest } from 'lumiverse-spindle-types'
+
+type FakeRoot = {
+  parentElement: object | null
+  removed: boolean
+  setAttribute(name: string, value: string): void
+  replaceChildren(): void
+  remove(): void
+}
+
+type PermissionResult = { granted: string[] }
+type LifecycleGlobals = typeof globalThis & Record<string, unknown>
+
+const lifecycleGlobals = globalThis as LifecycleGlobals
+const removedRoots: FakeRoot[] = []
+const wsHandlers = new Map<string, Set<(payload: unknown) => void>>()
+const windowHandlers = new Map<string, Set<EventListenerOrEventListenerObject>>()
+const placementDestroyCalls: string[] = []
+let permissionPromise: Promise<PermissionResult> = Promise.resolve({ granted: [] })
+let objectUrlSequence = 0
+let accessCreations = 0
+const windowMock = {
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+    const handlers = windowHandlers.get(type) ?? new Set<EventListenerOrEventListenerObject>()
+    handlers.add(listener)
+    windowHandlers.set(type, handlers)
+  },
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+    windowHandlers.get(type)?.delete(listener)
+  },
+  dispatchEvent(event: Event): boolean {
+    for (const listener of windowHandlers.get(event.type) ?? []) {
+      if (typeof listener === 'function') listener(event)
+      else listener.handleEvent(event)
+    }
+    return true
+  },
+}
+
+const documentMock = {
+  body: {
+    hasAttribute: () => false,
+  },
+  createElement: () => {
+    const root: FakeRoot = {
+      parentElement: null,
+      removed: false,
+      setAttribute() {},
+      replaceChildren() {},
+      remove() {
+        root.removed = true
+      },
+    }
+    removedRoots.push(root)
+    return root
+  },
+  querySelector: () => null,
+}
+
+class FakeMutationObserver {
+  constructor(_callback: MutationCallback) {}
+  observe() {}
+  disconnect() {}
+}
+
+Object.defineProperty(globalThis, 'window', { configurable: true, value: windowMock })
+Object.defineProperty(globalThis, 'document', { configurable: true, value: documentMock })
+Object.defineProperty(globalThis, 'MutationObserver', { configurable: true, value: FakeMutationObserver })
+Object.defineProperty(URL, 'createObjectURL', {
+  configurable: true,
+  value: () => {
+    objectUrlSequence += 1
+    const source = String(lifecycleGlobals.__lifecycleModuleSource ?? '')
+    return `data:text/javascript,${encodeURIComponent(source)}?${objectUrlSequence}`
+  },
+})
+Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: () => {} })
+const storeState = {
+  pendingPermissionRequest: null as { id: string; extensionId: string } | null,
+  showPermissionRequest(request: { id: string; extensionId: string }) {
+    storeState.pendingPermissionRequest = request
+  },
+}
+const useStoreMock = {
+  getState: () => storeState,
+  setState(update: { pendingPermissionRequest?: null } | ((state: typeof storeState) => Partial<typeof storeState>)) {
+    const next = typeof update === 'function' ? update(storeState) : update
+    Object.assign(storeState, next)
+  },
+}
+
+const wsClientMock = {
+  on(event: string, handler: (payload: unknown) => void) {
+    const handlers = wsHandlers.get(`ws:${event}`) ?? new Set<(payload: unknown) => void>()
+    handlers.add(handler)
+    wsHandlers.set(`ws:${event}`, handlers)
+    return () => handlers.delete(handler)
+  },
+  send() {},
+}
+function dispatchWs(event: string, payload: unknown): void {
+  for (const handler of wsHandlers.get(`ws:${event}`) ?? []) handler(payload)
+}
+function dispatchWindow(event: string, detail: unknown): void {
+  windowMock.dispatchEvent({ type: event, detail } as unknown as Event)
+}
+
+const presetAccessMock = {
+  createPresetEditorAccess: (
+    _extensionIdentifier: string,
+    getGrantedPermissions: () => readonly string[],
+  ) => {
+    accessCreations += 1
+    let disposed = false
+    const accessId = accessCreations
+    return {
+      acquire() {
+        if (disposed) throw new Error('PRESET_EDITOR_DISPOSED')
+        if (!getGrantedPermissions().includes('presets')) throw new Error('PERMISSION_DENIED:presets')
+        return {
+          getState() {
+            if (disposed) throw new Error('PRESET_EDITOR_DISPOSED')
+            return { accessId }
+          },
+        }
+      },
+      dispose() {
+        disposed = true
+      },
+    }
+  },
+}
+
+mock.module('@/store', () => ({ useStore: useStoreMock }))
+mock.module('@/ws/client', () => ({ wsClient: wsClientMock }))
+mock.module('@/api/spindle', () => ({ spindleApi: { getPermissions: () => permissionPromise } }))
+mock.module('@/api/characters', () => ({ charactersApi: { get: async () => null } }))
+mock.module('@/api/chats', () => ({ messagesApi: { update: async () => ({ id: 'message' }) } }))
+mock.module('./dom-helper', () => ({ createDOMHelper: () => ({ cleanup() {} }) }))
+mock.module('./message-interceptors', () => ({ registerTagInterceptor: () => () => {}, unregisterTagInterceptorsByExtension() {} }))
+mock.module('./display-resolver-registry', () => ({ registerDisplayResolver: () => () => {}, unregisterDisplayResolver() {} }))
+mock.module('@/hooks/useDisplayRegex', () => ({ invalidateDisplayRegexCache() {}, invalidateDisplayRegexCacheForVars() {} }))
+mock.module('./message-widgets', () => ({ removeMessageWidgetsByExtension() {}, upsertMessageWidget: () => {}, removeMessageWidget() {} }))
+mock.module('./placement-helper', () => ({
+  createDrawerTabHandle: () => ({ destroy() {} }),
+  createCharacterEditorTabHandle: () => ({ destroy() {} }),
+  createPresetEditorTabHandle: () => ({ destroy() {} }),
+  createPresetEditorToolbarItemHandle: () => ({ destroy() {} }),
+  createFloatWidgetHandle: () => ({ destroy() {} }),
+  createDockPanelHandle: () => ({ destroy() {} }),
+  createAppMountHandle: () => ({ destroy() {} }),
+  createInputBarActionHandle: () => ({ destroy() {} }),
+  createTabMobilityHandle: () => ({ requestTabLocation() {} }),
+  clearTabMobilityHandle() {},
+  destroyAllPlacementsForExtension(extensionId: string) { placementDestroyCalls.push(extensionId) },
+  destroyPresetEditorPlacementsForExtension(extensionId: string) { placementDestroyCalls.push(`preset:${extensionId}`) },
+}))
+mock.module('./character-editor-helper', () => ({
+  getCharacterEditorState: () => ({}),
+  subscribeCharacterEditorState: () => () => {},
+  setCharacterEditorExtensions() {},
+  updateCharacterEditorExtensions() {},
+  flushCharacterEditorExtensions: async () => {},
+}))
+mock.module('./preset-editor-helper', () => ({
+  getPresetEditorState: () => ({}),
+  subscribePresetEditorState: () => () => {},
+  updatePresetEditorDraft() {},
+  flushPresetEditorDraft: async () => {},
+}))
+mock.module('./preset-editor-access', () => presetAccessMock)
+mock.module('./components-helper', () => ({ createComponentsHelper: () => ({}), destroyAllComponentsForExtension() {} }))
+mock.module('@/lib/uuid', () => ({ generateUUID: () => 'request-id' }))
+mock.module('./navigation-guards', () => ({ installSpindleNavigationGuards() {} }))
+mock.module('@/lib/drawer-tab-registry', () => ({ DRAWER_TABS: [], ensureRegistryRoot: () => undefined }))
+mock.module('./ui-events-helper', () => ({ createUIEventsHelper: () => ({}) }))
+mock.module('./browser-scheduler', () => ({ yieldToBrowser: async () => {} }))
+
+const lifecycleModuleSource = `
+  export function teardown() {
+    globalThis["__lifecycleTeardownCalls"] = Number(globalThis["__lifecycleTeardownCalls"] || 0) + 1;
+  }
+  export function setup(context) {
+    globalThis["__lifecycleContext"] = context;
+    if (globalThis["__lifecycleCaptureHelper"]) {
+      globalThis["__lifecycleRetainedHelper"] = context["ui"]["presetEditor"]["extension"];
+    }
+    if (globalThis["__lifecycleMount"]) context["ui"]["mount"]('main');
+    const result = globalThis["__lifecycleSetupResult"];
+    if (globalThis["__lifecycleReturnStaticTeardown"] && result && typeof result["then"] === 'function') {
+      return result["then"](() => teardown);
+    }
+    return result;
+  }
+`
+lifecycleGlobals.__lifecycleModuleSource = lifecycleModuleSource
+
+globalThis.fetch = (async () => new Response(lifecycleModuleSource)) as unknown as typeof fetch
+
+const { getLoadedExtensions, loadFrontendExtension, unloadFrontendExtension } = await import('./loader')
+mock.restore()
+
+const manifest: SpindleManifest = {
+  version: '1.0.0',
+  name: 'Lifecycle test',
+  identifier: 'lifecycle_test',
+  author: 'test',
+  github: 'https://example.test/lifecycle',
+  homepage: 'https://example.test/lifecycle',
+  permissions: ['presets'],
+}
+
+type LifecycleContext = {
+  ui: {
+    mount(point: string): FakeRoot
+    presetEditor: {
+      extension: {
+        getState(): unknown
+      }
+    }
+  }
+  permissions: {
+    request(permissions: string[]): Promise<string[]>
+  }
+}
+
+function resetHarness(): void {
+  permissionPromise = Promise.resolve({ granted: [] })
+  lifecycleGlobals.__lifecycleSetupResult = undefined
+  lifecycleGlobals.__lifecycleContext = undefined
+  lifecycleGlobals.__lifecycleCaptureHelper = false
+  lifecycleGlobals.__lifecycleRetainedHelper = undefined
+  lifecycleGlobals.__lifecycleMount = false
+  lifecycleGlobals.__lifecycleReturnStaticTeardown = false
+  lifecycleGlobals.__lifecycleTeardownCalls = 0
+  storeState.pendingPermissionRequest = null
+  wsHandlers.clear()
+  windowHandlers.clear()
+  removedRoots.splice(0)
+  placementDestroyCalls.splice(0)
+  accessCreations = 0
+}
+
+async function flushLifecycleTasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+beforeAll(() => resetHarness())
+afterEach(() => resetHarness())
+
+describe('loader lifecycle orchestration', () => {
+  test('revocation observed before GET resolution wins, then a WS regrant creates fresh access', async () => {
+    let resolvePermissions!: (result: PermissionResult) => void
+    permissionPromise = new Promise<PermissionResult>((resolve) => {
+      resolvePermissions = resolve
+    })
+    const loading = loadFrontendExtension('revoke_before_get', manifest)
+    await Promise.resolve()
+    await Promise.resolve()
+    dispatchWs('SPINDLE_PERMISSION_CHANGED', {
+      extensionId: 'revoke_before_get',
+      allGranted: [],
+    })
+    resolvePermissions({ granted: ['presets'] })
+    await loading
+
+    const context = lifecycleGlobals.__lifecycleContext as LifecycleContext
+    expect(() => context.ui.presetEditor.extension).toThrow('PERMISSION_DENIED:presets')
+    dispatchWs('SPINDLE_PERMISSION_CHANGED', {
+      extensionId: 'revoke_before_get',
+      allGranted: ['presets'],
+    })
+    const fresh = context.ui.presetEditor.extension
+    expect(fresh.getState()).toMatchObject({ accessId: 2 })
+    await unloadFrontendExtension('revoke_before_get')
+  })
+
+  test('starts a fresh generation after unload invalidates a pending load', async () => {
+    const originalFetch = globalThis.fetch
+    let resolveFirstFetch!: (response: Response) => void
+    let fetchCount = 0
+    globalThis.fetch = (async () => {
+      fetchCount += 1
+      if (fetchCount === 1) {
+        return new Promise<Response>((resolve) => { resolveFirstFetch = resolve })
+      }
+      return new Response(lifecycleModuleSource)
+    }) as unknown as typeof fetch
+
+    try {
+      permissionPromise = Promise.resolve({ granted: [] })
+      const first = loadFrontendExtension('reload_after_invalidation', {
+        ...manifest,
+        identifier: 'reload_after_invalidation',
+      })
+      await Promise.resolve()
+      await Promise.resolve()
+      await unloadFrontendExtension('reload_after_invalidation')
+
+      const second = loadFrontendExtension('reload_after_invalidation', {
+        ...manifest,
+        identifier: 'reload_after_invalidation',
+      })
+      resolveFirstFetch(new Response(lifecycleModuleSource))
+      await Promise.all([first, second])
+
+      expect(fetchCount).toBe(2)
+      expect(getLoadedExtensions().has('reload_after_invalidation')).toBe(true)
+      await unloadFrontendExtension('reload_after_invalidation')
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  test('permission-request approval recreates access and rejects the retained helper', async () => {
+    permissionPromise = Promise.resolve({ granted: ['presets'] })
+    lifecycleGlobals.__lifecycleCaptureHelper = true
+    await loadFrontendExtension('request_regrant', { ...manifest, identifier: 'request_regrant' })
+
+    const context = lifecycleGlobals.__lifecycleContext as LifecycleContext
+    const retained = lifecycleGlobals.__lifecycleRetainedHelper as LifecycleContext['ui']['presetEditor']['extension']
+    dispatchWs('SPINDLE_PERMISSION_CHANGED', {
+      extensionId: 'request_regrant',
+      allGranted: [],
+    })
+    expect(() => retained.getState()).toThrow('PRESET_EDITOR_DISPOSED')
+
+    const request = context.permissions.request(['presets'])
+    dispatchWindow('spindle:permission-resolved', {
+      requestId: 'request-id',
+      approved: true,
+      granted: ['presets'],
+    })
+    await request
+    const fresh = context.ui.presetEditor.extension
+    expect(fresh.getState()).toMatchObject({ accessId: 2 })
+    await unloadFrontendExtension('request_regrant')
+  })
+
+  test('stale permission approval cannot restore access after a newer revoke', async () => {
+    permissionPromise = Promise.resolve({ granted: ['presets'] })
+    await loadFrontendExtension('stale_request', { ...manifest, identifier: 'stale_request' })
+
+    const context = lifecycleGlobals.__lifecycleContext as LifecycleContext
+    dispatchWs('SPINDLE_PERMISSION_CHANGED', {
+      extensionId: 'stale_request',
+      allGranted: [],
+    })
+    const request = context.permissions.request(['presets'])
+    dispatchWs('SPINDLE_PERMISSION_CHANGED', {
+      extensionId: 'stale_request',
+      allGranted: [],
+    })
+    dispatchWindow('spindle:permission-resolved', {
+      requestId: 'request-id',
+      approved: true,
+      granted: ['presets'],
+    })
+
+    expect(await request).toEqual([])
+    expect(() => context.ui.presetEditor.extension).toThrow('PERMISSION_DENIED:presets')
+    await unloadFrontendExtension('stale_request')
+  })
+
+  test('late setup rejection unloads roots, placements, and permission listeners', async () => {
+    let rejectSetup!: (error: Error) => void
+    lifecycleGlobals.__lifecycleSetupResult = new Promise<unknown>((_resolve, reject) => {
+      rejectSetup = reject
+    })
+    lifecycleGlobals.__lifecycleMount = true
+    const loading = loadFrontendExtension('late_setup_failure', { ...manifest, identifier: 'late_setup_failure' })
+    await loading
+    rejectSetup(new Error('late setup failure'))
+    await flushLifecycleTasks()
+
+    expect(getLoadedExtensions().has('late_setup_failure')).toBe(false)
+    expect(placementDestroyCalls).toContain('late_setup_failure')
+    expect(removedRoots.some((root) => root.removed)).toBe(true)
+    expect(wsHandlers.get('ws:SPINDLE_PERMISSION_CHANGED')?.size ?? 0).toBe(0)
+  })
+
+  test('late async setup teardown matching claimed static teardown runs once', async () => {
+    let resolveSetup!: () => void
+    lifecycleGlobals.__lifecycleReturnStaticTeardown = true
+    lifecycleGlobals.__lifecycleSetupResult = new Promise<void>((resolve) => {
+      resolveSetup = resolve
+    })
+    await loadFrontendExtension('same_teardown', { ...manifest, identifier: 'same_teardown' })
+    await unloadFrontendExtension('same_teardown')
+    resolveSetup()
+    await flushLifecycleTasks()
+
+    expect(lifecycleGlobals.__lifecycleTeardownCalls).toBe(1)
+  })
+})

--- a/frontend/src/lib/spindle/loader.test.ts
+++ b/frontend/src/lib/spindle/loader.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  adoptFrontendSetupTeardown,
+  createFrontendExtensionCleanup,
+  finalizeFrontendLoadFailure,
+  type FrontendExtensionCleanupResources,
+} from './frontend-extension-cleanup'
+
+function resources(teardown: () => void, events: string[]): FrontendExtensionCleanupResources {
+  return {
+    deactivatePresetEditor: () => { events.push('revoke') },
+    clearPresetEditorSubscriptions: () => { events.push('subscriptions') },
+    destroyPlacements: () => { events.push('placements') },
+    cleanupProcesses: () => { events.push('processes') },
+    teardown,
+    drainEventSubscriptions: () => { events.push('events') },
+    cleanupDomAndMounts: () => { events.push('dom') },
+    cleanupRegistries: () => { events.push('registries') },
+  }
+}
+
+describe('frontend extension cleanup lifecycle', () => {
+  test('setup-throw cleanup revokes authority and tears down each resource once', () => {
+    const events: string[] = []
+    let teardownCalls = 0
+    const loaded: { teardown?: () => void } = {}
+    const cleanup = createFrontendExtensionCleanup(resources(() => {
+      teardownCalls += 1
+      events.push('teardown')
+    }, events))
+
+    finalizeFrontendLoadFailure(cleanup, loaded, { superseded: false })
+    cleanup()
+
+    expect(events).toEqual([
+      'revoke',
+      'subscriptions',
+      'placements',
+      'processes',
+      'teardown',
+      'events',
+      'dom',
+      'registries',
+    ])
+    expect(teardownCalls).toBe(1)
+  })
+
+  test('superseded-generation cleanup assigns the returned teardown and runs it once', () => {
+    const events: string[] = []
+    let teardownCalls = 0
+    const loaded: { teardown?: () => void } = {
+      teardown: () => {
+        teardownCalls += 1
+        events.push('module-teardown')
+      },
+    }
+    const cleanup = createFrontendExtensionCleanup(resources(() => loaded.teardown?.(), events))
+    const returnedTeardown = () => {
+      teardownCalls += 1
+      events.push('returned-teardown')
+    }
+
+    finalizeFrontendLoadFailure(cleanup, loaded, {
+      superseded: true,
+      teardownResult: returnedTeardown,
+    })
+    cleanup()
+
+    expect(teardownCalls).toBe(1)
+    expect(events).toContain('returned-teardown')
+    expect(events).not.toContain('module-teardown')
+    expect(events.filter((event) => event === 'placements')).toHaveLength(1)
+    expect(events.filter((event) => event === 'events')).toHaveLength(1)
+  })
+
+  test('adopts current async teardown and executes stale async teardown after cleanup', () => {
+    let currentCalls = 0
+    const currentLoaded: { teardown?: () => void } = {}
+    const currentTeardown = () => { currentCalls += 1 }
+    adoptFrontendSetupTeardown(currentLoaded, currentTeardown, true)
+    currentLoaded.teardown?.()
+    expect(currentCalls).toBe(1)
+
+    let staleCalls = 0
+    let staleErrors = 0
+    const originalTeardown = () => { staleCalls += 1 }
+    const staleLoaded: { teardown?: () => void } = { teardown: originalTeardown }
+    const staleTeardown = () => { staleCalls += 1 }
+    adoptFrontendSetupTeardown(staleLoaded, staleTeardown, false, () => { staleErrors += 1 })
+    expect(staleLoaded.teardown).toBe(originalTeardown)
+    expect(staleCalls).toBe(1)
+
+    adoptFrontendSetupTeardown(
+      staleLoaded,
+      () => { throw new Error('stale teardown failed') },
+      false,
+      () => { staleErrors += 1 },
+    )
+    expect(staleErrors).toBe(1)
+  })
+})

--- a/frontend/src/lib/spindle/loader.test.ts
+++ b/frontend/src/lib/spindle/loader.test.ts
@@ -3,8 +3,18 @@ import {
   adoptFrontendSetupTeardown,
   createFrontendExtensionCleanup,
   finalizeFrontendLoadFailure,
+  isPermissionBootstrapCurrent,
+  observeFrontendSetupTeardown,
   type FrontendExtensionCleanupResources,
 } from './frontend-extension-cleanup'
+
+function invokeLoadedTeardown(loaded: { teardown?: () => void; teardownClaimed?: boolean }): void {
+  if (loaded.teardownClaimed) return
+  const teardown = loaded.teardown
+  if (!teardown) return
+  loaded.teardownClaimed = true
+  teardown()
+}
 
 function resources(teardown: () => void, events: string[]): FrontendExtensionCleanupResources {
   return {
@@ -20,6 +30,17 @@ function resources(teardown: () => void, events: string[]): FrontendExtensionCle
 }
 
 describe('frontend extension cleanup lifecycle', () => {
+  test('does not let a revoke event get overwritten by the in-flight permission GET', () => {
+    let adopted: string[] | undefined
+    const requestVersion = 0
+    const revokeEventVersion = 1
+    if (isPermissionBootstrapCurrent(requestVersion, revokeEventVersion)) {
+      adopted = ['presets']
+    }
+
+    expect(adopted).toBeUndefined()
+    expect(isPermissionBootstrapCurrent(requestVersion, requestVersion)).toBe(true)
+  })
   test('setup-throw cleanup revokes authority and tears down each resource once', () => {
     const events: string[] = []
     let teardownCalls = 0
@@ -97,5 +118,56 @@ describe('frontend extension cleanup lifecycle', () => {
       () => { staleErrors += 1 },
     )
     expect(staleErrors).toBe(1)
+  })
+  test('deduplicates repeated stale setup teardowns before invoking them', () => {
+    let calls = 0
+    let errors = 0
+    const loaded: { teardown?: () => void; teardownClaimed?: boolean; staleTeardowns?: Set<() => void> } = {}
+    const staleTeardown = () => { calls += 1 }
+
+    adoptFrontendSetupTeardown(loaded, staleTeardown, false, () => { errors += 1 })
+    adoptFrontendSetupTeardown(loaded, staleTeardown, false, () => { errors += 1 })
+
+    expect(calls).toBe(1)
+    expect(errors).toBe(0)
+  })
+
+  test('reports a late current setup error so the loader can dispose the extension', async () => {
+    let errors = 0
+    const loaded: { teardown?: () => void } = {}
+    observeFrontendSetupTeardown(
+      Promise.reject(new Error('setup failed late')),
+      loaded,
+      () => true,
+      () => { errors += 1 },
+    )
+
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(errors).toBe(1)
+  })
+
+  test('claims static teardown before a stale async setup result settles', async () => {
+    let staticCalls = 0
+    let staleCalls = 0
+    const loaded: { teardown?: () => void; teardownClaimed?: boolean; staleTeardowns?: Set<() => void> } = {
+      teardown: () => { staticCalls += 1 },
+    }
+    const cleanup = createFrontendExtensionCleanup(resources(() => {
+      invokeLoadedTeardown(loaded)
+    }, []))
+    let resolveSetup!: (teardown: () => void) => void
+    const setup = new Promise<() => void>((resolve) => {
+      resolveSetup = resolve
+    })
+
+    observeFrontendSetupTeardown(setup, loaded, () => false, () => {})
+    cleanup()
+    resolveSetup(() => { staleCalls += 1 })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(staticCalls).toBe(1)
+    expect(staleCalls).toBe(1)
   })
 })

--- a/frontend/src/lib/spindle/loader.ts
+++ b/frontend/src/lib/spindle/loader.ts
@@ -52,6 +52,11 @@ import { charactersApi } from '@/api/characters'
 import { messagesApi } from '@/api/chats'
 import { useStore } from '@/store'
 import { yieldToBrowser } from './browser-scheduler'
+import {
+  adoptFrontendSetupTeardown,
+  createFrontendExtensionCleanup,
+  finalizeFrontendLoadFailure,
+} from './frontend-extension-cleanup'
 
 interface LoadedExtension {
   id: string
@@ -282,6 +287,7 @@ function getFrontendBundleUrl(extensionId: string, manifest: SpindleManifest): s
     : getManifestSignature(manifest)
   return `/api/v1/spindle/${extensionId}/frontend?v=${encodeURIComponent(version)}`
 }
+
 
 async function doLoadFrontendExtension(
   extensionId: string,
@@ -990,101 +996,83 @@ async function doLoadFrontendExtension(
       manifest,
     }
 
-    let cleanupComplete = false
-    let teardownInvoked = false
-    const cleanup = (reportTeardownError = false): void => {
-      if (cleanupComplete) return
-      cleanupComplete = true
-
-      // Revoke extension authority before invoking any extension-owned callbacks.
-      loaded.deactivatePresetEditor()
-
-      try {
-        clearPresetEditorSubscriptions()
-      } catch {
-        // no-op
-      }
-      try {
-        destroyAllPlacementsForExtension(extensionId)
-      } catch {
-        // no-op
-      }
-
-      for (const process of Array.from(loaded.activeProcesses.values())) {
-        try {
-          loaded.activeProcesses.delete(process.processId)
-          process.terminal = true
-          void process.cleanup?.()
-          process.messageHandlers.clear()
-          process.stopHandlers.clear()
-          wsClient.send({
-            type: 'SPINDLE_FRONTEND_PROCESS_EVENT',
-            extensionId,
-            processId: process.processId,
-            event: 'frontend_unloaded',
-          })
-        } catch {
-          // no-op
-        }
-      }
-
-      if (!teardownInvoked) {
-        teardownInvoked = true
-        try {
-          loaded.teardown?.()
-        } catch (err) {
-          if (reportTeardownError) {
-            console.error(`[Spindle] Teardown error for ${loaded.identifier}:`, err)
-          }
-        }
-      }
-
-      while (loaded.eventUnsubs.length > 0) {
-        const unsubs = loaded.eventUnsubs.splice(0)
-        for (const unsub of unsubs) {
+    const cleanup = createFrontendExtensionCleanup({
+      deactivatePresetEditor: () => loaded.deactivatePresetEditor(),
+      clearPresetEditorSubscriptions,
+      destroyPlacements: () => destroyAllPlacementsForExtension(extensionId),
+      cleanupProcesses: () => {
+        for (const process of Array.from(loaded.activeProcesses.values())) {
           try {
-            unsub()
+            loaded.activeProcesses.delete(process.processId)
+            process.terminal = true
+            void process.cleanup?.()
+            process.messageHandlers.clear()
+            process.stopHandlers.clear()
+            wsClient.send({
+              type: 'SPINDLE_FRONTEND_PROCESS_EVENT',
+              extensionId,
+              processId: process.processId,
+              event: 'frontend_unloaded',
+            })
           } catch {
             // no-op
           }
         }
-      }
-
-      try {
-        loaded.context.dom.cleanup()
-      } catch {
-        // no-op
-      }
-      const stopMountSync = loaded.stopMountSync
-      loaded.stopMountSync = undefined
-      try {
-        stopMountSync?.()
-      } catch {
-        // no-op
-      }
-      for (const node of loaded.mountRoots) {
+      },
+      teardown: () => loaded.teardown?.(),
+      reportTeardownError: (error) => {
+        console.error(`[Spindle] Teardown error for ${loaded.identifier}:`, error)
+      },
+      drainEventSubscriptions: () => {
+        while (loaded.eventUnsubs.length > 0) {
+          const unsubs = loaded.eventUnsubs.splice(0)
+          for (const unsub of unsubs) {
+            try {
+              unsub()
+            } catch {
+              // no-op
+            }
+          }
+        }
+      },
+      cleanupDomAndMounts: () => {
         try {
-          node.remove()
+          loaded.context.dom.cleanup()
         } catch {
           // no-op
         }
-      }
-      loaded.mountRoots = []
+        const stopMountSync = loaded.stopMountSync
+        loaded.stopMountSync = undefined
+        try {
+          stopMountSync?.()
+        } catch {
+          // no-op
+        }
+        for (const node of loaded.mountRoots) {
+          try {
+            node.remove()
+          } catch {
+            // no-op
+          }
+        }
+        loaded.mountRoots = []
+      },
+      cleanupRegistries: () => {
+        clearReadyTimeout(loaded)
+        loaded.backendHandlers.clear()
+        loaded.processHandlers.clear()
+        loaded.activeProcesses.clear()
+        unregisterTagInterceptorsByExtension(extensionId)
+        unregisterDisplayResolver(loaded.identifier)
+        removeMessageWidgetsByExtension(extensionId)
+        destroyAllComponentsForExtension(extensionId)
+        clearTabMobilityHandle(extensionId)
 
-      clearReadyTimeout(loaded)
-      loaded.backendHandlers.clear()
-      loaded.processHandlers.clear()
-      loaded.activeProcesses.clear()
-      unregisterTagInterceptorsByExtension(extensionId)
-      unregisterDisplayResolver(loaded.identifier)
-      removeMessageWidgetsByExtension(extensionId)
-      destroyAllComponentsForExtension(extensionId)
-      clearTabMobilityHandle(extensionId)
-
-      if (loadedExtensions.get(extensionId) === loaded) {
-        loadedExtensions.delete(extensionId)
-      }
-    }
+        if (loadedExtensions.get(extensionId) === loaded) {
+          loadedExtensions.delete(extensionId)
+        }
+      },
+    })
     cleanupLoadedExtension = cleanup
 
     loaded = {
@@ -1118,14 +1106,14 @@ async function doLoadFrontendExtension(
       await yieldToBrowser({ when: 'paint' })
       teardownResult = mod.setup(context)
     } catch (err) {
-      cleanupLoadedExtension?.()
+      finalizeFrontendLoadFailure(cleanupLoadedExtension, loaded, { superseded: false })
       throw err
     }
     if (!currentGeneration()) {
-      if (typeof teardownResult === 'function') {
-        loaded.teardown = teardownResult as () => void
-      }
-      cleanupLoadedExtension?.()
+      finalizeFrontendLoadFailure(cleanupLoadedExtension, loaded, {
+        superseded: true,
+        teardownResult,
+      })
       return
     }
 
@@ -1135,10 +1123,12 @@ async function doLoadFrontendExtension(
     if (isPromiseLike(teardownResult)) {
       void Promise.resolve(teardownResult)
         .then((resolved) => {
-          if (!isCurrentLoadedExtension(loaded)) return
-          if (typeof resolved === 'function') {
-            loaded.teardown = resolved as () => void
-          }
+          adoptFrontendSetupTeardown(
+            loaded,
+            resolved,
+            isCurrentLoadedExtension(loaded),
+            (error) => console.error(`[Spindle] Async setup teardown error for ${loaded.identifier}:`, error),
+          )
         })
         .catch((err) => {
           if (!isCurrentLoadedExtension(loaded)) return

--- a/frontend/src/lib/spindle/loader.ts
+++ b/frontend/src/lib/spindle/loader.ts
@@ -53,9 +53,10 @@ import { messagesApi } from '@/api/chats'
 import { useStore } from '@/store'
 import { yieldToBrowser } from './browser-scheduler'
 import {
-  adoptFrontendSetupTeardown,
   createFrontendExtensionCleanup,
   finalizeFrontendLoadFailure,
+  isPermissionBootstrapCurrent,
+  observeFrontendSetupTeardown,
 } from './frontend-extension-cleanup'
 
 interface LoadedExtension {
@@ -66,6 +67,8 @@ interface LoadedExtension {
   module: SpindleFrontendModule
   context: SpindleFrontendContext
   teardown?: () => void
+  teardownClaimed: boolean
+  staleTeardowns: Set<() => void>
   eventUnsubs: (() => void)[]
   deactivatePresetEditor(): void
   backendHandlers: Set<(payload: unknown) => void>
@@ -167,11 +170,17 @@ type PendingStartupItem =
     }
 
 const loadedExtensions = new Map<string, LoadedExtension>()
-const loadInFlight = new Map<string, { promise: Promise<void>; force: boolean; manifestSignature: string }>()
+const loadInFlight = new Map<string, {
+  promise: Promise<void>
+  force: boolean
+  manifestSignature: string
+  invalidated: boolean
+}>()
 const loadGeneration = new Map<string, number>()
 const recentForceLoads = new Map<string, { manifestSignature: string; completedAt: number }>()
 const FORCE_LOAD_DEDUPE_MS = 2000
 const pendingStartupItems = new Map<string, PendingStartupItem[]>()
+const pendingPermissionBootstraps = new Map<string, () => void>()
 const MAX_PENDING_STARTUP_ITEMS = 100
 const FRONTEND_READY_TIMEOUT_MS = 10_000
 const extensionMountPoints = new Map<string, Set<SpindleMountPoint>>()
@@ -227,9 +236,6 @@ function queueStartupItem(extensionId: string, item: PendingStartupItem): void {
   pendingStartupItems.set(extensionId, queue)
 }
 
-function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
-  return !!value && typeof value === 'object' && typeof (value as PromiseLike<unknown>).then === 'function'
-}
 
 function clearReadyTimeout(loaded: LoadedExtension): void {
   if (loaded.readyTimeout) {
@@ -296,10 +302,6 @@ async function doLoadFrontendExtension(
 ): Promise<void> {
   let loaded!: LoadedExtension
   let cleanupLoadedExtension: ((reportTeardownError?: boolean) => void) | undefined
-  const generation = (loadGeneration.get(extensionId) || 0) + 1
-  loadGeneration.set(extensionId, generation)
-
-  const currentGeneration = () => loadGeneration.get(extensionId) === generation
   const manifestSignature = getManifestSignature(manifest)
   const existing = loadedExtensions.get(extensionId)
 
@@ -308,27 +310,138 @@ async function doLoadFrontendExtension(
   }
 
   if (existing) {
-    await unloadFrontendExtension(extensionId)
+    await unloadFrontendExtension(extensionId, { invalidateGeneration: false })
   }
 
+  const generation = (loadGeneration.get(extensionId) || 0) + 1
+  loadGeneration.set(extensionId, generation)
+  const currentGeneration = () => loadGeneration.get(extensionId) === generation
   const bundleUrl = getFrontendBundleUrl(extensionId, manifest)
+  const eventUnsubs: (() => void)[] = []
+  let cachedGrantedPermissions: string[] = []
+  let permissionEventVersion = 0
+  let presetEditorActive = true
+  let presetEditorAccessRevoked = false
+  const presetEditorUnsubscribers = new Set<() => void>()
+  const trackPresetEditorSubscription = (unsubscribe: () => void): (() => void) => {
+    const tracked = () => {
+      if (!presetEditorUnsubscribers.delete(tracked)) return
+      unsubscribe()
+    }
+    presetEditorUnsubscribers.add(tracked)
+    return tracked
+  }
+  const clearPresetEditorSubscriptions = () => {
+    for (const unsubscribe of [...presetEditorUnsubscribers]) {
+      unsubscribe()
+    }
+  }
+  let scopedPresetAccess = createPresetEditorAccess(
+    manifest.identifier,
+    () => cachedGrantedPermissions,
+    trackPresetEditorSubscription,
+  )
+  const revokePresetEditorAccess = () => {
+    if (presetEditorAccessRevoked) return
+    presetEditorAccessRevoked = true
+    scopedPresetAccess.dispose()
+    clearPresetEditorSubscriptions()
+    destroyPresetEditorPlacementsForExtension(extensionId)
+  }
+  const restorePresetEditorAccess = () => {
+    if (!presetEditorAccessRevoked) return
+    scopedPresetAccess = createPresetEditorAccess(
+      manifest.identifier,
+      () => cachedGrantedPermissions,
+      trackPresetEditorSubscription,
+    )
+    presetEditorAccessRevoked = false
+  }
+  const assertPresetPermission = () => {
+    if (!presetEditorActive) {
+      throw new Error('PRESET_EDITOR_DISPOSED: Extension frontend has been unloaded')
+    }
+    if (!cachedGrantedPermissions.includes('presets')) {
+      throw new Error('PERMISSION_DENIED:presets — preset editor operation requires the presets permission')
+    }
+  }
+  let permissionBootstrapCleaned = false
+  const cleanupPermissionBootstrap = () => {
+    if (permissionBootstrapCleaned) return
+    permissionBootstrapCleaned = true
+    pendingStartupItems.delete(extensionId)
+    if (pendingPermissionBootstraps.get(extensionId) === cleanupPermissionBootstrap) {
+      pendingPermissionBootstraps.delete(extensionId)
+    }
+    while (eventUnsubs.length > 0) {
+      const unsubs = eventUnsubs.splice(0)
+      for (const unsubscribe of unsubs) {
+        try {
+          unsubscribe()
+        } catch {
+          // no-op
+        }
+      }
+    }
+    try {
+      clearPresetEditorSubscriptions()
+    } catch {
+      // no-op
+    }
+    scopedPresetAccess.dispose()
+  }
+  pendingPermissionBootstraps.set(extensionId, cleanupPermissionBootstrap)
+  const unsubPermissionSync = wsClient.on('SPINDLE_PERMISSION_CHANGED', (payload: unknown) => {
+    if (!currentGeneration()) return
+    if (typeof payload !== 'object' || payload === null || !('extensionId' in payload) || !('allGranted' in payload)) return
+    const payloadExtensionId = payload.extensionId
+    const allGrantedValue = payload.allGranted
+    if (
+      payloadExtensionId !== extensionId
+      || !Array.isArray(allGrantedValue)
+      || !allGrantedValue.every((permission): permission is string => typeof permission === 'string')
+    ) return
+    permissionEventVersion += 1
+    cachedGrantedPermissions = allGrantedValue
+    if (cachedGrantedPermissions.includes('presets')) {
+      restorePresetEditorAccess()
+    } else {
+      revokePresetEditorAccess()
+    }
+  })
+  eventUnsubs.push(unsubPermissionSync)
 
   try {
     const responsePromise = fetch(bundleUrl)
+    const permissionReadVersion = permissionEventVersion
     const permissionsPromise = spindleApi.getPermissions(extensionId)
       .then((permRes) => permRes.granted)
       .catch(() => [] as string[])
     installSpindleNavigationGuards()
 
     const response = await responsePromise
-    if (!response.ok) return // No frontend bundle
+    if (!response.ok) {
+      cleanupPermissionBootstrap()
+      return // No frontend bundle
+    }
 
     const blob = await response.blob()
     const blobUrl = URL.createObjectURL(blob)
-
-    await yieldToBrowser({ when: 'paint' })
-    const mod: SpindleFrontendModule = await import(/* @vite-ignore */ blobUrl)
-    URL.revokeObjectURL(blobUrl)
+    let mod!: SpindleFrontendModule
+    try {
+      if (currentGeneration()) {
+        await yieldToBrowser({ when: 'paint' })
+        if (currentGeneration()) {
+          mod = await import(/* @vite-ignore */ blobUrl)
+        }
+      }
+    } finally {
+      URL.revokeObjectURL(blobUrl)
+    }
+    if (!currentGeneration()) {
+      cleanupPermissionBootstrap()
+      return
+    }
 
     // Frontend extensions still execute in the Lumiverse document context so
     // existing UI roots remain fully interactive. Scriptable iframe content must
@@ -336,10 +449,10 @@ async function doLoadFrontendExtension(
 
     if (typeof mod.setup !== 'function') {
       console.warn(`[Spindle:${manifest.identifier}] Frontend module missing setup()`)
+      cleanupPermissionBootstrap()
       return
     }
 
-    const eventUnsubs: (() => void)[] = []
     const backendHandlers = new Set<(payload: unknown) => void>()
     const processHandlers = new Map<string, FrontendProcessHandler>()
     const activeProcesses = new Map<string, ActiveFrontendProcess>()
@@ -406,51 +519,17 @@ async function doLoadFrontendExtension(
     )
     const uiEvents = createUIEventsHelper(extensionId)
 
-    let cachedGrantedPermissions: string[] = await permissionsPromise
-    let presetEditorActive = true
-    const presetEditorUnsubscribers = new Set<() => void>()
-    const trackPresetEditorSubscription = (unsubscribe: () => void): (() => void) => {
-      const tracked = () => {
-        if (!presetEditorUnsubscribers.delete(tracked)) return
-        unsubscribe()
-      }
-      presetEditorUnsubscribers.add(tracked)
-      return tracked
+    const initialPermissions = await permissionsPromise
+    if (isPermissionBootstrapCurrent(permissionReadVersion, permissionEventVersion)) {
+      cachedGrantedPermissions = initialPermissions
     }
-    const clearPresetEditorSubscriptions = () => {
-      for (const unsubscribe of [...presetEditorUnsubscribers]) {
-        unsubscribe()
-      }
+    if (!currentGeneration()) {
+      cleanupPermissionBootstrap()
+      return
     }
-
-    const scopedPresetAccess = createPresetEditorAccess(
-      manifest.identifier,
-      () => cachedGrantedPermissions,
-      trackPresetEditorSubscription,
-    )
-
-    const assertPresetPermission = () => {
-      if (!presetEditorActive) {
-        throw new Error('PRESET_EDITOR_DISPOSED: Extension frontend has been unloaded')
-      }
-      if (!cachedGrantedPermissions.includes('presets')) {
-        throw new Error('PERMISSION_DENIED:presets — preset editor operation requires the presets permission')
-      }
-    }
-
-    const unsubPermissionSync = wsClient.on('SPINDLE_PERMISSION_CHANGED', (payload: any) => {
-      if (payload?.extensionId !== extensionId || !Array.isArray(payload.allGranted)) return
-      const hadPresetPermission = cachedGrantedPermissions.includes('presets')
-      cachedGrantedPermissions = payload.allGranted
-      if (hadPresetPermission && !cachedGrantedPermissions.includes('presets')) {
-        scopedPresetAccess.revoke()
-        clearPresetEditorSubscriptions()
-        destroyPresetEditorPlacementsForExtension(extensionId)
-      }
-    })
-    eventUnsubs.push(unsubPermissionSync, clearPresetEditorSubscriptions)
     const mountedPoints = new Set<string>()
     let openModalCount = 0
+    const pendingPermissionCleanups = new Set<() => void>()
 
     const attachMountRoots = () => {
       if (document.body.hasAttribute('data-chat-chrome-entering')) {
@@ -642,6 +721,7 @@ async function doLoadFrontendExtension(
         },
         presetEditor: {
           get extension() {
+            assertPresetPermission()
             return scopedPresetAccess.acquire()
           },
           getState() {
@@ -862,19 +942,44 @@ async function doLoadFrontendExtension(
           if (needed.length === 0) return cachedGrantedPermissions
 
           const requestId = generateUUID()
+          const requestPermissionVersion = permissionEventVersion
 
           return new Promise<string[]>((resolve, reject) => {
-            const handler = ((e: CustomEvent) => {
-              if (e.detail.requestId !== requestId) return
+            let settled = false
+            const complete = (approved: boolean, granted: string[]) => {
+              if (settled) return
+              settled = true
               window.removeEventListener('spindle:permission-resolved', handler)
-              if (e.detail.approved) {
-                cachedGrantedPermissions = e.detail.granted
-                resolve(e.detail.granted)
+              pendingPermissionCleanups.delete(cancel)
+              if (approved) {
+                if (permissionEventVersion !== requestPermissionVersion) {
+                  resolve([...cachedGrantedPermissions])
+                  return
+                }
+                permissionEventVersion += 1
+                cachedGrantedPermissions = granted
+                if (cachedGrantedPermissions.includes('presets')) {
+                  restorePresetEditorAccess()
+                } else {
+                  revokePresetEditorAccess()
+                }
+                resolve(granted)
               } else {
                 reject(new Error('Permission request denied by user'))
               }
+            }
+            const handler = ((e: CustomEvent) => {
+              if (e.detail.requestId !== requestId) return
+              complete(!!e.detail.approved, e.detail.granted ?? [])
             }) as EventListener
-
+            const cancel = () => {
+              complete(false, [])
+              const pending = useStore.getState().pendingPermissionRequest
+              if (pending?.id === requestId && pending.extensionId === extensionId) {
+                useStore.setState({ pendingPermissionRequest: null })
+              }
+            }
+            pendingPermissionCleanups.add(cancel)
             window.addEventListener('spindle:permission-resolved', handler)
 
             useStore.getState().showPermissionRequest({
@@ -1019,7 +1124,14 @@ async function doLoadFrontendExtension(
           }
         }
       },
-      teardown: () => loaded.teardown?.(),
+      teardown: () => {
+        if (loaded.teardownClaimed) return
+        const teardown = loaded.teardown
+        if (!teardown) return
+        // Claim before invoking so a late async setup result cannot repeat it.
+        loaded.teardownClaimed = true
+        teardown()
+      },
       reportTeardownError: (error) => {
         console.error(`[Spindle] Teardown error for ${loaded.identifier}:`, error)
       },
@@ -1058,6 +1170,13 @@ async function doLoadFrontendExtension(
         loaded.mountRoots = []
       },
       cleanupRegistries: () => {
+        for (const cancel of [...pendingPermissionCleanups]) {
+          try {
+            cancel()
+          } catch {
+            // no-op
+          }
+        }
         clearReadyTimeout(loaded)
         loaded.backendHandlers.clear()
         loaded.processHandlers.clear()
@@ -1074,6 +1193,7 @@ async function doLoadFrontendExtension(
       },
     })
     cleanupLoadedExtension = cleanup
+    pendingPermissionBootstraps.delete(extensionId)
 
     loaded = {
       id: extensionId,
@@ -1083,6 +1203,8 @@ async function doLoadFrontendExtension(
       module: mod,
       context,
       teardown: mod.teardown,
+      teardownClaimed: false,
+      staleTeardowns: new Set(),
       eventUnsubs,
       deactivatePresetEditor: () => {
         presetEditorActive = false
@@ -1102,13 +1224,33 @@ async function doLoadFrontendExtension(
 
     let teardownResult: unknown
     try {
+      if (!currentGeneration()) {
+        finalizeFrontendLoadFailure(cleanupLoadedExtension, loaded, { superseded: true })
+        return
+      }
       loadedExtensions.set(extensionId, loaded)
       await yieldToBrowser({ when: 'paint' })
+      if (!currentGeneration()) {
+        finalizeFrontendLoadFailure(cleanupLoadedExtension, loaded, { superseded: true })
+        return
+      }
       teardownResult = mod.setup(context)
     } catch (err) {
       finalizeFrontendLoadFailure(cleanupLoadedExtension, loaded, { superseded: false })
       throw err
     }
+    observeFrontendSetupTeardown(
+      teardownResult,
+      loaded,
+      () => isCurrentLoadedExtension(loaded),
+      (error) => {
+        console.error(`[Spindle] Async setup error for ${loaded.identifier}:`, error)
+        void unloadFrontendExtension(loaded.id)
+      },
+      (error) => {
+        console.error(`[Spindle] Stale async setup teardown error for ${loaded.identifier}:`, error)
+      },
+    )
     if (!currentGeneration()) {
       finalizeFrontendLoadFailure(cleanupLoadedExtension, loaded, {
         superseded: true,
@@ -1119,25 +1261,10 @@ async function doLoadFrontendExtension(
 
     loaded.setupComplete = true
     loaded.mountRoots = Array.from(mountRoots.values())
-
-    if (isPromiseLike(teardownResult)) {
-      void Promise.resolve(teardownResult)
-        .then((resolved) => {
-          adoptFrontendSetupTeardown(
-            loaded,
-            resolved,
-            isCurrentLoadedExtension(loaded),
-            (error) => console.error(`[Spindle] Async setup teardown error for ${loaded.identifier}:`, error),
-          )
-        })
-        .catch((err) => {
-          if (!isCurrentLoadedExtension(loaded)) return
-          console.error(`[Spindle] Async setup error for ${loaded.identifier}:`, err)
-          void unloadFrontendExtension(loaded.id)
-        })
-    } else if (typeof teardownResult === 'function') {
+    if (typeof teardownResult === 'function') {
       loaded.teardown = teardownResult as () => void
     }
+
 
     console.debug(`[Spindle] Loaded frontend: ${manifest.identifier}`)
     if (!loaded.isReady) {
@@ -1148,6 +1275,9 @@ async function doLoadFrontendExtension(
       }
     }
   } catch (err) {
+    if (!cleanupLoadedExtension) {
+      cleanupPermissionBootstrap()
+    }
     console.error(`[Spindle] Failed to load frontend for ${manifest.identifier}:`, err)
   }
 }
@@ -1167,7 +1297,7 @@ export async function loadFrontendExtension(
     }
   }
 
-  if (pending && (!force || (pending.force && pending.manifestSignature === manifestSignature))) {
+  if (pending && !pending.invalidated && (!force || (pending.force && pending.manifestSignature === manifestSignature))) {
     await pending.promise
     return
   }
@@ -1178,7 +1308,7 @@ export async function loadFrontendExtension(
     })
     .then(() => doLoadFrontendExtension(extensionId, manifest, force))
 
-  loadInFlight.set(extensionId, { promise: next, force, manifestSignature })
+  loadInFlight.set(extensionId, { promise: next, force, manifestSignature, invalidated: false })
   try {
     await next
     if (force) {
@@ -1191,7 +1321,17 @@ export async function loadFrontendExtension(
   }
 }
 
-export async function unloadFrontendExtension(extensionId: string): Promise<void> {
+export async function unloadFrontendExtension(
+  extensionId: string,
+  options: { invalidateGeneration?: boolean } = {},
+): Promise<void> {
+  if (options.invalidateGeneration !== false) {
+    loadGeneration.set(extensionId, (loadGeneration.get(extensionId) || 0) + 1)
+    pendingStartupItems.delete(extensionId)
+    pendingPermissionBootstraps.get(extensionId)?.()
+    const pendingLoad = loadInFlight.get(extensionId)
+    if (pendingLoad) pendingLoad.invalidated = true
+  }
   const loaded = loadedExtensions.get(extensionId)
   if (!loaded) return
 

--- a/frontend/src/lib/spindle/loader.ts
+++ b/frontend/src/lib/spindle/loader.ts
@@ -72,6 +72,7 @@ interface LoadedExtension {
   holdReady: boolean
   setupComplete: boolean
   readyTimeout: ReturnType<typeof setTimeout> | null
+  cleanup(reportTeardownError?: boolean): void
 }
 
 type FrontendProcessHandler = (
@@ -287,6 +288,8 @@ async function doLoadFrontendExtension(
   manifest: SpindleManifest,
   force = false
 ): Promise<void> {
+  let loaded!: LoadedExtension
+  let cleanupLoadedExtension: ((reportTeardownError?: boolean) => void) | undefined
   const generation = (loadGeneration.get(extensionId) || 0) + 1
   loadGeneration.set(extensionId, generation)
 
@@ -477,7 +480,6 @@ async function doLoadFrontendExtension(
       clearExtensionMountPoints(extensionId)
     }
 
-    let loaded!: LoadedExtension
     const context: FrontendExtensionContext = {
       dom,
       ready() {
@@ -988,6 +990,103 @@ async function doLoadFrontendExtension(
       manifest,
     }
 
+    let cleanupComplete = false
+    let teardownInvoked = false
+    const cleanup = (reportTeardownError = false): void => {
+      if (cleanupComplete) return
+      cleanupComplete = true
+
+      // Revoke extension authority before invoking any extension-owned callbacks.
+      loaded.deactivatePresetEditor()
+
+      try {
+        clearPresetEditorSubscriptions()
+      } catch {
+        // no-op
+      }
+      try {
+        destroyAllPlacementsForExtension(extensionId)
+      } catch {
+        // no-op
+      }
+
+      for (const process of Array.from(loaded.activeProcesses.values())) {
+        try {
+          loaded.activeProcesses.delete(process.processId)
+          process.terminal = true
+          void process.cleanup?.()
+          process.messageHandlers.clear()
+          process.stopHandlers.clear()
+          wsClient.send({
+            type: 'SPINDLE_FRONTEND_PROCESS_EVENT',
+            extensionId,
+            processId: process.processId,
+            event: 'frontend_unloaded',
+          })
+        } catch {
+          // no-op
+        }
+      }
+
+      if (!teardownInvoked) {
+        teardownInvoked = true
+        try {
+          loaded.teardown?.()
+        } catch (err) {
+          if (reportTeardownError) {
+            console.error(`[Spindle] Teardown error for ${loaded.identifier}:`, err)
+          }
+        }
+      }
+
+      while (loaded.eventUnsubs.length > 0) {
+        const unsubs = loaded.eventUnsubs.splice(0)
+        for (const unsub of unsubs) {
+          try {
+            unsub()
+          } catch {
+            // no-op
+          }
+        }
+      }
+
+      try {
+        loaded.context.dom.cleanup()
+      } catch {
+        // no-op
+      }
+      const stopMountSync = loaded.stopMountSync
+      loaded.stopMountSync = undefined
+      try {
+        stopMountSync?.()
+      } catch {
+        // no-op
+      }
+      for (const node of loaded.mountRoots) {
+        try {
+          node.remove()
+        } catch {
+          // no-op
+        }
+      }
+      loaded.mountRoots = []
+
+      clearReadyTimeout(loaded)
+      loaded.backendHandlers.clear()
+      loaded.processHandlers.clear()
+      loaded.activeProcesses.clear()
+      unregisterTagInterceptorsByExtension(extensionId)
+      unregisterDisplayResolver(loaded.identifier)
+      removeMessageWidgetsByExtension(extensionId)
+      destroyAllComponentsForExtension(extensionId)
+      clearTabMobilityHandle(extensionId)
+
+      if (loadedExtensions.get(extensionId) === loaded) {
+        loadedExtensions.delete(extensionId)
+      }
+    }
+    cleanupLoadedExtension = cleanup
+
     loaded = {
       id: extensionId,
       generation,
@@ -1010,6 +1109,7 @@ async function doLoadFrontendExtension(
       holdReady: false,
       setupComplete: false,
       readyTimeout: null,
+      cleanup,
     }
 
     let teardownResult: unknown
@@ -1018,31 +1118,14 @@ async function doLoadFrontendExtension(
       await yieldToBrowser({ when: 'paint' })
       teardownResult = mod.setup(context)
     } catch (err) {
-      if (loadedExtensions.get(extensionId) === loaded) {
-        loadedExtensions.delete(extensionId)
-      }
-      clearReadyTimeout(loaded)
-      dom.cleanup()
-      cleanupMountInfra()
+      cleanupLoadedExtension?.()
       throw err
     }
-
     if (!currentGeneration()) {
-      try {
-        if (typeof teardownResult === 'function') {
-          teardownResult()
-        } else {
-          mod.teardown?.()
-        }
-      } catch {
-        // no-op
+      if (typeof teardownResult === 'function') {
+        loaded.teardown = teardownResult as () => void
       }
-      if (loadedExtensions.get(extensionId) === loaded) {
-        loadedExtensions.delete(extensionId)
-      }
-      clearReadyTimeout(loaded)
-      dom.cleanup()
-      cleanupMountInfra()
+      cleanupLoadedExtension?.()
       return
     }
 
@@ -1122,58 +1205,7 @@ export async function unloadFrontendExtension(extensionId: string): Promise<void
   const loaded = loadedExtensions.get(extensionId)
   if (!loaded) return
 
-  for (const process of Array.from(loaded.activeProcesses.values())) {
-    try {
-      loaded.activeProcesses.delete(process.processId)
-      process.terminal = true
-      void process.cleanup?.()
-      process.messageHandlers.clear()
-      process.stopHandlers.clear()
-      wsClient.send({
-        type: 'SPINDLE_FRONTEND_PROCESS_EVENT',
-        extensionId,
-        processId: process.processId,
-        event: 'frontend_unloaded',
-      })
-    } catch {
-      // no-op
-    }
-  }
-
-  loaded.deactivatePresetEditor()
-
-  try {
-    loaded.teardown?.()
-  } catch (err) {
-    console.error(`[Spindle] Teardown error for ${loaded.identifier}:`, err)
-  }
-
-  // Clean up DOM
-  loaded.context.dom.cleanup()
-  loaded.stopMountSync?.()
-  for (const node of loaded.mountRoots) {
-    try {
-      node.remove()
-    } catch {
-      // no-op
-    }
-  }
-
-  // Clean up event subscriptions
-  for (const unsub of loaded.eventUnsubs) {
-    unsub()
-  }
-
-  clearReadyTimeout(loaded)
-  loaded.backendHandlers.clear()
-  loaded.processHandlers.clear()
-  unregisterTagInterceptorsByExtension(extensionId)
-  unregisterDisplayResolver(loaded.identifier)
-  removeMessageWidgetsByExtension(extensionId)
-  destroyAllComponentsForExtension(extensionId)
-  destroyAllPlacementsForExtension(extensionId)
-  clearTabMobilityHandle(extensionId)
-  loadedExtensions.delete(extensionId)
+  loaded.cleanup(true)
 
   console.debug(`[Spindle] Unloaded frontend: ${loaded.identifier}`)
 }

--- a/frontend/src/lib/spindle/loader.ts
+++ b/frontend/src/lib/spindle/loader.ts
@@ -62,6 +62,7 @@ interface LoadedExtension {
   context: SpindleFrontendContext
   teardown?: () => void
   eventUnsubs: (() => void)[]
+  deactivatePresetEditor(): void
   backendHandlers: Set<(payload: unknown) => void>
   processHandlers: Map<string, FrontendProcessHandler>
   activeProcesses: Map<string, ActiveFrontendProcess>
@@ -397,6 +398,7 @@ async function doLoadFrontendExtension(
     const uiEvents = createUIEventsHelper(extensionId)
 
     let cachedGrantedPermissions: string[] = await permissionsPromise
+    let presetEditorActive = true
     const presetEditorUnsubscribers = new Set<() => void>()
     const trackPresetEditorSubscription = (unsubscribe: () => void): (() => void) => {
       const tracked = () => {
@@ -417,6 +419,15 @@ async function doLoadFrontendExtension(
       () => cachedGrantedPermissions,
       trackPresetEditorSubscription,
     )
+
+    const assertPresetPermission = () => {
+      if (!presetEditorActive) {
+        throw new Error('PRESET_EDITOR_DISPOSED: Extension frontend has been unloaded')
+      }
+      if (!cachedGrantedPermissions.includes('presets')) {
+        throw new Error('PERMISSION_DENIED:presets — preset editor operation requires the presets permission')
+      }
+    }
 
     const unsubPermissionSync = wsClient.on('SPINDLE_PERMISSION_CHANGED', (payload: any) => {
       if (payload?.extensionId !== extensionId || !Array.isArray(payload.allGranted)) return
@@ -532,18 +543,12 @@ async function doLoadFrontendExtension(
           return createCharacterEditorTabHandle(extensionId, options)
         },
         registerPresetEditorTab(options) {
-          const granted = cachedGrantedPermissions
-          if (!granted.includes('presets')) {
-            throw new Error('PERMISSION_DENIED:presets — registerPresetEditorTab requires the presets permission')
-          }
-          return createPresetEditorTabHandle(extensionId, options)
+          assertPresetPermission()
+          return createPresetEditorTabHandle(extensionId, options, assertPresetPermission)
         },
         registerPresetEditorToolbarItem(options) {
-          const granted = cachedGrantedPermissions
-          if (!granted.includes('presets')) {
-            throw new Error('PERMISSION_DENIED:presets — registerPresetEditorToolbarItem requires the presets permission')
-          }
-          return createPresetEditorToolbarItemHandle(extensionId, options)
+          assertPresetPermission()
+          return createPresetEditorToolbarItemHandle(extensionId, options, assertPresetPermission)
         },
         createFloatWidget(options) {
           const granted = cachedGrantedPermissions
@@ -632,31 +637,19 @@ async function doLoadFrontendExtension(
             return scopedPresetAccess.acquire()
           },
           getState() {
-            const granted = cachedGrantedPermissions
-            if (!granted.includes('presets')) {
-              throw new Error('PERMISSION_DENIED:presets — presetEditor.getState requires the presets permission')
-            }
+            assertPresetPermission()
             return getPresetEditorState()
           },
           onChange(handler) {
-            const granted = cachedGrantedPermissions
-            if (!granted.includes('presets')) {
-              throw new Error('PERMISSION_DENIED:presets — presetEditor.onChange requires the presets permission')
-            }
+            assertPresetPermission()
             return trackPresetEditorSubscription(subscribePresetEditorState(handler))
           },
           updatePreset(mutator, options) {
-            const granted = cachedGrantedPermissions
-            if (!granted.includes('presets')) {
-              throw new Error('PERMISSION_DENIED:presets — presetEditor.updatePreset requires the presets permission')
-            }
+            assertPresetPermission()
             updatePresetEditorDraft(mutator, options?.immediate === true)
           },
           flush() {
-            const granted = cachedGrantedPermissions
-            if (!granted.includes('presets')) {
-              throw new Error('PERMISSION_DENIED:presets — presetEditor.flush requires the presets permission')
-            }
+            assertPresetPermission()
             return flushPresetEditorDraft()
           },
         },
@@ -1004,6 +997,10 @@ async function doLoadFrontendExtension(
       context,
       teardown: mod.teardown,
       eventUnsubs,
+      deactivatePresetEditor: () => {
+        presetEditorActive = false
+        scopedPresetAccess.dispose()
+      },
       backendHandlers,
       processHandlers,
       activeProcesses,
@@ -1142,6 +1139,8 @@ export async function unloadFrontendExtension(extensionId: string): Promise<void
       // no-op
     }
   }
+
+  loaded.deactivatePresetEditor()
 
   try {
     loaded.teardown?.()

--- a/frontend/src/lib/spindle/loader.ts
+++ b/frontend/src/lib/spindle/loader.ts
@@ -17,6 +17,7 @@ import {
   createDrawerTabHandle,
   createCharacterEditorTabHandle,
   createPresetEditorTabHandle,
+  createPresetEditorToolbarItemHandle,
   createFloatWidgetHandle,
   createDockPanelHandle,
   createAppMountHandle,
@@ -24,6 +25,7 @@ import {
   createTabMobilityHandle,
   clearTabMobilityHandle,
   destroyAllPlacementsForExtension,
+  destroyPresetEditorPlacementsForExtension,
 } from './placement-helper'
 import {
   getCharacterEditorState,
@@ -37,6 +39,7 @@ import {
   subscribePresetEditorState,
   updatePresetEditorDraft,
   flushPresetEditorDraft,
+  createPresetEditorScopedHelper,
 } from './preset-editor-helper'
 import { createComponentsHelper, destroyAllComponentsForExtension } from './components-helper'
 import { generateUUID } from '@/lib/uuid'
@@ -393,16 +396,47 @@ async function doLoadFrontendExtension(
     )
     const uiEvents = createUIEventsHelper(extensionId)
 
-    // Cache granted permissions for synchronous permission checks in ui methods.
-    // Kept in sync via the SPINDLE_PERMISSION_CHANGED WS event so admin
-    // grant/revoke takes effect without a full extension reload.
     let cachedGrantedPermissions: string[] = await permissionsPromise
+    let presetPermissionEpoch = 0
+    const presetEditorUnsubscribers = new Set<() => void>()
+    const trackPresetEditorSubscription = (unsubscribe: () => void): (() => void) => {
+      const tracked = () => {
+        if (!presetEditorUnsubscribers.delete(tracked)) return
+        unsubscribe()
+      }
+      presetEditorUnsubscribers.add(tracked)
+      return tracked
+    }
+    const clearPresetEditorSubscriptions = () => {
+      for (const unsubscribe of [...presetEditorUnsubscribers]) {
+        unsubscribe()
+      }
+    }
+
+    const scopedPresetAccessEpoch = presetPermissionEpoch
+    const scopedPresetEditor = createPresetEditorScopedHelper(manifest.identifier, {
+      assertActive() {
+        if (!cachedGrantedPermissions.includes('presets')) {
+          throw new Error('PERMISSION_DENIED:presets — preset editor extension helper requires the presets permission')
+        }
+        if (presetPermissionEpoch !== scopedPresetAccessEpoch) {
+          throw new Error('PRESET_EDITOR_REVOKED: Register a new preset editor placement before using the extension helper')
+        }
+      },
+      trackSubscription: trackPresetEditorSubscription,
+    })
+
     const unsubPermissionSync = wsClient.on('SPINDLE_PERMISSION_CHANGED', (payload: any) => {
-      if (payload?.extensionId === extensionId && Array.isArray(payload.allGranted)) {
-        cachedGrantedPermissions = payload.allGranted
+      if (payload?.extensionId !== extensionId || !Array.isArray(payload.allGranted)) return
+      const hadPresetPermission = cachedGrantedPermissions.includes('presets')
+      cachedGrantedPermissions = payload.allGranted
+      if (hadPresetPermission && !cachedGrantedPermissions.includes('presets')) {
+        presetPermissionEpoch += 1
+        clearPresetEditorSubscriptions()
+        destroyPresetEditorPlacementsForExtension(extensionId)
       }
     })
-    eventUnsubs.push(unsubPermissionSync)
+    eventUnsubs.push(unsubPermissionSync, clearPresetEditorSubscriptions)
     const mountedPoints = new Set<string>()
     let openModalCount = 0
 
@@ -512,6 +546,13 @@ async function doLoadFrontendExtension(
           }
           return createPresetEditorTabHandle(extensionId, options)
         },
+        registerPresetEditorToolbarItem(options) {
+          const granted = cachedGrantedPermissions
+          if (!granted.includes('presets')) {
+            throw new Error('PERMISSION_DENIED:presets — registerPresetEditorToolbarItem requires the presets permission')
+          }
+          return createPresetEditorToolbarItemHandle(extensionId, options)
+        },
         createFloatWidget(options) {
           const granted = cachedGrantedPermissions
           if (!granted.includes('ui_panels')) {
@@ -595,6 +636,7 @@ async function doLoadFrontendExtension(
           },
         },
         presetEditor: {
+          extension: scopedPresetEditor,
           getState() {
             const granted = cachedGrantedPermissions
             if (!granted.includes('presets')) {
@@ -607,7 +649,7 @@ async function doLoadFrontendExtension(
             if (!granted.includes('presets')) {
               throw new Error('PERMISSION_DENIED:presets — presetEditor.onChange requires the presets permission')
             }
-            return subscribePresetEditorState(handler)
+            return trackPresetEditorSubscription(subscribePresetEditorState(handler))
           },
           updatePreset(mutator, options) {
             const granted = cachedGrantedPermissions

--- a/frontend/src/lib/spindle/loader.ts
+++ b/frontend/src/lib/spindle/loader.ts
@@ -39,8 +39,8 @@ import {
   subscribePresetEditorState,
   updatePresetEditorDraft,
   flushPresetEditorDraft,
-  createPresetEditorScopedHelper,
 } from './preset-editor-helper'
+import { createPresetEditorAccess } from './preset-editor-access'
 import { createComponentsHelper, destroyAllComponentsForExtension } from './components-helper'
 import { generateUUID } from '@/lib/uuid'
 import { installSpindleNavigationGuards } from './navigation-guards'
@@ -397,7 +397,6 @@ async function doLoadFrontendExtension(
     const uiEvents = createUIEventsHelper(extensionId)
 
     let cachedGrantedPermissions: string[] = await permissionsPromise
-    let presetPermissionEpoch = 0
     const presetEditorUnsubscribers = new Set<() => void>()
     const trackPresetEditorSubscription = (unsubscribe: () => void): (() => void) => {
       const tracked = () => {
@@ -413,25 +412,18 @@ async function doLoadFrontendExtension(
       }
     }
 
-    const scopedPresetAccessEpoch = presetPermissionEpoch
-    const scopedPresetEditor = createPresetEditorScopedHelper(manifest.identifier, {
-      assertActive() {
-        if (!cachedGrantedPermissions.includes('presets')) {
-          throw new Error('PERMISSION_DENIED:presets — preset editor extension helper requires the presets permission')
-        }
-        if (presetPermissionEpoch !== scopedPresetAccessEpoch) {
-          throw new Error('PRESET_EDITOR_REVOKED: Register a new preset editor placement before using the extension helper')
-        }
-      },
-      trackSubscription: trackPresetEditorSubscription,
-    })
+    const scopedPresetAccess = createPresetEditorAccess(
+      manifest.identifier,
+      () => cachedGrantedPermissions,
+      trackPresetEditorSubscription,
+    )
 
     const unsubPermissionSync = wsClient.on('SPINDLE_PERMISSION_CHANGED', (payload: any) => {
       if (payload?.extensionId !== extensionId || !Array.isArray(payload.allGranted)) return
       const hadPresetPermission = cachedGrantedPermissions.includes('presets')
       cachedGrantedPermissions = payload.allGranted
       if (hadPresetPermission && !cachedGrantedPermissions.includes('presets')) {
-        presetPermissionEpoch += 1
+        scopedPresetAccess.revoke()
         clearPresetEditorSubscriptions()
         destroyPresetEditorPlacementsForExtension(extensionId)
       }
@@ -636,7 +628,9 @@ async function doLoadFrontendExtension(
           },
         },
         presetEditor: {
-          extension: scopedPresetEditor,
+          get extension() {
+            return scopedPresetAccess.acquire()
+          },
           getState() {
             const granted = cachedGrantedPermissions
             if (!granted.includes('presets')) {

--- a/frontend/src/lib/spindle/placement-helper.test.ts
+++ b/frontend/src/lib/spindle/placement-helper.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
+import { createStore, type StoreApi } from 'zustand/vanilla'
+import * as presetEditorHelper from './preset-editor-helper'
+import type { SpindlePresetEditorState, SpindlePresetEditorTabHandle } from './preset-editor-types'
+import { createSpindlePlacementSlice } from '@/store/slices/spindle-placement'
+import type { SpindlePlacementSlice } from '@/types/store'
+
+// placement-helper imports the React store facade, which transitively loads
+// Vite-only import.meta.glob resources. Keep this test focused on the helper
+// by providing the same Zustand store API over the placement slice directly.
+const placementStoreFactory = createStore<SpindlePlacementSlice>()
+let placementStore: StoreApi<SpindlePlacementSlice> = placementStoreFactory(createSpindlePlacementSlice)
+const mockedUseStore = {
+  getState: () => placementStore.getState(),
+  setState: (...args: Parameters<StoreApi<SpindlePlacementSlice>['setState']>) => placementStore.setState(...args),
+  subscribe: (...args: Parameters<StoreApi<SpindlePlacementSlice>['subscribe']>) => placementStore.subscribe(...args),
+}
+mock.module('@/store', () => ({ useStore: mockedUseStore }))
+
+// The target module must load after the narrow store facade is registered.
+// This is a test-only module-loading boundary; production imports stay static.
+const { createPresetEditorTabHandle } = await import('./placement-helper')
+
+type TrackedRoot = {
+  root: HTMLElement
+  removed: boolean
+}
+
+const extensionId = 'placement-helper-test'
+const originalCreateElement = document.createElement.bind(document)
+const originalSubscribe = presetEditorHelper.subscribePresetEditorState
+
+let createdRoots: TrackedRoot[] = []
+let handles: SpindlePresetEditorTabHandle[] = []
+let activeSubscriptions = 0
+
+beforeEach(() => {
+  placementStore = placementStoreFactory(createSpindlePlacementSlice)
+  createdRoots = []
+  handles = []
+  activeSubscriptions = 0
+
+  document.createElement = ((tagName: string) => {
+    const root = originalCreateElement(tagName)
+    const entry: TrackedRoot = { root, removed: false }
+    root.remove = () => { entry.removed = true }
+    createdRoots.push(entry)
+    return root
+  }) as typeof document.createElement
+
+  spyOn(presetEditorHelper, 'subscribePresetEditorState').mockImplementation((handler: (state: SpindlePresetEditorState) => void) => {
+    activeSubscriptions += 1
+    const unsubscribe = originalSubscribe(handler)
+    let active = true
+    return () => {
+      if (!active) return
+      active = false
+      activeSubscriptions -= 1
+      unsubscribe()
+    }
+  })
+})
+
+afterEach(() => {
+  for (const handle of handles) handle.destroy()
+  placementStore = placementStoreFactory(createSpindlePlacementSlice)
+  document.createElement = originalCreateElement
+  mock.restore()
+})
+
+describe('preset editor tab registration', () => {
+  test('unwinds state subscription and root when per-extension or global cap rejects registration', () => {
+    for (let index = 0; index < 4; index += 1) {
+      handles.push(createPresetEditorTabHandle(extensionId, {
+        id: `per-extension-${index}`,
+        title: `Per-extension ${index}`,
+      }, () => {}))
+    }
+
+    expect(activeSubscriptions).toBe(4)
+    expect(() => createPresetEditorTabHandle(extensionId, {
+      id: 'per-extension-overflow',
+      title: 'Per-extension overflow',
+    }, () => {})).toThrow('Preset editor tab limit reached')
+    expect(activeSubscriptions).toBe(4)
+    expect(createdRoots[4]?.removed).toBe(true)
+    expect(placementStore.getState().presetEditorTabs).toHaveLength(4)
+
+    for (let index = 0; index < 4; index += 1) {
+      handles.push(createPresetEditorTabHandle(`global-extension-${index}`, {
+        id: `global-${index}`,
+        title: `Global ${index}`,
+      }, () => {}))
+    }
+
+    expect(activeSubscriptions).toBe(8)
+    expect(() => createPresetEditorTabHandle('global-overflow', {
+      id: 'global-overflow',
+      title: 'Global overflow',
+    }, () => {})).toThrow('Global preset editor tab limit reached')
+    expect(activeSubscriptions).toBe(8)
+    expect(createdRoots[9]?.removed).toBe(true)
+    expect(placementStore.getState().presetEditorTabs).toHaveLength(8)
+  })
+})

--- a/frontend/src/lib/spindle/placement-helper.test.ts
+++ b/frontend/src/lib/spindle/placement-helper.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import { createStore, type StoreApi } from 'zustand/vanilla'
 import * as presetEditorHelper from './preset-editor-helper'
-import type { SpindlePresetEditorState, SpindlePresetEditorTabHandle } from './preset-editor-types'
+import type {
+  SpindlePresetEditorState,
+  SpindlePresetEditorTabHandle,
+  SpindlePresetEditorToolbarItemHandle,
+} from './preset-editor-types'
 import { createSpindlePlacementSlice } from '@/store/slices/spindle-placement'
 import type { SpindlePlacementSlice } from '@/types/store'
 
@@ -19,7 +23,11 @@ mock.module('@/store', () => ({ useStore: mockedUseStore }))
 
 // The target module must load after the narrow store facade is registered.
 // This is a test-only module-loading boundary; production imports stay static.
-const { createPresetEditorTabHandle } = await import('./placement-helper')
+const {
+  createPresetEditorTabHandle,
+  createPresetEditorToolbarItemHandle,
+  destroyPresetEditorPlacementsForExtension,
+} = await import('./placement-helper')
 
 type TrackedRoot = {
   root: HTMLElement
@@ -32,13 +40,14 @@ const originalSubscribe = presetEditorHelper.subscribePresetEditorState
 
 let createdRoots: TrackedRoot[] = []
 let handles: SpindlePresetEditorTabHandle[] = []
+let toolbarHandles: SpindlePresetEditorToolbarItemHandle[] = []
 let activeSubscriptions = 0
 
 beforeEach(() => {
   placementStore = placementStoreFactory(createSpindlePlacementSlice)
   createdRoots = []
   handles = []
-  activeSubscriptions = 0
+  toolbarHandles = []
 
   document.createElement = ((tagName: string) => {
     const root = originalCreateElement(tagName)
@@ -62,6 +71,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  for (const handle of toolbarHandles) handle.destroy()
   for (const handle of handles) handle.destroy()
   placementStore = placementStoreFactory(createSpindlePlacementSlice)
   document.createElement = originalCreateElement
@@ -101,5 +111,57 @@ describe('preset editor tab registration', () => {
     expect(activeSubscriptions).toBe(8)
     expect(createdRoots[9]?.removed).toBe(true)
     expect(placementStore.getState().presetEditorTabs).toHaveLength(8)
+  })
+})
+
+describe('preset editor toolbar registration', () => {
+  test('unwinds the root when per-extension or global cap rejects registration', () => {
+    toolbarHandles.push(createPresetEditorToolbarItemHandle(extensionId, {
+      id: 'per-extension-0',
+      ariaLabel: 'Per-extension 0',
+    }, () => {}))
+
+    expect(() => createPresetEditorToolbarItemHandle(extensionId, {
+      id: 'per-extension-overflow',
+      ariaLabel: 'Per-extension overflow',
+    }, () => {})).toThrow('Preset editor toolbar item limit reached')
+    expect(createdRoots[1]?.removed).toBe(true)
+    expect(placementStore.getState().presetEditorToolbarItems).toHaveLength(1)
+
+    for (let index = 0; index < 3; index += 1) {
+      toolbarHandles.push(createPresetEditorToolbarItemHandle(`global-extension-${index}`, {
+        id: `global-${index}`,
+        ariaLabel: `Global ${index}`,
+      }, () => {}))
+    }
+
+    expect(() => createPresetEditorToolbarItemHandle('global-overflow', {
+      id: 'global-overflow',
+      ariaLabel: 'Global overflow',
+    }, () => {})).toThrow('Global preset editor toolbar item limit reached')
+    expect(createdRoots[5]?.removed).toBe(true)
+    expect(placementStore.getState().presetEditorToolbarItems).toHaveLength(4)
+  })
+
+  test('removes revoked toolbar resources and rejects stale handle calls', () => {
+    let active = true
+    const handle = createPresetEditorToolbarItemHandle(extensionId, {
+      id: 'revoked',
+      ariaLabel: 'Revoked toolbar item',
+    }, () => {
+      if (!active) throw new Error('PERMISSION_DENIED:presets')
+    })
+    toolbarHandles.push(handle)
+
+    handle.setVisible(false)
+    expect(placementStore.getState().presetEditorToolbarItems[0]?.visible).toBe(false)
+    active = false
+    destroyPresetEditorPlacementsForExtension(extensionId)
+
+    expect(createdRoots[0]?.removed).toBe(true)
+    expect(placementStore.getState().presetEditorToolbarItems).toHaveLength(0)
+    expect(() => handle.setVisible(true)).toThrow('PERMISSION_DENIED')
+    active = true
+    expect(() => handle.setVisible(true)).toThrow('PRESET_EDITOR_DESTROYED')
   })
 })

--- a/frontend/src/lib/spindle/placement-helper.ts
+++ b/frontend/src/lib/spindle/placement-helper.ts
@@ -190,6 +190,7 @@ export function createCharacterEditorTabHandle(
 export function createPresetEditorTabHandle(
   extensionId: string,
   options: SpindlePresetEditorTabOptions,
+  assertActive: () => void,
 ): SpindlePresetEditorTabHandle {
   const tabId = nextId(extensionId, `preset-editor-tab:${options.id}`)
   const root = document.createElement('div')
@@ -211,6 +212,10 @@ export function createPresetEditorTabHandle(
   getStore().registerPresetEditorTab({ id: tabId, extensionId, title: options.title, root })
 
   let destroyed = false
+  const assertUsable = () => {
+    assertActive()
+    if (destroyed) throw new Error('PRESET_EDITOR_DESTROYED: Preset editor tab has been destroyed')
+  }
   const destroy = () => {
     if (destroyed) return
     destroyed = true
@@ -226,13 +231,16 @@ export function createPresetEditorTabHandle(
     root,
     tabId,
     setTitle(title: string) {
+      assertUsable()
       getStore().updatePresetEditorTab(tabId, { title })
     },
     activate() {
+      assertUsable()
       setPresetEditorActiveTab(tabId)
     },
     destroy,
     onActivate(handler: () => void): () => void {
+      assertUsable()
       activateHandlers.add(handler)
       return () => { activateHandlers.delete(handler) }
     },
@@ -244,6 +252,7 @@ export function createPresetEditorTabHandle(
 export function createPresetEditorToolbarItemHandle(
   extensionId: string,
   options: SpindlePresetEditorToolbarItemOptions,
+  assertActive: () => void,
 ): SpindlePresetEditorToolbarItemHandle {
   const itemId = nextId(extensionId, `preset-editor-toolbar:${options.id}`)
   const root = document.createElement('div')
@@ -259,6 +268,10 @@ export function createPresetEditorToolbarItemHandle(
   })
 
   let destroyed = false
+  const assertUsable = () => {
+    assertActive()
+    if (destroyed) throw new Error('PRESET_EDITOR_DESTROYED: Preset editor toolbar item has been destroyed')
+  }
   const destroy = () => {
     if (destroyed) return
     destroyed = true
@@ -272,6 +285,7 @@ export function createPresetEditorToolbarItemHandle(
     root,
     itemId,
     setVisible(visible: boolean) {
+      assertUsable()
       getStore().setPresetEditorToolbarItemVisible(itemId, visible)
     },
     destroy,

--- a/frontend/src/lib/spindle/placement-helper.ts
+++ b/frontend/src/lib/spindle/placement-helper.ts
@@ -209,7 +209,14 @@ export function createPresetEditorTabHandle(
     wasActive = isActive
   })
 
-  getStore().registerPresetEditorTab({ id: tabId, extensionId, title: options.title, root })
+  try {
+    getStore().registerPresetEditorTab({ id: tabId, extensionId, title: options.title, root })
+  } catch (error) {
+    unsubscribeState()
+    root.remove()
+    activateHandlers.clear()
+    throw error
+  }
 
   let destroyed = false
   const assertUsable = () => {

--- a/frontend/src/lib/spindle/placement-helper.ts
+++ b/frontend/src/lib/spindle/placement-helper.ts
@@ -266,13 +266,18 @@ export function createPresetEditorToolbarItemHandle(
   root.setAttribute('data-spindle-extension-root', extensionId)
   root.setAttribute('data-spindle-preset-editor-toolbar-item', itemId)
 
-  getStore().registerPresetEditorToolbarItem({
-    id: itemId,
-    extensionId,
-    ariaLabel: options.ariaLabel,
-    root,
-    visible: true,
-  })
+  try {
+    getStore().registerPresetEditorToolbarItem({
+      id: itemId,
+      extensionId,
+      ariaLabel: options.ariaLabel,
+      root,
+      visible: true,
+    })
+  } catch (error) {
+    root.remove()
+    throw error
+  }
 
   let destroyed = false
   const assertUsable = () => {

--- a/frontend/src/lib/spindle/placement-helper.ts
+++ b/frontend/src/lib/spindle/placement-helper.ts
@@ -17,6 +17,8 @@ import type {
 import type {
   SpindlePresetEditorTabOptions,
   SpindlePresetEditorTabHandle,
+  SpindlePresetEditorToolbarItemOptions,
+  SpindlePresetEditorToolbarItemHandle,
 } from './preset-editor-types'
 import { useStore } from '@/store'
 import type { TabLocation } from './tab-mobility-types'
@@ -40,6 +42,21 @@ function nextId(extensionId: string, kind: string): string {
 // ── Tab Mobility Handle Cache ──
 // Each call to createTabMobilityHandle subscribes to useStore.
 // Cache one handle per extensionId to avoid subscription leaks.
+
+const presetEditorPlacementDisposers = new Map<string, Set<() => void>>()
+
+function trackPresetEditorPlacement(extensionId: string, dispose: () => void): void {
+  const disposers = presetEditorPlacementDisposers.get(extensionId) ?? new Set<() => void>()
+  disposers.add(dispose)
+  presetEditorPlacementDisposers.set(extensionId, disposers)
+}
+
+function untrackPresetEditorPlacement(extensionId: string, dispose: () => void): void {
+  const disposers = presetEditorPlacementDisposers.get(extensionId)
+  if (!disposers) return
+  disposers.delete(dispose)
+  if (disposers.size === 0) presetEditorPlacementDisposers.delete(extensionId)
+}
 const _tabMobilityCache = new Map<string, ReturnType<typeof createTabMobilityHandle>>
 
 function getStore() {
@@ -193,6 +210,18 @@ export function createPresetEditorTabHandle(
 
   getStore().registerPresetEditorTab({ id: tabId, extensionId, title: options.title, root })
 
+  let destroyed = false
+  const destroy = () => {
+    if (destroyed) return
+    destroyed = true
+    unsubscribeState()
+    root.remove()
+    getStore().unregisterPresetEditorTab(tabId)
+    activateHandlers.clear()
+    untrackPresetEditorPlacement(extensionId, destroy)
+  }
+  trackPresetEditorPlacement(extensionId, destroy)
+
   return {
     root,
     tabId,
@@ -202,15 +231,50 @@ export function createPresetEditorTabHandle(
     activate() {
       setPresetEditorActiveTab(tabId)
     },
-    destroy() {
-      unsubscribeState()
-      getStore().unregisterPresetEditorTab(tabId)
-      activateHandlers.clear()
-    },
+    destroy,
     onActivate(handler: () => void): () => void {
       activateHandlers.add(handler)
       return () => { activateHandlers.delete(handler) }
     },
+  }
+}
+
+// ── Preset Editor Toolbar ──
+
+export function createPresetEditorToolbarItemHandle(
+  extensionId: string,
+  options: SpindlePresetEditorToolbarItemOptions,
+): SpindlePresetEditorToolbarItemHandle {
+  const itemId = nextId(extensionId, `preset-editor-toolbar:${options.id}`)
+  const root = document.createElement('div')
+  root.setAttribute('data-spindle-extension-root', extensionId)
+  root.setAttribute('data-spindle-preset-editor-toolbar-item', itemId)
+
+  getStore().registerPresetEditorToolbarItem({
+    id: itemId,
+    extensionId,
+    ariaLabel: options.ariaLabel,
+    root,
+    visible: true,
+  })
+
+  let destroyed = false
+  const destroy = () => {
+    if (destroyed) return
+    destroyed = true
+    root.remove()
+    getStore().unregisterPresetEditorToolbarItem(itemId)
+    untrackPresetEditorPlacement(extensionId, destroy)
+  }
+  trackPresetEditorPlacement(extensionId, destroy)
+
+  return {
+    root,
+    itemId,
+    setVisible(visible: boolean) {
+      getStore().setPresetEditorToolbarItemVisible(itemId, visible)
+    },
+    destroy,
   }
 }
 
@@ -523,6 +587,26 @@ function createTabMobilityHandleUncached(extensionId: string): {
 
 // ── Cleanup ──
 
+/** Destroy preset-only roots and subscriptions without unloading other extension UI. */
+export function destroyPresetEditorPlacementsForExtension(extensionId: string): void {
+  const disposers = presetEditorPlacementDisposers.get(extensionId)
+  if (disposers) {
+    for (const dispose of [...disposers]) {
+      try { dispose() } catch { /* no-op */ }
+    }
+  }
+
+  const store = getStore()
+  for (const tab of store.presetEditorTabs.filter((entry) => entry.extensionId === extensionId)) {
+    try { tab.root.remove() } catch { /* no-op */ }
+    store.unregisterPresetEditorTab(tab.id)
+  }
+  for (const item of store.presetEditorToolbarItems.filter((entry) => entry.extensionId === extensionId)) {
+    try { item.root.remove() } catch { /* no-op */ }
+    store.unregisterPresetEditorToolbarItem(item.id)
+  }
+}
+
 export function destroyAllPlacementsForExtension(extensionId: string) {
   const store = getStore()
 
@@ -534,11 +618,7 @@ export function destroyAllPlacementsForExtension(extensionId: string) {
     try { tab.root.remove() } catch { /* no-op */ }
   }
 
-  for (const tab of store.presetEditorTabs.filter((t) => t.extensionId === extensionId)) {
-    try { tab.root.remove() } catch { /* no-op */ }
-  }
-
-  // Clean up DOM for app mounts
+  destroyPresetEditorPlacementsForExtension(extensionId)
   for (const m of store.appMounts.filter((m) => m.extensionId === extensionId)) {
     try { m.root.remove() } catch { /* no-op */ }
   }

--- a/frontend/src/lib/spindle/preset-editor-access.ts
+++ b/frontend/src/lib/spindle/preset-editor-access.ts
@@ -1,0 +1,38 @@
+import type { SpindlePresetEditorScopedHelper } from './preset-editor-types'
+import { createPresetEditorScopedHelper, type PresetEditorScopedAccess } from './preset-editor-helper'
+
+/**
+ * Owns the revocation epoch for one extension's scoped preset-editor helpers.
+ * A retained helper can never become valid again after `revoke()`; callers must
+ * acquire a new facade after the permission is granted again.
+ */
+export function createPresetEditorAccess(
+  extensionIdentifier: string,
+  getGrantedPermissions: () => readonly string[],
+  trackSubscription: PresetEditorScopedAccess['trackSubscription'],
+): {
+  acquire(): SpindlePresetEditorScopedHelper
+  revoke(): void
+} {
+  let epoch = 0
+
+  return {
+    acquire(): SpindlePresetEditorScopedHelper {
+      const acquiredEpoch = epoch
+      return createPresetEditorScopedHelper(extensionIdentifier, {
+        assertActive() {
+          if (!getGrantedPermissions().includes('presets')) {
+            throw new Error('PERMISSION_DENIED:presets — preset editor extension helper requires the presets permission')
+          }
+          if (epoch !== acquiredEpoch) {
+            throw new Error('PRESET_EDITOR_REVOKED: Acquire a fresh preset editor helper before using it')
+          }
+        },
+        trackSubscription,
+      })
+    },
+    revoke() {
+      epoch += 1
+    },
+  }
+}

--- a/frontend/src/lib/spindle/preset-editor-access.ts
+++ b/frontend/src/lib/spindle/preset-editor-access.ts
@@ -13,14 +13,25 @@ export function createPresetEditorAccess(
 ): {
   acquire(): SpindlePresetEditorScopedHelper
   revoke(): void
+  dispose(): void
 } {
   let epoch = 0
+  let disposed = false
 
   return {
     acquire(): SpindlePresetEditorScopedHelper {
+      if (disposed) {
+        throw new Error('PRESET_EDITOR_DISPOSED: Extension frontend has been unloaded')
+      }
+      if (!getGrantedPermissions().includes('presets')) {
+        throw new Error('PERMISSION_DENIED:presets — preset editor extension helper requires the presets permission')
+      }
       const acquiredEpoch = epoch
       return createPresetEditorScopedHelper(extensionIdentifier, {
         assertActive() {
+          if (disposed) {
+            throw new Error('PRESET_EDITOR_DISPOSED: Extension frontend has been unloaded')
+          }
           if (!getGrantedPermissions().includes('presets')) {
             throw new Error('PERMISSION_DENIED:presets — preset editor extension helper requires the presets permission')
           }
@@ -32,6 +43,11 @@ export function createPresetEditorAccess(
       })
     },
     revoke() {
+      epoch += 1
+    },
+    dispose() {
+      if (disposed) return
+      disposed = true
       epoch += 1
     },
   }

--- a/frontend/src/lib/spindle/preset-editor-helper.test.ts
+++ b/frontend/src/lib/spindle/preset-editor-helper.test.ts
@@ -9,7 +9,6 @@ import {
 } from './preset-editor-helper'
 import { createPresetEditorAccess } from './preset-editor-access'
 import type { SpindlePresetEditorDraft, SpindlePresetEditorState } from './preset-editor-types'
-import { SPINDLE_EXTENSION_METADATA_KEY } from '@/lib/loom/service'
 
 function draft(): SpindlePresetEditorDraft {
   return {
@@ -58,9 +57,7 @@ describe('scoped preset editor helper', () => {
     expect(current.metadata).toEqual({
       promptVariables: { 'block-1': { tone: 'neutral' } },
       another_extension: { preserved: true },
-      [SPINDLE_EXTENSION_METADATA_KEY]: {
-        agentic_preset_composer: { mode: 'parallel' },
-      },
+      agentic_preset_composer: { mode: 'parallel' },
     })
 
     helper.activateBuiltinTab('blocks')
@@ -88,7 +85,7 @@ describe('scoped preset editor helper', () => {
 
     open = false
     expect(() => helper.setMetadata({ mode: 'stale' })).toThrow('PRESET_EDITOR_CLOSED')
-    expect(current.metadata[SPINDLE_EXTENSION_METADATA_KEY]).toBeUndefined()
+    expect(current.metadata.agentic_preset_composer).toBeUndefined()
   })
 
   test('publishes a closed state before exposing the next selected preset', () => {
@@ -218,46 +215,19 @@ describe('scoped preset editor helper', () => {
     unsubscribe()
   })
 
-  test('keeps colliding extension identifiers separate from Loom-owned metadata', () => {
-    let current: SpindlePresetEditorDraft = {
-      ...draft(),
-      metadata: {
-        ...draft().metadata,
-        source: { type: 'native-source' },
-        description: 'Native description',
-      },
-    }
-    setPresetEditorController({
-      getState: (): SpindlePresetEditorState => ({
-        open: true,
-        presetId: current.id,
-        activeTabId: 'preset',
-        preset: current,
-      }),
-      setActiveTab() {},
-      updatePreset(mutator) { current = mutator(current) },
-      async flush() {},
-    })
-
-    const source = createPresetEditorScopedHelper('source', {
+  test('rejects extension identifiers that collide with Loom-owned metadata', () => {
+    expect(() => createPresetEditorScopedHelper('source', {
       assertActive() {},
       trackSubscription(unsubscribe) { return unsubscribe },
-    })
-    const description = createPresetEditorScopedHelper('description', {
+    })).toThrow('PRESET_EDITOR_RESERVED_METADATA_KEY')
+    expect(() => createPresetEditorScopedHelper('description', {
       assertActive() {},
       trackSubscription(unsubscribe) { return unsubscribe },
-    })
-    source.setMetadata({ mode: 'parallel' })
-    description.setMetadata({ mode: 'single' })
-
-    expect(current.metadata.source).toEqual({ type: 'native-source' })
-    expect(current.metadata.description).toBe('Native description')
-    expect(current.metadata[SPINDLE_EXTENSION_METADATA_KEY]).toEqual({
-      source: { mode: 'parallel' },
-      description: { mode: 'single' },
-    })
-    expect(source.getState().metadata).toEqual({ mode: 'parallel' })
-    expect(description.getState().metadata).toEqual({ mode: 'single' })
+    })).toThrow('PRESET_EDITOR_RESERVED_METADATA_KEY')
+    expect(() => createPresetEditorScopedHelper('_lumiverse_extension', {
+      assertActive() {},
+      trackSubscription(unsubscribe) { return unsubscribe },
+    })).toThrow('PRESET_EDITOR_RESERVED_METADATA_KEY')
   })
 
   test('rejects use after a permission revocation invalidates access', () => {
@@ -303,9 +273,7 @@ describe('scoped preset editor helper', () => {
 
     const reacquired = access.acquire()
     reacquired.setMetadata({ mode: 'parallel' })
-    expect(current.metadata[SPINDLE_EXTENSION_METADATA_KEY]).toEqual({
-      agentic_preset_composer: { mode: 'parallel' },
-    })
+    expect(current.metadata.agentic_preset_composer).toEqual({ mode: 'parallel' })
 
   })
   test('permanently invalidates helpers when the extension frontend unloads', () => {

--- a/frontend/src/lib/spindle/preset-editor-helper.test.ts
+++ b/frontend/src/lib/spindle/preset-editor-helper.test.ts
@@ -3,6 +3,7 @@ import {
   createPresetEditorScopedHelper,
   setPresetEditorController,
 } from './preset-editor-helper'
+import { createPresetEditorAccess } from './preset-editor-access'
 import type { SpindlePresetEditorDraft, SpindlePresetEditorState } from './preset-editor-types'
 
 function draft(): SpindlePresetEditorDraft {
@@ -71,5 +72,36 @@ describe('scoped preset editor helper', () => {
     expect(() => helper.getState()).toThrow('PRESET_EDITOR_REVOKED')
     active = true
     expect(() => helper.setMetadata({ mode: 'single' })).toThrow('PRESET_EDITOR_CLOSED')
+  })
+
+  test('invalidates retained helpers while allowing a newly acquired helper after regrant', () => {
+    let current = draft()
+    let permissions = ['presets']
+    setPresetEditorController({
+      getState: (): SpindlePresetEditorState => ({
+        open: true,
+        presetId: current.id,
+        activeTabId: 'preset',
+        preset: current,
+      }),
+      setActiveTab() {},
+      updatePreset(mutator) { current = mutator(current) },
+      async flush() {},
+    })
+    const access = createPresetEditorAccess(
+      'agentic_preset_composer',
+      () => permissions,
+      (unsubscribe) => unsubscribe,
+    )
+
+    const retained = access.acquire()
+    permissions = []
+    access.revoke()
+    permissions = ['presets']
+    expect(() => retained.setMetadata({ mode: 'stale' })).toThrow('PRESET_EDITOR_REVOKED')
+
+    const reacquired = access.acquire()
+    reacquired.setMetadata({ mode: 'parallel' })
+    expect(current.metadata.agentic_preset_composer).toEqual({ mode: 'parallel' })
   })
 })

--- a/frontend/src/lib/spindle/preset-editor-helper.test.ts
+++ b/frontend/src/lib/spindle/preset-editor-helper.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from 'bun:test'
 import {
   createPresetEditorScopedHelper,
+  getPresetEditorState,
   setPresetEditorController,
   subscribePresetEditorState,
   syncPresetEditorState,
@@ -93,11 +94,12 @@ describe('scoped preset editor helper', () => {
     const observed: SpindlePresetEditorState[] = []
     const unsubscribe = subscribePresetEditorState((state) => observed.push(state))
 
+    const first = draft()
     syncPresetEditorState({
-      open: false,
-      presetId: null,
+      open: true,
+      presetId: first.id,
       activeTabId: 'preset',
-      preset: null,
+      preset: first,
     })
     const next = { ...draft(), id: 'preset-2' }
     syncPresetEditorState({
@@ -107,9 +109,54 @@ describe('scoped preset editor helper', () => {
       preset: next,
     })
 
-    expect(observed).toHaveLength(2)
-    expect(observed[0]).toMatchObject({ open: false, presetId: null, preset: null })
-    expect(observed[1]).toMatchObject({ open: true, presetId: 'preset-2' })
+    expect(observed).toHaveLength(3)
+    expect(observed[0]).toMatchObject({ open: true, presetId: 'preset-1' })
+    expect(observed[1]).toMatchObject({ open: false, presetId: null, preset: null })
+    expect(observed[2]).toMatchObject({ open: true, presetId: 'preset-2' })
+    unsubscribe()
+  })
+
+  test('makes a synthetic close authoritative while notifying listeners', () => {
+    const first = draft()
+    const next = { ...draft(), id: 'preset-2' }
+    let updates = 0
+    setPresetEditorController({
+      getState: (): SpindlePresetEditorState => ({
+        open: true,
+        presetId: next.id,
+        activeTabId: 'preset',
+        preset: next,
+      }),
+      setActiveTab() {},
+      updatePreset() { updates += 1 },
+      async flush() {},
+    })
+    syncPresetEditorState({
+      open: true,
+      presetId: first.id,
+      activeTabId: 'preset',
+      preset: first,
+    })
+    const helper = createPresetEditorScopedHelper('agentic_preset_composer', {
+      assertActive() {},
+      trackSubscription(unsubscribe) { return unsubscribe },
+    })
+    const readsDuringClose: SpindlePresetEditorState[] = []
+    const unsubscribe = subscribePresetEditorState((state) => {
+      if (state.open) return
+      readsDuringClose.push(getPresetEditorState())
+      expect(() => helper.setMetadata({ mode: 'stale' })).toThrow('PRESET_EDITOR_CLOSED')
+    })
+
+    syncPresetEditorState({
+      open: true,
+      presetId: next.id,
+      activeTabId: 'preset',
+      preset: next,
+    })
+
+    expect(readsDuringClose).toEqual([expect.objectContaining({ open: false, presetId: null, preset: null })])
+    expect(updates).toBe(0)
     unsubscribe()
   })
 

--- a/frontend/src/lib/spindle/preset-editor-helper.test.ts
+++ b/frontend/src/lib/spindle/preset-editor-helper.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from 'bun:test'
 import {
   createPresetEditorScopedHelper,
+  flushPresetEditorDraft,
   getPresetEditorState,
   setPresetEditorController,
   subscribePresetEditorState,
@@ -143,6 +144,7 @@ describe('scoped preset editor helper', () => {
     })
     const readsDuringClose: SpindlePresetEditorState[] = []
     let closeMutationError: unknown
+    let closeTabError: unknown
     const unsubscribe = subscribePresetEditorState((state) => {
       if (state.open) return
       readsDuringClose.push(getPresetEditorState())
@@ -150,6 +152,11 @@ describe('scoped preset editor helper', () => {
         helper.setMetadata({ mode: 'stale' })
       } catch (error) {
         closeMutationError = error
+      }
+      try {
+        helper.activateBuiltinTab('blocks')
+      } catch (error) {
+        closeTabError = error
       }
     })
 
@@ -163,7 +170,51 @@ describe('scoped preset editor helper', () => {
     expect(readsDuringClose).toEqual([expect.objectContaining({ open: false, presetId: null, preset: null })])
     expect(closeMutationError).toBeInstanceOf(Error)
     expect((closeMutationError as Error).message).toContain('PRESET_EDITOR_CLOSED')
+    expect(closeTabError).toBeInstanceOf(Error)
+    expect((closeTabError as Error).message).toContain('PRESET_EDITOR_CLOSED')
     expect(updates).toBe(0)
+    unsubscribe()
+  })
+
+  test('rejects non-JSON extension metadata before it reaches coordinator state', () => {
+    const helper = createPresetEditorScopedHelper('agentic_preset_composer', {
+      assertActive() {},
+      trackSubscription(unsubscribe) { return unsubscribe },
+    })
+
+    expect(() => helper.setMetadata(new Map() as unknown as Record<string, unknown>))
+      .toThrow('PRESET_EDITOR_INVALID_METADATA')
+    expect(() => helper.setMetadata({ nested: { count: BigInt(1) } } as unknown as Record<string, unknown>))
+      .toThrow('PRESET_EDITOR_INVALID_METADATA')
+    expect(() => helper.setMetadata({ callback: () => {} } as unknown as Record<string, unknown>))
+      .toThrow('PRESET_EDITOR_INVALID_METADATA')
+  })
+
+  test('does not republish an obsolete controller after an in-flight flush', async () => {
+    const current = draft()
+    let resolveFlush!: () => void
+    const pendingFlush = new Promise<void>((resolve) => { resolveFlush = resolve })
+    setPresetEditorController({
+      getState: (): SpindlePresetEditorState => ({
+        open: true,
+        presetId: current.id,
+        activeTabId: 'preset',
+        preset: current,
+      }),
+      setActiveTab() {},
+      updatePreset() {},
+      flush: () => pendingFlush,
+    })
+    const observed: SpindlePresetEditorState[] = []
+    const unsubscribe = subscribePresetEditorState((state) => observed.push(state))
+
+    const flush = flushPresetEditorDraft()
+    setPresetEditorController(null)
+    resolveFlush()
+    await flush
+
+    expect(getPresetEditorState()).toMatchObject({ open: false, presetId: null, preset: null })
+    expect(observed).toEqual([expect.objectContaining({ open: false, presetId: null, preset: null })])
     unsubscribe()
   })
 

--- a/frontend/src/lib/spindle/preset-editor-helper.test.ts
+++ b/frontend/src/lib/spindle/preset-editor-helper.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+  createPresetEditorScopedHelper,
+  setPresetEditorController,
+} from './preset-editor-helper'
+import type { SpindlePresetEditorDraft, SpindlePresetEditorState } from './preset-editor-types'
+
+function draft(): SpindlePresetEditorDraft {
+  return {
+    id: 'preset-1',
+    name: 'Preset',
+    blocks: [],
+    parameters: {},
+    prompts: {},
+    metadata: {
+      promptVariables: { 'block-1': { tone: 'neutral' } },
+      another_extension: { preserved: true },
+    },
+    createdAt: 1,
+    updatedAt: 2,
+  }
+}
+
+afterEach(() => { setPresetEditorController(null) })
+
+describe('scoped preset editor helper', () => {
+  test('clones Main fields and mutates only its identifier namespace', () => {
+    let current = draft()
+    let activeTab = 'preset'
+    setPresetEditorController({
+      getState: (): SpindlePresetEditorState => ({
+        open: true,
+        presetId: current.id,
+        activeTabId: activeTab,
+        preset: current,
+      }),
+      setActiveTab(tabId) { activeTab = tabId },
+      updatePreset(mutator) { current = mutator(current) },
+      async flush() {},
+    })
+
+    const helper = createPresetEditorScopedHelper('agentic_preset_composer', {
+      assertActive() {},
+      trackSubscription(unsubscribe) { return unsubscribe },
+    })
+
+    const state = helper.getState()
+    ;(state.promptVariableValues as Record<string, Record<string, string>>)['block-1'].tone = 'changed locally'
+    expect(current.metadata.promptVariables).toEqual({ 'block-1': { tone: 'neutral' } })
+
+    helper.setMetadata({ mode: 'parallel' }, { immediate: true })
+    expect(current.metadata).toEqual({
+      promptVariables: { 'block-1': { tone: 'neutral' } },
+      another_extension: { preserved: true },
+      agentic_preset_composer: { mode: 'parallel' },
+    })
+
+    helper.activateBuiltinTab('blocks')
+    expect(activeTab).toBe('preset')
+  })
+
+  test('rejects use after a permission revocation invalidates access', () => {
+    let active = false
+    const helper = createPresetEditorScopedHelper('agentic_preset_composer', {
+      assertActive() {
+        if (!active) throw new Error('PRESET_EDITOR_REVOKED')
+      },
+      trackSubscription(unsubscribe) { return unsubscribe },
+    })
+
+    expect(() => helper.getState()).toThrow('PRESET_EDITOR_REVOKED')
+    active = true
+    expect(() => helper.setMetadata({ mode: 'single' })).toThrow('PRESET_EDITOR_CLOSED')
+  })
+})

--- a/frontend/src/lib/spindle/preset-editor-helper.test.ts
+++ b/frontend/src/lib/spindle/preset-editor-helper.test.ts
@@ -5,6 +5,7 @@ import {
 } from './preset-editor-helper'
 import { createPresetEditorAccess } from './preset-editor-access'
 import type { SpindlePresetEditorDraft, SpindlePresetEditorState } from './preset-editor-types'
+import { SPINDLE_EXTENSION_METADATA_KEY } from '@/lib/loom/service'
 
 function draft(): SpindlePresetEditorDraft {
   return {
@@ -53,11 +54,55 @@ describe('scoped preset editor helper', () => {
     expect(current.metadata).toEqual({
       promptVariables: { 'block-1': { tone: 'neutral' } },
       another_extension: { preserved: true },
-      agentic_preset_composer: { mode: 'parallel' },
+      [SPINDLE_EXTENSION_METADATA_KEY]: {
+        agentic_preset_composer: { mode: 'parallel' },
+      },
     })
 
     helper.activateBuiltinTab('blocks')
     expect(activeTab).toBe('preset')
+  })
+
+  test('keeps colliding extension identifiers separate from Loom-owned metadata', () => {
+    let current: SpindlePresetEditorDraft = {
+      ...draft(),
+      metadata: {
+        ...draft().metadata,
+        source: { type: 'native-source' },
+        description: 'Native description',
+      },
+    }
+    setPresetEditorController({
+      getState: (): SpindlePresetEditorState => ({
+        open: true,
+        presetId: current.id,
+        activeTabId: 'preset',
+        preset: current,
+      }),
+      setActiveTab() {},
+      updatePreset(mutator) { current = mutator(current) },
+      async flush() {},
+    })
+
+    const source = createPresetEditorScopedHelper('source', {
+      assertActive() {},
+      trackSubscription(unsubscribe) { return unsubscribe },
+    })
+    const description = createPresetEditorScopedHelper('description', {
+      assertActive() {},
+      trackSubscription(unsubscribe) { return unsubscribe },
+    })
+    source.setMetadata({ mode: 'parallel' })
+    description.setMetadata({ mode: 'single' })
+
+    expect(current.metadata.source).toEqual({ type: 'native-source' })
+    expect(current.metadata.description).toBe('Native description')
+    expect(current.metadata[SPINDLE_EXTENSION_METADATA_KEY]).toEqual({
+      source: { mode: 'parallel' },
+      description: { mode: 'single' },
+    })
+    expect(source.getState().metadata).toEqual({ mode: 'parallel' })
+    expect(description.getState().metadata).toEqual({ mode: 'single' })
   })
 
   test('rejects use after a permission revocation invalidates access', () => {
@@ -97,11 +142,27 @@ describe('scoped preset editor helper', () => {
     const retained = access.acquire()
     permissions = []
     access.revoke()
+    expect(() => access.acquire()).toThrow('PERMISSION_DENIED:presets')
     permissions = ['presets']
     expect(() => retained.setMetadata({ mode: 'stale' })).toThrow('PRESET_EDITOR_REVOKED')
 
     const reacquired = access.acquire()
     reacquired.setMetadata({ mode: 'parallel' })
-    expect(current.metadata.agentic_preset_composer).toEqual({ mode: 'parallel' })
+    expect(current.metadata[SPINDLE_EXTENSION_METADATA_KEY]).toEqual({
+      agentic_preset_composer: { mode: 'parallel' },
+    })
+
+  })
+  test('permanently invalidates helpers when the extension frontend unloads', () => {
+    const access = createPresetEditorAccess(
+      'agentic_preset_composer',
+      () => ['presets'],
+      (unsubscribe) => unsubscribe,
+    )
+    const retained = access.acquire()
+    access.dispose()
+
+    expect(() => access.acquire()).toThrow('PRESET_EDITOR_DISPOSED')
+    expect(() => retained.getState()).toThrow('PRESET_EDITOR_DISPOSED')
   })
 })

--- a/frontend/src/lib/spindle/preset-editor-helper.test.ts
+++ b/frontend/src/lib/spindle/preset-editor-helper.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, test } from 'bun:test'
 import {
   createPresetEditorScopedHelper,
   setPresetEditorController,
+  subscribePresetEditorState,
+  syncPresetEditorState,
 } from './preset-editor-helper'
 import { createPresetEditorAccess } from './preset-editor-access'
 import type { SpindlePresetEditorDraft, SpindlePresetEditorState } from './preset-editor-types'
@@ -61,6 +63,54 @@ describe('scoped preset editor helper', () => {
 
     helper.activateBuiltinTab('blocks')
     expect(activeTab).toBe('preset')
+  })
+
+  test('rejects a retained helper after the controller closes during a preset switch', () => {
+    let current = draft()
+    let open = true
+    setPresetEditorController({
+      getState: (): SpindlePresetEditorState => ({
+        open,
+        presetId: open ? current.id : null,
+        activeTabId: 'preset',
+        preset: open ? current : null,
+      }),
+      setActiveTab() {},
+      updatePreset(mutator) { current = mutator(current) },
+      async flush() {},
+    })
+    const helper = createPresetEditorScopedHelper('agentic_preset_composer', {
+      assertActive() {},
+      trackSubscription(unsubscribe) { return unsubscribe },
+    })
+
+    open = false
+    expect(() => helper.setMetadata({ mode: 'stale' })).toThrow('PRESET_EDITOR_CLOSED')
+    expect(current.metadata[SPINDLE_EXTENSION_METADATA_KEY]).toBeUndefined()
+  })
+
+  test('publishes a closed state before exposing the next selected preset', () => {
+    const observed: SpindlePresetEditorState[] = []
+    const unsubscribe = subscribePresetEditorState((state) => observed.push(state))
+
+    syncPresetEditorState({
+      open: false,
+      presetId: null,
+      activeTabId: 'preset',
+      preset: null,
+    })
+    const next = { ...draft(), id: 'preset-2' }
+    syncPresetEditorState({
+      open: true,
+      presetId: next.id,
+      activeTabId: 'preset',
+      preset: next,
+    })
+
+    expect(observed).toHaveLength(2)
+    expect(observed[0]).toMatchObject({ open: false, presetId: null, preset: null })
+    expect(observed[1]).toMatchObject({ open: true, presetId: 'preset-2' })
+    unsubscribe()
   })
 
   test('keeps colliding extension identifiers separate from Loom-owned metadata', () => {

--- a/frontend/src/lib/spindle/preset-editor-helper.test.ts
+++ b/frontend/src/lib/spindle/preset-editor-helper.test.ts
@@ -142,10 +142,15 @@ describe('scoped preset editor helper', () => {
       trackSubscription(unsubscribe) { return unsubscribe },
     })
     const readsDuringClose: SpindlePresetEditorState[] = []
+    let closeMutationError: unknown
     const unsubscribe = subscribePresetEditorState((state) => {
       if (state.open) return
       readsDuringClose.push(getPresetEditorState())
-      expect(() => helper.setMetadata({ mode: 'stale' })).toThrow('PRESET_EDITOR_CLOSED')
+      try {
+        helper.setMetadata({ mode: 'stale' })
+      } catch (error) {
+        closeMutationError = error
+      }
     })
 
     syncPresetEditorState({
@@ -156,6 +161,8 @@ describe('scoped preset editor helper', () => {
     })
 
     expect(readsDuringClose).toEqual([expect.objectContaining({ open: false, presetId: null, preset: null })])
+    expect(closeMutationError).toBeInstanceOf(Error)
+    expect((closeMutationError as Error).message).toContain('PRESET_EDITOR_CLOSED')
     expect(updates).toBe(0)
     unsubscribe()
   })

--- a/frontend/src/lib/spindle/preset-editor-helper.ts
+++ b/frontend/src/lib/spindle/preset-editor-helper.ts
@@ -29,6 +29,7 @@ const DEFAULT_STATE: SpindlePresetEditorState = {
 
 let controller: PresetEditorController | null = null
 let snapshot: SpindlePresetEditorState = DEFAULT_STATE
+let publishingDepth = 0
 const listeners = new Set<(state: SpindlePresetEditorState) => void>()
 
 function clone<T>(value: T): T {
@@ -53,14 +54,24 @@ function cloneState(state: SpindlePresetEditorState): SpindlePresetEditorState {
 }
 
 function publishState(next: SpindlePresetEditorState): void {
-  snapshot = cloneState(next)
-  for (const handler of listeners) {
-    try { handler(cloneState(snapshot)) } catch { /* no-op */ }
+  const published = cloneState(next)
+  snapshot = published
+  publishingDepth += 1
+  try {
+    for (const handler of listeners) {
+      try { handler(cloneState(published)) } catch { /* no-op */ }
+    }
+  } finally {
+    publishingDepth -= 1
   }
 }
 
+function getCurrentState(): SpindlePresetEditorState {
+  return publishingDepth > 0 || !controller ? snapshot : controller.getState()
+}
+
 function assertOpenController(): PresetEditorController {
-  const current = controller?.getState()
+  const current = getCurrentState()
   if (!controller || !current?.open || !current.preset) {
     throw new Error('PRESET_EDITOR_CLOSED: Preset editor is not open or has no selected preset')
   }
@@ -73,13 +84,21 @@ export function setPresetEditorController(next: PresetEditorController | null): 
 }
 
 export function syncPresetEditorState(next: SpindlePresetEditorState): void {
+  if (
+    snapshot.open
+    && snapshot.presetId
+    && next.open
+    && next.presetId
+    && snapshot.presetId !== next.presetId
+  ) {
+    publishState(DEFAULT_STATE)
+  }
   publishState(next)
 }
 
 export function getPresetEditorState(): SpindlePresetEditorState {
-  // Controller reads are synchronous; subscriptions still publish on the
-  // normal React synchronization path.
-  return cloneState(controller ? controller.getState() : snapshot)
+  // A published transition snapshot is authoritative during listener delivery.
+  return cloneState(getCurrentState())
 }
 
 export function subscribePresetEditorState(
@@ -100,7 +119,7 @@ export async function flushPresetEditorDraft(): Promise<void> {
 }
 
 export function setPresetEditorActiveTab(tabId: string): void {
-  if (!controller?.getState().open) return
+  if (!controller || !getCurrentState().open) return
   controller.setActiveTab(tabId)
 }
 

--- a/frontend/src/lib/spindle/preset-editor-helper.ts
+++ b/frontend/src/lib/spindle/preset-editor-helper.ts
@@ -4,6 +4,7 @@ import type {
   SpindlePresetEditorScopedHelper,
   SpindlePresetEditorState,
 } from './preset-editor-types'
+import { SPINDLE_EXTENSION_METADATA_KEY } from '@/lib/loom/service'
 
 type PresetMutator = (preset: SpindlePresetEditorDraft) => SpindlePresetEditorDraft
 
@@ -36,6 +37,10 @@ function clone<T>(value: T): T {
   } catch {
     return JSON.parse(JSON.stringify(value)) as T
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
 }
 
 function cloneState(state: SpindlePresetEditorState): SpindlePresetEditorState {
@@ -71,7 +76,9 @@ export function syncPresetEditorState(next: SpindlePresetEditorState): void {
 }
 
 export function getPresetEditorState(): SpindlePresetEditorState {
-  return cloneState(snapshot)
+  // Controller reads are synchronous; subscriptions still publish on the
+  // normal React synchronization path.
+  return cloneState(controller ? controller.getState() : snapshot)
 }
 
 export function subscribePresetEditorState(
@@ -101,8 +108,9 @@ function cloneExtensionState(
   extensionIdentifier: string,
 ): SpindlePresetEditorExtensionState {
   const draft = state.preset
-  const metadata = draft && Object.hasOwn(draft.metadata, extensionIdentifier)
-    ? clone(draft.metadata[extensionIdentifier])
+  const namespaces = draft?.metadata[SPINDLE_EXTENSION_METADATA_KEY]
+  const metadata = isRecord(namespaces) && Object.hasOwn(namespaces, extensionIdentifier)
+    ? clone(namespaces[extensionIdentifier])
     : undefined
   const promptVariableValues = draft?.metadata.promptVariables
   return {
@@ -137,9 +145,14 @@ export function createPresetEditorScopedHelper(
   ): void {
     access.assertActive()
     updatePresetEditorDraft((draft) => {
+      const namespaces = draft.metadata[SPINDLE_EXTENSION_METADATA_KEY]
+      if (namespaces !== undefined && !isRecord(namespaces)) {
+        throw new Error('PRESET_EDITOR_INVALID_METADATA_NAMESPACE: Spindle metadata namespace must be an object')
+      }
+      const namespaceBag = isRecord(namespaces) ? namespaces : {}
       const nextMetadata = mutator(
-        Object.hasOwn(draft.metadata, extensionIdentifier)
-          ? clone(draft.metadata[extensionIdentifier])
+        Object.hasOwn(namespaceBag, extensionIdentifier)
+          ? clone(namespaceBag[extensionIdentifier])
           : undefined,
       )
       assertMetadataObject(nextMetadata)
@@ -147,7 +160,10 @@ export function createPresetEditorScopedHelper(
         ...draft,
         metadata: {
           ...draft.metadata,
-          [extensionIdentifier]: clone(nextMetadata),
+          [SPINDLE_EXTENSION_METADATA_KEY]: {
+            ...namespaceBag,
+            [extensionIdentifier]: clone(nextMetadata),
+          },
         },
       }
     }, immediate)

--- a/frontend/src/lib/spindle/preset-editor-helper.ts
+++ b/frontend/src/lib/spindle/preset-editor-helper.ts
@@ -4,7 +4,7 @@ import type {
   SpindlePresetEditorScopedHelper,
   SpindlePresetEditorState,
 } from './preset-editor-types'
-import { SPINDLE_EXTENSION_METADATA_KEY } from '@/lib/loom/service'
+import { isLoomOwnedPresetMetadataKey } from '@/lib/loom/service'
 
 type PresetMutator = (preset: SpindlePresetEditorDraft) => SpindlePresetEditorDraft
 
@@ -172,9 +172,8 @@ function cloneExtensionState(
   extensionIdentifier: string,
 ): SpindlePresetEditorExtensionState {
   const draft = state.preset
-  const namespaces = draft?.metadata[SPINDLE_EXTENSION_METADATA_KEY]
-  const metadata = isRecord(namespaces) && Object.hasOwn(namespaces, extensionIdentifier)
-    ? clone(namespaces[extensionIdentifier])
+  const metadata = draft && Object.hasOwn(draft.metadata, extensionIdentifier)
+    ? clone(draft.metadata[extensionIdentifier])
     : undefined
   const promptVariableValues = draft?.metadata.promptVariables
   return {
@@ -203,20 +202,19 @@ export function createPresetEditorScopedHelper(
   extensionIdentifier: string,
   access: PresetEditorScopedAccess,
 ): SpindlePresetEditorScopedHelper {
+  if (isLoomOwnedPresetMetadataKey(extensionIdentifier)) {
+    throw new Error(`PRESET_EDITOR_RESERVED_METADATA_KEY: ${extensionIdentifier}`)
+  }
+
   function applyScopedMetadataMutation(
     mutator: (current: unknown) => Record<string, unknown>,
     immediate = false,
   ): void {
     access.assertActive()
     updatePresetEditorDraft((draft) => {
-      const namespaces = draft.metadata[SPINDLE_EXTENSION_METADATA_KEY]
-      if (namespaces !== undefined && !isRecord(namespaces)) {
-        throw new Error('PRESET_EDITOR_INVALID_METADATA_NAMESPACE: Spindle metadata namespace must be an object')
-      }
-      const namespaceBag = isRecord(namespaces) ? namespaces : {}
       const nextMetadata = mutator(
-        Object.hasOwn(namespaceBag, extensionIdentifier)
-          ? clone(namespaceBag[extensionIdentifier])
+        Object.hasOwn(draft.metadata, extensionIdentifier)
+          ? clone(draft.metadata[extensionIdentifier])
           : undefined,
       )
       assertMetadataObject(nextMetadata)
@@ -224,10 +222,7 @@ export function createPresetEditorScopedHelper(
         ...draft,
         metadata: {
           ...draft.metadata,
-          [SPINDLE_EXTENSION_METADATA_KEY]: {
-            ...namespaceBag,
-            [extensionIdentifier]: clone(nextMetadata),
-          },
+          [extensionIdentifier]: clone(nextMetadata),
         },
       }
     }, immediate)

--- a/frontend/src/lib/spindle/preset-editor-helper.ts
+++ b/frontend/src/lib/spindle/preset-editor-helper.ts
@@ -1,4 +1,9 @@
-import type { SpindlePresetEditorDraft, SpindlePresetEditorState } from './preset-editor-types'
+import type {
+  SpindlePresetEditorDraft,
+  SpindlePresetEditorExtensionState,
+  SpindlePresetEditorScopedHelper,
+  SpindlePresetEditorState,
+} from './preset-editor-types'
 
 type PresetMutator = (preset: SpindlePresetEditorDraft) => SpindlePresetEditorDraft
 
@@ -7,6 +12,11 @@ interface PresetEditorController {
   setActiveTab(tabId: string): void
   updatePreset(mutator: PresetMutator, immediate: boolean): void
   flush(): Promise<void>
+}
+
+export interface PresetEditorScopedAccess {
+  assertActive(): void
+  trackSubscription(unsubscribe: () => void): () => void
 }
 
 const DEFAULT_STATE: SpindlePresetEditorState = {
@@ -84,4 +94,92 @@ export async function flushPresetEditorDraft(): Promise<void> {
 export function setPresetEditorActiveTab(tabId: string): void {
   if (!controller || !snapshot.open) return
   controller.setActiveTab(tabId)
+}
+
+function cloneExtensionState(
+  state: SpindlePresetEditorState,
+  extensionIdentifier: string,
+): SpindlePresetEditorExtensionState {
+  const draft = state.preset
+  const metadata = draft && Object.hasOwn(draft.metadata, extensionIdentifier)
+    ? clone(draft.metadata[extensionIdentifier])
+    : undefined
+  const promptVariableValues = draft?.metadata.promptVariables
+  return {
+    open: state.open,
+    presetId: state.presetId,
+    activeTabId: state.activeTabId,
+    blocks: draft ? clone(draft.blocks) : [],
+    promptVariableValues: promptVariableValues && typeof promptVariableValues === 'object'
+      ? clone(promptVariableValues) as SpindlePresetEditorExtensionState['promptVariableValues']
+      : {},
+    metadata,
+  }
+}
+
+function assertMetadataObject(value: unknown): asserts value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('PRESET_EDITOR_INVALID_METADATA: Extension metadata must be an object')
+  }
+}
+
+/**
+ * Create the cooperative, extension-identifier-scoped editor facade. This
+ * constrains supported API mutations; it is not a sandbox for same-origin code.
+ */
+export function createPresetEditorScopedHelper(
+  extensionIdentifier: string,
+  access: PresetEditorScopedAccess,
+): SpindlePresetEditorScopedHelper {
+  function applyScopedMetadataMutation(
+    mutator: (current: unknown) => Record<string, unknown>,
+    immediate = false,
+  ): void {
+    access.assertActive()
+    updatePresetEditorDraft((draft) => {
+      const nextMetadata = mutator(
+        Object.hasOwn(draft.metadata, extensionIdentifier)
+          ? clone(draft.metadata[extensionIdentifier])
+          : undefined,
+      )
+      assertMetadataObject(nextMetadata)
+      return {
+        ...draft,
+        metadata: {
+          ...draft.metadata,
+          [extensionIdentifier]: clone(nextMetadata),
+        },
+      }
+    }, immediate)
+  }
+
+  return {
+    getState(): SpindlePresetEditorExtensionState {
+      access.assertActive()
+      return cloneExtensionState(getPresetEditorState(), extensionIdentifier)
+    },
+    onChange(handler: (state: SpindlePresetEditorExtensionState) => void): () => void {
+      access.assertActive()
+      const unsubscribe = subscribePresetEditorState((state) => {
+        handler(cloneExtensionState(state, extensionIdentifier))
+      })
+      return access.trackSubscription(unsubscribe)
+    },
+    setMetadata(value, options): void {
+      assertMetadataObject(value)
+      applyScopedMetadataMutation(() => value, options?.immediate === true)
+    },
+    updateMetadata(mutator, options): void {
+      applyScopedMetadataMutation(mutator, options?.immediate === true)
+    },
+    activateBuiltinTab(tab): void {
+      access.assertActive()
+      if (tab !== 'blocks') throw new Error(`PRESET_EDITOR_UNKNOWN_BUILTIN_TAB:${tab}`)
+      setPresetEditorActiveTab('preset')
+    },
+    flush(): Promise<void> {
+      access.assertActive()
+      return flushPresetEditorDraft()
+    },
+  }
 }

--- a/frontend/src/lib/spindle/preset-editor-helper.ts
+++ b/frontend/src/lib/spindle/preset-editor-helper.ts
@@ -60,7 +60,8 @@ function publishState(next: SpindlePresetEditorState): void {
 }
 
 function assertOpenController(): PresetEditorController {
-  if (!controller || !snapshot.open || !snapshot.preset) {
+  const current = controller?.getState()
+  if (!controller || !current?.open || !current.preset) {
     throw new Error('PRESET_EDITOR_CLOSED: Preset editor is not open or has no selected preset')
   }
   return controller
@@ -99,7 +100,7 @@ export async function flushPresetEditorDraft(): Promise<void> {
 }
 
 export function setPresetEditorActiveTab(tabId: string): void {
-  if (!controller || !snapshot.open) return
+  if (!controller?.getState().open) return
   controller.setActiveTab(tabId)
 }
 

--- a/frontend/src/lib/spindle/preset-editor-helper.ts
+++ b/frontend/src/lib/spindle/preset-editor-helper.ts
@@ -44,6 +44,49 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value)
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) return false
+  try {
+    const prototype = Object.getPrototypeOf(value)
+    return prototype === Object.prototype || prototype === null
+  } catch {
+    return false
+  }
+}
+
+function isJsonValue(value: unknown, ancestors = new WeakSet<object>()): boolean {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return true
+  if (typeof value === 'number') return Number.isFinite(value) && !Object.is(value, -0)
+  if (typeof value !== 'object') return false
+
+  if (ancestors.has(value)) return false
+  ancestors.add(value)
+  try {
+    if (Array.isArray(value)) {
+      for (let index = 0; index < value.length; index += 1) {
+        if (!(index in value) || !isJsonValue(value[index], ancestors)) return false
+      }
+      return Reflect.ownKeys(value).every((key) => (
+        key === 'length'
+        || (typeof key === 'string' && /^(0|[1-9]\d*)$/.test(key) && Number(key) < value.length)
+      ))
+    }
+    if (!isPlainObject(value)) return false
+    return Reflect.ownKeys(value).every((key) => {
+      if (typeof key !== 'string') return false
+      const descriptor = Object.getOwnPropertyDescriptor(value, key)
+      return !!descriptor
+        && descriptor.enumerable
+        && Object.hasOwn(descriptor, 'value')
+        && isJsonValue(descriptor.value, ancestors)
+    })
+  } catch {
+    return false
+  } finally {
+    ancestors.delete(value)
+  }
+}
+
 function cloneState(state: SpindlePresetEditorState): SpindlePresetEditorState {
   return {
     open: state.open,
@@ -115,12 +158,13 @@ export function updatePresetEditorDraft(mutator: PresetMutator, immediate = fals
 export async function flushPresetEditorDraft(): Promise<void> {
   const activeController = assertOpenController()
   await activeController.flush()
-  publishState(activeController.getState())
+  if (controller === activeController) {
+    syncPresetEditorState(activeController.getState())
+  }
 }
 
 export function setPresetEditorActiveTab(tabId: string): void {
-  if (!controller || !getCurrentState().open) return
-  controller.setActiveTab(tabId)
+  assertOpenController().setActiveTab(tabId)
 }
 
 function cloneExtensionState(
@@ -146,8 +190,8 @@ function cloneExtensionState(
 }
 
 function assertMetadataObject(value: unknown): asserts value is Record<string, unknown> {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error('PRESET_EDITOR_INVALID_METADATA: Extension metadata must be an object')
+  if (!isPlainObject(value) || !isJsonValue(value)) {
+    throw new Error('PRESET_EDITOR_INVALID_METADATA: Extension metadata must be a plain JSON object')
   }
 }
 

--- a/frontend/src/lib/spindle/preset-editor-types.ts
+++ b/frontend/src/lib/spindle/preset-editor-types.ts
@@ -68,7 +68,7 @@ export interface SpindlePresetEditorExtensionState {
   blocks: PromptBlockDTO[]
   /** Detached prompt-variable values cloned from the host draft. */
   promptVariableValues: PromptVariableValuesDTO
-  /** Structured clone of metadata[callingExtensionIdentifier]. */
+  /** Structured clone of the calling extension's host-managed metadata namespace. */
   readonly metadata: unknown
 }
 

--- a/frontend/src/lib/spindle/preset-editor-types.ts
+++ b/frontend/src/lib/spindle/preset-editor-types.ts
@@ -64,8 +64,10 @@ export interface SpindlePresetEditorExtensionState {
   readonly open: boolean
   readonly presetId: string | null
   readonly activeTabId: string | null
-  readonly blocks: readonly PromptBlockDTO[]
-  readonly promptVariableValues: Readonly<PromptVariableValuesDTO>
+  /** A detached array cloned from the host draft. */
+  blocks: PromptBlockDTO[]
+  /** Detached prompt-variable values cloned from the host draft. */
+  promptVariableValues: PromptVariableValuesDTO
   /** Structured clone of metadata[callingExtensionIdentifier]. */
   readonly metadata: unknown
 }

--- a/frontend/src/lib/spindle/preset-editor-types.ts
+++ b/frontend/src/lib/spindle/preset-editor-types.ts
@@ -65,9 +65,9 @@ export interface SpindlePresetEditorExtensionState {
   readonly presetId: string | null
   readonly activeTabId: string | null
   /** A detached array cloned from the host draft. */
-  blocks: PromptBlockDTO[]
+  readonly blocks: readonly PromptBlockDTO[]
   /** Detached prompt-variable values cloned from the host draft. */
-  promptVariableValues: PromptVariableValuesDTO
+  readonly promptVariableValues: Readonly<PromptVariableValuesDTO>
   /** Structured clone of the calling extension's top-level metadata value. */
   readonly metadata: unknown
 }

--- a/frontend/src/lib/spindle/preset-editor-types.ts
+++ b/frontend/src/lib/spindle/preset-editor-types.ts
@@ -68,7 +68,7 @@ export interface SpindlePresetEditorExtensionState {
   blocks: PromptBlockDTO[]
   /** Detached prompt-variable values cloned from the host draft. */
   promptVariableValues: PromptVariableValuesDTO
-  /** Structured clone of the calling extension's host-managed metadata namespace. */
+  /** Structured clone of the calling extension's top-level metadata value. */
   readonly metadata: unknown
 }
 

--- a/frontend/src/lib/spindle/preset-editor-types.ts
+++ b/frontend/src/lib/spindle/preset-editor-types.ts
@@ -1,4 +1,4 @@
-import type { PromptBlockDTO, SpindleFrontendContext } from 'lumiverse-spindle-types'
+import type { PromptBlockDTO, PromptVariableValuesDTO, SpindleFrontendContext } from 'lumiverse-spindle-types'
 
 export interface SpindlePresetEditorTabOptions {
   id: string
@@ -12,6 +12,20 @@ export interface SpindlePresetEditorTabHandle {
   activate(): void
   destroy(): void
   onActivate(handler: () => void): () => void
+}
+
+export type SpindlePresetEditorBuiltinTabId = 'blocks'
+
+export interface SpindlePresetEditorToolbarItemOptions {
+  id: string
+  ariaLabel: string
+}
+
+export interface SpindlePresetEditorToolbarItemHandle {
+  readonly root: HTMLElement
+  readonly itemId: string
+  setVisible(visible: boolean): void
+  destroy(): void
 }
 
 export interface SpindlePresetEditorDraft {
@@ -46,7 +60,41 @@ export interface SpindlePresetEditorHelper {
   flush(): Promise<void>
 }
 
-export type SpindlePresetEditorUI = SpindleFrontendContext['ui'] & {
-  registerPresetEditorTab(options: SpindlePresetEditorTabOptions): SpindlePresetEditorTabHandle
-  presetEditor: SpindlePresetEditorHelper
+export interface SpindlePresetEditorExtensionState {
+  readonly open: boolean
+  readonly presetId: string | null
+  readonly activeTabId: string | null
+  readonly blocks: readonly PromptBlockDTO[]
+  readonly promptVariableValues: Readonly<PromptVariableValuesDTO>
+  /** Structured clone of metadata[callingExtensionIdentifier]. */
+  readonly metadata: unknown
 }
+
+export interface SpindlePresetEditorScopedHelper {
+  getState(): SpindlePresetEditorExtensionState
+  onChange(handler: (state: SpindlePresetEditorExtensionState) => void): () => void
+  setMetadata(value: Record<string, unknown>, options?: SpindlePresetEditorSaveOptions): void
+  updateMetadata(
+    mutator: (current: unknown) => Record<string, unknown>,
+    options?: SpindlePresetEditorSaveOptions,
+  ): void
+  activateBuiltinTab(tab: SpindlePresetEditorBuiltinTabId): void
+  flush(): Promise<void>
+}
+
+export interface SpindlePresetEditorToolbarUI {
+  registerPresetEditorToolbarItem(
+    options: SpindlePresetEditorToolbarItemOptions,
+  ): SpindlePresetEditorToolbarItemHandle
+}
+
+export interface SpindlePresetEditorExtensionHelper {
+  extension: SpindlePresetEditorScopedHelper
+}
+
+export type SpindlePresetEditorUI = SpindleFrontendContext['ui']
+  & SpindlePresetEditorToolbarUI
+  & {
+    registerPresetEditorTab(options: SpindlePresetEditorTabOptions): SpindlePresetEditorTabHandle
+    presetEditor: SpindlePresetEditorHelper & SpindlePresetEditorExtensionHelper
+  }

--- a/frontend/src/lib/spindle/preset-editor-types.ts
+++ b/frontend/src/lib/spindle/preset-editor-types.ts
@@ -91,7 +91,7 @@ export interface SpindlePresetEditorToolbarUI {
 }
 
 export interface SpindlePresetEditorExtensionHelper {
-  extension: SpindlePresetEditorScopedHelper
+  readonly extension: SpindlePresetEditorScopedHelper
 }
 
 export type SpindlePresetEditorUI = SpindleFrontendContext['ui']

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -35,6 +35,9 @@ import { createConnectionSlice } from './slices/connection'
 import { createWeaverSlice } from './slices/weaver'
 import { createContainersSlice } from './slices/containers'
 import { registerUserScopedResetStore } from './user-scoped-reset'
+import { configurePresetSelectionCoordinator } from '@/lib/loom/preset-selection-coordinator'
+import { flushPresetForGeneration } from '@/lib/loom/preset-save-coordinator'
+
 
 export const useStore = create<AppStore>()((...a) => ({
   ...createChatSlice(...a),
@@ -72,5 +75,11 @@ export const useStore = create<AppStore>()((...a) => ({
   ...createWeaverSlice(...a),
   ...createContainersSlice(...a),
 }))
+
+configurePresetSelectionCoordinator({
+  getActivePresetId: () => useStore.getState().activeLoomPresetId,
+  setActivePresetId: (presetId) => useStore.getState().setActiveLoomPreset(presetId),
+  flushPreset: flushPresetForGeneration,
+})
 
 registerUserScopedResetStore(useStore, useStore.getState())

--- a/frontend/src/store/slices/auth.ts
+++ b/frontend/src/store/slices/auth.ts
@@ -4,6 +4,7 @@ import { authClient, getAuthErrorMessage, readAuthErrorResponseMeta, type AuthEr
 import { post, get, del } from '@/api/client'
 import { resetUserScopedStoreState } from '../user-scoped-reset'
 import { setSettingsPersistenceScope } from './settings'
+import { setPresetSaveCoordinatorScope } from '@/lib/loom/preset-save-coordinator'
 
 let authMutationGeneration = 0
 let sessionCheckGeneration = 0
@@ -46,6 +47,7 @@ export const createAuthSlice: StateCreator<AuthSlice> = (set, getState) => ({
       if (data?.user) {
         resetUserScopedStoreState()
         setSettingsPersistenceScope(data.user.id)
+        setPresetSaveCoordinatorScope(data.user.id)
         set({
           user: data.user as AuthUser,
           session: { token: data.token } as any,
@@ -107,6 +109,7 @@ export const createAuthSlice: StateCreator<AuthSlice> = (set, getState) => ({
           resetUserScopedStoreState()
         }
         setSettingsPersistenceScope(data.user.id)
+        setPresetSaveCoordinatorScope(data.user.id)
         set({
           user: data.user as AuthUser,
           session: data.session as any,

--- a/frontend/src/store/slices/settings-load-generation.test.ts
+++ b/frontend/src/store/slices/settings-load-generation.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test'
+import { createSettingsLoadGenerationGuard } from './settings-load-generation'
+
+// The settings slice depends on the full store and browser APIs, so the token
+// seam is tested directly instead of mocking the entire slice.
+describe('settings load generation guard', () => {
+  test('keeps an older response stale after a newer load starts', () => {
+    const guard = createSettingsLoadGenerationGuard()
+    const firstGeneration = guard.begin()
+
+    expect(guard.isCurrent(firstGeneration)).toBe(true)
+
+    const secondGeneration = guard.begin()
+
+    expect(guard.isCurrent(firstGeneration)).toBe(false)
+    expect(guard.isCurrent(secondGeneration)).toBe(true)
+  })
+})

--- a/frontend/src/store/slices/settings-load-generation.ts
+++ b/frontend/src/store/slices/settings-load-generation.ts
@@ -1,0 +1,13 @@
+export interface SettingsLoadGenerationGuard {
+  begin(): number
+  isCurrent(generation: number): boolean
+}
+
+export function createSettingsLoadGenerationGuard(): SettingsLoadGenerationGuard {
+  let currentGeneration = 0
+
+  return {
+    begin: () => ++currentGeneration,
+    isCurrent: (generation) => generation === currentGeneration,
+  }
+}

--- a/frontend/src/store/slices/settings.ts
+++ b/frontend/src/store/slices/settings.ts
@@ -3,7 +3,7 @@ import type { AppStore, SettingsSlice, StartupSettings, ThemeConfig, ReasoningSe
 import { settingsApi } from '@/api/settings'
 import { themeAssetsApi } from '@/api/theme-assets'
 import { BASE_URL } from '@/api/client'
-import { transitionActiveLoomPreset } from '@/lib/loom/preset-selection-coordinator'
+import { beginActiveLoomPresetSelection, type PresetSelectionRequest } from '@/lib/loom/preset-selection-coordinator'
 import { generateUUID } from '@/lib/uuid'
 import { DEFAULT_THEME, normalizeTheme } from '@/theme/presets'
 import {
@@ -794,9 +794,11 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
     settingsSelectionAbort?.abort()
     const selectionAbort = new AbortController()
     settingsSelectionAbort = selectionAbort
+    let selection: PresetSelectionRequest | null = null
     const loadGeneration = ++settingsLoadGeneration
     const localRevisionAtLoadStart = localSettingsRevision
     try {
+      selection = beginActiveLoomPresetSelection({ signal: selectionAbort.signal })
       const rows = await settingsApi.getAll()
       if (loadGeneration !== settingsLoadGeneration) return
       const patch: Record<string, any> = {}
@@ -891,11 +893,8 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
       if (Object.keys(patch).length > 0) {
         set(patch as any)
       }
-      if (
-        requestedActiveLoomPresetId !== undefined
-        && requestedActiveLoomPresetId !== get().activeLoomPresetId
-      ) {
-        await transitionActiveLoomPreset(requestedActiveLoomPresetId, { signal: selectionAbort.signal })
+      if (requestedActiveLoomPresetId !== undefined && selection) {
+        await selection.transition(requestedActiveLoomPresetId)
       }
 
       // Reorder profile slices to match persisted connectionsOrder. Without
@@ -945,6 +944,7 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
     } catch (err) {
       console.error('[settings] Failed to load settings:', err)
     } finally {
+      selection?.cancel()
       if (settingsSelectionAbort === selectionAbort) {
         settingsSelectionAbort = null
       }

--- a/frontend/src/store/slices/settings.ts
+++ b/frontend/src/store/slices/settings.ts
@@ -6,6 +6,7 @@ import { BASE_URL } from '@/api/client'
 import { beginActiveLoomPresetSelection, type PresetSelectionRequest } from '@/lib/loom/preset-selection-coordinator'
 import { generateUUID } from '@/lib/uuid'
 import { DEFAULT_THEME, normalizeTheme } from '@/theme/presets'
+import { createSettingsLoadGenerationGuard } from './settings-load-generation'
 import {
   deriveReorderArgs,
   normalizeConnectionsOrder,
@@ -160,6 +161,7 @@ export function setSettingsPersistenceScope(userId: string | null): void {
 }
 
 let settingsSelectionAbort: AbortController | null = null
+const settingsLoadGeneration = createSettingsLoadGenerationGuard()
 
 function persistBatch(batch: Record<string, any>): Promise<void> {
   const generation = persistenceGeneration
@@ -791,6 +793,8 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
   },
 
   loadSettings: async () => {
+    const loadGeneration = settingsLoadGeneration.begin()
+    const isCurrentLoad = () => settingsLoadGeneration.isCurrent(loadGeneration)
     settingsSelectionAbort?.abort()
     const selectionAbort = new AbortController()
     settingsSelectionAbort = selectionAbort
@@ -800,7 +804,7 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
     try {
       selection = beginActiveLoomPresetSelection({ signal: selectionAbort.signal })
       const rows = await settingsApi.getAll()
-      if (loadGeneration !== settingsLoadGeneration) return
+      if (!isCurrentLoad()) return
       const patch: Record<string, any> = {}
       const defaults = get()
       const pendingImageGenerationPatch = {
@@ -815,6 +819,7 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
       // no UI setter; wipe it from the DB on load so it stops resolving to a
       // preset behind the user's back.
       if (rows.some((r) => r.key === 'activeLumiPresetId')) {
+        if (!isCurrentLoad()) return
         settingsApi.delete('activeLumiPresetId').catch(() => {})
       }
       for (const row of rows) {
@@ -838,6 +843,7 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
         }
       }
 
+      if (!isCurrentLoad()) return
       // Migration: discard old ThemeConfig shape (has baseColors but no accent)
       if (patch.theme && 'baseColors' in patch.theme && !('accent' in patch.theme)) {
         patch.theme = null
@@ -889,12 +895,16 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
         }
       }
       const requestedActiveLoomPresetId = patch.activeLoomPresetId as string | null | undefined
+      if (!isCurrentLoad()) return
       delete patch.activeLoomPresetId
       if (Object.keys(patch).length > 0) {
         set(patch as any)
+        if (!isCurrentLoad()) return
       }
       if (requestedActiveLoomPresetId !== undefined && selection) {
+        if (!isCurrentLoad()) return
         await selection.transition(requestedActiveLoomPresetId)
+        if (!isCurrentLoad()) return
       }
 
       // Reorder profile slices to match persisted connectionsOrder. Without
@@ -902,6 +912,7 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
       // ConnectionSelect, etc.) keep the backend order until the user drags
       // something in the panel — which is the visible divergence C3 found.
       if (patch.connectionsOrder) {
+        if (!isCurrentLoad()) return
         const order = patch.connectionsOrder as ConnectionsOrder
         const args = deriveReorderArgs(order, {
           llm: get().profiles,
@@ -909,22 +920,37 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
           stt: get().sttProfiles,
           tts: get().ttsProfiles,
         })
-        if (args.llm) get().applyProfileOrder(args.llm)
-        if (args.imageGen) get().applyImageGenProfileOrder(args.imageGen)
-        if (args.stt) get().applySttProfileOrder(args.stt)
-        if (args.tts) get().applyTtsProfileOrder(args.tts)
+        if (args.llm) {
+          if (!isCurrentLoad()) return
+          get().applyProfileOrder(args.llm)
+        }
+        if (args.imageGen) {
+          if (!isCurrentLoad()) return
+          get().applyImageGenProfileOrder(args.imageGen)
+        }
+        if (args.stt) {
+          if (!isCurrentLoad()) return
+          get().applySttProfileOrder(args.stt)
+        }
+        if (args.tts) {
+          if (!isCurrentLoad()) return
+          get().applyTtsProfileOrder(args.tts)
+        }
       }
       if (migratedCharacterFilterTab) {
+        if (!isCurrentLoad()) return
         persistKey('filterTab', 'characters')
       }
 
       // Full settings are now authoritative. Queue recovered bridge values
       // through the same serialized persistence path as normal edits; a bridged
       // image-generation row still waits for profile reconciliation when needed.
+      if (!isCurrentLoad()) return
       set({ fullSettingsLoaded: true })
       if (pendingKeys) {
         for (const [key, value] of Object.entries(pendingKeys)) {
           if (!DATA_KEYS.has(key) || key === 'imageGeneration') continue
+          if (!isCurrentLoad()) return
           persistKey(key, patch[key] ?? value)
         }
       }
@@ -939,16 +965,19 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
           || (get().imageGenProfilesLoaded && hasPendingImageGeneration)
         )
       ) {
+        if (!isCurrentLoad()) return
         persistKey('imageGeneration', patch.imageGeneration)
       }
     } catch (err) {
-      console.error('[settings] Failed to load settings:', err)
+      if (isCurrentLoad()) {
+        console.error('[settings] Failed to load settings:', err)
+      }
     } finally {
       selection?.cancel()
       if (settingsSelectionAbort === selectionAbort) {
         settingsSelectionAbort = null
       }
-      if (loadGeneration === settingsLoadGeneration) {
+      if (isCurrentLoad())
         set({ settingsLoaded: true })
       }
     }

--- a/frontend/src/store/slices/settings.ts
+++ b/frontend/src/store/slices/settings.ts
@@ -146,7 +146,6 @@ let flushInFlight = false
 let activeFlushPromise: Promise<void> | null = null
 let activeFlushBatch: Record<string, any> | null = null
 let persistenceGeneration = 0
-let settingsLoadGeneration = 0
 let localSettingsRevision = 0
 const localSettingRevisions = new Map<string, number>()
 let persistenceScope: string | null = null
@@ -422,7 +421,7 @@ export function resetSettingsPersistence(): void {
     } catch {}
   }
   persistenceGeneration += 1
-  settingsLoadGeneration += 1
+  settingsLoadGeneration.begin()
   dirtyKeys.clear()
   flushInFlight = false
   activeFlushPromise = null
@@ -799,7 +798,6 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
     const selectionAbort = new AbortController()
     settingsSelectionAbort = selectionAbort
     let selection: PresetSelectionRequest | null = null
-    const loadGeneration = ++settingsLoadGeneration
     const localRevisionAtLoadStart = localSettingsRevision
     try {
       selection = beginActiveLoomPresetSelection({ signal: selectionAbort.signal })
@@ -977,7 +975,7 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
       if (settingsSelectionAbort === selectionAbort) {
         settingsSelectionAbort = null
       }
-      if (isCurrentLoad())
+      if (isCurrentLoad()) {
         set({ settingsLoaded: true })
       }
     }

--- a/frontend/src/store/slices/settings.ts
+++ b/frontend/src/store/slices/settings.ts
@@ -3,6 +3,7 @@ import type { AppStore, SettingsSlice, StartupSettings, ThemeConfig, ReasoningSe
 import { settingsApi } from '@/api/settings'
 import { themeAssetsApi } from '@/api/theme-assets'
 import { BASE_URL } from '@/api/client'
+import { transitionActiveLoomPreset } from '@/lib/loom/preset-selection-coordinator'
 import { generateUUID } from '@/lib/uuid'
 import { DEFAULT_THEME, normalizeTheme } from '@/theme/presets'
 import {
@@ -157,6 +158,8 @@ function bridgeStorageKey(key: string): string {
 export function setSettingsPersistenceScope(userId: string | null): void {
   persistenceScope = userId
 }
+
+let settingsSelectionAbort: AbortController | null = null
 
 function persistBatch(batch: Record<string, any>): Promise<void> {
   const generation = persistenceGeneration
@@ -788,6 +791,9 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
   },
 
   loadSettings: async () => {
+    settingsSelectionAbort?.abort()
+    const selectionAbort = new AbortController()
+    settingsSelectionAbort = selectionAbort
     const loadGeneration = ++settingsLoadGeneration
     const localRevisionAtLoadStart = localSettingsRevision
     try {
@@ -880,8 +886,16 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
           patch.activeImageGenConnectionId = savedConnectionId
         }
       }
+      const requestedActiveLoomPresetId = patch.activeLoomPresetId as string | null | undefined
+      delete patch.activeLoomPresetId
       if (Object.keys(patch).length > 0) {
         set(patch as any)
+      }
+      if (
+        requestedActiveLoomPresetId !== undefined
+        && requestedActiveLoomPresetId !== get().activeLoomPresetId
+      ) {
+        await transitionActiveLoomPreset(requestedActiveLoomPresetId, { signal: selectionAbort.signal })
       }
 
       // Reorder profile slices to match persisted connectionsOrder. Without
@@ -931,6 +945,9 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
     } catch (err) {
       console.error('[settings] Failed to load settings:', err)
     } finally {
+      if (settingsSelectionAbort === selectionAbort) {
+        settingsSelectionAbort = null
+      }
       if (loadGeneration === settingsLoadGeneration) {
         set({ settingsLoaded: true })
       }

--- a/frontend/src/store/slices/spindle-placement.test.ts
+++ b/frontend/src/store/slices/spindle-placement.test.ts
@@ -111,6 +111,22 @@ describe('preset editor placements', () => {
     slice.state.removeAllByExtension('ext-1')
     expect(slice.state.presetEditorTabs).toHaveLength(0)
   })
+
+  test('registers and synchronously removes extension toolbar roots', () => {
+    const slice = makeSlice()
+    const root = {} as HTMLElement
+    slice.state.registerPresetEditorToolbarItem({
+      id: 'toolbar-1',
+      extensionId: 'ext-1',
+      ariaLabel: 'Agent mode controls',
+      root,
+      visible: true,
+    })
+    slice.state.setPresetEditorToolbarItemVisible('toolbar-1', false)
+    expect(slice.state.presetEditorToolbarItems[0].visible).toBe(false)
+    slice.state.removeAllByExtension('ext-1')
+    expect(slice.state.presetEditorToolbarItems).toHaveLength(0)
+  })
 })
 
 describe('hideAllPlacements / showAllPlacements', () => {

--- a/frontend/src/store/slices/spindle-placement.ts
+++ b/frontend/src/store/slices/spindle-placement.ts
@@ -9,6 +9,7 @@ const PLACEMENT_LIMITS = {
   drawerTabs: { perExtension: 4, global: 8 },
   characterEditorTabs: { perExtension: 4, global: 8 },
   presetEditorTabs: { perExtension: 4, global: 8 },
+  presetEditorToolbarItems: { perExtension: 1, global: 4 },
   floatWidgets: { perExtension: 2, global: 8 },
   dockPanels: { perExtensionPerEdge: 1, globalPerEdge: 2 },
   appMounts: { perExtension: 1, global: 4 },
@@ -47,6 +48,14 @@ export interface PresetEditorTabState {
   extensionId: string
   title: string
   root: HTMLElement
+}
+
+export interface PresetEditorToolbarItemState {
+  id: string
+  extensionId: string
+  ariaLabel: string
+  root: HTMLElement
+  visible: boolean
 }
 
 export interface FloatWidgetState {
@@ -140,6 +149,7 @@ export const createSpindlePlacementSlice: StateCreator<SpindlePlacementSlice> = 
   drawerTabs: [],
   characterEditorTabs: [],
   presetEditorTabs: [],
+  presetEditorToolbarItems: [],
   floatWidgets: [],
   dockPanels: [],
   appMounts: [],
@@ -228,6 +238,34 @@ export const createSpindlePlacementSlice: StateCreator<SpindlePlacementSlice> = 
   updatePresetEditorTab: (tabId: string, updates: Partial<Pick<PresetEditorTabState, 'title'>>) => {
     set((state) => ({
       presetEditorTabs: state.presetEditorTabs.map((t) => t.id === tabId ? { ...t, ...updates } : t),
+    }))
+  },
+
+  // ── Preset Editor Toolbar ──
+
+  registerPresetEditorToolbarItem: (item: PresetEditorToolbarItemState) => {
+    const state = get()
+    const extCount = state.presetEditorToolbarItems.filter((entry) => entry.extensionId === item.extensionId).length
+    if (extCount >= PLACEMENT_LIMITS.presetEditorToolbarItems.perExtension) {
+      throw new Error(`Preset editor toolbar item limit reached (max ${PLACEMENT_LIMITS.presetEditorToolbarItems.perExtension} per extension)`)
+    }
+    if (state.presetEditorToolbarItems.length >= PLACEMENT_LIMITS.presetEditorToolbarItems.global) {
+      throw new Error(`Global preset editor toolbar item limit reached (max ${PLACEMENT_LIMITS.presetEditorToolbarItems.global})`)
+    }
+    set({ presetEditorToolbarItems: [...state.presetEditorToolbarItems, item] })
+  },
+
+  unregisterPresetEditorToolbarItem: (itemId: string) => {
+    set((state) => ({
+      presetEditorToolbarItems: state.presetEditorToolbarItems.filter((item) => item.id !== itemId),
+    }))
+  },
+
+  setPresetEditorToolbarItemVisible: (itemId: string, visible: boolean) => {
+    set((state) => ({
+      presetEditorToolbarItems: state.presetEditorToolbarItems.map((item) =>
+        item.id === itemId ? { ...item, visible } : item
+      ),
     }))
   },
 
@@ -371,6 +409,7 @@ export const createSpindlePlacementSlice: StateCreator<SpindlePlacementSlice> = 
       drawerTabs: state.drawerTabs.filter((t) => t.extensionId !== extensionId),
       characterEditorTabs: state.characterEditorTabs.filter((t) => t.extensionId !== extensionId),
       presetEditorTabs: state.presetEditorTabs.filter((t) => t.extensionId !== extensionId),
+      presetEditorToolbarItems: state.presetEditorToolbarItems.filter((item) => item.extensionId !== extensionId),
       floatWidgets: state.floatWidgets.filter((w) => w.extensionId !== extensionId),
       dockPanels: state.dockPanels.filter((p) => p.extensionId !== extensionId),
       appMounts: state.appMounts.filter((m) => m.extensionId !== extensionId),

--- a/frontend/src/store/user-scoped-reset.ts
+++ b/frontend/src/store/user-scoped-reset.ts
@@ -1,6 +1,7 @@
 import type { AppStore } from '@/types/store'
 import { clearChatHeadsPersistence } from './slices/chat-heads'
 import { resetSettingsPersistence } from './slices/settings'
+import { setPresetSaveCoordinatorScope } from '@/lib/loom/preset-save-coordinator'
 type StoreApi = {
   getState: () => AppStore
   setState: (partial: Partial<AppStore>) => void
@@ -24,6 +25,7 @@ export function registerUserScopedResetStore(api: StoreApi, initial: AppStore): 
 
 export function resetUserScopedStoreState(): void {
   resetSettingsPersistence()
+  setPresetSaveCoordinatorScope(null)
   if (!storeApi || !initialState) return
 
   const patch: Partial<AppStore> = {}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -686,6 +686,8 @@ export interface Preset {
   metadata: Record<string, any>;
   created_at: number;
   updated_at: number;
+  /** Monotonic persisted revision used for conditional preset updates. */
+  cache_revision?: number;
 }
 
 export interface CreatePresetInput {
@@ -697,7 +699,10 @@ export interface CreatePresetInput {
   metadata?: Record<string, any>;
 }
 
-export type UpdatePresetInput = Partial<CreatePresetInput>;
+export type UpdatePresetInput = Partial<CreatePresetInput> & {
+  /** Transport-only precondition for an atomic cache revision check. */
+  expected_cache_revision?: number;
+};
 
 export interface PresetRegistryItem {
   id: string;

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -1131,6 +1131,7 @@ import type {
   DrawerTabState,
   CharacterEditorTabState,
   PresetEditorTabState,
+  PresetEditorToolbarItemState,
   FloatWidgetState,
   DockPanelState,
   AppMountState,
@@ -1143,6 +1144,7 @@ export interface SpindlePlacementSlice {
   drawerTabs: DrawerTabState[]
   characterEditorTabs: CharacterEditorTabState[]
   presetEditorTabs: PresetEditorTabState[]
+  presetEditorToolbarItems: PresetEditorToolbarItemState[]
   floatWidgets: FloatWidgetState[]
   dockPanels: DockPanelState[]
   appMounts: AppMountState[]
@@ -1166,6 +1168,10 @@ export interface SpindlePlacementSlice {
   registerPresetEditorTab: (tab: PresetEditorTabState) => void
   unregisterPresetEditorTab: (tabId: string) => void
   updatePresetEditorTab: (tabId: string, updates: Partial<Pick<PresetEditorTabState, 'title'>>) => void
+
+  registerPresetEditorToolbarItem: (item: PresetEditorToolbarItemState) => void
+  unregisterPresetEditorToolbarItem: (itemId: string) => void
+  setPresetEditorToolbarItemVisible: (itemId: string, visible: boolean) => void
 
   registerFloatWidget: (widget: FloatWidgetState) => void
   unregisterFloatWidget: (widgetId: string) => void

--- a/src/auth/default-preset.test.ts
+++ b/src/auth/default-preset.test.ts
@@ -30,7 +30,8 @@ function initDefaultPresetTestDb(): void {
     updated_at INTEGER NOT NULL DEFAULT 0,
     prompts TEXT NOT NULL DEFAULT '{}',
     user_id TEXT,
-    engine TEXT NOT NULL DEFAULT 'classic'
+    engine TEXT NOT NULL DEFAULT 'classic',
+    cache_revision INTEGER NOT NULL DEFAULT 0
   )`);
 
   db.run(`CREATE TABLE settings (
@@ -170,6 +171,9 @@ describe("default preset seeding", () => {
     expect(countPresets("u1")).toBe(1);
     expect(findBuiltInPreset("u1")?.id).toBe("legacy-built-in");
     expect(settingsSvc.getSetting("u1", BUILTIN_DEFAULT_PRESET_SEED_SETTING_KEY)?.value).toBe(1);
+    expect(getDb().query("SELECT cache_revision FROM presets WHERE id = ?").get("legacy-built-in")).toEqual({
+      cache_revision: 1,
+    });
   });
 
   test("startup backfill seeds all unmarked users once and only auto-activates empty accounts", () => {

--- a/src/auth/default-preset.ts
+++ b/src/auth/default-preset.ts
@@ -431,7 +431,7 @@ function upgradeLegacyPresetMetadata(userId: string, row: PresetRow): void {
   metadata._lumiverse_preset_slug = BUILTIN_DEFAULT_PRESET_SLUG;
   metadata.isDefault = true;
   getDb()
-    .query("UPDATE presets SET metadata = ?, updated_at = ? WHERE id = ? AND user_id = ?")
+    .query("UPDATE presets SET metadata = ?, updated_at = ?, cache_revision = cache_revision + 1 WHERE id = ? AND user_id = ?")
     .run(
       JSON.stringify(metadata),
       Math.floor(Date.now() / 1000),

--- a/src/db/migrate.test.ts
+++ b/src/db/migrate.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { runMigrations } from "./migrate";
+
+describe("database migrations", () => {
+  test("fresh bootstrap applies the preset cache revision exactly once", async () => {
+    const db = new Database(":memory:");
+    try {
+      await runMigrations(db);
+      const columns = db.query("PRAGMA table_info(presets)").all() as Array<{ name: string }>;
+      expect(columns.some((column) => column.name === "cache_revision")).toBe(true);
+      expect(
+        db.query("SELECT name FROM _migrations WHERE name = ?").get("093_preset_cache_revision.sql"),
+      ).toEqual({ name: "093_preset_cache_revision.sql" });
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/src/db/migrations/093_preset_cache_revision.sql
+++ b/src/db/migrations/093_preset_cache_revision.sql
@@ -1,0 +1,1 @@
+ALTER TABLE presets ADD COLUMN cache_revision INTEGER NOT NULL DEFAULT 0;

--- a/src/lumihub/installer.test.ts
+++ b/src/lumihub/installer.test.ts
@@ -157,4 +157,41 @@ describe("LumiHub preset installer metadata", () => {
     expect(validation.ok).toBe(false);
     if (!validation.ok) expect(validation.error).toContain("passthroughMetadata");
   });
+
+  test("rejects accessor-backed metadata before it can execute", async () => {
+    const preset = {
+      name: "Accessor-backed",
+      blocks: [],
+    } as Record<string, unknown>;
+    Object.defineProperty(preset, "passthroughMetadata", {
+      enumerable: true,
+      get() {
+        throw new Error("metadata getter executed");
+      },
+    });
+
+    const validation = validateInstallPresetPayload(installPayload("hub-4", preset));
+    expect(validation.ok).toBe(false);
+
+    const result = await installPreset("request-5", installPayload("hub-4", preset));
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("passthroughMetadata");
+  });
+
+  test("rejects hidden metadata serialization hooks", () => {
+    const metadata = {
+      agentic_preset_composer: { mode: "single" },
+    };
+    Object.defineProperty(metadata, "toJSON", {
+      enumerable: false,
+      value: () => ({ injected: true }),
+    });
+
+    const validation = validateInstallPresetPayload(installPayload("hub-5", {
+      name: "Hidden hook",
+      blocks: [],
+      passthroughMetadata: metadata,
+    }));
+    expect(validation.ok).toBe(false);
+  });
 });

--- a/src/lumihub/installer.test.ts
+++ b/src/lumihub/installer.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { closeDatabase, getDb, initDatabase } from "../db/connection";
+import { getPreset } from "../services/presets.service";
+import { validateInstallPresetPayload } from "./payload-validation";
+import { installPreset } from "./installer";
+import type { InstallPresetPayload } from "./types";
+
+const USER_ID = "owner-1";
+
+function initInstallerTestDb(): void {
+  closeDatabase();
+  initDatabase(":memory:");
+  const db = getDb();
+  db.run(`CREATE TABLE "user" (
+    id TEXT PRIMARY KEY,
+    createdAt INTEGER NOT NULL
+  )`);
+  db.run(`INSERT INTO "user" (id, createdAt) VALUES (?, ?)` , [USER_ID, 1]);
+  db.run(`CREATE TABLE presets (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    parameters TEXT NOT NULL DEFAULT '{}',
+    prompt_order TEXT NOT NULL DEFAULT '[]',
+    metadata TEXT NOT NULL DEFAULT '{}',
+    created_at INTEGER NOT NULL DEFAULT 0,
+    updated_at INTEGER NOT NULL DEFAULT 0,
+    prompts TEXT NOT NULL DEFAULT '{}',
+    user_id TEXT,
+    engine TEXT NOT NULL DEFAULT 'classic',
+    cache_revision INTEGER NOT NULL DEFAULT 0
+  )`);
+  db.run(`CREATE TABLE settings (
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (key, user_id)
+  )`);
+  db.run(`CREATE TABLE regex_scripts (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    preset_id TEXT
+  )`);
+}
+
+function installPayload(
+  presetId: string,
+  preset: Record<string, unknown>,
+): InstallPresetPayload {
+  return {
+    source: "lumihub",
+    presetId,
+    presetName: "Hub preset",
+    presetVersion: "1.0.0",
+    presetCreator: "creator",
+    presetSlug: "creator/hub-preset",
+    presetData: {
+      type: "lumiverse_preset",
+      preset,
+    },
+  };
+}
+
+beforeEach(initInstallerTestDb);
+afterEach(() => closeDatabase());
+
+describe("LumiHub preset installer metadata", () => {
+  test("preserves internal passthrough metadata on create and serialized metadata on update", async () => {
+    const first = await installPreset("request-1", installPayload("hub-1", {
+      name: "Hub preset",
+      blocks: [],
+      source: { kind: "loom" },
+      description: "Native description",
+      passthroughMetadata: {
+        agentic_preset_composer: { mode: "single", revision: 1 },
+        unrelated_extension: { enabled: true },
+        source: { attempted: "override" },
+        description: "attempted override",
+        _lumiverse_lumihub_id: "attempted override",
+      },
+    }));
+
+    expect(first.success).toBe(true);
+    expect(first.presetId).toBeString();
+    const created = getPreset(USER_ID, first.presetId!);
+    expect(created?.metadata).toMatchObject({
+      agentic_preset_composer: { mode: "single", revision: 1 },
+      unrelated_extension: { enabled: true },
+      source: { kind: "loom" },
+      description: "Native description",
+      _lumiverse_lumihub_id: "hub-1",
+      _lumiverse_install_source: "lumihub",
+    });
+
+    const second = await installPreset("request-2", installPayload("hub-1", {
+      name: "Hub preset updated",
+      blocks: [],
+      source: { kind: "loom-updated" },
+      description: "Native updated description",
+      metadata: {
+        agentic_preset_composer: { mode: "parallel", revision: 2 },
+        unrelated_extension: { enabled: false, revision: 2 },
+        _lumiverse_lumihub_id: "attempted override",
+        description: "attempted override",
+      },
+    }));
+
+    expect(second.success).toBe(true);
+    expect(second.presetId).toBe(first.presetId);
+    const updated = getPreset(USER_ID, first.presetId!);
+    expect(updated?.name).toBe("Hub preset updated");
+    expect(updated?.metadata).toMatchObject({
+      agentic_preset_composer: { mode: "parallel", revision: 2 },
+      unrelated_extension: { enabled: false, revision: 2 },
+      source: { kind: "loom-updated" },
+      description: "Native updated description",
+      _lumiverse_lumihub_id: "hub-1",
+      _lumiverse_install_source: "lumihub",
+    });
+  });
+
+  test("preserves a locally-added passthrough key when an update omits it", async () => {
+    const first = await installPreset("request-3", installPayload("hub-3", {
+      name: "Hub preset",
+      blocks: [],
+      passthroughMetadata: {
+        agentic_preset_composer: { mode: "parallel", graph: true },
+      },
+    }));
+    expect(first.success).toBe(true);
+
+    const updated = await installPreset("request-4", installPayload("hub-3", {
+      name: "Hub preset update",
+      blocks: [],
+      metadata: {
+        unrelated_extension: { retained: true },
+      },
+    }));
+    expect(updated.success).toBe(true);
+    const saved = getPreset(USER_ID, first.presetId!);
+    expect(saved?.metadata).toMatchObject({
+      agentic_preset_composer: { mode: "parallel", graph: true },
+      unrelated_extension: { retained: true },
+    });
+  });
+
+  test("rejects metadata with an arbitrary prototype", () => {
+    const metadata = Object.create({ inherited: true }) as Record<string, unknown>;
+    metadata.agentic_preset_composer = { mode: "single" };
+    const validation = validateInstallPresetPayload(installPayload("hub-2", {
+      name: "Malformed",
+      blocks: [],
+      passthroughMetadata: metadata,
+    }));
+
+    expect(validation.ok).toBe(false);
+    if (!validation.ok) expect(validation.error).toContain("passthroughMetadata");
+  });
+});

--- a/src/lumihub/installer.ts
+++ b/src/lumihub/installer.ts
@@ -653,6 +653,11 @@ export async function installPreset(
       return { requestId, success: false, error: "Preset export is missing preset data" };
     }
     const p = preset as Record<string, any>;
+    const existing = presetsSvc.findPresetByLumihubId(userId, payload.presetId);
+    const existingPassthroughMetadata = existing
+      ? extractPresetPassthroughMetadata({ metadata: existing.metadata })
+      : {};
+    const passthroughMetadata = extractPresetPassthroughMetadata(p);
     const name = typeof p.name === "string" && p.name.trim() ? p.name : payload.presetName;
     const blocks = Array.isArray(p.blocks) ? p.blocks : [];
 
@@ -680,6 +685,8 @@ export async function installPreset(
         advancedSettings: isPlainObject(p.advancedSettings) ? p.advancedSettings : {},
       },
       metadata: {
+        ...existingPassthroughMetadata,
+        ...passthroughMetadata,
         source: isPlainObject(p.source) ? p.source : null,
         modelProfiles: isPlainObject(p.modelProfiles) ? p.modelProfiles : {},
         schemaVersion: typeof p.schemaVersion === "number" ? p.schemaVersion : exported.schemaVersion ?? 1,
@@ -700,7 +707,6 @@ export async function installPreset(
 
     // Update the existing installation in place when this preset was installed
     // from LumiHub before, so "Update" advances the version instead of duplicating.
-    const existing = presetsSvc.findPresetByLumihubId(userId, payload.presetId);
     let saved;
     if (existing) {
       saved = presetsSvc.updatePreset(userId, existing.id, presetInput)!;
@@ -746,6 +752,77 @@ export async function installPreset(
 
 function isPlainObject(value: unknown): value is Record<string, any> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Clone metadata supplied by the hub before spreading it into the persisted
+ * metadata object. Install requests normally arrive from JSON, but keeping the
+ * check here makes direct callers obey the same plain-JSON contract and avoids
+ * invoking getters or copying values from arbitrary prototypes.
+ */
+function extractPresetPassthroughMetadata(
+  preset: Record<string, any>,
+): Record<string, any> {
+  const serializedMetadata = Object.hasOwn(preset, "metadata")
+    ? clonePresetMetadata(preset.metadata, "metadata")
+    : {};
+  const internalMetadata = Object.hasOwn(preset, "passthroughMetadata")
+    ? clonePresetMetadata(preset.passthroughMetadata, "passthroughMetadata")
+    : {};
+
+  // Both forms have appeared in exports. If an export carries both, the
+  // internal Loom bag wins conflicts while the installer-owned fields below
+  // remain authoritative either way.
+  return { ...serializedMetadata, ...internalMetadata };
+}
+
+function clonePresetMetadata(value: unknown, fieldName: string): Record<string, any> {
+  try {
+    if (!isSafeJsonObject(value)) {
+      throw new Error("not a plain JSON object");
+    }
+    const cloned = JSON.parse(JSON.stringify(value));
+    if (!isSafeJsonObject(cloned)) {
+      throw new Error("clone is not a plain JSON object");
+    }
+    return cloned;
+  } catch {
+    throw new Error(`Preset export has invalid ${fieldName}`);
+  }
+}
+
+function isSafeJsonObject(value: unknown): value is Record<string, any> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const seen = new Set<object>();
+  return isSafeJsonValue(value, seen);
+}
+
+function isSafeJsonValue(value: unknown, seen: Set<object>): boolean {
+  if (value === null) return true;
+  if (typeof value === "string" || typeof value === "boolean") return true;
+  if (typeof value === "number") return Number.isFinite(value);
+  if (typeof value !== "object") return false;
+
+  if (seen.has(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  if (Array.isArray(value)) {
+    if (prototype !== Array.prototype) return false;
+  } else if (prototype !== Object.prototype && prototype !== null) {
+    return false;
+  }
+
+  seen.add(value);
+  try {
+    for (const key of Object.keys(value)) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor || !Object.hasOwn(descriptor, "value") || !isSafeJsonValue(descriptor.value, seen)) {
+        return false;
+      }
+    }
+    return true;
+  } finally {
+    seen.delete(value);
+  }
 }
 
 async function materializeSealedPresetBlocks(

--- a/src/lumihub/installer.ts
+++ b/src/lumihub/installer.ts
@@ -21,6 +21,7 @@ import * as themeAssetsSvc from "../services/theme-assets.service";
 import { getCharacterWorldBookIds, setCharacterWorldBookIds } from "../utils/character-world-books";
 import { applyCharxModulesAndAssets } from "../services/charx-import.service";
 import { resolveSealedPresetBlocksForInstall, type SealedManifest } from "./sealed-presets";
+import { cloneSafePlainJsonObject } from "./payload-validation";
 import type {
   InstallCharacterPayload,
   InstallPresetPayload,
@@ -763,11 +764,13 @@ function isPlainObject(value: unknown): value is Record<string, any> {
 function extractPresetPassthroughMetadata(
   preset: Record<string, any>,
 ): Record<string, any> {
-  const serializedMetadata = Object.hasOwn(preset, "metadata")
-    ? clonePresetMetadata(preset.metadata, "metadata")
+  const serializedField = readPresetMetadataField(preset, "metadata");
+  const internalField = readPresetMetadataField(preset, "passthroughMetadata");
+  const serializedMetadata = serializedField.present
+    ? clonePresetMetadata(serializedField.value, "metadata")
     : {};
-  const internalMetadata = Object.hasOwn(preset, "passthroughMetadata")
-    ? clonePresetMetadata(preset.passthroughMetadata, "passthroughMetadata")
+  const internalMetadata = internalField.present
+    ? clonePresetMetadata(internalField.value, "passthroughMetadata")
     : {};
 
   // Both forms have appeared in exports. If an export carries both, the
@@ -776,52 +779,23 @@ function extractPresetPassthroughMetadata(
   return { ...serializedMetadata, ...internalMetadata };
 }
 
-function clonePresetMetadata(value: unknown, fieldName: string): Record<string, any> {
-  try {
-    if (!isSafeJsonObject(value)) {
-      throw new Error("not a plain JSON object");
-    }
-    const cloned = JSON.parse(JSON.stringify(value));
-    if (!isSafeJsonObject(cloned)) {
-      throw new Error("clone is not a plain JSON object");
-    }
-    return cloned;
-  } catch {
+function readPresetMetadataField(
+  preset: Record<string, any>,
+  fieldName: "metadata" | "passthroughMetadata",
+): { present: boolean; value?: unknown } {
+  const descriptor = Object.getOwnPropertyDescriptor(preset, fieldName);
+  if (!descriptor) return { present: false };
+  if (!Object.hasOwn(descriptor, "value")) {
     throw new Error(`Preset export has invalid ${fieldName}`);
   }
+  return { present: true, value: descriptor.value };
 }
 
-function isSafeJsonObject(value: unknown): value is Record<string, any> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
-  const seen = new Set<object>();
-  return isSafeJsonValue(value, seen);
-}
-
-function isSafeJsonValue(value: unknown, seen: Set<object>): boolean {
-  if (value === null) return true;
-  if (typeof value === "string" || typeof value === "boolean") return true;
-  if (typeof value === "number") return Number.isFinite(value);
-  if (typeof value !== "object") return false;
-
-  if (seen.has(value)) return false;
-  const prototype = Object.getPrototypeOf(value);
-  if (Array.isArray(value)) {
-    if (prototype !== Array.prototype) return false;
-  } else if (prototype !== Object.prototype && prototype !== null) {
-    return false;
-  }
-
-  seen.add(value);
+function clonePresetMetadata(value: unknown, fieldName: string): Record<string, any> {
   try {
-    for (const key of Object.keys(value)) {
-      const descriptor = Object.getOwnPropertyDescriptor(value, key);
-      if (!descriptor || !Object.hasOwn(descriptor, "value") || !isSafeJsonValue(descriptor.value, seen)) {
-        return false;
-      }
-    }
-    return true;
-  } finally {
-    seen.delete(value);
+    return cloneSafePlainJsonObject(value) as Record<string, any>;
+  } catch {
+    throw new Error(`Preset export has invalid ${fieldName}`);
   }
 }
 

--- a/src/lumihub/installer.ts
+++ b/src/lumihub/installer.ts
@@ -710,7 +710,10 @@ export async function installPreset(
     // from LumiHub before, so "Update" advances the version instead of duplicating.
     let saved;
     if (existing) {
-      saved = presetsSvc.updatePreset(userId, existing.id, presetInput)!;
+      saved = presetsSvc.updatePreset(userId, existing.id, {
+        ...presetInput,
+        expected_cache_revision: existing.cache_revision,
+      })!;
     } else {
       saved = presetsSvc.createPreset(userId, presetInput);
       eventBus.emit(EventType.PRESET_CHANGED, { id: saved.id, preset: saved }, userId);

--- a/src/lumihub/payload-validation.ts
+++ b/src/lumihub/payload-validation.ts
@@ -25,6 +25,11 @@ export type ValidationResult<T> =
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
+function isPlainJsonObject(value: unknown): value is Record<string, unknown> {
+  if (!isPlainObject(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
 
 function isString(value: unknown, max = MAX_STRING_LEN): value is string {
   return typeof value === "string" && value.length <= max;
@@ -179,7 +184,22 @@ export function validateInstallPresetPayload(
   if (!isPlainObject(raw.presetData)) {
     return { ok: false, error: "presetData must be an object" };
   }
-  if (JSON.stringify(raw.presetData).length > MAX_PRESET_DATA_BYTES) {
+  const presetData = raw.presetData;
+  const preset = isPlainObject(presetData.preset) ? presetData.preset : null;
+  if (preset) {
+    for (const key of ["passthroughMetadata", "metadata"] as const) {
+      if (preset[key] !== undefined && !isPlainJsonObject(preset[key])) {
+        return { ok: false, error: `preset.${key} must be a plain JSON object` };
+      }
+    }
+  }
+  let serializedPresetData: string;
+  try {
+    serializedPresetData = JSON.stringify(presetData);
+  } catch {
+    return { ok: false, error: "presetData must contain valid JSON" };
+  }
+  if (serializedPresetData.length > MAX_PRESET_DATA_BYTES) {
     return { ok: false, error: `presetData exceeds ${MAX_PRESET_DATA_BYTES} bytes` };
   }
   if (raw.presetVersion != null && !isString(raw.presetVersion, 64)) {

--- a/src/lumihub/payload-validation.ts
+++ b/src/lumihub/payload-validation.ts
@@ -25,10 +25,102 @@ export type ValidationResult<T> =
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
-function isPlainJsonObject(value: unknown): value is Record<string, unknown> {
-  if (!isPlainObject(value)) return false;
+/**
+ * Validate and clone a metadata bag without invoking accessors or accepting
+ * values that cannot be represented by the JSON-over-WebSocket contract.
+ */
+export function isSafePlainJsonObject(value: unknown): value is Record<string, unknown> {
+  try {
+    cloneSafeJsonValue(value, new Set<object>());
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+  } catch {
+    return false;
+  }
+}
+
+export function cloneSafePlainJsonObject(value: unknown): Record<string, unknown> {
+  const cloned = cloneSafeJsonValue(value, new Set<object>());
+  if (typeof cloned !== "object" || cloned === null || Array.isArray(cloned)) {
+    throw new Error("value must be a plain JSON object");
+  }
+  return cloned as Record<string, unknown>;
+}
+
+function cloneSafeJsonValue(value: unknown, seen: Set<object>): unknown {
+  if (value === null) return null;
+  if (typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value !== "object") throw new Error("value is not JSON-compatible");
+  if (seen.has(value)) throw new Error("value contains a cycle");
+
   const prototype = Object.getPrototypeOf(value);
-  return prototype === Object.prototype || prototype === null;
+  if (Array.isArray(value)) {
+    if (prototype !== Array.prototype) throw new Error("array has an invalid prototype");
+    const lengthDescriptor = Object.getOwnPropertyDescriptor(value, "length");
+    if (
+      !lengthDescriptor
+      || !Object.hasOwn(lengthDescriptor, "value")
+      || !Number.isSafeInteger(lengthDescriptor.value)
+      || lengthDescriptor.value < 0
+    ) {
+      throw new Error("array has an invalid length");
+    }
+
+    const length = lengthDescriptor.value;
+    const cloned: unknown[] = new Array(length);
+    seen.add(value);
+    try {
+      for (const key of Reflect.ownKeys(value)) {
+        if (key === "length") continue;
+        if (typeof key !== "string") throw new Error("array has a symbol key");
+        const index = Number(key);
+        if (!Number.isSafeInteger(index) || index < 0 || index >= length || String(index) !== key) {
+          throw new Error("array has a non-index property");
+        }
+        const descriptor = Object.getOwnPropertyDescriptor(value, key);
+        if (!descriptor || !descriptor.enumerable || !Object.hasOwn(descriptor, "value")) {
+          throw new Error("array has an accessor, hidden property, or hole");
+        }
+        Object.defineProperty(cloned, key, {
+          value: cloneSafeJsonValue(descriptor.value, seen),
+          enumerable: true,
+          writable: true,
+          configurable: true,
+        });
+      }
+      for (let index = 0; index < length; index += 1) {
+        if (!Object.hasOwn(value, String(index))) throw new Error("array has a hole");
+      }
+      return cloned;
+    } finally {
+      seen.delete(value);
+    }
+  }
+
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error("object has an invalid prototype");
+  }
+
+  const cloned = Object.create(prototype === null ? null : Object.prototype) as Record<string, unknown>;
+  seen.add(value);
+  try {
+    for (const key of Reflect.ownKeys(value)) {
+      if (typeof key !== "string") throw new Error("object has a symbol key");
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor || !descriptor.enumerable || !Object.hasOwn(descriptor, "value")) {
+        throw new Error("object has an accessor or hidden property");
+      }
+      Object.defineProperty(cloned, key, {
+        value: cloneSafeJsonValue(descriptor.value, seen),
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      });
+    }
+    return cloned;
+  } finally {
+    seen.delete(value);
+  }
 }
 
 function isString(value: unknown, max = MAX_STRING_LEN): value is string {
@@ -185,12 +277,21 @@ export function validateInstallPresetPayload(
     return { ok: false, error: "presetData must be an object" };
   }
   const presetData = raw.presetData;
-  const preset = isPlainObject(presetData.preset) ? presetData.preset : null;
+  const presetDescriptor = Object.getOwnPropertyDescriptor(presetData, "preset");
+  const preset = presetDescriptor && Object.hasOwn(presetDescriptor, "value") && isPlainObject(presetDescriptor.value)
+    ? presetDescriptor.value
+    : null;
   if (preset) {
-    for (const key of ["passthroughMetadata", "metadata"] as const) {
-      if (preset[key] !== undefined && !isPlainJsonObject(preset[key])) {
-        return { ok: false, error: `preset.${key} must be a plain JSON object` };
+    try {
+      for (const key of ["passthroughMetadata", "metadata"] as const) {
+        const descriptor = Object.getOwnPropertyDescriptor(preset, key);
+        if (!descriptor) continue;
+        if (!Object.hasOwn(descriptor, "value") || !isSafePlainJsonObject(descriptor.value)) {
+          return { ok: false, error: `preset.${key} must be a plain JSON object` };
+        }
       }
+    } catch {
+      return { ok: false, error: "preset metadata must be a plain JSON object" };
     }
   }
   let serializedPresetData: string;

--- a/src/middleware/compress.test.ts
+++ b/src/middleware/compress.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { compress } from "./compress";
+
+const app = new Hono();
+app.use("*", compress());
+app.get("/payload", (c) => c.newResponse("x".repeat(2048), 200, {
+  "Content-Type": "application/json",
+  ETag: 'W/"preset-1"',
+  Vary: "Cookie, Accept-Encoding",
+}));
+app.get("/not-modified", () => new Response(null, {
+  status: 304,
+  headers: {
+    ETag: 'W/"preset-1"',
+    Vary: "Cookie, Accept-Encoding",
+  },
+}));
+
+describe("compression cache variants", () => {
+  test("preserves a weak validator and deduplicated variant dimensions", async () => {
+    const response = await app.request("http://localhost/payload", {
+      headers: { "Accept-Encoding": "gzip" },
+    });
+
+    expect(response.headers.get("etag")).toBe('W/"preset-1"');
+    expect(response.headers.get("content-encoding")).toBe("gzip");
+    expect(response.headers.get("vary")).toBe("Cookie, Accept-Encoding");
+  });
+
+  test("does not rewrite 304 variant metadata", async () => {
+    const response = await app.request("http://localhost/not-modified", {
+      headers: { "Accept-Encoding": "gzip" },
+    });
+
+    expect(response.status).toBe(304);
+    expect(response.headers.get("content-encoding")).toBeNull();
+    expect(response.headers.get("etag")).toBe('W/"preset-1"');
+    expect(response.headers.get("vary")).toBe("Cookie, Accept-Encoding");
+  });
+});

--- a/src/middleware/compress.ts
+++ b/src/middleware/compress.ts
@@ -53,6 +53,17 @@ function negotiate(header: string): Encoding | null {
   return best;
 }
 
+function appendVary(headers: Headers, field: string): void {
+  const existing = headers.get("Vary");
+  if (!existing) {
+    headers.set("Vary", field);
+    return;
+  }
+  const fields = existing.split(",").map((value) => value.trim());
+  if (fields.includes("*") || fields.some((value) => value.toLowerCase() === field.toLowerCase())) return;
+  headers.set("Vary", [...fields, field].join(", "));
+}
+
 /** Pipe a web ReadableStream through the chosen compressor. */
 function compressStream(body: ReadableStream, encoding: Encoding): ReadableStream {
   if (encoding === "br") {
@@ -96,6 +107,6 @@ export function compress() {
     c.res = new Response(compressStream(res.body, encoding), res);
     c.res.headers.set("Content-Encoding", encoding);
     c.res.headers.delete("Content-Length");
-    c.res.headers.append("Vary", "Accept-Encoding");
+    appendVary(c.res.headers, "Accept-Encoding");
   });
 }

--- a/src/routes/presets.routes.test.ts
+++ b/src/routes/presets.routes.test.ts
@@ -73,4 +73,58 @@ describe("preset cache validators", () => {
     expect(second.headers.get("etag")).not.toBe(etag);
     expect(second.headers.get("vary")).toBe("Cookie, Accept-Encoding");
   });
+  test("returns a revision conflict without clobbering, then increments on a matching update", async () => {
+    insertPreset("preset-1", "u1", 3);
+
+    const stale = await app.request("http://localhost/preset-1", {
+      method: "PUT",
+      headers: { "x-test-user": "u1", "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "stale",
+        metadata: { stale: true },
+        expected_cache_revision: 2,
+      }),
+    });
+    expect(stale.status).toBe(409);
+    expect(await stale.json()).toEqual({
+      error: "Preset preset-1 changed since revision 2; current revision is 3",
+      code: "PRESET_REVISION_CONFLICT",
+      expected_cache_revision: 2,
+      actual_cache_revision: 3,
+    });
+
+    const successful = await app.request("http://localhost/preset-1", {
+      method: "PUT",
+      headers: { "x-test-user": "u1", "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "newer",
+        expected_cache_revision: 3,
+      }),
+    });
+    expect(successful.status).toBe(200);
+    const updated = await successful.json();
+    expect(updated.name).toBe("newer");
+    expect(updated.cache_revision).toBe(4);
+
+    const row = getDb().query("SELECT name, metadata, cache_revision FROM presets WHERE id = ?").get("preset-1");
+    expect(row).toEqual({ name: "newer", metadata: "{}", cache_revision: 4 });
+  });
+
+  test("rejects unconditional updates without a revision precondition", async () => {
+    insertPreset("preset-1", "u1", 3);
+
+    const response = await app.request("http://localhost/preset-1", {
+      method: "PUT",
+      headers: { "x-test-user": "u1", "content-type": "application/json" },
+      body: JSON.stringify({ metadata: { stale: true } }),
+    });
+
+    expect(response.status).toBe(428);
+    expect(await response.json()).toEqual({
+      error: "expected_cache_revision is required",
+      code: "PRESET_REVISION_REQUIRED",
+    });
+    const row = getDb().query("SELECT metadata, cache_revision FROM presets WHERE id = ?").get("preset-1");
+    expect(row).toEqual({ metadata: "{}", cache_revision: 3 });
+  });
 });

--- a/src/routes/presets.routes.test.ts
+++ b/src/routes/presets.routes.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { closeDatabase, getDb, initDatabase } from "../db/connection";
+import { presetsRoutes } from "./presets.routes";
+
+function initPresetsTestDb(): void {
+  closeDatabase();
+  initDatabase(":memory:");
+  getDb().run(`CREATE TABLE presets (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    parameters TEXT NOT NULL DEFAULT '{}',
+    prompt_order TEXT NOT NULL DEFAULT '[]',
+    metadata TEXT NOT NULL DEFAULT '{}',
+    created_at INTEGER NOT NULL DEFAULT 0,
+    updated_at INTEGER NOT NULL DEFAULT 0,
+    prompts TEXT NOT NULL DEFAULT '{}',
+    user_id TEXT,
+    engine TEXT NOT NULL DEFAULT 'classic',
+    cache_revision INTEGER NOT NULL DEFAULT 0
+  )`);
+}
+
+function insertPreset(id: string, userId: string, cacheRevision = 0): void {
+  getDb().run(
+    `INSERT INTO presets (id, name, provider, parameters, prompt_order, metadata, created_at, updated_at, prompts, user_id, engine, cache_revision)
+     VALUES (?, 'Preset', 'loom', '{}', '[]', '{}', 1, 1, '{}', ?, 'classic', ?)`,
+    [id, userId, cacheRevision],
+  );
+}
+
+const app = new Hono();
+app.use("*", async (c, next) => {
+  c.set("userId", c.req.header("x-test-user")!);
+  await next();
+});
+app.route("/", presetsRoutes);
+
+beforeEach(initPresetsTestDb);
+afterEach(() => closeDatabase());
+
+describe("preset cache validators", () => {
+  test("scopes empty registry ETags to the authenticated user and varies on cookies", async () => {
+    const first = await app.request("http://localhost/registry", { headers: { "x-test-user": "u1" } });
+    const second = await app.request("http://localhost/registry", { headers: { "x-test-user": "u2" } });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(first.headers.get("etag")).not.toBe(second.headers.get("etag"));
+    expect(first.headers.get("vary")).toBe("Cookie");
+  });
+
+  test("invalidates a full preset ETag when its cache revision changes", async () => {
+    insertPreset("preset-1", "u1");
+    const first = await app.request("http://localhost/preset-1", { headers: { "x-test-user": "u1" } });
+    const etag = first.headers.get("etag");
+    expect(first.status).toBe(200);
+    expect(etag).not.toBeNull();
+
+    getDb().run("UPDATE presets SET cache_revision = 1 WHERE id = ?", ["preset-1"]);
+    const second = await app.request("http://localhost/preset-1", {
+      headers: { "x-test-user": "u1", "if-none-match": etag! },
+    });
+    expect(second.status).toBe(200);
+    expect(second.headers.get("etag")).not.toBe(etag);
+    expect(second.headers.get("vary")).toBe("Cookie");
+  });
+});

--- a/src/routes/presets.routes.test.ts
+++ b/src/routes/presets.routes.test.ts
@@ -48,7 +48,7 @@ describe("preset cache validators", () => {
     expect(first.status).toBe(200);
     expect(second.status).toBe(200);
     expect(first.headers.get("etag")).not.toBe(second.headers.get("etag"));
-    expect(first.headers.get("vary")).toBe("Cookie");
+    expect(first.headers.get("vary")).toBe("Cookie, Accept-Encoding");
   });
 
   test("invalidates a full preset ETag when its cache revision changes", async () => {
@@ -57,6 +57,13 @@ describe("preset cache validators", () => {
     const etag = first.headers.get("etag");
     expect(first.status).toBe(200);
     expect(etag).not.toBeNull();
+    expect(etag).toStartWith('W/"');
+    const notModified = await app.request("http://localhost/preset-1", {
+      headers: { "x-test-user": "u1", "if-none-match": etag!.slice(2) },
+    });
+    expect(notModified.status).toBe(304);
+    expect(notModified.headers.get("etag")).toBe(etag);
+    expect(notModified.headers.get("vary")).toBe("Cookie, Accept-Encoding");
 
     getDb().run("UPDATE presets SET cache_revision = 1 WHERE id = ?", ["preset-1"]);
     const second = await app.request("http://localhost/preset-1", {
@@ -64,6 +71,6 @@ describe("preset cache validators", () => {
     });
     expect(second.status).toBe(200);
     expect(second.headers.get("etag")).not.toBe(etag);
-    expect(second.headers.get("vary")).toBe("Cookie");
+    expect(second.headers.get("vary")).toBe("Cookie, Accept-Encoding");
   });
 });

--- a/src/routes/presets.routes.ts
+++ b/src/routes/presets.routes.ts
@@ -1,9 +1,14 @@
+import { createHash } from "node:crypto";
 import { Hono } from "hono";
 import * as svc from "../services/presets.service";
 import { parsePagination } from "../services/pagination";
 import { REVALIDATE_PRIVATE, ifNoneMatchSatisfies } from "../utils/http-cache";
 
 const app = new Hono();
+
+function userEtagScope(userId: string): string {
+  return createHash("sha256").update(userId).digest("base64url");
+}
 
 app.get("/", (c) => {
   const userId = c.get("userId");
@@ -17,15 +22,16 @@ app.get("/registry", (c) => {
   const provider = c.req.query("provider") || undefined;
   const engine = c.req.query("engine") || undefined;
 
-  // ETag from a cheap signature of the filtered set + the page window, so a
-  // repeat open returns 304 (no body) until a preset is created/edited/deleted.
+  // Hashing the filtered `(id, cache_revision)` sequence catches every update
+  // and delete/create replacement without reading preset JSON blobs.
   const sig = svc.getPresetRegistrySignature(userId, provider, engine);
-  const etag = `"presets-reg-${sig.count}-${sig.maxUpdatedAt}-${provider ?? ""}-${engine ?? ""}-${pagination.limit}-${pagination.offset}"`;
+  const etag = `"presets-reg-${sig}-${pagination.limit}-${pagination.offset}"`;
   if (ifNoneMatchSatisfies(c.req.header("if-none-match"), etag)) {
-    return new Response(null, { status: 304, headers: { ETag: etag, "Cache-Control": REVALIDATE_PRIVATE } });
+    return new Response(null, { status: 304, headers: { ETag: etag, "Cache-Control": REVALIDATE_PRIVATE, Vary: "Cookie" } });
   }
   c.header("ETag", etag);
   c.header("Cache-Control", REVALIDATE_PRIVATE);
+  c.header("Vary", "Cookie");
   return c.json(svc.listPresetRegistry(userId, pagination, provider, engine));
 });
 
@@ -40,21 +46,21 @@ app.get("/:id", (c) => {
   const userId = c.get("userId");
   const id = c.req.param("id");
 
-  // Cheap updated_at lookup drives the ETag, so a cache hit returns 304 without
-  // reading + JSON-parsing the full (potentially large) preset or transferring
-  // its body. updated_at is bumped on every update, so the ETag is never stale.
-  const updatedAt = svc.getPresetUpdatedAt(userId, id);
-  if (updatedAt == null) return c.json({ error: "Not found" }, 404);
+  // A dedicated monotonic revision drives this ETag, so same-second updates
+  // invalidate cache entries without altering the user's visible update time.
+  const cacheRevision = svc.getPresetCacheRevision(userId, id);
+  if (cacheRevision == null) return c.json({ error: "Not found" }, 404);
 
-  const etag = `"preset-${id}-${updatedAt}"`;
+  const etag = `"preset-${id}-${cacheRevision}-${userEtagScope(userId)}"`;
   if (ifNoneMatchSatisfies(c.req.header("if-none-match"), etag)) {
-    return new Response(null, { status: 304, headers: { ETag: etag, "Cache-Control": REVALIDATE_PRIVATE } });
+    return new Response(null, { status: 304, headers: { ETag: etag, "Cache-Control": REVALIDATE_PRIVATE, Vary: "Cookie" } });
   }
 
   const preset = svc.getPreset(userId, id);
   if (!preset) return c.json({ error: "Not found" }, 404); // deleted between lookups
   c.header("ETag", etag);
   c.header("Cache-Control", REVALIDATE_PRIVATE);
+  c.header("Vary", "Cookie");
   return c.json(preset);
 });
 

--- a/src/routes/presets.routes.ts
+++ b/src/routes/presets.routes.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { Hono } from "hono";
 import * as svc from "../services/presets.service";
+import { PresetRevisionConflictError } from "../types/preset";
 import { parsePagination } from "../services/pagination";
 import { REVALIDATE_PRIVATE, ifNoneMatchSatisfies } from "../utils/http-cache";
 
@@ -67,9 +68,31 @@ app.get("/:id", (c) => {
 app.put("/:id", async (c) => {
   const userId = c.get("userId");
   const body = await c.req.json();
-  const preset = svc.updatePreset(userId, c.req.param("id"), body);
-  if (!preset) return c.json({ error: "Not found" }, 404);
-  return c.json(preset);
+  if (
+    typeof body.expected_cache_revision !== "number"
+    || !Number.isSafeInteger(body.expected_cache_revision)
+    || body.expected_cache_revision < 0
+  ) {
+    return c.json({
+      error: "expected_cache_revision is required",
+      code: "PRESET_REVISION_REQUIRED",
+    }, 428);
+  }
+  try {
+    const preset = svc.updatePreset(userId, c.req.param("id"), body);
+    if (!preset) return c.json({ error: "Not found" }, 404);
+    return c.json(preset);
+  } catch (err) {
+    if (err instanceof PresetRevisionConflictError) {
+      return c.json({
+        error: err.message,
+        code: err.code,
+        expected_cache_revision: err.expectedCacheRevision,
+        actual_cache_revision: err.actualCacheRevision,
+      }, 409);
+    }
+    throw err;
+  }
 });
 
 app.delete("/:id", (c) => {

--- a/src/routes/presets.routes.ts
+++ b/src/routes/presets.routes.ts
@@ -25,13 +25,13 @@ app.get("/registry", (c) => {
   // Hashing the filtered `(id, cache_revision)` sequence catches every update
   // and delete/create replacement without reading preset JSON blobs.
   const sig = svc.getPresetRegistrySignature(userId, provider, engine);
-  const etag = `"presets-reg-${sig}-${pagination.limit}-${pagination.offset}"`;
+  const etag = `W/"presets-reg-${sig}-${pagination.limit}-${pagination.offset}"`;
   if (ifNoneMatchSatisfies(c.req.header("if-none-match"), etag)) {
-    return new Response(null, { status: 304, headers: { ETag: etag, "Cache-Control": REVALIDATE_PRIVATE, Vary: "Cookie" } });
+    return new Response(null, { status: 304, headers: { ETag: etag, "Cache-Control": REVALIDATE_PRIVATE, Vary: "Cookie, Accept-Encoding" } });
   }
   c.header("ETag", etag);
   c.header("Cache-Control", REVALIDATE_PRIVATE);
-  c.header("Vary", "Cookie");
+  c.header("Vary", "Cookie, Accept-Encoding");
   return c.json(svc.listPresetRegistry(userId, pagination, provider, engine));
 });
 
@@ -51,16 +51,16 @@ app.get("/:id", (c) => {
   const cacheRevision = svc.getPresetCacheRevision(userId, id);
   if (cacheRevision == null) return c.json({ error: "Not found" }, 404);
 
-  const etag = `"preset-${id}-${cacheRevision}-${userEtagScope(userId)}"`;
+  const etag = `W/"preset-${id}-${cacheRevision}-${userEtagScope(userId)}"`;
   if (ifNoneMatchSatisfies(c.req.header("if-none-match"), etag)) {
-    return new Response(null, { status: 304, headers: { ETag: etag, "Cache-Control": REVALIDATE_PRIVATE, Vary: "Cookie" } });
+    return new Response(null, { status: 304, headers: { ETag: etag, "Cache-Control": REVALIDATE_PRIVATE, Vary: "Cookie, Accept-Encoding" } });
   }
 
   const preset = svc.getPreset(userId, id);
   if (!preset) return c.json({ error: "Not found" }, 404); // deleted between lookups
   c.header("ETag", etag);
   c.header("Cache-Control", REVALIDATE_PRIVATE);
-  c.header("Vary", "Cookie");
+  c.header("Vary", "Cookie, Accept-Encoding");
   return c.json(preset);
 });
 

--- a/src/services/presets.service.test.ts
+++ b/src/services/presets.service.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { closeDatabase, getDb, initDatabase } from "../db/connection";
-import { getPreset, getPresetUpdatedAt, getPresetRegistrySignature } from "./presets.service";
+import { getPreset, getPresetCacheRevision, getPresetUpdatedAt, getPresetRegistrySignature, updatePreset } from "./presets.service";
 
 function initPresetsTestDb(): void {
   closeDatabase();
@@ -16,7 +16,8 @@ function initPresetsTestDb(): void {
     updated_at INTEGER NOT NULL DEFAULT 0,
     prompts TEXT NOT NULL DEFAULT '{}',
     user_id TEXT,
-    engine TEXT NOT NULL DEFAULT 'classic'
+    engine TEXT NOT NULL DEFAULT 'classic',
+    cache_revision INTEGER NOT NULL DEFAULT 0
   )`);
 }
 
@@ -88,22 +89,44 @@ describe("presets.service — ETag sources + row trim", () => {
     expect(getPresetUpdatedAt("u2", "p1")).toBeNull();
   });
 
-  test("registry signature reflects count + max(updated_at), scoped by user and provider", () => {
+  test("registry signatures are scoped by user and filters", () => {
     insertPreset({ id: "p1", name: "A", provider: "openai", user_id: "u1", updated_at: 100 });
     insertPreset({ id: "p2", name: "B", provider: "loom", user_id: "u1", updated_at: 250 });
     insertPreset({ id: "p3", name: "C", provider: "loom", user_id: "u2", updated_at: 999 });
 
-    expect(getPresetRegistrySignature("u1")).toEqual({ count: 2, maxUpdatedAt: 250 });
-    expect(getPresetRegistrySignature("u1", "loom")).toEqual({ count: 1, maxUpdatedAt: 250 });
-    expect(getPresetRegistrySignature("u1", "anthropic")).toEqual({ count: 0, maxUpdatedAt: 0 });
+    const all = getPresetRegistrySignature("u1");
+    const loom = getPresetRegistrySignature("u1", "loom");
+    const empty = getPresetRegistrySignature("u1", "anthropic");
+    expect(all).not.toBe(loom);
+    expect(loom).not.toBe(empty);
+    expect(empty).not.toBe(getPresetRegistrySignature("u2", "anthropic"));
+    expect(empty).toBe(getPresetRegistrySignature("u1", "anthropic"));
   });
 
-  test("registry signature changes when a preset is edited (drives ETag invalidation)", () => {
+  test("registry signature changes for a same-second non-maximum edit", () => {
     insertPreset({ id: "p1", name: "A", provider: "loom", user_id: "u1", updated_at: 100 });
+    insertPreset({ id: "p2", name: "B", provider: "loom", user_id: "u1", updated_at: 250 });
     const before = getPresetRegistrySignature("u1", "loom");
-    getDb().run("UPDATE presets SET updated_at = ? WHERE id = ?", [500, "p1"]);
+    getDb().run("UPDATE presets SET cache_revision = ? WHERE id = ?", [1, "p1"]);
     const after = getPresetRegistrySignature("u1", "loom");
-    expect(after.maxUpdatedAt).toBeGreaterThan(before.maxUpdatedAt);
-    expect(after.count).toBe(before.count);
+    expect(after).not.toBe(before);
+  });
+
+  test("registry signature changes for a same-timestamp delete/create replacement", () => {
+    insertPreset({ id: "p1", name: "A", provider: "loom", user_id: "u1", updated_at: 250 });
+    const before = getPresetRegistrySignature("u1", "loom");
+    getDb().run("DELETE FROM presets WHERE id = ?", ["p1"]);
+    insertPreset({ id: "p2", name: "B", provider: "loom", user_id: "u1", updated_at: 250 });
+    expect(getPresetRegistrySignature("u1", "loom")).not.toBe(before);
+  });
+
+  test("updatePreset increments a dedicated cache revision without distorting timestamps", () => {
+    insertPreset({ id: "p1", name: "A", provider: "loom", user_id: "u1", updated_at: 2_000_000_000 });
+    const first = updatePreset("u1", "p1", { name: "B" });
+    const second = updatePreset("u1", "p1", { name: "C" });
+    expect(first?.updated_at).toBeLessThan(2_000_000_000);
+    expect(getPresetCacheRevision("u1", "p1")).toBe(2);
+    expect(second?.name).toBe("C");
+    expect(getPresetCacheRevision("u1", "missing")).toBeNull();
   });
 });

--- a/src/services/presets.service.test.ts
+++ b/src/services/presets.service.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { closeDatabase, getDb, initDatabase } from "../db/connection";
-import { getPreset, getPresetCacheRevision, getPresetUpdatedAt, getPresetRegistrySignature, updatePreset } from "./presets.service";
+import { getPreset, getPresetCacheRevision, getPresetRegistrySignature, updatePreset } from "./presets.service";
 
 function initPresetsTestDb(): void {
   closeDatabase();
@@ -82,12 +82,6 @@ describe("presets.service — ETag sources + row trim", () => {
     expect(getPreset("u2", "p1")).toBeNull();
   });
 
-  test("getPresetUpdatedAt returns updated_at, null for missing or other-user", () => {
-    insertPreset({ id: "p1", name: "A", provider: "openai", user_id: "u1", updated_at: 42 });
-    expect(getPresetUpdatedAt("u1", "p1")).toBe(42);
-    expect(getPresetUpdatedAt("u1", "missing")).toBeNull();
-    expect(getPresetUpdatedAt("u2", "p1")).toBeNull();
-  });
 
   test("registry signatures are scoped by user and filters", () => {
     insertPreset({ id: "p1", name: "A", provider: "openai", user_id: "u1", updated_at: 100 });

--- a/src/services/presets.service.test.ts
+++ b/src/services/presets.service.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { closeDatabase, getDb, initDatabase } from "../db/connection";
 import { getPreset, getPresetCacheRevision, getPresetRegistrySignature, updatePreset } from "./presets.service";
+import { PresetRevisionConflictError } from "../types/preset";
 
 function initPresetsTestDb(): void {
   closeDatabase();
@@ -75,6 +76,7 @@ describe("presets.service — ETag sources + row trim", () => {
     expect(preset!.prompt_order).toEqual([{ id: "b1" }]);
     expect(preset!.engine).toBe("loom");
     expect(preset!.updated_at).toBe(100);
+    expect(preset!.cache_revision).toBe(0);
   });
 
   test("getPreset is scoped to the owning user", () => {
@@ -122,5 +124,47 @@ describe("presets.service — ETag sources + row trim", () => {
     expect(getPresetCacheRevision("u1", "p1")).toBe(2);
     expect(second?.name).toBe("C");
     expect(getPresetCacheRevision("u1", "missing")).toBeNull();
+  });
+
+  test("rejects a stale conditional writer without changing newer metadata or blocks", () => {
+    insertPreset({
+      id: "p1",
+      name: "A",
+      provider: "loom",
+      user_id: "u1",
+      prompt_order: [{ id: "original" }],
+    });
+
+    const first = updatePreset("u1", "p1", {
+      name: "newer",
+      prompt_order: [{ id: "newer-block" }],
+      expected_cache_revision: 0,
+    });
+    expect(first?.cache_revision).toBe(1);
+
+    expect(() => updatePreset("u1", "p1", {
+      metadata: { source: "stale-writer" },
+      prompt_order: [{ id: "stale-block" }],
+      expected_cache_revision: 0,
+    })).toThrow(PresetRevisionConflictError);
+
+    const current = getPreset("u1", "p1");
+    expect(current?.name).toBe("newer");
+    expect(current?.prompt_order).toEqual([{ id: "newer-block" }]);
+    expect(current?.metadata).toEqual({});
+    expect(current?.cache_revision).toBe(1);
+  });
+
+  test("rejects stale conditional no-op writers", () => {
+    insertPreset({ id: "p1", name: "A", provider: "loom", user_id: "u1" });
+    const current = updatePreset("u1", "p1", { name: "newer" });
+    expect(current?.cache_revision).toBe(1);
+
+    expect(() => updatePreset("u1", "p1", {
+      expected_cache_revision: 0,
+    })).toThrow(PresetRevisionConflictError);
+
+    expect(getPreset("u1", "p1")?.name).toBe("newer");
+    expect(getPreset("u1", "p1")?.cache_revision).toBe(1);
   });
 });

--- a/src/services/presets.service.ts
+++ b/src/services/presets.service.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { getDb } from "../db/connection";
 import { eventBus } from "../ws/bus";
 import { EventType } from "../ws/events";
@@ -127,16 +128,15 @@ export function listPresetRegistry(
 }
 
 /**
- * Cheap signature of the registry result set for ETag generation. Any
- * create/delete changes the count; any edit/rename bumps updated_at (and thus
- * the max), so (count, maxUpdatedAt) over the same filter uniquely identifies
- * the current registry without serializing it.
+ * Stable content signature for registry ETags. The ordered `(id, cache_revision)`
+ * stream changes for creates, deletes, and every content update without
+ * serializing large JSON columns or distorting user-visible update times.
  */
 export function getPresetRegistrySignature(
   userId: string,
   provider?: string,
   engine?: string,
-): { count: number; maxUpdatedAt: number } {
+): string {
   const filters: string[] = [];
   const params: any[] = [userId];
   if (provider) {
@@ -148,13 +148,15 @@ export function getPresetRegistrySignature(
     params.push(engine);
   }
   const filterSQL = filters.length > 0 ? " AND " + filters.join(" AND ") : "";
-  const row = getDb()
-    .query(
-      `SELECT COUNT(*) as count, COALESCE(MAX(updated_at), 0) as maxUpdatedAt
-       FROM presets WHERE user_id = ?${filterSQL}`
-    )
-    .get(...params) as { count: number; maxUpdatedAt: number };
-  return { count: row.count, maxUpdatedAt: row.maxUpdatedAt };
+  const rows = getDb()
+    .query(`SELECT id, cache_revision FROM presets WHERE user_id = ?${filterSQL} ORDER BY id`)
+    .all(...params) as Array<{ id: string; cache_revision: number }>;
+  const digest = createHash("sha256");
+  digest.update(userId).update("\0").update(provider ?? "").update("\0").update(engine ?? "").update("\0");
+  for (const row of rows) {
+    digest.update(row.id).update("\0").update(String(row.cache_revision)).update("\0");
+  }
+  return digest.digest("base64url");
 }
 
 // Prepared statement for hot-path preset fetch (avoids re-compiling for large JSON blobs)
@@ -221,9 +223,16 @@ export function listPresetsForManifest(userId: string): PresetManifestRow[] {
   });
 }
 
+/** Fetch a monotonic row revision for cache validation without reading preset JSON. */
+export function getPresetCacheRevision(userId: string, id: string): number | null {
+  const row = getDb()
+    .query("SELECT cache_revision FROM presets WHERE id = ? AND user_id = ?")
+    .get(id, userId) as { cache_revision: number } | null;
+  return row ? row.cache_revision : null;
+}
+
 /**
- * Fetch just the preset's updated_at for ETag generation, avoiding the full
- * row read + JSON parse of the (potentially large) preset on a cache hit.
+ * Fetch a preset's user-visible update timestamp without reading the full row.
  * Returns null when the preset doesn't exist for this user.
  */
 export function getPresetUpdatedAt(userId: string, id: string): number | null {
@@ -315,7 +324,7 @@ export function updatePreset(userId: string, id: string, input: UpdatePresetInpu
 
   if (fields.length === 0) return existing;
 
-  fields.push("updated_at = ?");
+  fields.push("updated_at = ?", "cache_revision = cache_revision + 1");
   values.push(Math.floor(Date.now() / 1000));
   values.push(id);
   values.push(userId);

--- a/src/services/presets.service.ts
+++ b/src/services/presets.service.ts
@@ -3,6 +3,7 @@ import { getDb } from "../db/connection";
 import { eventBus } from "../ws/bus";
 import { EventType } from "../ws/events";
 import type { Preset, CreatePresetInput, UpdatePresetInput, PromptBlock, PromptVariableValue } from "../types/preset";
+import { PresetRevisionConflictError } from "../types/preset";
 import type { ConnectionProfile } from "../types/connection-profile";
 import type { PaginationParams, PaginatedResult } from "../types/pagination";
 import { paginatedQuery } from "./pagination";
@@ -74,6 +75,7 @@ function rowToPreset(row: any): Preset {
     prompt_order: JSON.parse(row.prompt_order),
     prompts: JSON.parse(row.prompts),
     metadata: JSON.parse(row.metadata),
+    cache_revision: row.cache_revision ?? 0,
     created_at: row.created_at,
     updated_at: row.updated_at,
   };
@@ -312,15 +314,42 @@ export function updatePreset(userId: string, id: string, input: UpdatePresetInpu
   if (input.prompts !== undefined) { fields.push("prompts = ?"); values.push(JSON.stringify(input.prompts)); }
   if (writeMetadata !== undefined) { fields.push("metadata = ?"); values.push(JSON.stringify(writeMetadata)); }
 
-  if (fields.length === 0) return existing;
+  const expectedCacheRevision = input.expected_cache_revision;
+  if (fields.length === 0) {
+    if (expectedCacheRevision !== undefined && expectedCacheRevision !== (existing.cache_revision ?? 0)) {
+      throw new PresetRevisionConflictError(id, expectedCacheRevision, existing.cache_revision ?? 0);
+    }
+    return existing;
+  }
 
   fields.push("updated_at = ?", "cache_revision = cache_revision + 1");
   values.push(Math.floor(Date.now() / 1000));
-  values.push(id);
-  values.push(userId);
 
-  getDb().query(`UPDATE presets SET ${fields.join(", ")} WHERE id = ? AND user_id = ?`).run(...values);
-  const updated = getPreset(userId, id)!;
+  const where = ["id = ?", "user_id = ?"];
+  values.push(id, userId);
+  if (expectedCacheRevision !== undefined) {
+    where.push("cache_revision = ?");
+    values.push(expectedCacheRevision);
+  }
+
+  const changes = getDb()
+    .query(`UPDATE presets SET ${fields.join(", ")} WHERE ${where.join(" AND ")}`)
+    .run(...values)
+    .changes;
+  if (changes === 0) {
+    // A conditional miss is either a deleted row (the normal not-found result)
+    // or a stale writer. Read the current revision only after the atomic update
+    // has failed so the distinction cannot race the mutation itself.
+    const current = getPreset(userId, id);
+    if (!current) return null;
+    if (expectedCacheRevision !== undefined) {
+      throw new PresetRevisionConflictError(id, expectedCacheRevision, current.cache_revision ?? 0);
+    }
+    return null;
+  }
+
+  const updated = getPreset(userId, id);
+  if (!updated) return null;
   eventBus.emit(EventType.PRESET_CHANGED, { id, preset: updated }, userId);
   return updated;
 }
@@ -442,7 +471,7 @@ export function createPromptBlock(
     : blocks.length;
   blocks.splice(insertAt, 0, block);
 
-  updatePreset(userId, presetId, { prompt_order: blocks });
+  updatePreset(userId, presetId, { prompt_order: blocks, expected_cache_revision: preset.cache_revision });
   return block;
 }
 
@@ -461,7 +490,7 @@ export function updatePromptBlock(
 
   const updated = normalizePromptBlock({ ...blocks[index], ...(input || {}), id: blockId });
   blocks[index] = updated;
-  updatePreset(userId, presetId, { prompt_order: blocks });
+  updatePreset(userId, presetId, { prompt_order: blocks, expected_cache_revision: preset.cache_revision });
   return updated;
 }
 
@@ -474,7 +503,7 @@ export function deletePromptBlock(userId: string, presetId: string, blockId: str
   if (index === -1) return false;
 
   blocks.splice(index, 1);
-  updatePreset(userId, presetId, { prompt_order: blocks });
+  updatePreset(userId, presetId, { prompt_order: blocks, expected_cache_revision: preset.cache_revision });
   return true;
 }
 

--- a/src/services/presets.service.ts
+++ b/src/services/presets.service.ts
@@ -231,16 +231,6 @@ export function getPresetCacheRevision(userId: string, id: string): number | nul
   return row ? row.cache_revision : null;
 }
 
-/**
- * Fetch a preset's user-visible update timestamp without reading the full row.
- * Returns null when the preset doesn't exist for this user.
- */
-export function getPresetUpdatedAt(userId: string, id: string): number | null {
-  const row = getDb()
-    .query("SELECT updated_at FROM presets WHERE id = ? AND user_id = ?")
-    .get(id, userId) as { updated_at: number } | null;
-  return row ? row.updated_at : null;
-}
 
 /**
  * Validate that a usable preset exists for generation. Throws a config error

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -121,7 +121,7 @@ import {
   type SharedRpcEndpointPolicy,
 } from "./shared-rpc-pool.service";
 import { getTextContent, type LlmMessage } from "../llm/types";
-import type { CreatePresetInput, UpdatePresetInput } from "../types/preset";
+import { PresetRevisionConflictError, type CreatePresetInput, type UpdatePresetInput } from "../types/preset";
 import { getDb } from "../db/connection";
 import { normalizeSpindleAppNavigationPath } from "./url-safety";
 import {
@@ -156,6 +156,13 @@ import { createHash } from "crypto";
 import { join, resolve, relative, sep, extname } from "path";
 import { tmpdir } from "os";
 
+type PresetConflictWorkerError = {
+  code: string;
+  message: string;
+  presetId?: string;
+  expectedCacheRevision?: number;
+  actualCacheRevision?: number;
+};
 const EPHEMERAL_MAX_FILES = 250;
 const sharedRpcPermissionScope = new AsyncLocalStorage<string | undefined>();
 
@@ -6290,11 +6297,26 @@ export class WorkerHost {
   private handlePresetsUpdate(requestId: string, presetId: string, input: UpdatePresetInput, userId?: string): void {
     try {
       const resolvedUserId = this.resolvePresetUserOrThrow(userId);
-      const preset = presetsSvc.updatePreset(resolvedUserId, presetId, input || {});
+      const requestedInput = input || {};
+      if (requestedInput.expected_cache_revision === undefined) {
+        throw new Error("Preset revision is required for preset updates");
+      }
+      const preset = presetsSvc.updatePreset(resolvedUserId, presetId, requestedInput);
       if (!preset) throw new Error("Preset not found");
       this.postToWorker({ type: "response", requestId, result: preset });
     } catch (err: any) {
-      this.postToWorker({ type: "response", requestId, error: err.message });
+      const error: string | PresetConflictWorkerError = err instanceof PresetRevisionConflictError
+        ? {
+            code: err.code,
+            message: err.message,
+            presetId: err.presetId,
+            expectedCacheRevision: err.expectedCacheRevision,
+            actualCacheRevision: err.actualCacheRevision,
+          }
+        : err.message;
+      // The published 0.6.2 host contract types errors as strings; the
+      // revision-safe candidate widens this field to structured metadata.
+      this.postToWorker({ type: "response", requestId, error: error as unknown as string });
     }
   }
 

--- a/src/spindle/worker-response-error.test.ts
+++ b/src/spindle/worker-response-error.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { deserializeWorkerResponseError } from "./worker-response-error";
+
+describe("worker response errors", () => {
+  test("preserves preset revision conflict metadata for extension recovery", () => {
+    const error = deserializeWorkerResponseError({
+      code: "PRESET_REVISION_CONFLICT",
+      message: "Preset changed",
+      presetId: "preset-1",
+      expectedCacheRevision: 3,
+      actualCacheRevision: 4,
+    });
+
+    expect(error.message).toBe("Preset changed");
+    expect(error).toMatchObject({
+      code: "PRESET_REVISION_CONFLICT",
+      presetId: "preset-1",
+      expectedCacheRevision: 3,
+      actualCacheRevision: 4,
+    });
+  });
+});

--- a/src/spindle/worker-response-error.ts
+++ b/src/spindle/worker-response-error.ts
@@ -1,0 +1,17 @@
+export interface HostResponseError {
+  code: string;
+  message: string;
+  presetId?: string;
+  expectedCacheRevision?: number;
+  actualCacheRevision?: number;
+}
+
+export type WorkerResponseError = string | HostResponseError;
+
+/** Reconstruct host error metadata without losing optimistic-concurrency fields. */
+export function deserializeWorkerResponseError(value: WorkerResponseError): Error {
+  if (typeof value === "string") return new Error(value);
+  const error = new Error(value.message);
+  Object.assign(error, value);
+  return error;
+}

--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -88,6 +88,7 @@ import type {
   MediaTransformResultDTO,
 } from "../services/media.service";
 import { initializeSandbox } from "./worker-runtime-sandbox";
+import { deserializeWorkerResponseError } from "./worker-response-error";
 import {
   assertValidSharedRpcEndpoint,
   normalizeOwnedSharedRpcEndpoint,
@@ -4026,10 +4027,11 @@ async function handleHostMessage(msg: RuntimeHostToWorker): Promise<void> {
         if (msg.error) {
           // Convert host-side abort errors back into a real DOMException so
           // extensions can do `err.name === "AbortError"` the usual way.
-          if (msg.error.startsWith("AbortError:")) {
-            pending.reject(makeAbortError(msg.error.slice("AbortError:".length).trim()));
+          const responseError = msg.error
+          if (typeof responseError === "string" && responseError.startsWith("AbortError:")) {
+            pending.reject(makeAbortError(responseError.slice("AbortError:".length).trim()))
           } else {
-            pending.reject(new Error(msg.error));
+            pending.reject(deserializeWorkerResponseError(responseError))
           }
         } else {
           pending.resolve(msg.result);

--- a/src/types/preset.ts
+++ b/src/types/preset.ts
@@ -7,6 +7,7 @@ export interface Preset {
   prompt_order: any[];
   prompts: Record<string, any>;
   metadata: Record<string, any>;
+  cache_revision?: number;
   created_at: number;
   updated_at: number;
 }
@@ -21,7 +22,27 @@ export interface CreatePresetInput {
   metadata?: Record<string, any>;
 }
 
-export type UpdatePresetInput = Partial<CreatePresetInput>;
+export type UpdatePresetInput = Partial<CreatePresetInput> & {
+  /** Transport-only optimistic concurrency precondition; never persisted. */
+  expected_cache_revision?: number;
+};
+
+export class PresetRevisionConflictError extends Error {
+  readonly code = "PRESET_REVISION_CONFLICT";
+  readonly presetId: string;
+  readonly expectedCacheRevision: number;
+  readonly actualCacheRevision: number;
+
+  constructor(presetId: string, expectedCacheRevision: number, actualCacheRevision: number) {
+    super(
+      `Preset ${presetId} changed since revision ${expectedCacheRevision}; current revision is ${actualCacheRevision}`,
+    );
+    this.name = "PresetRevisionConflictError";
+    this.presetId = presetId;
+    this.expectedCacheRevision = expectedCacheRevision;
+    this.actualCacheRevision = actualCacheRevision;
+  }
+}
 
 // --- Loom Preset Assembly Types ---
 

--- a/src/utils/http-cache.test.ts
+++ b/src/utils/http-cache.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { ifNoneMatchSatisfies } from "./http-cache";
+
+describe("ifNoneMatchSatisfies", () => {
+  test("uses weak comparison for If-None-Match validators", () => {
+    expect(ifNoneMatchSatisfies('"preset-1"', 'W/"preset-1"')).toBe(true);
+    expect(ifNoneMatchSatisfies('W/"preset-1"', '"preset-1"')).toBe(true);
+    expect(ifNoneMatchSatisfies('"other", W/"preset-1"', 'W/"preset-1"')).toBe(true);
+  });
+
+  test("rejects unequal validators while honoring wildcard", () => {
+    expect(ifNoneMatchSatisfies('W/"other"', 'W/"preset-1"')).toBe(false);
+    expect(ifNoneMatchSatisfies("*", 'W/"preset-1"')).toBe(true);
+  });
+});

--- a/src/utils/http-cache.ts
+++ b/src/utils/http-cache.ts
@@ -13,15 +13,21 @@ export const REVALIDATE_PRIVATE = "private, no-cache";
 
 /**
  * RFC 7232 If-None-Match evaluation: true when the client's header lists the
- * current etag (or "*"). Handles comma-separated lists and surrounding spaces.
+ * current entity tag (or "*"). If-None-Match uses weak comparison, so a weak
+ * tag and its otherwise-identical strong form represent the same resource.
  */
 export function ifNoneMatchSatisfies(
   ifNoneMatch: string | null | undefined,
   etag: string,
 ): boolean {
   if (!ifNoneMatch) return false;
+  const normalize = (value: string): string => {
+    const trimmed = value.trim();
+    return trimmed.startsWith("W/") ? trimmed.slice(2).trim() : trimmed;
+  };
+  const current = normalize(etag);
   return ifNoneMatch
     .split(",")
     .map((value) => value.trim())
-    .some((value) => value === "*" || value === etag);
+    .some((value) => value === "*" || normalize(value) === current);
 }


### PR DESCRIPTION
## Summary

This PR ports the complementary host work required by the native Spindle preset-editor surfaces:

- serialize whole-preset writes across Loom, prompt-variable, profile, selection, recovery, and generation paths
- add cache-revision preconditions, atomic stale-write rejection, REST 409 details, prompt-block forwarding, and LumiHub update protection
- preserve extension-owned preset metadata while rebasing partial responses and scoped durable recovery
- make profile queues user/context-safe and harden loader permission revoke/regrant, generation invalidation, teardown, and placement cleanup
- add deterministic race/regression coverage and backend/frontend typecheck coverage

## Prerequisite

The companion type-contract change is in `prolix-oc/lumiverse-spindle-types#30` (`TheLiquorPriest:feat/preset-revision-contract`). The host remains source-compatible with the currently published `0.6.2` package while the candidate adds typed preset revisions and structured worker conflict metadata.

## Validation

- backend `bunx tsc --noEmit -p tsconfig.json`
- frontend `bunx tsc --noEmit`
- frontend generated `bun run typecheck`
- frontend production `bun run build` (generated `frontend/dist/` restored to the staging baseline)
- focused backend and frontend regression suites

The PR contains no `frontend/dist/` changes. `frontend/bun.lock` only carries the existing `0.6.2` dependency alignment from the native editor surface stack.