### PR TITLE
Prevent large user-data archives from exhausting memory during verification

### DIFF
--- a/src/routes/user-data.routes.ts
+++ b/src/routes/user-data.routes.ts
@@ -278,10 +278,10 @@ app.post("/import", async (c) => {
 
   // ── Pre-flight: confirm this is a real Lumiverse archive ───────────────
   // Fast path: read the ZIP central directory at the tail of the file and
-  // decompress just the manifest.json bytes (O(64 KB + manifest_size) for
-  // any archive size, location-independent — legacy archives that write
-  // manifest last verify in tens of milliseconds instead of streaming
-  // gigabytes).
+  // decompress just the manifest.json bytes. The directory is scanned in
+  // fixed-size pages, so memory remains bounded even when an archive contains
+  // hundreds of thousands of files. Legacy archives that write manifest last
+  // avoid streaming the full archive body.
   // Streaming fallback handles unusual cases (ZIP64, malformed CD) where
   // the fast parser bails out.
   eventBus.emit(

--- a/src/services/user-data/import.service.ts
+++ b/src/services/user-data/import.service.ts
@@ -8,7 +8,8 @@
 // The import runs as a background job; the HTTP route returns a jobId and
 // progress flows over the WebSocket EventBus.
 
-import { Unzip, UnzipInflate, inflateSync, type UnzipFile } from "fflate";
+import { inflateRawSync } from "node:zlib";
+import { Unzip, UnzipInflate, type UnzipFile } from "fflate";
 import {
   decryptSecret,
   lookupConsumedTicket,
@@ -322,6 +323,9 @@ export async function persistUploadedArchive(
  */
 const MAX_MANIFEST_BYTES = 16 * 1024 * 1024;
 
+/** A manifest should never be larger compressed than this. */
+const MAX_MANIFEST_COMPRESSED_BYTES = 32 * 1024 * 1024;
+
 // ─── ZIP central-directory primitives ──────────────────────────────────
 //
 // Every ZIP file ends with an End-of-Central-Directory (EOCD) record, which
@@ -352,6 +356,10 @@ const EOCD_MIN_BYTES = 22;
 const ZIP64_EOCD_LOCATOR_BYTES = 20;
 const ZIP64_EOCD_RECORD_BYTES = 56;
 const ZIP_COMMENT_MAX = 65535;
+/** Bounded read window used while scanning a potentially huge central directory. */
+const CENTRAL_DIRECTORY_READ_BYTES = 256 * 1024;
+/** Bounded compressed input window for the full-file fallback verifier. */
+const FALLBACK_VERIFY_READ_BYTES = 256 * 1024;
 
 interface CentralDirEntry {
   name: string;
@@ -378,6 +386,7 @@ function readZip64Extra(
     const view = new DataView(extra.buffer, extra.byteOffset, extra.byteLength);
     const tag = view.getUint16(pos, true);
     const size = view.getUint16(pos + 2, true);
+    if (pos + 4 + size > end) return null;
     if (tag === ZIP64_EXTRA_TAG) {
       return new DataView(extra.buffer, extra.byteOffset + pos + 4, size);
     }
@@ -390,11 +399,139 @@ async function readBytes(file: Bun.BunFile, start: number, end: number): Promise
   return new Uint8Array(await file.slice(start, end).arrayBuffer());
 }
 
+function isSafeZipNumber(value: number): boolean {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+/**
+ * Scan central-directory records in fixed-size windows and return the
+ * manifest record. A large account can contain enough individual files for
+ * its central directory to reach tens or hundreds of megabytes; loading that
+ * range with one arrayBuffer() defeats the otherwise-streaming import path.
+ */
+async function findManifestInCentralDirectory(
+  file: Bun.BunFile,
+  cdOffset: number,
+  cdSize: number,
+  totalEntries: number,
+): Promise<CentralDirEntry | null> {
+  const decoder = new TextDecoder();
+  let fetched = 0;
+  let entriesRead = 0;
+  let pending = new Uint8Array(0);
+
+  while (fetched < cdSize && entriesRead < totalEntries) {
+    const readSize = Math.min(CENTRAL_DIRECTORY_READ_BYTES, cdSize - fetched);
+    const chunk = await readBytes(
+      file,
+      cdOffset + fetched,
+      cdOffset + fetched + readSize,
+    );
+    if (chunk.byteLength !== readSize) {
+      throw new ArchiveValidationError("not_zip", "central directory is truncated");
+    }
+    fetched += chunk.byteLength;
+
+    let data: Uint8Array;
+    if (pending.byteLength === 0) {
+      data = chunk;
+    } else {
+      // A CD record is bounded by its three uint16 length fields, so this
+      // carry buffer stays below ~192 KB regardless of total archive size.
+      data = new Uint8Array(pending.byteLength + chunk.byteLength);
+      data.set(pending, 0);
+      data.set(chunk, pending.byteLength);
+    }
+
+    let pos = 0;
+    while (pos + 46 <= data.byteLength && entriesRead < totalEntries) {
+      const view = new DataView(data.buffer, data.byteOffset + pos);
+      if (view.getUint32(0, true) !== CDH_SIG) {
+        throw new ArchiveValidationError(
+          "not_zip",
+          `central directory header signature invalid at entry ${entriesRead}`,
+        );
+      }
+
+      const compression = view.getUint16(10, true);
+      let compressedSize = view.getUint32(20, true);
+      let uncompressedSize = view.getUint32(24, true);
+      const nameLen = view.getUint16(28, true);
+      const extraLen = view.getUint16(30, true);
+      const commentLen = view.getUint16(32, true);
+      let localHeaderOffset = view.getUint32(42, true);
+      const recordSize = 46 + nameLen + extraLen + commentLen;
+      if (pos + recordSize > data.byteLength) break;
+
+      const name = decoder.decode(data.subarray(pos + 46, pos + 46 + nameLen));
+      if (
+        extraLen > 0 &&
+        (uncompressedSize === 0xffffffff ||
+          compressedSize === 0xffffffff ||
+          localHeaderOffset === 0xffffffff)
+      ) {
+        const zip64 = readZip64Extra(data, pos + 46 + nameLen, extraLen);
+        if (!zip64) {
+          throw new ArchiveValidationError(
+            "not_zip",
+            `ZIP64 extra field missing or truncated for ${name || `entry ${entriesRead}`}`,
+          );
+        }
+        let cursor = 0;
+        if (uncompressedSize === 0xffffffff) {
+          if (cursor + 8 > zip64.byteLength) {
+            throw new ArchiveValidationError("not_zip", "ZIP64 uncompressed size is truncated");
+          }
+          uncompressedSize = Number(zip64.getBigUint64(cursor, true));
+          cursor += 8;
+        }
+        if (compressedSize === 0xffffffff) {
+          if (cursor + 8 > zip64.byteLength) {
+            throw new ArchiveValidationError("not_zip", "ZIP64 compressed size is truncated");
+          }
+          compressedSize = Number(zip64.getBigUint64(cursor, true));
+          cursor += 8;
+        }
+        if (localHeaderOffset === 0xffffffff) {
+          if (cursor + 8 > zip64.byteLength) {
+            throw new ArchiveValidationError("not_zip", "ZIP64 local-header offset is truncated");
+          }
+          localHeaderOffset = Number(zip64.getBigUint64(cursor, true));
+        }
+      }
+
+      if (
+        !isSafeZipNumber(compressedSize) ||
+        !isSafeZipNumber(uncompressedSize) ||
+        !isSafeZipNumber(localHeaderOffset)
+      ) {
+        throw new ArchiveValidationError("not_zip", "central directory contains unsafe ZIP64 values");
+      }
+
+      entriesRead++;
+      if (name === "manifest.json") {
+        return { name, compression, compressedSize, uncompressedSize, localHeaderOffset };
+      }
+      pos += recordSize;
+    }
+
+    // Copy only the partial record at the page boundary. Do not retain the
+    // full page (or the entire central directory) through a subarray view.
+    pending = data.slice(pos);
+  }
+
+  if (entriesRead < totalEntries) {
+    throw new ArchiveValidationError("not_zip", "central directory entry is truncated");
+  }
+  return null;
+}
+
 /**
  * Fast-path verifier: parses the ZIP central directory, finds manifest.json,
- * reads only its bytes, and parses the manifest. O(64 KB + manifest_size)
- * regardless of total archive size. Throws ArchiveValidationError if the
- * archive's central directory can't be located or manifest.json is absent.
+ * reads only its bytes, and parses the manifest. Memory stays bounded to the
+ * tail window, one central-directory page, and the manifest bytes regardless
+ * of total archive size. Throws ArchiveValidationError if the archive's
+ * central directory can't be located or manifest.json is absent.
  *
  * Supports ZIP64 (PPAPP 6.2): when the standard EOCD reports 0xFFFFFFFF /
  * 0xFFFF sentinels, we read the ZIP64 EOCD locator sitting immediately
@@ -422,8 +559,14 @@ export async function verifyArchiveFast(archivePath: string): Promise<ArchiveMan
       tail[i + 2] === 0x05 &&
       tail[i + 3] === 0x06
     ) {
-      eocdOffsetInTail = i;
-      break;
+      // A signature may occur inside the ZIP comment. Only accept a record
+      // whose declared comment length lands exactly at end-of-file.
+      const candidate = new DataView(tail.buffer, tail.byteOffset + i, EOCD_MIN_BYTES);
+      const commentLen = candidate.getUint16(20, true);
+      if (i + EOCD_MIN_BYTES + commentLen === tail.byteLength) {
+        eocdOffsetInTail = i;
+        break;
+      }
     }
   }
   if (eocdOffsetInTail < 0) {
@@ -498,63 +641,29 @@ export async function verifyArchiveFast(archivePath: string): Promise<ArchiveMan
     cdSize = Number(zip64Eocd.getBigUint64(40, true));
     cdOffset = Number(zip64Eocd.getBigUint64(48, true));
   }
-  if (cdOffset + cdSize > size) {
+  if (
+    !isSafeZipNumber(totalEntries) ||
+    !isSafeZipNumber(cdSize) ||
+    !isSafeZipNumber(cdOffset)
+  ) {
+    throw new ArchiveValidationError("not_zip", "ZIP central directory contains unsafe 64-bit values");
+  }
+  if (totalEntries > MAX_ENTRIES) {
+    throw new ArchiveValidationError(
+      "size",
+      `archive contains too many entries (>${MAX_ENTRIES})`,
+    );
+  }
+  if (cdSize > size || cdOffset > size - cdSize) {
     throw new ArchiveValidationError("not_zip", "central directory extends past end of file");
   }
 
-  // Load the entire central directory (typically a few hundred KB even for
-  // an archive with tens of thousands of entries).
-  const cd = await readBytes(file, cdOffset, cdOffset + cdSize);
-  const decoder = new TextDecoder();
-  let pos = 0;
-  let manifestEntry: CentralDirEntry | null = null;
-  while (pos + 46 <= cd.length) {
-    const view = new DataView(cd.buffer, cd.byteOffset + pos);
-    if (view.getUint32(0, true) !== CDH_SIG) break;
-    const compression = view.getUint16(10, true);
-    let compressedSize = view.getUint32(20, true);
-    let uncompressedSize = view.getUint32(24, true);
-    const nameLen = view.getUint16(28, true);
-    const extraLen = view.getUint16(30, true);
-    const commentLen = view.getUint16(32, true);
-    let localHeaderOffset = view.getUint32(42, true);
-    const name = decoder.decode(cd.subarray(pos + 46, pos + 46 + nameLen));
-
-    // ZIP64: when the standard 32-bit fields hold the 0xFFFFFFFF sentinel,
-    // the real value lives in the ZIP64 extra block (tag 0x0001) of the
-    // central directory header's extra field. Order inside the block per
-    // PKWARE APPNOTE 4.5: uncompressed size, compressed size, local header
-    // offset, disk number start. Only the fields that would otherwise be
-    // 0xFFFFFFFF are emitted.
-    if (
-      extraLen > 0 &&
-      (uncompressedSize === 0xffffffff ||
-        compressedSize === 0xffffffff ||
-        localHeaderOffset === 0xffffffff)
-    ) {
-      const zip64 = readZip64Extra(cd, pos + 46 + nameLen, extraLen);
-      if (zip64) {
-        let cursor = 0;
-        if (uncompressedSize === 0xffffffff && cursor + 8 <= zip64.byteLength) {
-          uncompressedSize = Number(zip64.getBigUint64(cursor, true));
-          cursor += 8;
-        }
-        if (compressedSize === 0xffffffff && cursor + 8 <= zip64.byteLength) {
-          compressedSize = Number(zip64.getBigUint64(cursor, true));
-          cursor += 8;
-        }
-        if (localHeaderOffset === 0xffffffff && cursor + 8 <= zip64.byteLength) {
-          localHeaderOffset = Number(zip64.getBigUint64(cursor, true));
-        }
-      }
-    }
-
-    if (name === "manifest.json") {
-      manifestEntry = { name, compression, compressedSize, uncompressedSize, localHeaderOffset };
-      break;
-    }
-    pos += 46 + nameLen + extraLen + commentLen;
-  }
+  const manifestEntry = await findManifestInCentralDirectory(
+    file,
+    cdOffset,
+    cdSize,
+    totalEntries,
+  );
   if (!manifestEntry) {
     throw new ArchiveValidationError("no_manifest", "archive central directory has no manifest.json");
   }
@@ -562,6 +671,12 @@ export async function verifyArchiveFast(archivePath: string): Promise<ArchiveMan
     throw new ArchiveValidationError(
       "bad_manifest",
       `manifest.json declares ${manifestEntry.uncompressedSize} bytes (cap ${MAX_MANIFEST_BYTES})`,
+    );
+  }
+  if (manifestEntry.compressedSize > MAX_MANIFEST_COMPRESSED_BYTES) {
+    throw new ArchiveValidationError(
+      "bad_manifest",
+      `manifest.json declares ${manifestEntry.compressedSize} compressed bytes (cap ${MAX_MANIFEST_COMPRESSED_BYTES})`,
     );
   }
   if (manifestEntry.compression !== 0 && manifestEntry.compression !== 8) {
@@ -593,10 +708,18 @@ export async function verifyArchiveFast(archivePath: string): Promise<ArchiveMan
     throw new ArchiveValidationError("bad_manifest", "manifest data extends past end of file");
   }
   const compressed = await readBytes(file, dataStart, dataEnd);
-  const bytes =
-    manifestEntry.compression === 0
-      ? compressed
-      : inflateSync(compressed);
+  let bytes: Uint8Array;
+  try {
+    bytes =
+      manifestEntry.compression === 0
+        ? compressed
+        : inflateRawSync(compressed, { maxOutputLength: MAX_MANIFEST_BYTES });
+  } catch (err) {
+    throw new ArchiveValidationError(
+      "bad_manifest",
+      `manifest.json decompression failed: ${(err as Error).message}`,
+    );
+  }
   if (bytes.byteLength > MAX_MANIFEST_BYTES) {
     throw new ArchiveValidationError(
       "bad_manifest",
@@ -626,8 +749,6 @@ export async function verifyArchiveFast(archivePath: string): Promise<ArchiveMan
 export async function verifyArchive(archivePath: string): Promise<ArchiveManifest> {
   return new Promise<ArchiveManifest>((resolve, reject) => {
     const file = Bun.file(archivePath);
-    // Inferred reader type so Bun's stream variance lines up with TS lib types.
-    let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
     let manifestBytes = 0;
     let manifestText = "";
     let resolved = false;
@@ -636,21 +757,11 @@ export async function verifyArchive(archivePath: string): Promise<ArchiveManifes
     const fail = (err: any) => {
       if (resolved) return;
       resolved = true;
-      try {
-        reader?.cancel();
-      } catch {
-        /* ignore */
-      }
       reject(err);
     };
     const succeed = (m: ArchiveManifest) => {
       if (resolved) return;
       resolved = true;
-      try {
-        reader?.cancel();
-      } catch {
-        /* ignore */
-      }
       resolve(m);
     };
 
@@ -707,45 +818,66 @@ export async function verifyArchive(archivePath: string): Promise<ArchiveManifes
             ),
           );
         }
+        return;
       }
-      // Any other entry is silently skipped (no entry.start() call).
+
+      // fflate retains every compressed chunk for an entry until start() is
+      // called. Leaving a large pre-manifest entry untouched therefore makes
+      // this "streaming" fallback hold most of the archive in RAM. Start and
+      // drain non-manifest entries immediately; their output is discarded.
+      entry.ondata = (err) => {
+        if (err && !resolved) {
+          fail(
+            new ArchiveValidationError(
+              "bad_manifest",
+              `archive entry ${entry.name} failed while locating manifest.json: ${(err as Error).message}`,
+            ),
+          );
+        }
+      };
+      try {
+        entry.start();
+      } catch (startErr) {
+        fail(
+          new ArchiveValidationError(
+            "bad_manifest",
+            `archive entry ${entry.name} could not be drained: ${(startErr as Error).message}`,
+          ),
+        );
+      }
     });
     unzip.register(UnzipInflate);
 
-    reader = file.stream().getReader() as ReadableStreamDefaultReader<Uint8Array>;
     (async () => {
       try {
-        while (!resolved) {
-          const { value, done } = await reader!.read();
-          if (done) {
-            unzip.push(new Uint8Array(0), true);
-            if (!resolved) {
-              fail(
-                new ArchiveValidationError(
-                  "no_manifest",
-                  manifestStarted
-                    ? "manifest.json entry truncated"
-                    : "archive does not contain manifest.json",
-                ),
-              );
-            }
-            break;
+        // Read explicit windows rather than relying on Blob.stream() chunking,
+        // which is runtime-defined. This keeps both fflate's compressed input
+        // and each discarded decompression step bounded on every Bun build.
+        let offset = 0;
+        while (!resolved && offset < file.size) {
+          const end = Math.min(file.size, offset + FALLBACK_VERIFY_READ_BYTES);
+          const chunk = await readBytes(file, offset, end);
+          if (chunk.byteLength !== end - offset) {
+            throw new ArchiveValidationError("not_zip", "archive is truncated during verification");
           }
-          if (value) {
-            // Coerce Bun's typed buffer view to a plain Uint8Array so fflate's
-            // push() signature matches.
-            const view = value as unknown as Uint8Array;
-            unzip.push(view, false);
-          }
+          offset = end;
+          unzip.push(chunk, offset === file.size);
+        }
+        if (!resolved && file.size === 0) {
+          unzip.push(new Uint8Array(0), true);
+        }
+        if (!resolved) {
+          fail(
+            new ArchiveValidationError(
+              "no_manifest",
+              manifestStarted
+                ? "manifest.json entry truncated"
+                : "archive does not contain manifest.json",
+            ),
+          );
         }
       } catch (e) {
         fail(e instanceof ArchiveValidationError ? e : new ArchiveValidationError("bad_manifest", String((e as Error).message ?? e)));
-      } finally {
-        try {
-          reader?.releaseLock();
-        } catch {
-          /* ignore */
-        }
       }
     })();
   });

--- a/tests/user-data-export-roundtrip.test.ts
+++ b/tests/user-data-export-roundtrip.test.ts
@@ -19,6 +19,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { strToU8, zipSync } from "fflate";
 import { join } from "path";
 import { writeFileSync, mkdtempSync, rmSync, existsSync } from "fs";
 import { tmpdir } from "os";
@@ -31,6 +32,20 @@ import { buildExportStream } from "../src/services/user-data/export.service";
 import { verifyArchiveFast, verifyArchive } from "../src/services/user-data/import.service";
 
 const USER_ID = "export-roundtrip-user";
+
+function testManifest(archiveId: string): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    producer: "lumiverse",
+    exportedAt: 0,
+    archiveId,
+    producerVersion: "test",
+    includeVectors: false,
+    embeddingConfig: { provider: null, model: null, dimension: null },
+    counts: {},
+    missingFiles: [],
+  };
+}
 
 async function applyBaseline(): Promise<void> {
   const db = getDb();
@@ -155,6 +170,80 @@ describe("user-data export ZIP64 round-trip", () => {
     const manifest = await verifyArchive(archivePath);
     expect(manifest.producer).toBe("lumiverse");
     expect(manifest.schemaVersion).toBe(1);
+  });
+
+  test("fast verifier scans a multi-page central directory without loading it whole", async () => {
+    const archiveId = crypto.randomUUID();
+    const entries: Record<string, Uint8Array> = {};
+    const empty = new Uint8Array(0);
+    // Put the manifest last and make the directory comfortably larger than
+    // two verifier pages so records and names cross read boundaries.
+    for (let i = 0; i < 8_000; i++) {
+      entries[`files/images/${i.toString(36).padStart(6, "0")}-asset.bin`] = empty;
+    }
+    entries["manifest.json"] = strToU8(JSON.stringify(testManifest(archiveId)));
+
+    const bytes = zipSync(entries, { level: 0 });
+    expect(bytes.byteLength).toBeGreaterThan(512 * 1024);
+    const archivePath = join(workDir, "large-central-directory.lvbak");
+    writeFileSync(archivePath, bytes);
+
+    const manifest = await verifyArchiveFast(archivePath);
+    expect(manifest.archiveId).toBe(archiveId);
+  });
+
+  test("streaming fallback drains large entries before a trailing manifest", async () => {
+    const archiveId = crypto.randomUUID();
+    const leadingData = new Uint8Array(8 * 1024 * 1024);
+    const bytes = zipSync(
+      {
+        "files/images/large.bin": leadingData,
+        "manifest.json": strToU8(JSON.stringify(testManifest(archiveId))),
+      },
+      { level: 0 },
+    );
+    const archivePath = join(workDir, "manifest-last.lvbak");
+    writeFileSync(archivePath, bytes);
+
+    const manifest = await verifyArchive(archivePath);
+    expect(manifest.archiveId).toBe(archiveId);
+  });
+
+  test("fast verifier caps manifest inflation even when ZIP metadata lies", async () => {
+    const archiveId = crypto.randomUUID();
+    const oversized = {
+      ...testManifest(archiveId),
+      padding: "x".repeat(17 * 1024 * 1024),
+    };
+    const bytes = zipSync(
+      { "manifest.json": strToU8(JSON.stringify(oversized)) },
+      { level: 9 },
+    );
+
+    // Lie about the uncompressed size in the central-directory record so the
+    // preflight metadata check passes. The bounded inflater must still reject
+    // the actual >16 MB output rather than allocating it without limit.
+    let cdh = -1;
+    for (let i = bytes.byteLength - 46; i >= 0; i--) {
+      if (
+        bytes[i] === 0x50 &&
+        bytes[i + 1] === 0x4b &&
+        bytes[i + 2] === 0x01 &&
+        bytes[i + 3] === 0x02
+      ) {
+        cdh = i;
+        break;
+      }
+    }
+    expect(cdh).toBeGreaterThanOrEqual(0);
+    new DataView(bytes.buffer, bytes.byteOffset).setUint32(cdh + 24, 1, true);
+
+    const archivePath = join(workDir, "manifest-inflate-cap.lvbak");
+    writeFileSync(archivePath, bytes);
+    await expect(verifyArchiveFast(archivePath)).rejects.toMatchObject({
+      name: "ArchiveValidationError",
+      code: "bad_manifest",
+    });
   });
 
   test("export with 10⁵ character rows streams to ~100 MB without OOM", async () => {


### PR DESCRIPTION
This pull request hardens the user-data archive verification pipeline against memory exhaustion on Termux and other memory-constrained servers. Large `.lvbak` files could still crash after uploading successfully because the fast verifier loaded the complete ZIP central directory into memory, while the streaming fallback allowed fflate to retain the compressed contents of every entry preceding `manifest.json`.

**Bounded central-directory verification:**

- Reworked `verifyArchiveFast` to scan ZIP central-directory records in fixed 256 KB pages rather than loading the complete directory through a single `arrayBuffer()` call. (`src/services/user-data/import.service.ts`)
- Added a bounded carry buffer for directory records split across page boundaries. Only the incomplete record is retained between reads, keeping memory usage independent of the total directory size. (`src/services/user-data/import.service.ts`)
- Preserved support for archives where `manifest.json` appears late in the central directory without requiring the complete archive or directory to remain in memory. (`src/services/user-data/import.service.ts`)
- Added validation for ZIP64 entry counts, central-directory sizes, offsets, compressed sizes, uncompressed sizes, and local-header offsets before those values are used for file reads. (`src/services/user-data/import.service.ts`)
- Enforced the existing 500,000-entry safety limit during verification so oversized directories are rejected before a full scan. (`src/services/user-data/import.service.ts`)
- Improved ZIP64 extra-field parsing to reject missing, truncated, or unsafe 64-bit values instead of continuing with sentinel values. (`src/services/user-data/import.service.ts`)

**Streaming fallback memory fixes:**

- Updated the fallback verifier to immediately start and drain every non-manifest entry. fflate retains compressed chunks for entries that are never started, which previously allowed a trailing manifest to make verification retain nearly the complete archive in memory. (`src/services/user-data/import.service.ts`)
- Discarded decompressed output from non-manifest entries as it is produced, allowing legacy archives with a late `manifest.json` to be scanned without accumulating their contents. (`src/services/user-data/import.service.ts`)
- Replaced runtime-defined `Blob.stream()` chunking with explicit 256 KB file reads, ensuring compressed input remains bounded across different Bun builds and host platforms. (`src/services/user-data/import.service.ts`)
- Retained early termination once a valid manifest is found, avoiding unnecessary reads of the remaining archive. (`src/services/user-data/import.service.ts`)
- Added clearer validation errors when entries cannot be decoded or drained while locating the manifest. (`src/services/user-data/import.service.ts`)

**Manifest and ZIP validation hardening:**

- Added a 32 MB cap for the compressed `manifest.json` entry before its data is loaded. (`src/services/user-data/import.service.ts`)
- Added a hard 16 MB output limit during raw-DEFLATE decompression, preventing falsified ZIP metadata from turning a small manifest entry into a decompression-based OOM. (`src/services/user-data/import.service.ts`)
- Wrapped decompression failures in `ArchiveValidationError` so malformed or oversized manifests produce controlled validation responses instead of uncaught runtime failures. (`src/services/user-data/import.service.ts`)
- Improved EOCD detection by validating the declared ZIP comment length, preventing signature-like bytes inside a comment from being mistaken for the real end-of-directory record. (`src/services/user-data/import.service.ts`)
- Updated import-route documentation to describe the verifier’s bounded-memory central-directory scanning behavior accurately. (`src/routes/user-data.routes.ts`)

**Regression coverage and validation:**

- Added coverage for a central directory spanning multiple 256 KB pages with `manifest.json` placed at the end. (`tests/user-data-export-roundtrip.test.ts`)
- Added coverage for the streaming fallback with a large stored entry preceding a trailing manifest, reproducing the structure that previously caused fflate to retain archive contents. (`tests/user-data-export-roundtrip.test.ts`)
- Added coverage for malicious ZIP metadata that understates the manifest’s decompressed size, confirming the hard inflation limit rejects it safely. (`tests/user-data-export-roundtrip.test.ts`)
- Verified compatibility with existing ZIP64 exports and the 100,000-row streaming archive test. (`tests/user-data-export-roundtrip.test.ts`)
- Validated the changes with the backend TypeScript check and user-data archive suites: 8 tests passed, with 1 optional benchmark skipped.