### PR TITLE
Add regression coverage for extension-triggered frontend freezes

### DIFF
--- a/frontend/src/lib/swUpdatePolicy.test.ts
+++ b/frontend/src/lib/swUpdatePolicy.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test'
+import { isServiceWorkerReplacement } from './swUpdatePolicy'
+
+describe('service-worker update policy', () => {
+  test('does not treat a first install as an application update', () => {
+    expect(isServiceWorkerReplacement(false, false)).toBe(false)
+  })
+
+  test('recognizes replacement workers from either browser signal', () => {
+    expect(isServiceWorkerReplacement(true, false)).toBe(true)
+    expect(isServiceWorkerReplacement(false, true)).toBe(true)
+    expect(isServiceWorkerReplacement(true, true)).toBe(true)
+  })
+})

--- a/frontend/src/lib/swUpdatePolicy.ts
+++ b/frontend/src/lib/swUpdatePolicy.ts
@@ -1,0 +1,10 @@
+/**
+ * `updatefound` fires both for a first install and for a replacement worker.
+ * Only a replacement should block the application behind the update overlay.
+ */
+export function isServiceWorkerReplacement(
+  hasActiveWorker: boolean,
+  hasController: boolean,
+): boolean {
+  return hasActiveWorker || hasController
+}

--- a/frontend/src/lib/swUpdater.ts
+++ b/frontend/src/lib/swUpdater.ts
@@ -1,4 +1,5 @@
 import { useStore } from '@/store'
+import { isServiceWorkerReplacement } from './swUpdatePolicy'
 
 /**
  * Module-level handle to the active service worker registration. Held outside
@@ -49,7 +50,10 @@ export function rememberRegistration(reg: ServiceWorkerRegistration | undefined)
     // A first-time service-worker install also emits updatefound. It is not an
     // application update and must not put a freshly loaded page behind the
     // blocking update overlay.
-    if (!reg.active && !navigator.serviceWorker.controller) return
+    if (!isServiceWorkerReplacement(
+      Boolean(reg.active),
+      Boolean(navigator.serviceWorker.controller),
+    )) return
     setBundleUpdatePending(true)
 
     // If the new worker fails to install (e.g. precache fetch fails), clear

--- a/src/middleware/compress.test.ts
+++ b/src/middleware/compress.test.ts
@@ -71,4 +71,25 @@ describe("Bun streaming-response compatibility", () => {
     expect(response.headers.get("content-length")).toBeNull();
     expect(new TextDecoder().decode(Bun.gunzipSync(compressed))).toBe(source);
   });
+
+  test("returns fixed gzip bytes for affected Windows extension bundles", async () => {
+    const fallbackApp = new Hono();
+    fallbackApp.use("*", compress({ platform: "win32", bunVersion: "1.3.14" }));
+    const source = "export function setup() {}".repeat(128);
+    fallbackApp.get("/api/v1/spindle/test-id/frontend", (c) => c.newResponse(source, 200, {
+      "Content-Type": "application/javascript",
+      "Content-Length": String(source.length),
+      ETag: '"spindle-frontend-test"',
+    }));
+
+    const response = await fallbackApp.request(
+      "http://localhost/api/v1/spindle/test-id/frontend?v=bundle-1",
+      { headers: { "Accept-Encoding": "br, gzip" } },
+    );
+    const compressed = new Uint8Array(await response.arrayBuffer());
+
+    expect(response.headers.get("content-encoding")).toBe("gzip");
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(new TextDecoder().decode(Bun.gunzipSync(compressed))).toBe(source);
+  });
 });


### PR DESCRIPTION
This PR adds targeted regression coverage for the two failure paths responsible for extension-triggered crashes and the persistent “Updating Lumiverse” screen on Windows. It verifies the Bun 1.3.14 response-stream workaround for Spindle frontend bundles and makes the service-worker replacement logic independently testable.

The most important changes are:

**Service-worker update detection:**

- Extracted service-worker replacement detection into the shared `isServiceWorkerReplacement` helper.
- Updated `swUpdater` to use the helper when distinguishing an existing worker replacement from a first-time installation.
- Ensured first-time service-worker installations remain excluded from the blocking application-update state.
- Added tests covering active-worker, controlled-page, and first-install scenarios.

**Windows Bun regression coverage:**

- Added a compression test for the exact `/api/v1/spindle/:id/frontend` route used to load extension frontend bundles.
- Verified that Windows Bun 1.3.14 uses a fixed gzip response even when the browser advertises Brotli support.
- Confirmed that the compressed response has no stale content length and decompresses back to the original extension bundle.

These changes protect against regressions that could leave the frontend stuck behind the update overlay or trigger Bun’s aborted streamed-response crash and freeze behavior when extensions are enabled.