### PR TITLE
Add token count to persona description

### DIFF
--- a/frontend/src/components/panels/persona-browser/PersonaEditor.module.css
+++ b/frontend/src/components/panels/persona-browser/PersonaEditor.module.css
@@ -118,6 +118,18 @@
   gap: 6px;
 }
 
+.descriptionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.descriptionLabel {
+  font-size: calc(11px * var(--lumiverse-font-scale, 1));
+  font-weight: 500;
+  color: var(--lumiverse-text-muted);
+}
+
 .descTextarea {
   width: 100%;
   background: var(--lumiverse-bg);

--- a/frontend/src/components/panels/persona-browser/PersonaEditor.tsx
+++ b/frontend/src/components/panels/persona-browser/PersonaEditor.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { User, Crown, Copy, Trash2, Play, Upload, Pencil, MessagesSquare, Link, Globe, RefreshCw, X, BookOpen } from 'lucide-react'
 import { IconPlaylistAdd } from '@tabler/icons-react'
 import { ExpandableTextarea } from '@/components/shared/ExpandedTextEditor'
+import TokenCountButton from '@/components/shared/TokenCountButton'
 import { getPersonaAvatarLargeUrl } from '@/lib/avatarUrls'
 import { worldBooksApi } from '@/api/world-books'
 import { chatsApi } from '@/api/chats'
@@ -486,6 +487,10 @@ export default function PersonaEditor({
 
       {/* Description */}
       <div className={styles.section}>
+        <div className={styles.descriptionHeader}>
+          <span className={styles.descriptionLabel}>{t('personaEditor.description')}</span>
+          <TokenCountButton text={description} />
+        </div>
         <ExpandableTextarea
           className={styles.descTextarea}
           value={description}


### PR DESCRIPTION
This pull request enhances the description editing section in the `PersonaEditor` component by improving its layout and adding a token count feature. The main changes are:

**UI Improvements:**
* Added a new header above the description textarea that includes a label and aligns elements using the `.descriptionHeader` and `.descriptionLabel` CSS classes for better visual structure. [[1]](diffhunk://#diff-b4cb8ec397ca5a513ecd484d022729ce03b311ff82b8d151b2beded91a6c8771R121-R132) [[2]](diffhunk://#diff-7f054a690c1b6fc4d47cfdf5abf03613fd1310e10ea9dc20c5fa81b7720afcfaR490-R493)

**New Features:**
* Integrated the `TokenCountButton` component to display the token count for the persona description, helping users track content length. [[1]](diffhunk://#diff-7f054a690c1b6fc4d47cfdf5abf03613fd1310e10ea9dc20c5fa81b7720afcfaR7) [[2]](diffhunk://#diff-7f054a690c1b6fc4d47cfdf5abf03613fd1310e10ea9dc20c5fa81b7720afcfaR490-R493)