### PR TITLE
Prevent large user-data imports from exhausting memory on Termux

### DIFF
--- a/src/routes/user-data.routes.ts
+++ b/src/routes/user-data.routes.ts
@@ -242,23 +242,26 @@ app.post("/import", async (c) => {
   let jobId: string;
   try {
     const ct = c.req.header("content-type") || "";
-    let body: ReadableStream<Uint8Array> | null = null;
-    let size: number | null = declared > 0 ? declared : null;
-
     if (ct.startsWith("multipart/form-data")) {
-      // FormData is buffered by Bun; fine for archives up to a few hundred MB.
-      // For larger payloads, clients should POST the raw archive as the body.
-      const form = await c.req.formData();
-      const file = form.get("archive");
-      if (!(file instanceof File)) {
-        return c.json({ error: "form field 'archive' (File) is required" }, 400);
-      }
-      body = file.stream();
-      size = file.size;
-    } else {
-      // Raw upload (preferred for large archives).
-      body = c.req.raw.body;
+      // Bun's formData() parser materializes the complete multipart body in
+      // memory. That is unsafe for account archives on low-memory hosts
+      // (especially Termux), where a single large upload can kill the server
+      // before persistUploadedArchive gets a chance to stream it to disk.
+      // The Data Portability UI has always sent the File as a raw body, so
+      // reject this legacy/undocumented shape instead of retaining an OOM
+      // footgun for direct API clients.
+      return c.json(
+        {
+          error:
+            "multipart archive uploads are not supported; send the archive as the raw request body",
+          code: "multipart_not_supported",
+        },
+        415,
+      );
     }
+
+    const body = c.req.raw.body;
+    const size = declared > 0 ? declared : null;
     if (!body) return c.json({ error: "request body is empty" }, 400);
 
     const persisted = await persistUploadedArchive(userId, body, size);

--- a/src/services/user-data/import.service.ts
+++ b/src/services/user-data/import.service.ts
@@ -19,7 +19,15 @@ import {
   type EncryptedSecretEntry,
 } from "./secret-ticket.service";
 import { putSecret } from "../secrets.service";
-import { mkdirSync, existsSync, unlinkSync, statSync } from "fs";
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  statSync,
+  unlinkSync,
+  writeSync,
+} from "fs";
 import { join, dirname, basename, resolve, sep } from "path";
 import { getDb } from "../../db/connection";
 import { env } from "../../env";
@@ -189,24 +197,49 @@ export async function persistUploadedArchive(
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   const path = join(dir, "archive.lvbak");
 
-  const sink = Bun.file(path).writer();
+  // Keep Bun's internal queue deliberately small. More importantly, every
+  // write below is awaited: FileSink.write() returns a Promise when the disk
+  // cannot keep pace with the request. Ignoring that Promise turns the sink
+  // into an unbounded RAM queue on slow Android/Termux storage.
+  const sink = Bun.file(path).writer({ highWaterMark: 256 * 1024 });
   const reader = body.getReader();
-  let header = new Uint8Array(0);
+  const header = new Uint8Array(4);
+  let headerBytes = 0;
   let magicChecked = false;
   let total = 0;
-  let aborted = false;
+  let sinkClosed = false;
 
-  const cleanup = () => {
+  const closeSink = async (ignoreError = false) => {
+    if (sinkClosed) return;
+    sinkClosed = true;
     try {
-      sink.end();
-    } catch {
-      /* ignore */
+      await sink.end();
+    } catch (err) {
+      if (!ignoreError) throw err;
     }
+  };
+
+  const cleanup = async () => {
+    // Cleanup runs while another validation/write error is already in flight;
+    // don't replace that useful error with a secondary close failure.
+    await closeSink(true);
     try {
       unlinkSync(path);
     } catch {
       /* ignore */
     }
+  };
+
+  const writeChunk = async (chunk: Uint8Array) => {
+    if (chunk.byteLength === 0) return;
+    if (total + chunk.byteLength > MAX_COMPRESSED_BYTES) {
+      throw new ArchiveValidationError(
+        "size",
+        `archive exceeds compressed size cap (${total + chunk.byteLength} bytes)`,
+      );
+    }
+    await sink.write(chunk);
+    total += chunk.byteLength;
   };
 
   try {
@@ -215,62 +248,47 @@ export async function persistUploadedArchive(
       if (done) break;
       if (!value || value.byteLength === 0) continue;
 
-      // Accumulate the first chunk(s) until we have ≥ 4 bytes, then verify.
+      // Accumulate only the four magic bytes. The previous implementation
+      // copied the *entire* first stream chunk into a new Uint8Array; some Bun
+      // builds can deliver a very large first chunk for a known-length body,
+      // temporarily doubling an already-large archive in memory.
       if (!magicChecked) {
-        const combined = new Uint8Array(header.byteLength + value.byteLength);
-        combined.set(header, 0);
-        combined.set(value, header.byteLength);
-        header = combined;
-        if (header.byteLength >= 4) {
-          if (!startsWithZipMagic(header)) {
-            aborted = true;
-            cleanup();
-            throw new ArchiveValidationError(
-              "not_zip",
-              "Uploaded file is not a ZIP archive (missing PK\\x03\\x04 header).",
-            );
-          }
-          magicChecked = true;
-          sink.write(header);
-          total += header.byteLength;
-          header = new Uint8Array(0);
+        const take = Math.min(4 - headerBytes, value.byteLength);
+        header.set(value.subarray(0, take), headerBytes);
+        headerBytes += take;
+        if (headerBytes < 4) continue;
+
+        if (!startsWithZipMagic(header)) {
+          throw new ArchiveValidationError(
+            "not_zip",
+            "Uploaded file is not a ZIP archive (missing PK\\x03\\x04 header).",
+          );
         }
+
+        magicChecked = true;
+        await writeChunk(header);
+        await writeChunk(value.subarray(take));
         continue;
       }
 
-      sink.write(value);
-      total += value.byteLength;
-      if (total > MAX_COMPRESSED_BYTES) {
-        aborted = true;
-        cleanup();
-        throw new ArchiveValidationError(
-          "size",
-          `archive exceeds compressed size cap (${total} bytes)`,
-        );
-      }
+      await writeChunk(value);
     }
 
     // Body ended before we had 4 bytes — treat as invalid.
     if (!magicChecked) {
-      aborted = true;
-      cleanup();
       throw new ArchiveValidationError("not_zip", "Upload is empty or shorter than a ZIP header.");
     }
 
-    await sink.end();
+    await closeSink();
   } catch (err) {
-    if (!aborted) {
-      try {
-        sink.end();
-      } catch {
-        /* ignore */
-      }
-      try {
-        unlinkSync(path);
-      } catch {
-        /* ignore */
-      }
+    // Stop accepting network data immediately on validation/write failure,
+    // then remove the partial archive after the sink has actually closed.
+    try {
+      await reader.cancel(err);
+    } catch {
+      /* ignore */
     }
+    await cleanup();
     throw err;
   } finally {
     try {
@@ -863,6 +881,16 @@ interface ImportBuffer {
   stagingDir: string;
 }
 
+/** Write a complete Uint8Array even if the OS performs a short write. */
+function writeAllSync(fd: number, chunk: Uint8Array): void {
+  let offset = 0;
+  while (offset < chunk.byteLength) {
+    const written = writeSync(fd, chunk, offset, chunk.byteLength - offset);
+    if (written <= 0) throw new Error("archive staging write made no progress");
+    offset += written;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Phase 1: extract archive into staging
 // ---------------------------------------------------------------------------
@@ -895,7 +923,12 @@ async function extractArchive(job: ImportJob): Promise<ImportBuffer> {
   // fflate's Unzip is a sync API; we feed chunks as we read them, and it
   // hands us files via the callback. Each file's `ondata` is wired to
   // append to a staging file on disk.
-  const openFiles = new Map<UnzipFile, { writeStream: Bun.FileSink; entry: BufferedEntry; closed: boolean }>();
+  // fflate's callbacks are synchronous and expose no pause/backpressure hook.
+  // A Bun.FileSink can therefore queue decompressed chunks faster than slow
+  // Android storage can flush them. Use synchronous file descriptors here:
+  // extraction is already CPU-synchronous, and this guarantees each chunk is
+  // on disk before fflate is allowed to produce the next one.
+  const openFiles = new Map<UnzipFile, { fd: number; entry: BufferedEntry; closed: boolean }>();
   let openFileError: any = null;
 
   const unzip = new Unzip((file) => {
@@ -929,7 +962,18 @@ async function extractArchive(job: ImportJob): Promise<ImportBuffer> {
     // Stage every entry as a real file on disk so the apply phase can re-read
     // it in topological order without buffering anything in JS memory.
     const stagingPath = join(buf.stagingDir, `${buf.entryCount.toString(36)}.bin`);
-    const sink = Bun.file(stagingPath).writer();
+    let fd: number;
+    try {
+      fd = openSync(stagingPath, "w");
+    } catch (err) {
+      openFileError = err;
+      try {
+        file.terminate?.();
+      } catch {
+        /* ignore */
+      }
+      return;
+    }
 
     let entry: BufferedEntry;
     switch (descriptor.kind) {
@@ -979,7 +1023,7 @@ async function extractArchive(job: ImportJob): Promise<ImportBuffer> {
         break;
     }
 
-    openFiles.set(file, { writeStream: sink, entry, closed: false });
+    openFiles.set(file, { fd, entry, closed: false });
     buf.entries.push(entry);
 
     file.ondata = (err, chunk, final) => {
@@ -991,27 +1035,19 @@ async function extractArchive(job: ImportJob): Promise<ImportBuffer> {
       if (!handle) return;
       if (chunk && chunk.byteLength > 0) {
         try {
-          handle.writeStream.write(chunk);
+          enforceQuota(chunk.byteLength);
+          writeAllSync(handle.fd, chunk);
+          handle.entry.byteSize += chunk.byteLength;
         } catch (writeErr) {
           openFileError = writeErr;
-          return;
-        }
-        handle.entry.byteSize += chunk.byteLength;
-        try {
-          enforceQuota(chunk.byteLength);
-        } catch (quotaErr) {
-          openFileError = quotaErr;
           return;
         }
       }
       if (final) {
         if (!handle.closed) {
           handle.closed = true;
-          // FileSink.end() flushes; ignore returned promise to keep the sync
-          // ondata path simple. The OS write is durable enough for our
-          // purposes (we re-read inside the same process).
           try {
-            handle.writeStream.end();
+            closeSync(handle.fd);
           } catch {
             /* ignore */
           }
@@ -1056,8 +1092,10 @@ async function extractArchive(job: ImportJob): Promise<ImportBuffer> {
     }
     // Force-close any still-open sinks (shouldn't happen for well-formed zips).
     for (const handle of openFiles.values()) {
+      if (handle.closed) continue;
+      handle.closed = true;
       try {
-        handle.writeStream.end();
+        closeSync(handle.fd);
       } catch {
         /* ignore */
       }

--- a/tests/user-data-import-upload.test.ts
+++ b/tests/user-data-import-upload.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { env } from "../src/env";
+import {
+  ArchiveValidationError,
+  persistUploadedArchive,
+} from "../src/services/user-data/import.service";
+
+function streamChunks(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  let index = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      const chunk = chunks[index++];
+      if (chunk) controller.enqueue(chunk);
+      else controller.close();
+    },
+  });
+}
+
+describe("user-data import upload staging", () => {
+  let workDir: string;
+  let originalDataDir: string;
+
+  beforeEach(() => {
+    originalDataDir = env.dataDir;
+    workDir = mkdtempSync(join(tmpdir(), "lvbak-upload-test-"));
+    env.dataDir = workDir;
+  });
+
+  afterEach(() => {
+    env.dataDir = originalDataDir;
+    if (existsSync(workDir)) rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test("stages a raw archive without losing bytes when ZIP magic spans chunks", async () => {
+    const chunks = [
+      new Uint8Array([0x50]),
+      new Uint8Array([0x4b, 0x03]),
+      new Uint8Array([0x04, 0xaa, 0xbb]),
+      new Uint8Array([0xcc, 0xdd, 0xee]),
+    ];
+
+    const result = await persistUploadedArchive(
+      "upload-user",
+      streamChunks(chunks),
+      9,
+    );
+
+    expect(await Bun.file(result.path).bytes()).toEqual(
+      new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0xaa, 0xbb, 0xcc, 0xdd, 0xee]),
+    );
+  });
+
+  test("rejects invalid magic and removes the partial archive", async () => {
+    let caught: unknown;
+    try {
+      await persistUploadedArchive(
+        "upload-user",
+        streamChunks([new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04])]),
+        5,
+      );
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(ArchiveValidationError);
+    expect((caught as ArchiveValidationError).code).toBe("not_zip");
+
+    const importsDir = join(workDir, "imports", "upload-user");
+    const archivePaths = new Bun.Glob("**/archive.lvbak").scanSync({
+      cwd: importsDir,
+      absolute: true,
+      onlyFiles: true,
+    });
+    expect([...archivePaths]).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
This pull request hardens the user-data archive import pipeline against memory exhaustion on Termux and other systems with slow or memory-constrained storage. The most significant changes are enforcing disk-write backpressure during upload staging, preventing decompressed archive entries from accumulating in memory during extraction, and removing the multipart import path that buffered complete archives through Bun’s `formData()` parser.

**Upload streaming and memory management:**

- Updated `persistUploadedArchive` to await every `FileSink.write()` operation, ensuring incoming request data cannot outpace disk writes and accumulate in memory. (`src/services/user-data/import.service.ts`)
- Configured the upload staging sink with a 256 KB high-water mark to keep its internal buffer bounded on slow Android storage. (`src/services/user-data/import.service.ts`)
- Changed ZIP signature validation to retain only the four required magic bytes instead of copying the entire first request chunk into a new `Uint8Array`. This avoids temporarily duplicating a potentially large chunk in memory. (`src/services/user-data/import.service.ts`)
- Moved compressed-size enforcement ahead of each disk write so oversized archives are rejected before additional data is persisted. (`src/services/user-data/import.service.ts`)
- Added explicit request-stream cancellation, sink closure, and partial-file cleanup when validation or filesystem writes fail. (`src/services/user-data/import.service.ts`)
- Preserved propagation of primary upload and close errors while preventing secondary cleanup failures from masking the original problem. (`src/services/user-data/import.service.ts`)

**Archive extraction and disk backpressure:**

- Replaced asynchronous `Bun.FileSink` staging inside fflate callbacks with synchronous file-descriptor writes. Because fflate invokes extraction callbacks synchronously and provides no pause mechanism, this guarantees each decompressed chunk reaches disk before extraction continues. (`src/services/user-data/import.service.ts`)
- Added a complete-write helper that handles short filesystem writes and continues until the entire decompressed chunk has been persisted. (`src/services/user-data/import.service.ts`)
- Explicitly closes completed and interrupted staging files, preventing descriptor leaks when extraction finishes or fails. (`src/services/user-data/import.service.ts`)
- Retained the existing decompressed-size and entry-count protections while ensuring those limits no longer represent potential in-memory queue sizes. (`src/services/user-data/import.service.ts`)

**Import API safety and compatibility:**

- Removed the multipart archive parsing fallback from the user-data import route because Bun’s `formData()` parser materializes the complete request body in memory. (`src/routes/user-data.routes.ts`)
- Multipart archive requests now return `415 Unsupported Media Type` with a clear `multipart_not_supported` error directing API clients to send the archive as the raw request body. (`src/routes/user-data.routes.ts`)
- The Data Portability settings UI remains compatible because it already uploads `.lvbak` files as raw `application/octet-stream` request bodies. (`frontend/src/api/user-data.ts`)

**Regression coverage and validation:**

- Added tests confirming ZIP magic detection works when the signature is fragmented across multiple request chunks. (`tests/user-data-import-upload.test.ts`)
- Added byte-for-byte verification that raw archive streams are staged without losing or duplicating data. (`tests/user-data-import-upload.test.ts`)
- Added coverage ensuring invalid archives return the expected validation error and leave no partial archive behind. (`tests/user-data-import-upload.test.ts`)
- Validated the changes with the backend TypeScript check and the existing ZIP64 export/import verification suite, including the 100,000-row streaming archive test.