### PR TITLE
World info activation performance optimization

### DIFF
--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -454,6 +454,7 @@ export interface AssemblyResult {
   assistantPrefill?: string;
   /** Summary of all world info entries activated during this assembly. */
   activatedWorldInfo?: ActivatedWorldInfoEntry[];
+  spindleWorldInfoCaptures?: Record<string, ActivatedWorldInfoEntry[]>;
   /** Statistics from the World Info activation pipeline (budget enforcement, etc.). */
   worldInfoStats?: {
     totalCandidates: number;

--- a/src/services/generate.service.ts
+++ b/src/services/generate.service.ts
@@ -582,6 +582,7 @@ interface SpindleContext {
   userId?: string;
   cancelGeneration?: boolean;
   activatedWorldInfo?: ActivatedWorldInfoEntry[];
+  __spindleWorldInfoCaptures?: Record<string, ActivatedWorldInfoEntry[]>;
   [key: string]: unknown;
 }
 
@@ -1316,6 +1317,9 @@ async function runPromptPipeline(opts: {
   let interceptorBreakdown: InterceptorBreakdownEntry[] | undefined;
   let assistantPrefill: string | undefined;
   let activatedWorldInfo: ActivatedWorldInfoEntry[] | undefined;
+  let spindleWorldInfoCaptures:
+    | Record<string, ActivatedWorldInfoEntry[]>
+    | undefined;
   let worldInfoStats: DryRunResult["worldInfoStats"] | undefined;
   let memoryStats: import("../llm/types").MemoryStats | undefined;
   let databankStats: import("../llm/types").DatabankStats | undefined;
@@ -1390,6 +1394,7 @@ async function runPromptPipeline(opts: {
     breakdown = assemblyResult.breakdown;
     assistantPrefill = assemblyResult.assistantPrefill;
     activatedWorldInfo = assemblyResult.activatedWorldInfo;
+    spindleWorldInfoCaptures = assemblyResult.spindleWorldInfoCaptures;
     worldInfoStats = assemblyResult.worldInfoStats;
     memoryStats = assemblyResult.memoryStats;
     databankStats = assemblyResult.databankStats;
@@ -1416,6 +1421,10 @@ async function runPromptPipeline(opts: {
   // Expose activated world info to spindle context
   if (activatedWorldInfo) {
     spindleContext.activatedWorldInfo = activatedWorldInfo;
+  }
+  delete spindleContext.__spindleWorldInfoCaptures;
+  if (spindleWorldInfoCaptures) {
+    spindleContext.__spindleWorldInfoCaptures = spindleWorldInfoCaptures;
   }
 
   // Run Spindle interceptor pipeline on assembled messages

--- a/src/services/prompt-assembly-world-info-query.test.ts
+++ b/src/services/prompt-assembly-world-info-query.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
+import { initMacros } from "../macros";
+import type { MacroEnv } from "../macros";
 import type { Message } from "../types/message";
-import { buildWorldInfoVectorQuery } from "./prompt-assembly.service";
+import {
+  __worldInfoVectorQueryTest,
+  buildWorldInfoVectorQuery,
+  collectVectorActivatedWorldInfoDetailed,
+} from "./prompt-assembly.service";
 
 function message(
   index: number,
@@ -23,6 +29,75 @@ function message(
     parent_message_id: null,
     branch_id: null,
     created_at: index,
+  };
+}
+
+function macroEnv(): MacroEnv {
+  return {
+    commit: false,
+    names: {
+      user: "User",
+      char: "Character",
+      group: "",
+      groupNotMuted: "",
+      notChar: "",
+      charGroupFocused: "",
+      groupOthers: "",
+      groupMemberCount: "0",
+      isGroupChat: "no",
+      isNarrator: "no",
+      groupLastSpeaker: "",
+      groupCardMode: "solo",
+    },
+    character: {
+      name: "Character",
+      description: "",
+      personality: "",
+      scenario: "",
+      persona: "",
+      personaSubjectivePronoun: "",
+      personaObjectivePronoun: "",
+      personaPossessivePronoun: "",
+      personaReflexivePronoun: "",
+      personaPossessivePronounStandalone: "",
+      mesExamples: "",
+      mesExamplesRaw: "",
+      systemPrompt: "",
+      postHistoryInstructions: "",
+      depthPrompt: "",
+      creatorNotes: "",
+      version: "",
+      creator: "",
+      firstMessage: "",
+    },
+    chat: {
+      id: "chat-1",
+      messageCount: 0,
+      lastMessage: "",
+      lastMessageName: "",
+      lastUserMessage: "",
+      lastCharMessage: "",
+      lastMessageId: 0,
+      firstIncludedMessageId: 0,
+      lastSwipeId: 0,
+      currentSwipeId: 0,
+      rejectedSwipe: "",
+    },
+    system: {
+      model: "",
+      maxPrompt: 0,
+      maxContext: 0,
+      maxResponse: 0,
+      lastGenerationType: "normal",
+      isMobile: false,
+    },
+    variables: {
+      local: new Map(),
+      global: new Map(),
+      chat: new Map(),
+    },
+    dynamicMacros: {},
+    extra: {},
   };
 }
 
@@ -69,5 +144,201 @@ describe("world-book vector query scope", () => {
     expect(result.queryPreview.length).toBe(24_000);
     expect(result.queryPreview).not.toContain("old marker");
     expect(result.queryPreview).toContain("new marker");
+  });
+
+  test("skips chat content when no vector entry is eligible", async () => {
+    let reads = 0;
+    const source = message(0, "unused");
+    Object.defineProperty(source, "content", {
+      enumerable: true,
+      get: () => {
+        reads++;
+        return "unused";
+      },
+    });
+
+    const result = await collectVectorActivatedWorldInfoDetailed(
+      "user",
+      "chat",
+      ["book"],
+      [{
+        id: "entry",
+        world_book_id: "book",
+        disabled: false,
+        vectorized: false,
+        content: "memory",
+        vector_index_status: "not_enabled",
+      } as never],
+      [source],
+      undefined,
+      {},
+    );
+
+    expect(result.entries).toEqual([]);
+    expect(result.queryScope.messagesSelected).toBe(0);
+    expect(reads).toBe(0);
+  });
+
+  test("bounded construction is byte-identical to the historical sanitizer pipeline", async () => {
+    const cases: Array<{
+      messages: Message[];
+      depth: number | null;
+      reasoning?: { reasoningPrefix: string; reasoningSuffix: string };
+    }> = [
+      {
+        messages: [
+          message(0, `old ${"a".repeat(30_000)}`),
+          message(1, "<think>private chain</think>kept"),
+          message(2, "<details><summary>meta</summary>inside</details>tail"),
+          message(3, "newest"),
+        ],
+        depth: null,
+      },
+      {
+        messages: [
+          message(0, "ignored by depth"),
+          message(1, "   "),
+          message(2, "hidden", { hidden: true }),
+          message(3, "<reasoning>unfinished"),
+          message(4, `${"b".repeat(24_001)}END`),
+        ],
+        depth: 2,
+      },
+      {
+        messages: [
+          message(0, `prefix ${"x".repeat(23_999)}`),
+          message(1, "🙂 surrogate boundary"),
+          message(2, "[[private]]remove me[[/private]] visible"),
+        ],
+        depth: null,
+        reasoning: {
+          reasoningPrefix: "[[private]]",
+          reasoningSuffix: "[[/private]]",
+        },
+      },
+      {
+        messages: [
+          message(
+            0,
+            `${"alpha\t beta\n\n\n".repeat(10_000)}${"tail ".repeat(10_000)}`,
+          ),
+        ],
+        depth: null,
+      },
+    ];
+
+    for (const fixture of cases) {
+      const visible = fixture.messages.filter(
+        (item) => !item.extra?.hidden && item.content.trim().length > 0,
+      );
+      const selected = fixture.depth === null
+        ? visible
+        : visible.slice(-fixture.depth);
+      const reference = await __worldInfoVectorQueryTest.buildReference(
+        selected,
+        null,
+        fixture.reasoning,
+      );
+      const actual = await buildWorldInfoVectorQuery(
+        fixture.messages,
+        fixture.depth,
+        null,
+        fixture.reasoning,
+      );
+
+      expect(actual.queryPreview).toBe(reference.text);
+      expect(actual.queryScope.tokenTruncated).toBe(reference.truncated);
+    }
+  });
+
+  test("macro-bearing queries retain oldest-to-newest shared-env evaluation", async () => {
+    initMacros();
+    const messages = [
+      message(0, "{{counter::query-order}}"),
+      message(1, "x".repeat(25_000)),
+      message(2, "{{counter::query-order}}"),
+    ];
+
+    const reference = await __worldInfoVectorQueryTest.buildReference(
+      messages,
+      macroEnv(),
+    );
+    const actual = await buildWorldInfoVectorQuery(
+      messages,
+      null,
+      macroEnv(),
+    );
+
+    expect(actual.queryPreview).toBe(reference.text);
+    expect(actual.queryPreview.endsWith("[USER | User]: 2")).toBe(true);
+    expect(actual.queryScope.tokenTruncated).toBe(reference.truncated);
+  });
+
+  test("reasoning stripping cannot hide a macro from bounded-path classification", async () => {
+    initMacros();
+    const splitMacro = "{<think>private</think>{counter::split-marker}}";
+    const messages = [
+      message(0, splitMacro),
+      message(1, "x".repeat(25_000)),
+      message(2, splitMacro),
+    ];
+
+    const reference = await __worldInfoVectorQueryTest.buildReference(
+      messages,
+      macroEnv(),
+    );
+    const actual = await buildWorldInfoVectorQuery(
+      messages,
+      null,
+      macroEnv(),
+    );
+
+    expect(actual.queryPreview).toBe(reference.text);
+    expect(actual.queryPreview.endsWith("[USER | User]: 2")).toBe(true);
+  });
+
+  test("oversized plain-message suffixes match the reference sanitizer", async () => {
+    const contents = [
+      "plain prose ".repeat(2_600),
+      "alpha\t \t beta\n\n\n".repeat(1_800),
+      `head${"\r\u00a0middle ".repeat(4_000)}tail`,
+      "value < 3 and prose ".repeat(1_800),
+      `${" ".repeat(30_000)}${"tail ".repeat(5_200)}`,
+    ];
+
+    for (const content of contents) {
+      const messages = [message(0, content)];
+      const reference = await __worldInfoVectorQueryTest.buildReference(
+        messages,
+        macroEnv(),
+      );
+      const actual = await buildWorldInfoVectorQuery(
+        messages,
+        null,
+        macroEnv(),
+      );
+
+      expect(actual.queryPreview).toBe(reference.text);
+      expect(actual.queryScope.tokenTruncated).toBe(reference.truncated);
+    }
+  });
+
+  test("bounds an oversized older plain message behind recent text", async () => {
+    const messages = [
+      message(0, "older prose ".repeat(100_000)),
+      message(1, "recent text"),
+    ];
+    const reference = await __worldInfoVectorQueryTest.buildReference(
+      messages,
+      macroEnv(),
+    );
+    const actual = await buildWorldInfoVectorQuery(
+      messages,
+      null,
+      macroEnv(),
+    );
+
+    expect(actual.queryPreview).toBe(reference.text);
+    expect(actual.queryScope.tokenTruncated).toBe(reference.truncated);
   });
 });

--- a/src/services/prompt-assembly.service.ts
+++ b/src/services/prompt-assembly.service.ts
@@ -57,6 +57,10 @@ import {
 } from "./world-info-activation.service";
 import { worldInfoInterceptorChain } from "../spindle/world-info-interceptor";
 import { buildWorldInfoCaptureMap } from "../spindle/world-info-capture";
+import {
+  getSourceMessageMetadata,
+  stampSourceMessageMetadata,
+} from "../spindle/source-message-metadata";
 import * as chatsSvc from "./chats.service";
 import { stripReasoningTags, buildMacroEnvForChat } from "./chats.service";
 import {
@@ -173,7 +177,7 @@ const CONTINUE_NUDGE_KEY = "__continueNudge";
 
 function markAsChatHistory(
   msg: LlmMessage,
-  source?: { id: string; index_in_chat: number },
+  source?: { id: string; index_in_chat: number; metadata?: unknown },
   contextAnchorProtected = false,
 ): LlmMessage {
   (msg as any)[CHAT_HISTORY_KEY] = true;
@@ -183,6 +187,7 @@ function markAsChatHistory(
   if (source) {
     (msg as any)[SOURCE_ID_KEY] = source.id;
     (msg as any)[SOURCE_INDEX_KEY] = source.index_in_chat;
+    stampSourceMessageMetadata(msg, source.metadata);
   }
   return msg;
 }
@@ -213,6 +218,8 @@ export function getSourceIndexInChat(msg: LlmMessage): number | undefined {
   const v = (msg as any)[SOURCE_INDEX_KEY];
   return typeof v === "number" ? v : undefined;
 }
+
+export { getSourceMessageMetadata };
 
 function markPreserveDisplayReasoningDelimiters(msg: LlmMessage): LlmMessage {
   (msg as any)[PRESERVE_DISPLAY_REASONING_DELIMS_KEY] = true;
@@ -2831,7 +2838,11 @@ export async function assemblePrompt(
               });
             }
           }
-          const source = { id: msg.id, index_in_chat: msg.index_in_chat };
+          const source = {
+            id: msg.id,
+            index_in_chat: msg.index_in_chat,
+            metadata: msg.extra?.spindle_metadata,
+          };
           const contextAnchorProtected =
             contextAnchorIndex != null &&
             msg.index_in_chat >= contextAnchorIndex;
@@ -2856,7 +2867,11 @@ export async function assemblePrompt(
           result.push(
             markAsChatHistory(
               { role, content: contentForPrompt },
-              { id: msg.id, index_in_chat: msg.index_in_chat },
+              {
+                id: msg.id,
+                index_in_chat: msg.index_in_chat,
+                metadata: msg.extra?.spindle_metadata,
+              },
               contextAnchorIndex != null &&
                 msg.index_in_chat >= contextAnchorIndex,
             ),
@@ -5810,10 +5825,19 @@ function mergeConsecutiveUserMessages(
       const wasContextAnchorProtected =
         isContextAnchorProtected(result[i]) ||
         isContextAnchorProtected(result[i + 1]);
-      const mergedSourceId =
-        getSourceMessageId(result[i]) ?? getSourceMessageId(result[i + 1]);
-      const mergedSourceIndex =
-        getSourceIndexInChat(result[i]) ?? getSourceIndexInChat(result[i + 1]);
+      const mergedSource = [result[i], result[i + 1]]
+        .map((message) => {
+          const id = getSourceMessageId(message);
+          const index_in_chat = getSourceIndexInChat(message);
+          return id !== undefined && index_in_chat !== undefined
+            ? {
+                id,
+                index_in_chat,
+                metadata: getSourceMessageMetadata(message),
+              }
+            : undefined;
+        })
+        .find((source) => source !== undefined);
       if (allParts.length > 0) {
         result[i] = {
           role: "user",
@@ -5825,9 +5849,7 @@ function mergeConsecutiveUserMessages(
       if (wasChatHistory) {
         markAsChatHistory(
           result[i],
-          typeof mergedSourceId === "string" && typeof mergedSourceIndex === "number"
-            ? { id: mergedSourceId, index_in_chat: mergedSourceIndex }
-            : undefined,
+          mergedSource,
           wasContextAnchorProtected,
         );
       }
@@ -5841,6 +5863,10 @@ function mergeConsecutiveUserMessages(
   }
   return remaining;
 }
+
+export const __sourceMessageMetadataTest = {
+  mergeConsecutiveUserMessages,
+};
 
 /**
  * Strip reasoning tags (and surrounding whitespace) from older assistant messages
@@ -7435,15 +7461,33 @@ async function legacyAssembly(
           parts.push({ type: "audio", data: b64, mime_type: att.mime_type });
         }
       }
-      llmMessages.push({
-        role: (m.is_user ? "user" : "assistant") as LlmMessage["role"],
-        content: parts.length > 0 ? parts : resolved,
-      });
+      llmMessages.push(
+        markAsChatHistory(
+          {
+            role: (m.is_user ? "user" : "assistant") as LlmMessage["role"],
+            content: parts.length > 0 ? parts : resolved,
+          },
+          {
+            id: m.id,
+            index_in_chat: m.index_in_chat,
+            metadata: m.extra?.spindle_metadata,
+          },
+        ),
+      );
     } else {
-      llmMessages.push({
-        role: (m.is_user ? "user" : "assistant") as LlmMessage["role"],
-        content: resolved,
-      });
+      llmMessages.push(
+        markAsChatHistory(
+          {
+            role: (m.is_user ? "user" : "assistant") as LlmMessage["role"],
+            content: resolved,
+          },
+          {
+            id: m.id,
+            index_in_chat: m.index_in_chat,
+            metadata: m.extra?.spindle_metadata,
+          },
+        ),
+      );
     }
     legacyHistoryCount++;
   }

--- a/src/services/prompt-assembly.service.ts
+++ b/src/services/prompt-assembly.service.ts
@@ -4009,6 +4009,7 @@ export function selectMergedWorldInfoEntries(
   vectorEntries: VectorActivatedEntry[],
   settingsInput?: Partial<WorldInfoSettings>,
   bookSourceMap?: Map<string, BookSource>,
+  random?: () => number,
 ): WorldInfoMergeSelection {
   const settings = normalizeWorldInfoSettings(settingsInput);
   const mergedEntries: WorldBookEntryModel[] = [];
@@ -4057,7 +4058,10 @@ export function selectMergedWorldInfoEntries(
 
   // Group selection uses configured priorities and weights. Retrieval-score
   // boosts are intentionally introduced only after this step.
-  const groupSelected = applyWorldInfoGroupLogic(dedupResult.entries);
+  const groupSelected = applyWorldInfoGroupLogic(
+    dedupResult.entries,
+    random,
+  );
   const groupSelectedIds = new Set(groupSelected.map((entry) => entry.id));
   for (const item of vectorEntries) {
     if (dispositions.has(item.entry.id) || groupSelectedIds.has(item.entry.id)) continue;
@@ -4128,6 +4132,7 @@ export function mergeActivatedWorldInfoEntries(
   settingsInput?: Partial<WorldInfoSettings>,
   bookSourceMap?: Map<string, BookSource>,
   bookNameMap?: Map<string, string>,
+  random?: () => number,
 ): MergedWorldInfoEntriesResult {
   const mergeStartedAt = performance.now();
   const selection = selectMergedWorldInfoEntries(
@@ -4135,6 +4140,7 @@ export function mergeActivatedWorldInfoEntries(
     vectorEntries,
     settingsInput,
     bookSourceMap,
+    random,
   );
   const { finalized, sources, dedupResult, dispositions } = selection;
 

--- a/src/services/prompt-assembly.service.ts
+++ b/src/services/prompt-assembly.service.ts
@@ -56,7 +56,10 @@ import {
 import { worldInfoInterceptorChain } from "../spindle/world-info-interceptor";
 import * as chatsSvc from "./chats.service";
 import { stripReasoningTags, buildMacroEnvForChat } from "./chats.service";
-import { resolveAndSanitizeForVectorization } from "./vectorization-content.service";
+import {
+  contentHasMacroHints,
+  resolveAndSanitizeForVectorization,
+} from "./vectorization-content.service";
 import {
   stripDetailsBlocks as _stripDetailsBlocks,
   stripLoomTags as _stripLoomTags,
@@ -4213,25 +4216,228 @@ function truncateToContextSize(text: string, maxTokens: number): string {
 
 const WORLD_INFO_VECTOR_QUERY_MAX_TOKENS = 8000;
 
+interface PreparedWorldInfoVectorQuery {
+  queryPreview: string;
+  queryScope: WorldInfoVectorQueryScope;
+}
+
+function selectWorldInfoVectorQueryMessages(
+  messages: Message[],
+  globalScanDepth: number | null,
+): { visibleMessages: Message[]; queryMessages: Message[] } {
+  const visibleMessages = messages.filter(
+    (m) => !m.extra?.hidden && m.content.trim().length > 0,
+  );
+  return {
+    visibleMessages,
+    queryMessages: globalScanDepth === null
+      ? visibleMessages
+      : visibleMessages.slice(-globalScanDepth),
+  };
+}
+
+async function formatWorldInfoVectorQueryMessage(
+  message: Message,
+  env: MacroEnv | null,
+  reasoningStrip?: SanitizeOptions,
+): Promise<string> {
+  const sanitized = await resolveAndSanitizeForVectorization(
+    stripReasoningTags(message.content),
+    env,
+    reasoningStrip,
+  );
+  return `[${message.is_user ? "USER" : "CHARACTER"} | ${message.name}]: ${sanitized}`;
+}
+
+async function buildWorldInfoVectorQueryTextReference(
+  queryMessages: Message[],
+  env: MacroEnv | null,
+  reasoningStrip?: SanitizeOptions,
+): Promise<{ text: string; truncated: boolean }> {
+  const parts = await Promise.all(
+    queryMessages.map((message) =>
+      formatWorldInfoVectorQueryMessage(message, env, reasoningStrip)
+    ),
+  );
+  return truncateToContextSizeWithStatus(
+    parts.join("\n").trim(),
+    WORLD_INFO_VECTOR_QUERY_MAX_TOKENS,
+  );
+}
+
+const DEFAULT_REASONING_OPEN_TAG_RE = /<(?:think|thinking|reasoning)>/i;
+const HTML_LIKE_VECTOR_HINT_RE = /<\s*\/?\s*[a-zA-Z]/;
+
+function worldInfoVectorMessageHasMacroHints(message: Message): boolean {
+  if (contentHasMacroHints(message.content)) return true;
+  return (
+    DEFAULT_REASONING_OPEN_TAG_RE.test(message.content) &&
+    contentHasMacroHints(stripReasoningTags(message.content))
+  );
+}
+
+function hasPlainVectorSuffix(
+  content: string,
+  reasoningStrip?: SanitizeOptions,
+): boolean {
+  if (HTML_LIKE_VECTOR_HINT_RE.test(content)) return false;
+  const prefix = reasoningStrip?.reasoningPrefix?.replace(/^\n+|\n+$/g, "");
+  const suffix = reasoningStrip?.reasoningSuffix?.replace(/^\n+|\n+$/g, "");
+  return !(prefix && suffix && content.includes(prefix));
+}
+
+function isPlainVectorHorizontalWhitespace(code: number): boolean {
+  return code === 0x20 || code === 0x09 || code === 0x0c || code === 0x0b;
+}
+
+function normalizePlainVectorQuerySuffix(
+  content: string,
+  maxChars: number,
+): { text: string; fillsLimit: boolean } {
+  const trimmed = content.trim();
+  const reversed: string[] = [];
+  let index = trimmed.length - 1;
+
+  while (index >= 0 && reversed.length < maxChars) {
+    const code = trimmed.charCodeAt(index);
+    if (code === 0x0a || isPlainVectorHorizontalWhitespace(code)) {
+      let newlineCount = 0;
+      while (index >= 0) {
+        const runCode = trimmed.charCodeAt(index);
+        if (
+          runCode !== 0x0a &&
+          !isPlainVectorHorizontalWhitespace(runCode)
+        ) {
+          break;
+        }
+        if (runCode === 0x0a) newlineCount++;
+        index--;
+      }
+      const outputCount = newlineCount > 0
+        ? Math.min(newlineCount, 2)
+        : 1;
+      const output = newlineCount > 0 ? "\n" : " ";
+      for (
+        let count = 0;
+        count < outputCount && reversed.length < maxChars;
+        count++
+      ) {
+        reversed.push(output);
+      }
+      continue;
+    }
+    reversed.push(trimmed[index]);
+    index--;
+  }
+
+  return {
+    text: reversed.reverse().join(""),
+    fillsLimit: reversed.length === maxChars,
+  };
+}
+
+function buildPlainVectorQueryMessageSuffix(
+  message: Message,
+  maxChars: number,
+  reasoningStrip?: SanitizeOptions,
+): { part: string; truncated: boolean } | null {
+  if (
+    message.content.length <= maxChars ||
+    !hasPlainVectorSuffix(message.content, reasoningStrip)
+  ) {
+    return null;
+  }
+
+  const normalized = normalizePlainVectorQuerySuffix(
+    message.content,
+    maxChars,
+  );
+  if (normalized.fillsLimit) {
+    return {
+      part: normalized.text,
+      truncated: true,
+    };
+  }
+  return {
+    part: `[${message.is_user ? "USER" : "CHARACTER"} | ${message.name}]: ${normalized.text}`,
+    truncated: false,
+  };
+}
+
+async function buildWorldInfoVectorQueryTextBounded(
+  queryMessages: Message[],
+  env: MacroEnv | null,
+  reasoningStrip?: SanitizeOptions,
+): Promise<{ text: string; truncated: boolean }> {
+  if (
+    env &&
+    queryMessages.some(worldInfoVectorMessageHasMacroHints)
+  ) {
+    return buildWorldInfoVectorQueryTextReference(
+      queryMessages,
+      env,
+      reasoningStrip,
+    );
+  }
+
+  const maxChars = WORLD_INFO_VECTOR_QUERY_MAX_TOKENS * 3;
+  const reverseParts: string[] = [];
+  let suffix = "";
+  let firstIncludedIndex = queryMessages.length;
+
+  for (let index = queryMessages.length - 1; index >= 0; index--) {
+    const remainingChars =
+      maxChars - suffix.length - (suffix ? 1 : 0);
+    if (remainingChars <= 0) {
+      return {
+        text: `\n${suffix}`.slice(-maxChars),
+        truncated: true,
+      };
+    }
+    const messageSuffix = buildPlainVectorQueryMessageSuffix(
+      queryMessages[index],
+      remainingChars,
+      reasoningStrip,
+    );
+    if (messageSuffix?.truncated) {
+      const text = suffix
+        ? `${messageSuffix.part}\n${suffix}`
+        : messageSuffix.part;
+      return { text: text.slice(-maxChars), truncated: true };
+    }
+    const part =
+      messageSuffix?.part ??
+      await formatWorldInfoVectorQueryMessage(
+        queryMessages[index],
+        env,
+        reasoningStrip,
+      );
+    reverseParts.push(part);
+    firstIncludedIndex = index;
+    suffix = suffix ? `${part}\n${suffix}` : part;
+    if (suffix.trim().length >= maxChars) break;
+  }
+
+  const text = reverseParts.reverse().join("\n").trim();
+  const omittedOlderMessages = firstIncludedIndex > 0;
+  return {
+    text: text.length <= maxChars ? text : text.slice(-maxChars),
+    truncated: omittedOlderMessages || text.length > maxChars,
+  };
+}
+
 export async function buildWorldInfoVectorQuery(
   messages: Message[],
   globalScanDepth: number | null,
   env: MacroEnv | null,
   reasoningStrip?: SanitizeOptions,
 ): Promise<{ queryPreview: string; queryScope: WorldInfoVectorQueryScope }> {
-  const visibleMessages = messages.filter(
-    (m) => !m.extra?.hidden && m.content.trim().length > 0,
-  );
-  const queryMessages = globalScanDepth === null
-    ? visibleMessages
-    : visibleMessages.slice(-globalScanDepth);
-  const parts = await Promise.all(queryMessages.map(async (m) => {
-    const sanitized = await resolveAndSanitizeForVectorization(stripReasoningTags(m.content), env, reasoningStrip);
-    return `[${m.is_user ? "USER" : "CHARACTER"} | ${m.name}]: ${sanitized}`;
-  }));
-  const truncated = truncateToContextSizeWithStatus(
-    parts.join("\n").trim(),
-    WORLD_INFO_VECTOR_QUERY_MAX_TOKENS,
+  const { visibleMessages, queryMessages } =
+    selectWorldInfoVectorQueryMessages(messages, globalScanDepth);
+  const truncated = await buildWorldInfoVectorQueryTextBounded(
+    queryMessages,
+    env,
+    reasoningStrip,
   );
   return {
     queryPreview: truncated.text,
@@ -4244,6 +4450,10 @@ export async function buildWorldInfoVectorQuery(
     },
   };
 }
+
+export const __worldInfoVectorQueryTest = {
+  buildReference: buildWorldInfoVectorQueryTextReference,
+};
 
 function resolveWorldInfoVectorSettings(
   userId: string,
@@ -4433,6 +4643,7 @@ export async function collectVectorActivatedWorldInfoDetailed(
   messages: Message[],
   signal?: AbortSignal,
   settingsInput?: Partial<WorldInfoSettings>,
+  preparedQuery?: PreparedWorldInfoVectorQuery,
 ): Promise<VectorWorldInfoRetrievalResult> {
   const startedAt = performance.now();
   const emptyResult: VectorWorldInfoRetrievalResult = {
@@ -4472,27 +4683,88 @@ export async function collectVectorActivatedWorldInfoDetailed(
     };
   }
 
+  const eligibleEntries = entries.filter(isVectorEligibleWorldInfoEntry);
+  const searchableWorldBookIds = getVectorSearchableWorldBookIds(
+    worldBookIds,
+    entries,
+  );
+  const worldInfoSettings = resolveWorldInfoVectorSettings(userId, settingsInput);
+  if (
+    eligibleEntries.length === 0 ||
+    searchableWorldBookIds.length === 0
+  ) {
+    return {
+      ...emptyResult,
+      queryScope: {
+        ...emptyResult.queryScope,
+        configuredScanDepth: worldInfoSettings.globalScanDepth,
+      },
+      eligibleCount: eligibleEntries.length,
+      blockerMessages: [
+        eligibleEntries.length === 0
+          ? "This chat has no indexed, vector-enabled, non-disabled, non-empty lorebook entries to search."
+          : "No attached world book has a search-ready vector entry.",
+      ],
+      timingsMs: {
+        ...emptyResult.timingsMs!,
+        totalMs: performance.now() - startedAt,
+      },
+    };
+  }
   const cfg = await embeddingsSvc.getEmbeddingConfig(userId);
   const worldBookVectorSettings = loadWorldBookVectorSettings(userId, {
     retrievalTopK: cfg.retrieval_top_k,
   });
   const blockerMessages: string[] = [];
   const topK = Math.max(1, worldBookVectorSettings.retrievalTopK || cfg.retrieval_top_k || 4);
+  if (!cfg.enabled)
+    blockerMessages.push(
+      "Embeddings are disabled, so lorebooks will use keyword matching only.",
+    );
+  if (!cfg.has_api_key)
+    blockerMessages.push("No embedding API key is configured.");
+  if (!cfg.dimensions)
+    blockerMessages.push(
+      "Embeddings have not been tested yet, so dimensions are still unknown.",
+    );
+  if (!cfg.vectorize_world_books)
+    blockerMessages.push(
+      "World-book vectorization is disabled in embeddings settings.",
+    );
+  if (blockerMessages.length > 0) {
+    return {
+      ...emptyResult,
+      queryScope: {
+        ...emptyResult.queryScope,
+        configuredScanDepth: worldInfoSettings.globalScanDepth,
+      },
+      eligibleCount: eligibleEntries.length,
+      topK,
+      cap: topK,
+      blockerMessages,
+      timingsMs: {
+        queryBuildMs: 0,
+        queryEmbedMs: 0,
+        searchMs: 0,
+        rankingMs: 0,
+        totalMs: performance.now() - startedAt,
+      },
+    };
+  }
+
   const queryBuildStartedAt = performance.now();
-  const env = buildMacroEnvForChat(userId, chatId);
-  const worldInfoSettings = resolveWorldInfoVectorSettings(userId, settingsInput);
-  const { queryPreview: queryText, queryScope } = await buildWorldInfoVectorQuery(
-    messages,
-    worldInfoSettings.globalScanDepth,
-    env,
-    getReasoningStripOptions(userId),
-  );
-  const queryBuildMs = performance.now() - queryBuildStartedAt;
-  const eligibleEntries = entries.filter(isVectorEligibleWorldInfoEntry);
-  const searchableWorldBookIds = getVectorSearchableWorldBookIds(
-    worldBookIds,
-    entries,
-  );
+  const query =
+    preparedQuery ??
+    (await buildWorldInfoVectorQuery(
+      messages,
+      worldInfoSettings.globalScanDepth,
+      buildMacroEnvForChat(userId, chatId),
+      getReasoningStripOptions(userId),
+  ));
+  const { queryPreview: queryText, queryScope } = query;
+  const queryBuildMs = preparedQuery
+    ? 0
+    : performance.now() - queryBuildStartedAt;
   const lexicalQueryPreviews = buildWorldInfoLexicalQueryBatches(
     queryText,
     eligibleEntries,
@@ -4518,27 +4790,9 @@ export async function collectVectorActivatedWorldInfoDetailed(
     return cached;
   }
 
-  if (!cfg.enabled)
-    blockerMessages.push(
-      "Embeddings are disabled, so lorebooks will use keyword matching only.",
-    );
-  if (!cfg.has_api_key)
-    blockerMessages.push("No embedding API key is configured.");
-  if (!cfg.dimensions)
-    blockerMessages.push(
-      "Embeddings have not been tested yet, so dimensions are still unknown.",
-    );
-  if (!cfg.vectorize_world_books)
-    blockerMessages.push(
-      "World-book vectorization is disabled in embeddings settings.",
-    );
   if (!queryText)
     blockerMessages.push(
       "The current chat does not have enough visible recent text to build a vector query.",
-    );
-  if (eligibleEntries.length === 0)
-    blockerMessages.push(
-      "This chat has no indexed, vector-enabled, non-disabled, non-empty lorebook entries to search.",
     );
 
   if (blockerMessages.length > 0) {

--- a/src/services/prompt-assembly.service.ts
+++ b/src/services/prompt-assembly.service.ts
@@ -47,13 +47,16 @@ import type { MacroEnv } from "../macros";
 import {
   activateWorldInfo,
   applyWorldInfoGroupLogic,
+  createWorldInfoActivationScanCache,
   finalizeActivatedWorldInfoEntries,
+  primeWorldInfoActivationScanCache,
   type WiState,
   type WorldInfoSettings,
   type FinalizedWorldInfoEntries,
   normalizeWorldInfoSettings,
 } from "./world-info-activation.service";
 import { worldInfoInterceptorChain } from "../spindle/world-info-interceptor";
+import { buildWorldInfoCaptureMap } from "../spindle/world-info-capture";
 import * as chatsSvc from "./chats.service";
 import { stripReasoningTags, buildMacroEnvForChat } from "./chats.service";
 import {
@@ -1768,7 +1771,7 @@ export async function assemblePrompt(
       | Partial<WorldInfoSettings>
       | undefined) ??
     {};
-  const intercepted = await worldInfoInterceptorChain.run(
+  const interception = await worldInfoInterceptorChain.run(
     wiEntries,
     {
       chatId: ctx.chatId,
@@ -1798,13 +1801,33 @@ export async function assemblePrompt(
     ctx.userId,
     wiSources.bookSourceMap
   );
-  const wiResult = activateWorldInfo({
-    entries: intercepted,
-    messages,
-    chatTurn: messages.length,
-    wiState,
-    settings: worldInfoSettings,
-  });
+  const intercepted = interception.entries;
+  const hasCaptureRequests = interception.captureRequests.size > 0;
+  const hasCapturedIds = [...interception.captureRequests.values()].some(
+    (ids) => ids.size > 0,
+  );
+  const captureWiState =
+    hasCapturedIds ? structuredClone(wiState) : null;
+  const activationScanCache =
+    captureWiState ? createWorldInfoActivationScanCache() : undefined;
+  if (activationScanCache) {
+    primeWorldInfoActivationScanCache(
+      activationScanCache,
+      [intercepted, wiEntries],
+      worldInfoSettings,
+    );
+  }
+  const wiResult = profiler.measureSync(
+    "world-info-keyword",
+    () => activateWorldInfo({
+      entries: intercepted,
+      messages,
+      chatTurn: messages.length,
+      wiState,
+      settings: worldInfoSettings,
+      scanCache: activationScanCache,
+    }),
+  );
 
   // Yield after world-info activation — the keyword scanning loop above is
   // synchronous and can block for 50-200ms on large setups (hundreds of
@@ -1818,32 +1841,59 @@ export async function assemblePrompt(
   // These entries are merged with keyword-activated entries when enabled.
   // When pre-computed results are available (from the generation pipeline's
   // council enrichment phase), reuse them to avoid redundant embedding queries.
-  const vectorQueryPreview = await getWorldInfoVectorQueryPreview(
-    ctx.userId,
-    messages,
-    ctx.chatId,
-    worldInfoSettings,
-  );
-  const currentWorldInfoEntryIds = new Set(wiEntries.map((entry) => entry.id));
-  let vectorActivated = ctx.precomputedVectorEntries
-    ? ctx.precomputedVectorEntries.filter((item) =>
-        currentWorldInfoEntryIds.has(item.entry.id),
-      )
-    : null;
+  let vectorQueryPreview = "";
   let vectorRetrievalDetails: VectorWorldInfoRetrievalResult | null = null;
+  let captureVectorQuery: PreparedWorldInfoVectorQuery | undefined;
+  const vectorViewsEquivalent = areWorldInfoVectorViewsEquivalent(
+    wiEntries,
+    intercepted,
+  );
+  const captureVectorViewCanShareNative =
+    captureWiState !== null && vectorViewsEquivalent;
+  const nativeWorldInfoEntryIds = new Set(
+    intercepted.map((entry) => entry.id),
+  );
+  let vectorActivated =
+    ctx.precomputedVectorEntries &&
+      !hasCaptureRequests &&
+      vectorViewsEquivalent
+      ? projectVectorActivatedEntries(
+          ctx.precomputedVectorEntries.filter((item) =>
+            nativeWorldInfoEntryIds.has(item.entry.id),
+          ),
+          intercepted,
+        )
+      : null;
+  let rawVectorActivated: VectorActivatedEntry[] | null = null;
   if (!vectorActivated) {
     try {
-      const detailed = await collectVectorActivatedWorldInfoDetailed(
-        ctx.userId,
-        ctx.chatId,
-        wiSources.worldBookIds,
-        wiEntries,
-        messages,
-        ctx.signal,
-        worldInfoSettings,
+      const detailed = await profiler.measure(
+        "world-info-vector",
+        () => collectVectorActivatedWorldInfoDetailed(
+          ctx.userId,
+          ctx.chatId,
+          wiSources.worldBookIds,
+          intercepted,
+          messages,
+          ctx.signal,
+          worldInfoSettings,
+        ),
       );
       vectorActivated = detailed.entries;
       vectorRetrievalDetails = detailed;
+      vectorQueryPreview = detailed.queryPreview;
+      if (detailed.queryPreview.length > 0) {
+        captureVectorQuery = {
+          queryPreview: detailed.queryPreview,
+          queryScope: detailed.queryScope,
+        };
+      }
+      if (captureVectorViewCanShareNative) {
+        rawVectorActivated = projectVectorActivatedEntries(
+          detailed.entries,
+          wiEntries,
+        );
+      }
 
       if (detailed.blockerMessages.length > 0 && detailed.eligibleCount > 0) {
         console.log(
@@ -1877,18 +1927,88 @@ export async function assemblePrompt(
         err,
       );
       vectorActivated = [];
+      if (captureVectorViewCanShareNative) rawVectorActivated = [];
     }
   }
-  const mergedWorldInfo = mergeActivatedWorldInfoEntries(
-    wiResult.activatedEntries,
-    vectorActivated,
-    worldInfoSettings,
-    wiSources.bookSourceMap,
-    wiSources.bookNameMap,
+  const mergedWorldInfo = profiler.measureSync(
+    "world-info-merge",
+    () => mergeActivatedWorldInfoEntries(
+      wiResult.activatedEntries,
+      vectorActivated ?? [],
+      worldInfoSettings,
+      wiSources.bookSourceMap,
+      wiSources.bookNameMap,
+    ),
   );
   const wiCache = mergedWorldInfo.cache;
   wiResult.activatedEntries = mergedWorldInfo.activatedEntries;
   const activatedWorldInfo = mergedWorldInfo.activatedWorldInfo;
+  let spindleWorldInfoCaptures:
+    | Record<string, ActivatedWorldInfoEntry[]>
+    | undefined;
+  if (hasCaptureRequests && !captureWiState) {
+    spindleWorldInfoCaptures = buildWorldInfoCaptureMap(
+      interception.captureRequests,
+      [],
+    );
+  } else if (captureWiState) {
+    const captureRandom = createWorldInfoCaptureRandom();
+    const captureKeywordResult = profiler.measureSync(
+      "world-info-capture-keyword",
+      () => activateWorldInfo({
+        entries: wiEntries,
+        messages,
+        chatTurn: messages.length,
+        wiState: captureWiState,
+        settings: worldInfoSettings,
+        scanCache: activationScanCache,
+        random: captureRandom,
+      }),
+    );
+    if (!rawVectorActivated) {
+      try {
+        rawVectorActivated = (
+          await profiler.measure(
+            "world-info-capture-vector",
+            () => collectVectorActivatedWorldInfoDetailed(
+              ctx.userId,
+              ctx.chatId,
+              wiSources.worldBookIds,
+              wiEntries,
+              messages,
+              ctx.signal,
+              worldInfoSettings,
+              captureVectorQuery,
+            ),
+          )
+        ).entries;
+      } catch (err) {
+        if (ctx.signal?.aborted || (err as any)?.name === "AbortError") {
+          throw err;
+        }
+        console.warn(
+          "[prompt-assembly] Raw capture vector activation failed, continuing with keyword-only:",
+          err,
+        );
+        rawVectorActivated = [];
+      }
+    }
+    const capturedMergedWorldInfo = profiler.measureSync(
+      "world-info-capture-merge",
+      () => mergeActivatedWorldInfoEntries(
+        captureKeywordResult.activatedEntries,
+        rawVectorActivated ?? [],
+        worldInfoSettings,
+        wiSources.bookSourceMap,
+        wiSources.bookNameMap,
+        captureRandom,
+      ),
+    );
+    spindleWorldInfoCaptures = buildWorldInfoCaptureMap(
+      interception.captureRequests,
+      capturedMergedWorldInfo.activatedWorldInfo,
+    );
+  }
 
   const worldInfoStats = {
     ...wiResult.stats,
@@ -3603,6 +3723,7 @@ export async function assemblePrompt(
     assistantPrefill,
     activatedWorldInfo:
       activatedWorldInfo.length > 0 ? activatedWorldInfo : undefined,
+    spindleWorldInfoCaptures,
     worldInfoStats,
     memoryStats,
     databankStats,
@@ -4501,6 +4622,45 @@ function isVectorEligibleWorldInfoEntry(
   return isWorldBookEntryVectorSearchReady(entry);
 }
 
+function areWorldInfoVectorViewsEquivalent(
+  source: readonly WorldBookEntryModel[],
+  effective: readonly WorldBookEntryModel[],
+): boolean {
+  const sourceEligible = source.filter(isVectorEligibleWorldInfoEntry);
+  const effectiveEligible = effective.filter(isVectorEligibleWorldInfoEntry);
+  if (sourceEligible.length !== effectiveEligible.length) return false;
+  return sourceEligible.every(
+    (entry, index) => effectiveEligible[index] === entry,
+  );
+}
+
+function createWorldInfoCaptureRandom(): () => number {
+  const seed = new Uint32Array(1);
+  crypto.getRandomValues(seed);
+  let state = seed[0] || 0x9e3779b9;
+  return () => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    return (state >>> 0) / 0x1_0000_0000;
+  };
+}
+
+function projectVectorActivatedEntries(
+  activated: readonly VectorActivatedEntry[],
+  entries: readonly WorldBookEntryModel[],
+): VectorActivatedEntry[] {
+  const byId = new Map(
+    entries
+      .filter(isVectorEligibleWorldInfoEntry)
+      .map((entry) => [entry.id, entry] as const),
+  );
+  return activated.flatMap((item) => {
+    const entry = byId.get(item.entry.id);
+    return entry ? [{ ...item, entry }] : [];
+  });
+}
+
 function getVectorSearchableWorldBookIds(
   worldBookIds: string[],
   entries: WorldBookEntryModel[],
@@ -4633,6 +4793,7 @@ export const __vectorWiCacheTest = {
 
 export const __vectorWiRetrievalTest = {
   getSearchableWorldBookIds: getVectorSearchableWorldBookIds,
+  viewsEquivalent: areWorldInfoVectorViewsEquivalent,
 };
 
 export async function collectVectorActivatedWorldInfoDetailed(

--- a/src/services/world-info-activation-scan-cache.test.ts
+++ b/src/services/world-info-activation-scan-cache.test.ts
@@ -1,0 +1,444 @@
+import { describe, expect, test } from "bun:test";
+import type { Message } from "../types/message";
+import type { WorldBookEntry } from "../types/world-book";
+import {
+  activateWorldInfo,
+  createWorldInfoActivationScanCache,
+  primeWorldInfoActivationScanCache,
+} from "./world-info-activation.service";
+
+function entry(overrides: Partial<WorldBookEntry> = {}): WorldBookEntry {
+  const id = crypto.randomUUID();
+  return {
+    id,
+    uid: id,
+    world_book_id: "book",
+    outlet_name: null,
+    wi_marker: null,
+    wi_marker_side: null,
+    key: [],
+    keysecondary: [],
+    content: "memory",
+    comment: "",
+    position: 0,
+    depth: 4,
+    role: null,
+    order_value: 100,
+    selective: false,
+    constant: false,
+    disabled: false,
+    group_name: "",
+    group_override: false,
+    group_weight: 100,
+    probability: 100,
+    scan_depth: null,
+    case_sensitive: false,
+    match_whole_words: false,
+    automation_id: null,
+    use_regex: false,
+    prevent_recursion: true,
+    exclude_recursion: false,
+    delay_until_recursion: false,
+    priority: 10,
+    sticky: 0,
+    cooldown: 0,
+    delay: 0,
+    selective_logic: 0,
+    use_probability: true,
+    vectorized: false,
+    vector_index_status: "not_enabled",
+    vector_indexed_at: null,
+    vector_index_error: null,
+    extensions: {},
+    created_at: 0,
+    updated_at: 0,
+    ...overrides,
+  };
+}
+
+function message(content: () => string): Message {
+  const value = {
+    id: crypto.randomUUID(),
+    chat_id: "chat",
+    index_in_chat: 0,
+    is_user: true,
+    name: "User",
+    send_date: 0,
+    swipe_id: 0,
+    swipes: [],
+    swipe_dates: [],
+    extra: {},
+    parent_message_id: null,
+    branch_id: null,
+    created_at: 0,
+  } as unknown as Message;
+  Object.defineProperty(value, "content", { enumerable: true, get: content });
+  return value;
+}
+
+function messages(prefix: string, contents: string[]): Message[] {
+  return contents.map((content, index) => ({
+    id: `${prefix}-message-${index}`,
+    chat_id: "chat",
+    index_in_chat: index,
+    is_user: true,
+    name: "User",
+    content,
+    send_date: 0,
+    swipe_id: 0,
+    swipes: [],
+    swipe_dates: [],
+    extra: {},
+    parent_message_id: null,
+    branch_id: null,
+    created_at: 0,
+  })) as Message[];
+}
+
+function labels(result: ReturnType<typeof activateWorldInfo>): string[] {
+  return result.activatedEntries.map((item) => item.comment).sort();
+}
+
+function differingViews(prefix: string): {
+  native: WorldBookEntry[];
+  raw: WorldBookEntry[];
+} {
+  const make = (
+    name: string,
+    overrides: Partial<WorldBookEntry> = {},
+  ): WorldBookEntry =>
+    entry({
+      id: `${prefix}-${name}`,
+      uid: `${prefix}-${name}`,
+      comment: name,
+      ...overrides,
+    });
+  const regexDeep = make("regex-deep", {
+    key: ["^old code\\d+"],
+    use_regex: true,
+    scan_depth: 2,
+  });
+  const regexShallow = make("regex-shallow", {
+    key: ["^old code\\d+"],
+    use_regex: true,
+    scan_depth: 1,
+  });
+  const selective = make("selective", {
+    key: ["primary"],
+    keysecondary: ["secondary", "absent"],
+    selective: true,
+    selective_logic: 2,
+  });
+  const forced = make("forced", { key: ["missing"] });
+  const enabled = make("enabled", {
+    key: ["primary"],
+    disabled: true,
+  });
+  const constant = make("constant", {
+    constant: true,
+    content: "raw-trigger",
+    prevent_recursion: false,
+  });
+  const nativeTarget = make("native-target", { key: ["native-trigger"] });
+  const rawTarget = make("raw-target", { key: ["raw-trigger"] });
+  const wholeWord = make("whole-word", { key: ["cat"] });
+  const caseSensitive = make("case-sensitive", { key: ["Needle"] });
+  const raw = [
+    regexDeep,
+    regexShallow,
+    selective,
+    forced,
+    enabled,
+    constant,
+    nativeTarget,
+    rawTarget,
+    wholeWord,
+    caseSensitive,
+  ];
+  return {
+    raw,
+    native: raw.map((item) => {
+      if (item === regexDeep) return { ...item, disabled: true };
+      if (item === forced) return { ...item, constant: true };
+      if (item === enabled) return { ...item, disabled: false };
+      if (item === constant) return { ...item, content: "native-trigger" };
+      return item;
+    }),
+  };
+}
+
+describe("world-info activation scan reuse", () => {
+  test("constant-only activation does not read chat content", () => {
+    let reads = 0;
+    const messages = [message(() => {
+      reads++;
+      return "large chat";
+    })];
+
+    const result = activateWorldInfo({
+      entries: [entry({ constant: true })],
+      messages,
+      chatTurn: 1,
+      wiState: {},
+    });
+
+    expect(result.activatedEntries).toHaveLength(1);
+    expect(reads).toBe(0);
+  });
+
+  test("two activation views reuse the message signature and base scan", () => {
+    let reads = 0;
+    const messages = [message(() => {
+      reads++;
+      return "needle";
+    })];
+    const conditional = entry({ key: ["needle"] });
+    const constant = entry({ constant: true });
+    const scanCache = createWorldInfoActivationScanCache();
+
+    const native = activateWorldInfo({
+      entries: [conditional],
+      messages,
+      chatTurn: 1,
+      wiState: {},
+      scanCache,
+    });
+    const readsAfterNative = reads;
+    const raw = activateWorldInfo({
+      entries: [constant, conditional],
+      messages,
+      chatTurn: 1,
+      wiState: {},
+      scanCache,
+    });
+
+    expect(native.activatedEntries.map((item) => item.id)).toEqual([
+      conditional.id,
+    ]);
+    expect(raw.activatedEntries.map((item) => item.id).sort()).toEqual(
+      [constant.id, conditional.id].sort(),
+    );
+    expect(readsAfterNative).toBeGreaterThan(0);
+    expect(reads).toBe(readsAfterNative);
+  });
+
+  test("different conditional views share one union scan", () => {
+    let reads = 0;
+    const messages = [message(() => {
+      reads++;
+      return "needle and second";
+    })];
+    const first = entry({ key: ["needle"] });
+    const second = entry({ key: ["second"] });
+    const nativeEntries = [first];
+    const rawEntries = [first, second];
+    const scanCache = createWorldInfoActivationScanCache();
+    primeWorldInfoActivationScanCache(
+      scanCache,
+      [nativeEntries, rawEntries],
+    );
+
+    const native = activateWorldInfo({
+      entries: nativeEntries,
+      messages,
+      chatTurn: 1,
+      wiState: {},
+      scanCache,
+    });
+    const readsAfterNative = reads;
+    const raw = activateWorldInfo({
+      entries: rawEntries,
+      messages,
+      chatTurn: 1,
+      wiState: {},
+      scanCache,
+    });
+
+    expect(native.activatedEntries.map((item) => item.id)).toEqual([first.id]);
+    expect(raw.activatedEntries.map((item) => item.id)).toEqual([
+      first.id,
+      second.id,
+    ]);
+    expect(readsAfterNative).toBeGreaterThan(0);
+    expect(reads).toBe(readsAfterNative);
+  });
+
+  test("primed native and raw views match uncached activation", () => {
+    const settings = {
+      forceCaseSensitive: true,
+      forceMatchWholeWords: true,
+      maxRecursionPasses: 3,
+    };
+    const cachedViews = differingViews("cached");
+    const scanCache = createWorldInfoActivationScanCache();
+    primeWorldInfoActivationScanCache(
+      scanCache,
+      [cachedViews.native, cachedViews.raw],
+      settings,
+    );
+    const cachedNative = activateWorldInfo({
+      entries: cachedViews.native,
+      messages: messages("cached", [
+        "old code42",
+        "recent catapult needle primary secondary",
+      ]),
+      chatTurn: 2,
+      wiState: {},
+      settings,
+      scanCache,
+    });
+    const cachedRaw = activateWorldInfo({
+      entries: cachedViews.raw,
+      messages: messages("cached", [
+        "old code42",
+        "recent catapult needle primary secondary",
+      ]),
+      chatTurn: 2,
+      wiState: {},
+      settings,
+      scanCache,
+    });
+
+    const directViews = differingViews("direct");
+    const directNative = activateWorldInfo({
+      entries: directViews.native,
+      messages: messages("direct", [
+        "old code42",
+        "recent catapult needle primary secondary",
+      ]),
+      chatTurn: 2,
+      wiState: {},
+      settings,
+    });
+    const directRaw = activateWorldInfo({
+      entries: directViews.raw,
+      messages: messages("direct", [
+        "old code42",
+        "recent catapult needle primary secondary",
+      ]),
+      chatTurn: 2,
+      wiState: {},
+      settings,
+    });
+
+    expect(labels(cachedNative)).toEqual(labels(directNative));
+    expect(labels(cachedRaw)).toEqual(labels(directRaw));
+    expect(labels(cachedNative)).toEqual([
+      "constant",
+      "enabled",
+      "forced",
+      "native-target",
+      "selective",
+    ]);
+    expect(labels(cachedRaw)).toEqual([
+      "constant",
+      "raw-target",
+      "regex-deep",
+      "selective",
+    ]);
+    expect(cachedNative.stats).toEqual(directNative.stats);
+    expect(cachedRaw.stats).toEqual(directRaw.stats);
+  });
+
+  test("same uid with different scan plans stays view-local", () => {
+    const cachedShallow = entry({
+      id: "cached-shared",
+      uid: "cached-shared",
+      comment: "shared",
+      key: ["needle"],
+      scan_depth: 1,
+    });
+    const cachedDeep = { ...cachedShallow, scan_depth: 2 };
+    const scanCache = createWorldInfoActivationScanCache();
+    primeWorldInfoActivationScanCache(
+      scanCache,
+      [[cachedShallow], [cachedDeep]],
+    );
+
+    const cachedShallowResult = activateWorldInfo({
+      entries: [cachedShallow],
+      messages: messages("cached-shared", ["needle", "recent"]),
+      chatTurn: 2,
+      wiState: {},
+      scanCache,
+    });
+    const cachedDeepResult = activateWorldInfo({
+      entries: [cachedDeep],
+      messages: messages("cached-shared", ["needle", "recent"]),
+      chatTurn: 2,
+      wiState: {},
+      scanCache,
+    });
+    const directDeep = entry({
+      id: "direct-shared",
+      uid: "direct-shared",
+      comment: "shared",
+      key: ["needle"],
+      scan_depth: 2,
+    });
+    const directDeepResult = activateWorldInfo({
+      entries: [directDeep],
+      messages: messages("direct-shared", ["needle", "recent"]),
+      chatTurn: 2,
+      wiState: {},
+    });
+
+    expect(labels(cachedShallowResult)).toEqual([]);
+    expect(labels(cachedDeepResult)).toEqual(labels(directDeepResult));
+  });
+
+  test("different message snapshots invalidate cached scan state", () => {
+    const conditional = entry({
+      id: "snapshot-entry",
+      uid: "snapshot-entry",
+      key: ["needle"],
+    });
+    const scanCache = createWorldInfoActivationScanCache();
+    primeWorldInfoActivationScanCache(
+      scanCache,
+      [[conditional], [conditional]],
+    );
+
+    const first = activateWorldInfo({
+      entries: [conditional],
+      messages: messages("snapshot-first", ["needle"]),
+      chatTurn: 1,
+      wiState: {},
+      scanCache,
+    });
+    const second = activateWorldInfo({
+      entries: [conditional],
+      messages: messages("snapshot-second", ["absent"]),
+      chatTurn: 1,
+      wiState: {},
+      scanCache,
+    });
+
+    expect(first.activatedEntries.map((item) => item.id)).toEqual([
+      conditional.id,
+    ]);
+    expect(second.activatedEntries).toEqual([]);
+  });
+
+  test("saturates repeated shared-key outputs after their first match", () => {
+    const entries = Array.from({ length: 1_000 }, (_, index) =>
+      entry({
+        id: `shared-${index}`,
+        uid: `shared-${index}`,
+        key: ["needle"],
+      })
+    );
+    const chat = messages("shared", ["needle ".repeat(100_000)]);
+    const startedAt = performance.now();
+    const result = activateWorldInfo({
+      entries,
+      messages: chat,
+      chatTurn: 1,
+      wiState: {},
+    });
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(result.activatedEntries).toHaveLength(entries.length);
+    expect(elapsedMs).toBeLessThan(1_000);
+  });
+});

--- a/src/services/world-info-activation.service.ts
+++ b/src/services/world-info-activation.service.ts
@@ -94,6 +94,57 @@ export interface ActivationInput {
   chatTurn: number;           // current turn number (messages.length)
   wiState: WiState;           // mutable — updated in place
   settings?: Partial<WorldInfoSettings>;
+  scanCache?: WorldInfoActivationScanCache;
+  random?: () => number;
+}
+
+export interface WorldInfoActivationScanCache {
+  messages?: readonly Message[];
+  messageSignature?: string;
+  baseStates: Map<string, ScanState>;
+  plan?: WorldInfoActivationScanPlan;
+}
+
+interface WorldInfoActivationScanPlan {
+  views: WorldBookEntry[][];
+  unionEntries: WorldBookEntry[];
+  settings: WorldInfoSettings;
+}
+
+export function createWorldInfoActivationScanCache(): WorldInfoActivationScanCache {
+  return { baseStates: new Map() };
+}
+
+export function primeWorldInfoActivationScanCache(
+  cache: WorldInfoActivationScanCache,
+  entryViews: readonly WorldBookEntry[][],
+  settingsInput?: Partial<WorldInfoSettings>,
+): void {
+  cache.messages = undefined;
+  cache.messageSignature = undefined;
+  cache.baseStates.clear();
+  const settings = normalizeWorldInfoSettings(settingsInput);
+  const views = entryViews.map((entries) =>
+    conditionalEntriesForScan(entries, settings)
+  );
+  const union = new Map<string, WorldBookEntry>();
+  const unionSignatures = new Map<string, string>();
+  for (const entries of views) {
+    for (const entry of entries) {
+      const signature = scanEntrySignature(entry);
+      const existingSignature = unionSignatures.get(entry.uid);
+      if (
+        existingSignature !== undefined &&
+        existingSignature !== signature
+      ) {
+        cache.plan = undefined;
+        return;
+      }
+      unionSignatures.set(entry.uid, signature);
+      if (!union.has(entry.uid)) union.set(entry.uid, entry);
+    }
+  }
+  cache.plan = { views, unionEntries: [...union.values()], settings };
 }
 
 /** Statistics about the activation run, useful for dry-run / debugging. */
@@ -131,6 +182,7 @@ export interface FinalizedWorldInfoEntries {
 export interface FinalizeWorldInfoOptions {
   skipGroupLogic?: boolean;
   preserveOrder?: boolean;
+  random?: () => number;
   /** Internal competition priorities used only for budget ordering. */
   budgetPriorityById?: ReadonlyMap<string, number>;
 }
@@ -161,13 +213,37 @@ function pruneWiActivationCache(now = Date.now()): void {
   }
 }
 
+function conditionalEntriesForScan(
+  entries: readonly WorldBookEntry[],
+  settings: WorldInfoSettings,
+): WorldBookEntry[] {
+  return entries.filter(
+    (entry) =>
+      !entry.disabled &&
+      !entry.constant &&
+      (settings.minPriority === 0 || entry.priority >= settings.minPriority),
+  );
+}
+
+function computeMessageSignature(messages: readonly Message[]): string {
+  const hasher = new Bun.CryptoHasher("sha256");
+  for (const message of messages) {
+    hasher.update(
+      JSON.stringify({ id: message.id, content: message.content }),
+    );
+    hasher.update("\0");
+  }
+  return hasher.digest("hex");
+}
+
 function computeWiActivationCacheKey(input: ActivationInput): string {
   const entries = input.entries;
   const messages = input.messages;
   const wiState = input.wiState;
   const settings = normalizeWorldInfoSettings(input.settings);
-  const entrySig = entries
-    .map((e) => JSON.stringify({
+  const hasher = new Bun.CryptoHasher("sha256");
+  for (const e of entries) {
+    hasher.update(JSON.stringify({
       id: e.id,
       uid: e.uid,
       world_book_id: e.world_book_id,
@@ -199,12 +275,43 @@ function computeWiActivationCacheKey(input: ActivationInput): string {
       selective_logic: e.selective_logic,
       use_probability: e.use_probability,
       vectorized: e.vectorized,
-    }))
-    .join("|");
-  const msgSig = messages.map((m) => JSON.stringify({ id: m.id, content: m.content })).join("|");
-  const stateSig = JSON.stringify(wiState);
-  const settingsSig = JSON.stringify(settings);
-  return `${entrySig}::${msgSig}::${stateSig}::${settingsSig}`;
+    }));
+    hasher.update("\0");
+  }
+  const readsMessages = entries.some(
+    (entry) =>
+      !entry.disabled &&
+      !entry.constant &&
+      entry.key.length > 0 &&
+      (settings.minPriority === 0 || entry.priority >= settings.minPriority),
+  );
+  let msgSig = "";
+  if (readsMessages) {
+    msgSig = input.scanCache?.messageSignature ?? "";
+    if (!msgSig) {
+      msgSig = computeMessageSignature(messages);
+      if (input.scanCache) input.scanCache.messageSignature = msgSig;
+    }
+  }
+  hasher.update(msgSig);
+  hasher.update("\0");
+  hasher.update(JSON.stringify(wiState));
+  hasher.update("\0");
+  hasher.update(JSON.stringify(settings));
+  return hasher.digest("hex");
+}
+
+function bindWorldInfoActivationScanCache(
+  cache: WorldInfoActivationScanCache,
+  messages: readonly Message[],
+): void {
+  if (cache.messages === messages) return;
+  if (cache.messages !== undefined) {
+    cache.messageSignature = undefined;
+    cache.baseStates.clear();
+    cache.plan = undefined;
+  }
+  cache.messages = messages;
 }
 
 function deepCloneWiState(state: WiState): WiState {
@@ -244,8 +351,11 @@ function setCachedActivationResult(cacheKey: string, result: ActivationResult): 
  * budget enforcement → bucket by position.
  */
 export function activateWorldInfo(input: ActivationInput): ActivationResult {
-  const cacheKey = computeWiActivationCacheKey(input);
-  const cached = getCachedActivationResult(cacheKey);
+  if (input.scanCache) {
+    bindWorldInfoActivationScanCache(input.scanCache, input.messages);
+  }
+  const cacheKey = input.random ? null : computeWiActivationCacheKey(input);
+  const cached = cacheKey ? getCachedActivationResult(cacheKey) : null;
   if (cached) return cached;
 
   const { entries, messages, wiState } = input;
@@ -305,7 +415,7 @@ export function activateWorldInfo(input: ActivationInput): ActivationResult {
   const recursionPassesUsed = runAhoCorasickPasses({
     conditional, constants, messages, settings, wiState,
     activated, activatedUids, blockedByCooldown, matchedThisTurn, delayIncremented,
-    maxPasses,
+    maxPasses, scanCache: input.scanCache, random: input.random ?? Math.random,
   });
 
   for (const entry of conditional) {
@@ -332,7 +442,9 @@ export function activateWorldInfo(input: ActivationInput): ActivationResult {
     }
   }
 
-  const finalized = finalizeActivatedWorldInfoEntries(activated, settings);
+  const finalized = finalizeActivatedWorldInfoEntries(activated, settings, {
+    random: input.random,
+  });
 
   const stats: ActivationStats = {
     totalCandidates: candidates.length,
@@ -350,7 +462,7 @@ export function activateWorldInfo(input: ActivationInput): ActivationResult {
   };
 
   const result: ActivationResult = { cache: finalized.cache, activatedEntries: finalized.activatedEntries, wiState, stats };
-  setCachedActivationResult(cacheKey, result);
+  if (cacheKey) setCachedActivationResult(cacheKey, result);
   return result;
 }
 
@@ -363,7 +475,7 @@ export function finalizeActivatedWorldInfoEntries(
 
   const afterGroups = options.skipGroupLogic
     ? [...entries]
-    : applyWorldInfoGroupLogic([...entries]);
+    : applyWorldInfoGroupLogic([...entries], options.random);
   const insertableEntries = afterGroups.filter(hasMeaningfulWorldInfoContent);
 
   if (!options.preserveOrder) {
@@ -471,22 +583,62 @@ interface AhoCorasickPassArgs {
   matchedThisTurn: Set<string>;
   delayIncremented: Set<string>;
   maxPasses: number;
+  scanCache?: WorldInfoActivationScanCache;
+  random: () => number;
 }
 
-function runAhoCorasickPasses(args: AhoCorasickPassArgs): number {
-  const { conditional, constants, messages, settings, wiState,
-    activated, activatedUids, blockedByCooldown, matchedThisTurn, delayIncremented,
-    maxPasses } = args;
+function cloneScanState(
+  state: ScanState,
+  include?: ReadonlySet<string>,
+): ScanState {
+  const selected = <T>(entries: Iterable<[string, T]>): Array<[string, T]> =>
+    [...entries].filter(([uid]) => !include || include.has(uid));
+  return {
+    primaryHits: new Map(
+      selected(state.primaryHits).map(([uid, hits]) => [uid, new Set(hits)]),
+    ),
+    secondaryHits: new Map(
+      selected(state.secondaryHits).map(([uid, hits]) => [uid, new Set(hits)]),
+    ),
+    regexCache: new Map(),
+  };
+}
 
-  const matcher = new WorldInfoMatcher(conditional, {
+function baseScanCacheKey(
+  conditional: readonly WorldBookEntry[],
+  settings: WorldInfoSettings,
+): string {
+  return JSON.stringify({
     forceCaseSensitive: settings.forceCaseSensitive,
     forceMatchWholeWords: settings.forceMatchWholeWords,
+    globalScanDepth: settings.globalScanDepth,
+    entries: conditional.map(scanEntryCacheValue),
   });
-  const state: ScanState = makeScanState();
+}
 
-  // Pass 0 base: scan messages once per unique effective scan_depth.
-  // Pre-compute scan text per depth key and memoize so entries sharing the
-  // same effective depth don't rebuild the same concatenated string.
+function scanEntryCacheValue(entry: WorldBookEntry): object {
+  return {
+    uid: entry.uid,
+    key: entry.key,
+    keysecondary: entry.keysecondary,
+    scan_depth: entry.scan_depth,
+    case_sensitive: entry.case_sensitive,
+    match_whole_words: entry.match_whole_words,
+    use_regex: entry.use_regex,
+  };
+}
+
+function scanEntrySignature(entry: WorldBookEntry): string {
+  return JSON.stringify(scanEntryCacheValue(entry));
+}
+
+function scanBaseState(
+  matcher: WorldInfoMatcher,
+  conditional: readonly WorldBookEntry[],
+  messages: Message[],
+  settings: WorldInfoSettings,
+): ScanState {
+  const state = makeScanState();
   const depthBuckets = new Map<string, Set<string>>();
   const depthKey = (d: number | null) => (d === null ? "all" : String(d));
   for (const e of conditional) {
@@ -494,7 +646,10 @@ function runAhoCorasickPasses(args: AhoCorasickPassArgs): number {
     const d = e.scan_depth ?? settings.globalScanDepth;
     const k = depthKey(d);
     let set = depthBuckets.get(k);
-    if (!set) { set = new Set(); depthBuckets.set(k, set); }
+    if (!set) {
+      set = new Set();
+      depthBuckets.set(k, set);
+    }
     set.add(e.uid);
   }
   const scanTextCache = new Map<string, string>();
@@ -506,6 +661,56 @@ function runAhoCorasickPasses(args: AhoCorasickPassArgs): number {
       scanTextCache.set(k, text);
     }
     matcher.scanChunk(text, state, scope);
+  }
+  return state;
+}
+
+function materializeScanPlan(
+  cache: WorldInfoActivationScanCache,
+  messages: Message[],
+): void {
+  const plan = cache.plan;
+  if (!plan) return;
+  cache.plan = undefined;
+  const matcher = new WorldInfoMatcher(plan.unionEntries, {
+    forceCaseSensitive: plan.settings.forceCaseSensitive,
+    forceMatchWholeWords: plan.settings.forceMatchWholeWords,
+  });
+  const unionState = scanBaseState(
+    matcher,
+    plan.unionEntries,
+    messages,
+    plan.settings,
+  );
+  for (const entries of plan.views) {
+    cache.baseStates.set(
+      baseScanCacheKey(entries, plan.settings),
+      cloneScanState(unionState, new Set(entries.map((entry) => entry.uid))),
+    );
+  }
+}
+
+function runAhoCorasickPasses(args: AhoCorasickPassArgs): number {
+  const { conditional, constants, messages, settings, wiState,
+    activated, activatedUids, blockedByCooldown, matchedThisTurn, delayIncremented,
+    maxPasses, scanCache, random } = args;
+
+  const matcher = new WorldInfoMatcher(conditional, {
+    forceCaseSensitive: settings.forceCaseSensitive,
+    forceMatchWholeWords: settings.forceMatchWholeWords,
+  });
+  if (scanCache?.plan) materializeScanPlan(scanCache, messages);
+  const scanKey = scanCache ? baseScanCacheKey(conditional, settings) : null;
+  const cachedBaseState =
+    scanKey === null ? undefined : scanCache?.baseStates.get(scanKey);
+  let state: ScanState;
+  if (cachedBaseState) {
+    state = cloneScanState(cachedBaseState);
+  } else {
+    state = scanBaseState(matcher, conditional, messages, settings);
+    if (scanKey !== null) {
+      scanCache?.baseStates.set(scanKey, cloneScanState(state));
+    }
   }
 
   let recursionPassesUsed = 0;
@@ -545,7 +750,7 @@ function runAhoCorasickPasses(args: AhoCorasickPassArgs): number {
       if (entry.delay > 0 && entryState.delayCount < entry.delay) continue;
 
       if (entry.use_probability && entry.probability < 100) {
-        if (Math.random() * 100 >= entry.probability) continue;
+        if (random() * 100 >= entry.probability) continue;
       }
 
       entryState.active = true;
@@ -617,7 +822,10 @@ function joinMessageContents(messages: Message[]): string {
  * - group_override: highest priority entry wins
  * - Otherwise: weighted random selection by group_weight
  */
-export function applyWorldInfoGroupLogic(entries: WorldBookEntry[]): WorldBookEntry[] {
+export function applyWorldInfoGroupLogic(
+  entries: WorldBookEntry[],
+  random: () => number = Math.random,
+): WorldBookEntry[] {
   const grouped = new Map<string, WorldBookEntry[]>();
   const ungrouped: WorldBookEntry[] = [];
 
@@ -655,7 +863,7 @@ export function applyWorldInfoGroupLogic(entries: WorldBookEntry[]): WorldBookEn
       continue;
     }
 
-    let roll = Math.random() * totalWeight;
+    let roll = random() * totalWeight;
     for (const entry of group) {
       roll -= entry.group_weight || 1;
       if (roll <= 0) {

--- a/src/services/world-info-large-book.test.ts
+++ b/src/services/world-info-large-book.test.ts
@@ -141,6 +141,168 @@ function asVectorCandidate(entry: WorldBookEntry, finalScore = 0.8): VectorActiv
   };
 }
 
+describe("world info RNG injection", () => {
+  test("probability rolls use the injected random source", () => {
+    const prefix = crypto.randomUUID();
+    const accepted = makeEntry({
+      id: `${prefix}-accepted`,
+      uid: `${prefix}-accepted`,
+      key: ["needle"],
+      content: "accepted",
+      selective: false,
+      vectorized: false,
+      probability: 50,
+    });
+    const rejected = makeEntry({
+      id: `${prefix}-rejected`,
+      uid: `${prefix}-rejected`,
+      key: ["needle"],
+      content: "rejected",
+      selective: false,
+      vectorized: false,
+      probability: 50,
+    });
+    const rolls = [0.25, 0.75];
+    let rollIndex = 0;
+
+    const result = activateWorldInfo({
+      entries: [accepted, rejected],
+      messages: [makeMessage("needle")],
+      chatTurn: 1,
+      wiState: {},
+      random: () => rolls[rollIndex++],
+    });
+
+    expect(rollIndex).toBe(2);
+    expect(result.activatedEntries.map((entry) => entry.id)).toEqual([
+      accepted.id,
+    ]);
+  });
+
+  test("injected activation neither advances global RNG nor pollutes its result cache", () => {
+    const prefix = crypto.randomUUID();
+    const probabilistic = makeEntry({
+      id: `${prefix}-entry`,
+      uid: `${prefix}-entry`,
+      key: ["needle"],
+      content: "cache isolation",
+      selective: false,
+      vectorized: false,
+      probability: 50,
+    });
+    const activationMessages = [makeMessage("needle")];
+    const originalRandom = Math.random;
+    let globalRolls = 0;
+
+    Math.random = () => {
+      globalRolls++;
+      return 0.75;
+    };
+    try {
+      const injected = activateWorldInfo({
+        entries: [probabilistic],
+        messages: activationMessages,
+        chatTurn: 1,
+        wiState: {},
+        random: () => 0.25,
+      });
+      expect(injected.activatedEntries.map((entry) => entry.id)).toEqual([
+        probabilistic.id,
+      ]);
+      expect(globalRolls).toBe(0);
+
+      const ordinary = activateWorldInfo({
+        entries: [probabilistic],
+        messages: activationMessages,
+        chatTurn: 1,
+        wiState: {},
+      });
+      expect(ordinary.activatedEntries).toEqual([]);
+      expect(globalRolls).toBe(1);
+
+      const cachedOrdinary = activateWorldInfo({
+        entries: [probabilistic],
+        messages: activationMessages,
+        chatTurn: 1,
+        wiState: {},
+      });
+      expect(cachedOrdinary.activatedEntries).toEqual([]);
+      expect(globalRolls).toBe(1);
+    } finally {
+      Math.random = originalRandom;
+    }
+  });
+
+  test("raw activation and merge do not advance global RNG when given an isolated source", () => {
+    const prefix = crypto.randomUUID();
+    const keyword = makeEntry({
+      id: `${prefix}-keyword`,
+      uid: `${prefix}-keyword`,
+      key: ["needle"],
+      content: "amber",
+      selective: false,
+      vectorized: false,
+      probability: 50,
+      group_name: `${prefix}-group`,
+      group_weight: 1,
+    });
+    const vector = makeEntry({
+      id: `${prefix}-vector`,
+      uid: `${prefix}-vector`,
+      content: "zephyr",
+      group_name: `${prefix}-group`,
+      group_weight: 1,
+    });
+    const activationMessages = [makeMessage("needle")];
+    const originalRandom = Math.random;
+    const globalValues = [0.25, 0.75, 0.42];
+    let globalRolls = 0;
+
+    Math.random = () => globalValues[globalRolls++];
+    try {
+      const nativeActivation = activateWorldInfo({
+        entries: [keyword],
+        messages: activationMessages,
+        chatTurn: 1,
+        wiState: {},
+      });
+      const nativeMerge = mergeActivatedWorldInfoEntries(
+        nativeActivation.activatedEntries,
+        [asVectorCandidate(vector)],
+      );
+      expect(globalRolls).toBe(2);
+
+      const isolatedValues = [0.25, 0.75];
+      let isolatedRolls = 0;
+      const isolatedRandom = () => isolatedValues[isolatedRolls++];
+      const rawActivation = activateWorldInfo({
+        entries: [keyword],
+        messages: activationMessages,
+        chatTurn: 1,
+        wiState: {},
+        random: isolatedRandom,
+      });
+      const rawMerge = mergeActivatedWorldInfoEntries(
+        rawActivation.activatedEntries,
+        [asVectorCandidate(vector)],
+        undefined,
+        undefined,
+        undefined,
+        isolatedRandom,
+      );
+
+      expect(isolatedRolls).toBe(2);
+      expect(globalRolls).toBe(2);
+      expect(rawMerge.activatedEntries.map((entry) => entry.id)).toEqual(
+        nativeMerge.activatedEntries.map((entry) => entry.id),
+      );
+      expect(Math.random()).toBe(0.42);
+    } finally {
+      Math.random = originalRandom;
+    }
+  });
+});
+
 describe("finalizeActivatedWorldInfoEntries", () => {
   test("drops whitespace-only world info entries from activation and cache", () => {
     const result = finalizeActivatedWorldInfoEntries([

--- a/src/services/world-info-matcher.service.ts
+++ b/src/services/world-info-matcher.service.ts
@@ -91,21 +91,6 @@ function verifyWordBoundary(text: string, start: number, end: number): boolean {
   return true;
 }
 
-function* runAutomaton(ac: Automaton, text: string): Generator<{ id: number; end: number }> {
-  if (ac.empty) return;
-  const nodes = ac.nodes;
-  let state = 0;
-  for (let i = 0; i < text.length; i++) {
-    const c = text.charCodeAt(i);
-    while (state !== 0 && !nodes[state].next.has(c)) state = nodes[state].fail;
-    const nxt = nodes[state].next.get(c);
-    state = nxt !== undefined ? nxt : 0;
-    if (nodes[state].out.length) {
-      for (const id of nodes[state].out) yield { id, end: i };
-    }
-  }
-}
-
 /** Accumulated hit state across recursion passes. Hits are keyed by entry uid. */
 export interface ScanState {
   primaryHits: Map<string, Set<number>>;    // uid -> primary key indices that matched
@@ -179,14 +164,58 @@ export class WorldInfoMatcher {
     if (!chunk) return;
 
     const runAC = (ac: Automaton, text: string) => {
-      for (const { id, end } of runAutomaton(ac, text)) {
-        const m = ac.meta[id];
-        if (scope && !scope.has(m.entryUid)) continue;
-        if (m.wholeWord) {
-          const start = end - m.patternLen + 1;
-          if (!verifyWordBoundary(text, start, end)) continue;
+      if (ac.empty) return;
+      const active = new Uint8Array(ac.meta.length);
+      let remaining = 0;
+      for (let id = 0; id < ac.meta.length; id++) {
+        const meta = ac.meta[id];
+        if (scope && !scope.has(meta.entryUid)) continue;
+        const bucket =
+          meta.role === "primary" ? state.primaryHits : state.secondaryHits;
+        if (bucket.get(meta.entryUid)?.has(meta.keyIndex)) continue;
+        active[id] = 1;
+        remaining++;
+      }
+      if (remaining === 0) return;
+
+      const nodes = ac.nodes;
+      const activeOutputs: Array<number[] | undefined> = new Array(nodes.length);
+      let nodeIndex = 0;
+      for (let end = 0; end < text.length; end++) {
+        const code = text.charCodeAt(end);
+        while (
+          nodeIndex !== 0 &&
+          !nodes[nodeIndex].next.has(code)
+        ) {
+          nodeIndex = nodes[nodeIndex].fail;
         }
-        this.recordHit(state, m);
+        const next = nodes[nodeIndex].next.get(code);
+        nodeIndex = next !== undefined ? next : 0;
+
+        let outputs = activeOutputs[nodeIndex];
+        if (outputs === undefined) {
+          outputs = nodes[nodeIndex].out.filter((id) => active[id] === 1);
+          activeOutputs[nodeIndex] = outputs;
+        }
+        if (outputs.length === 0) continue;
+
+        let pending = 0;
+        for (const id of outputs) {
+          if (active[id] === 0) continue;
+          const meta = ac.meta[id];
+          if (meta.wholeWord) {
+            const start = end - meta.patternLen + 1;
+            if (!verifyWordBoundary(text, start, end)) {
+              outputs[pending++] = id;
+              continue;
+            }
+          }
+          this.recordHit(state, meta);
+          active[id] = 0;
+          remaining--;
+        }
+        outputs.length = pending;
+        if (remaining === 0) return;
       }
     };
 

--- a/src/spindle/interceptor-pipeline.ts
+++ b/src/spindle/interceptor-pipeline.ts
@@ -1,6 +1,10 @@
 import type { InterceptorMatchDTO, LlmMessageDTO } from "lumiverse-spindle-types";
 import { DEFAULT_INTERCEPTOR_TIMEOUT_MS } from "../services/spindle-settings.service";
 import { emitSpindlePreGenerationActivity } from "./pre-generation-activity";
+import {
+  collectSourceMessageMetadata,
+  restoreSourceMessageMetadata,
+} from "./source-message-metadata";
 
 export interface InterceptorBreakdownEntry {
   messageIndex: number;
@@ -98,6 +102,7 @@ class InterceptorPipeline {
     signal?: AbortSignal,
   ): Promise<InterceptorResult> {
     let result = messages;
+    const sourceMessageMetadata = collectSourceMessageMetadata(messages);
     let mergedParameters: Record<string, unknown> | undefined;
     const mergedBreakdown: InterceptorBreakdownEntry[] = [];
     const chatId = getChatId(context);
@@ -135,6 +140,7 @@ class InterceptorPipeline {
       let timeout: ReturnType<typeof setTimeout> | undefined;
       let abortHandler: (() => void) | undefined;
       try {
+        restoreSourceMessageMetadata(result, sourceMessageMetadata);
         const output = await Promise.race([
           interceptor.handler(result, context),
           new Promise<never>((_, reject) => {

--- a/src/spindle/source-message-metadata.test.ts
+++ b/src/spindle/source-message-metadata.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import type { LlmMessage } from "../llm/types";
+import {
+  __sourceMessageMetadataTest,
+  getSourceMessageId,
+  getSourceIndexInChat,
+  isChatHistoryMessage,
+} from "../services/prompt-assembly.service";
+import {
+  collectSourceMessageMetadata,
+  getSourceMessageMetadata,
+  projectSourceMessageMetadata,
+  restoreSourceMessageMetadata,
+  stampSourceMessageMetadata,
+} from "./source-message-metadata";
+
+function historyMessage(
+  id: string,
+  index: number,
+  metadata: Record<string, unknown>,
+): LlmMessage {
+  const message = {
+    role: "user",
+    content: id,
+    __chatHistorySource: true,
+    __sourceMessageId: id,
+    __sourceIndexInChat: index,
+  } as LlmMessage;
+  stampSourceMessageMetadata(message, metadata);
+  return message;
+}
+
+describe("source message metadata", () => {
+  test("keeps metadata paired with the preserved source id when user turns merge", () => {
+    const messages = [
+      historyMessage("first", 1, { owner: "first" }),
+      historyMessage("second", 2, { owner: "second" }),
+    ];
+
+    const count =
+      __sourceMessageMetadataTest.mergeConsecutiveUserMessages(
+        messages,
+        0,
+        messages.length,
+      );
+
+    expect(count).toBe(1);
+    expect(getSourceMessageId(messages[0])).toBe("first");
+    expect(getSourceMessageMetadata(messages[0])).toEqual({ owner: "first" });
+  });
+
+  test("projects only permission-gated metadata and restores it between interceptors", () => {
+    const source = historyMessage("source", 1, { shelf: "abc" });
+    const metadataById = collectSourceMessageMetadata([source]);
+
+    const allowed = projectSourceMessageMetadata(source, true, true);
+    expect(allowed.sourceMessageMetadata).toEqual({ shelf: "abc" });
+    expect(allowed).not.toHaveProperty("__sourceMessageMetadata");
+
+    const denied = projectSourceMessageMetadata(
+      {
+        ...source,
+        sourceMessageMetadata: { forged: true },
+      } as never,
+      true,
+      false,
+    );
+    expect(denied).not.toHaveProperty("sourceMessageMetadata");
+    expect(denied).not.toHaveProperty("__sourceMessageMetadata");
+
+    const returned = {
+      role: "user",
+      content: "source",
+      __isChatHistory: true,
+      sourceMessageId: "source",
+    };
+    restoreSourceMessageMetadata([returned], metadataById);
+    expect(getSourceMessageMetadata(returned)).toEqual({ shelf: "abc" });
+
+    const forged = {
+      role: "user",
+      content: "forged",
+      sourceMessageId: "unknown",
+      __sourceMessageMetadata: { forged: true },
+    };
+    restoreSourceMessageMetadata([forged], metadataById);
+    expect(getSourceMessageMetadata(forged)).toBeUndefined();
+
+    expect(
+      projectSourceMessageMetadata(
+        { role: "user", content: "untagged" },
+        true,
+        true,
+      ).sourceMessageMetadata,
+    ).toEqual({});
+  });
+
+  test("restores authentic provenance on reconstructed DTOs and clears forged provenance", () => {
+    const source = historyMessage("source", 7, { shelf: "authentic" });
+    const metadataById = collectSourceMessageMetadata([source]);
+    const reconstructed = {
+      role: "user",
+      content: "reconstructed",
+      __isChatHistory: true,
+      sourceMessageId: "source",
+      sourceIndexInChat: 999,
+      sourceMessageMetadata: { forged: true },
+      __chatHistorySource: true,
+      __sourceMessageId: "forged-internal",
+      __sourceIndexInChat: 998,
+      __sourceMessageMetadata: { forged: true },
+    };
+
+    restoreSourceMessageMetadata([reconstructed], metadataById);
+
+    expect(isChatHistoryMessage(reconstructed as LlmMessage)).toBe(true);
+    expect(getSourceMessageId(reconstructed as LlmMessage)).toBe("source");
+    expect(getSourceIndexInChat(reconstructed as LlmMessage)).toBe(7);
+    expect(getSourceMessageMetadata(reconstructed)).toEqual({
+      shelf: "authentic",
+    });
+
+    const forged = {
+      role: "user",
+      content: "forged",
+      __isChatHistory: true,
+      sourceMessageId: "unknown",
+      sourceIndexInChat: 999,
+      sourceMessageMetadata: { forged: true },
+      __chatHistorySource: true,
+      __sourceMessageId: "unknown",
+      __sourceIndexInChat: 999,
+      __sourceMessageMetadata: { forged: true },
+    };
+
+    restoreSourceMessageMetadata([forged], metadataById);
+
+    expect(isChatHistoryMessage(forged as LlmMessage)).toBe(false);
+    expect(getSourceMessageId(forged as LlmMessage)).toBeUndefined();
+    expect(getSourceIndexInChat(forged as LlmMessage)).toBeUndefined();
+    expect(getSourceMessageMetadata(forged)).toBeUndefined();
+    expect(forged).not.toHaveProperty("__isChatHistory");
+    expect(forged).not.toHaveProperty("sourceMessageId");
+    expect(forged).not.toHaveProperty("sourceIndexInChat");
+    expect(forged).not.toHaveProperty("sourceMessageMetadata");
+  });
+});

--- a/src/spindle/source-message-metadata.ts
+++ b/src/spindle/source-message-metadata.ts
@@ -1,0 +1,133 @@
+import type { LlmMessageDTO } from "lumiverse-spindle-types";
+
+const INTERNAL_SOURCE_MESSAGE_METADATA_KEY = "__sourceMessageMetadata";
+const INTERNAL_CHAT_HISTORY_KEY = "__chatHistorySource";
+const INTERNAL_SOURCE_MESSAGE_ID_KEY = "__sourceMessageId";
+const INTERNAL_SOURCE_MESSAGE_INDEX_KEY = "__sourceIndexInChat";
+
+export type SourceMessageMetadata = Readonly<Record<string, unknown>>;
+
+interface SourceMessageIdentity {
+  index: number;
+  metadata: SourceMessageMetadata;
+}
+
+function normalizeMetadata(value: unknown): SourceMessageMetadata {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+export function stampSourceMessageMetadata(
+  message: object,
+  value: unknown,
+): void {
+  (message as Record<string, unknown>)[INTERNAL_SOURCE_MESSAGE_METADATA_KEY] =
+    normalizeMetadata(value);
+}
+
+export function getSourceMessageMetadata(
+  message: object,
+): SourceMessageMetadata | undefined {
+  const value = (message as Record<string, unknown>)[
+    INTERNAL_SOURCE_MESSAGE_METADATA_KEY
+  ];
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as SourceMessageMetadata)
+    : undefined;
+}
+
+function getSourceMessageId(message: object): string | undefined {
+  const value = message as Record<string, unknown>;
+  const internal = value[INTERNAL_SOURCE_MESSAGE_ID_KEY];
+  if (typeof internal === "string") return internal;
+  return typeof value.sourceMessageId === "string"
+    ? value.sourceMessageId
+    : undefined;
+}
+
+function getSourceMessageIndex(message: object): number | undefined {
+  const value = message as Record<string, unknown>;
+  const internal = value[INTERNAL_SOURCE_MESSAGE_INDEX_KEY];
+  if (typeof internal === "number" && Number.isFinite(internal)) {
+    return internal;
+  }
+  const projected = value.sourceIndexInChat;
+  return typeof projected === "number" && Number.isFinite(projected)
+    ? projected
+    : undefined;
+}
+
+export function collectSourceMessageMetadata(
+  messages: readonly object[],
+): Map<string, SourceMessageIdentity> {
+  const result = new Map<string, SourceMessageIdentity>();
+  for (const message of messages) {
+    const value = message as Record<string, unknown>;
+    if (value[INTERNAL_CHAT_HISTORY_KEY] !== true) continue;
+    const id = getSourceMessageId(message);
+    const index = getSourceMessageIndex(message);
+    if (id === undefined || index === undefined) continue;
+    result.set(id, {
+      index,
+      metadata: getSourceMessageMetadata(message) ?? {},
+    });
+  }
+  return result;
+}
+
+export function restoreSourceMessageMetadata(
+  messages: readonly object[],
+  metadataById: ReadonlyMap<string, SourceMessageIdentity>,
+): void {
+  for (const message of messages) {
+    const value = message as Record<string, unknown>;
+    const isChatHistory =
+      value[INTERNAL_CHAT_HISTORY_KEY] === true ||
+      value.__isChatHistory === true;
+    const id =
+      typeof value.sourceMessageId === "string"
+        ? value.sourceMessageId
+        : getSourceMessageId(message);
+    delete value[INTERNAL_SOURCE_MESSAGE_METADATA_KEY];
+    delete value[INTERNAL_CHAT_HISTORY_KEY];
+    delete value[INTERNAL_SOURCE_MESSAGE_ID_KEY];
+    delete value[INTERNAL_SOURCE_MESSAGE_INDEX_KEY];
+    delete value.__isChatHistory;
+    delete value.sourceMessageId;
+    delete value.sourceIndexInChat;
+    delete value.sourceMessageMetadata;
+    const identity =
+      isChatHistory && id !== undefined ? metadataById.get(id) : undefined;
+    if (!identity) continue;
+    value[INTERNAL_CHAT_HISTORY_KEY] = true;
+    value[INTERNAL_SOURCE_MESSAGE_ID_KEY] = id;
+    value[INTERNAL_SOURCE_MESSAGE_INDEX_KEY] = identity.index;
+    stampSourceMessageMetadata(message, identity.metadata);
+  }
+}
+
+export function projectSourceMessageMetadata(
+  message: LlmMessageDTO,
+  isChatHistory: boolean,
+  allowed: boolean,
+): LlmMessageDTO & { sourceMessageMetadata?: SourceMessageMetadata } {
+  const metadata = getSourceMessageMetadata(message);
+  const projected = {
+    ...message,
+  } as LlmMessageDTO & Record<string, unknown> & {
+    sourceMessageMetadata?: SourceMessageMetadata;
+  };
+  delete projected[INTERNAL_SOURCE_MESSAGE_METADATA_KEY];
+  delete projected[INTERNAL_CHAT_HISTORY_KEY];
+  delete projected[INTERNAL_SOURCE_MESSAGE_ID_KEY];
+  delete projected[INTERNAL_SOURCE_MESSAGE_INDEX_KEY];
+  delete projected.__isChatHistory;
+  delete projected.sourceMessageId;
+  delete projected.sourceIndexInChat;
+  delete projected.sourceMessageMetadata;
+  if (isChatHistory && allowed) {
+    projected.sourceMessageMetadata = metadata ?? {};
+  }
+  return projected;
+}

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -47,6 +47,7 @@ import {
   type WorldInfoInterceptorCtxDTO,
   type WorldInfoInterceptorResultDTO,
 } from "./world-info-interceptor";
+import { projectWorldInfoCaptureContext } from "./world-info-capture";
 import { toolRegistry } from "./tool-registry";
 import {
   setPromptRegexOwnedChats,
@@ -2685,7 +2686,11 @@ export class WorkerHost {
           };
         });
 
-        const interceptorContext = context as Omit<InterceptorContextDTO, "signal">;
+        const interceptorContext =
+          projectWorldInfoCaptureContext(
+            context,
+            this.extensionId,
+          ) as unknown as Omit<InterceptorContextDTO, "signal">;
         this.activeInterceptorContexts.set(registrationId, interceptorContext);
         this.postToWorker({
           type: "intercept_request",

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -48,6 +48,7 @@ import {
   type WorldInfoInterceptorResultDTO,
 } from "./world-info-interceptor";
 import { projectWorldInfoCaptureContext } from "./world-info-capture";
+import { projectSourceMessageMetadata } from "./source-message-metadata";
 import { toolRegistry } from "./tool-registry";
 import {
   setPromptRegexOwnedChats,
@@ -2670,15 +2671,21 @@ export class WorkerHost {
         // can distinguish real chat turns and standalone World Info blocks
         // from other prompt material. Shallow-copy so the synthetic flags never
         // leak onto the outbound LLM payload.
+        const canReadSourceMetadata = this.hasPermission("chat_mutation");
         const messagesWithSourceFlags = messages.map((m) => {
           const llm = m as unknown as LlmMessage;
           const isChatHistory = promptAssemblySvc.isChatHistoryMessage(llm);
           const isWorldInfoEntry = promptAssemblySvc.isWorldInfoEntryMessage(llm);
-          if (!isChatHistory && !isWorldInfoEntry) return m;
+          const projected = projectSourceMessageMetadata(
+            m,
+            isChatHistory,
+            canReadSourceMetadata,
+          );
+          if (!isChatHistory && !isWorldInfoEntry) return projected;
           const sourceMessageId = promptAssemblySvc.getSourceMessageId(llm);
           const sourceIndexInChat = promptAssemblySvc.getSourceIndexInChat(llm);
           return {
-            ...m,
+            ...projected,
             ...(isChatHistory ? { __isChatHistory: true } : {}),
             ...(isWorldInfoEntry ? { __isWorldInfoEntry: true } : {}),
             ...(sourceMessageId !== undefined ? { sourceMessageId } : {}),

--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -663,6 +663,7 @@ type RuntimeSpindleAPI = Omit<SpindleAPI, "presets" | "imageGen"> & {
       enabled?: readonly string[];
       forced?: readonly string[];
       mutated?: ReadonlyArray<{ id: string; content?: string }>;
+      captured?: readonly string[];
     } | void>,
     priority?: number
   ): void;
@@ -3529,7 +3530,10 @@ const spindleApi: RuntimeSpindleAPI = {
     });
   },
 
-  contracts: Object.freeze({ preAssemblyGenerationContext: 1 }),
+  contracts: Object.freeze({
+    preAssemblyGenerationContext: 1,
+    worldInfoActivationCapture: 1,
+  }),
 
   registerContextHandler(
     handler: (context: unknown) => Promise<unknown>,

--- a/src/spindle/world-info-capture.test.ts
+++ b/src/spindle/world-info-capture.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import type { ActivatedWorldInfoEntry } from "../llm/types";
+import type { WorldBookEntry } from "../types/world-book";
+import { __vectorWiRetrievalTest } from "../services/prompt-assembly.service";
+import {
+  buildWorldInfoCaptureMap,
+  INTERNAL_WORLD_INFO_CAPTURES_KEY,
+  projectWorldInfoCaptureContext,
+} from "./world-info-capture";
+
+const activated: ActivatedWorldInfoEntry[] = [
+  {
+    id: "shelf-a",
+    comment: "Shelf A",
+    keys: ["alpha"],
+    source: "keyword",
+    bookId: "book-a",
+    bookSource: "chat",
+  },
+  {
+    id: "peer-b",
+    comment: "Peer B",
+    keys: [],
+    source: "vector",
+    score: 0.9,
+    bookId: "book-b",
+    bookSource: "peer",
+  },
+];
+
+describe("world-info activation capture", () => {
+  test("keeps requested active entries isolated per extension, including empty captures", () => {
+    const captures = buildWorldInfoCaptureMap(
+      new Map([
+        ["one", new Set(["shelf-a", "missing"])],
+        ["two", new Set(["peer-b", "shelf-a"])],
+        ["empty", new Set()],
+      ]),
+      activated,
+    );
+
+    expect(captures.one.map((entry) => entry.id)).toEqual(["shelf-a"]);
+    expect(captures.two.map((entry) => entry.id)).toEqual([
+      "shelf-a",
+      "peer-b",
+    ]);
+    expect(captures.empty).toEqual([]);
+
+    const shared = {
+      chatId: "chat",
+      [INTERNAL_WORLD_INFO_CAPTURES_KEY]: captures,
+    };
+    expect(projectWorldInfoCaptureContext(shared, "one").capturedWorldInfo).toEqual([
+      expect.objectContaining({ id: "shelf-a", bookSource: "chat" }),
+    ]);
+    expect(projectWorldInfoCaptureContext(shared, "two").capturedWorldInfo).toEqual([
+      expect.objectContaining({ id: "shelf-a", bookSource: "chat" }),
+      expect.objectContaining({ id: "peer-b", bookSource: "persona" }),
+    ]);
+    expect(projectWorldInfoCaptureContext(shared, "empty").capturedWorldInfo).toEqual([]);
+    expect(projectWorldInfoCaptureContext(shared, "other").capturedWorldInfo).toBeUndefined();
+    expect(projectWorldInfoCaptureContext(shared, "one")).not.toHaveProperty(
+      INTERNAL_WORLD_INFO_CAPTURES_KEY,
+    );
+  });
+
+  test("projects native activated entries through the public DTO", () => {
+    const projected = projectWorldInfoCaptureContext(
+      {
+        chatId: "chat",
+        activatedWorldInfo: [
+          {
+            ...activated[1],
+            content: "private lore content",
+            internalOnly: "private",
+          },
+        ],
+      },
+      "one",
+    );
+
+    expect(projected.activatedWorldInfo).toEqual([
+      {
+        id: "peer-b",
+        comment: "Peer B",
+        keys: [],
+        source: "vector",
+        score: 0.9,
+        bookId: "book-b",
+        bookSource: "persona",
+      },
+    ]);
+  });
+
+  test("shares vector retrieval only when the raw and native candidate views are identical", () => {
+    const vector = {
+      id: "vector",
+      vectorized: true,
+      disabled: false,
+      content: "indexed",
+      vector_index_status: "indexed",
+    } as WorldBookEntry;
+    const keywordOnly = {
+      id: "keyword",
+      vectorized: false,
+      disabled: false,
+      content: "keyword",
+      vector_index_status: "not_enabled",
+    } as WorldBookEntry;
+    expect(
+      __vectorWiRetrievalTest.viewsEquivalent(
+        [vector, keywordOnly],
+        [vector, { ...keywordOnly, disabled: true }],
+      ),
+    ).toBe(true);
+    expect(
+      __vectorWiRetrievalTest.viewsEquivalent(
+        [vector, keywordOnly],
+        [{ ...vector, disabled: true }, keywordOnly],
+      ),
+    ).toBe(false);
+    expect(
+      __vectorWiRetrievalTest.viewsEquivalent(
+        [vector, keywordOnly],
+        [{ ...vector, content: "mutated" }, keywordOnly],
+      ),
+    ).toBe(false);
+  });
+
+  test("does not share vector retrieval when eligible entries are reordered", () => {
+    const first = {
+      id: "first",
+      vectorized: true,
+      disabled: false,
+      content: "first",
+      vector_index_status: "indexed",
+    } as WorldBookEntry;
+    const second = {
+      ...first,
+      id: "second",
+      content: "second",
+    } as WorldBookEntry;
+
+    expect(
+      __vectorWiRetrievalTest.viewsEquivalent(
+        [first, second],
+        [second, first],
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/spindle/world-info-capture.ts
+++ b/src/spindle/world-info-capture.ts
@@ -1,0 +1,73 @@
+import type { ActivatedWorldInfoEntryDTO } from "lumiverse-spindle-types";
+import type { ActivatedWorldInfoEntry } from "../llm/types";
+
+export const INTERNAL_WORLD_INFO_CAPTURES_KEY = "__spindleWorldInfoCaptures";
+
+export function buildWorldInfoCaptureMap(
+  requests: ReadonlyMap<string, ReadonlySet<string>>,
+  activated: readonly ActivatedWorldInfoEntry[],
+): Record<string, ActivatedWorldInfoEntry[]> {
+  const result: Record<string, ActivatedWorldInfoEntry[]> = {};
+  for (const [extensionId, ids] of requests) {
+    result[extensionId] = activated.filter((entry) => ids.has(entry.id));
+  }
+  return result;
+}
+
+function toCaptureDTO(entry: ActivatedWorldInfoEntry): ActivatedWorldInfoEntryDTO {
+  const dto: ActivatedWorldInfoEntryDTO = {
+    id: entry.id,
+    comment: entry.comment,
+    keys: entry.keys,
+    source: entry.source,
+  };
+  if (entry.score !== undefined) dto.score = entry.score;
+  if (entry.bookId !== undefined) dto.bookId = entry.bookId;
+  if (entry.bookSource === "peer") dto.bookSource = "persona";
+  else if (entry.bookSource !== undefined) dto.bookSource = entry.bookSource;
+  return dto;
+}
+
+export function projectWorldInfoCaptureContext(
+  context: unknown,
+  extensionId: string,
+): Record<string, unknown> {
+  const projected =
+    context && typeof context === "object"
+      ? { ...(context as Record<string, unknown>) }
+      : {};
+  const rawCaptures = projected[INTERNAL_WORLD_INFO_CAPTURES_KEY];
+  delete projected[INTERNAL_WORLD_INFO_CAPTURES_KEY];
+  delete projected.capturedWorldInfo;
+
+  if (Array.isArray(projected.activatedWorldInfo)) {
+    projected.activatedWorldInfo = projected.activatedWorldInfo
+      .filter(
+        (entry): entry is ActivatedWorldInfoEntry =>
+          !!entry &&
+          typeof entry === "object" &&
+          typeof (entry as { id?: unknown }).id === "string",
+      )
+      .map(toCaptureDTO);
+  }
+
+  if (
+    !rawCaptures ||
+    typeof rawCaptures !== "object" ||
+    !Object.prototype.hasOwnProperty.call(rawCaptures, extensionId)
+  ) {
+    return projected;
+  }
+  const entries = (rawCaptures as Record<string, unknown>)[extensionId];
+  projected.capturedWorldInfo = Array.isArray(entries)
+    ? entries
+        .filter(
+          (entry): entry is ActivatedWorldInfoEntry =>
+            !!entry &&
+            typeof entry === "object" &&
+            typeof (entry as { id?: unknown }).id === "string",
+        )
+        .map(toCaptureDTO)
+    : [];
+  return projected;
+}

--- a/src/spindle/world-info-interceptor.test.ts
+++ b/src/spindle/world-info-interceptor.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import type { WorldBookEntry } from "../types/world-book";
+import { WorldInfoInterceptorChain } from "./world-info-interceptor";
+
+function makeEntry(id: string): WorldBookEntry {
+  return {
+    id,
+    world_book_id: "book",
+    uid: id,
+    outlet_name: null,
+    wi_marker: null,
+    wi_marker_side: null,
+    key: [id],
+    keysecondary: [],
+    content: `content-${id}`,
+    comment: id,
+    position: 0,
+    depth: 4,
+    role: null,
+    order_value: 100,
+    selective: false,
+    constant: false,
+    disabled: false,
+    group_name: "",
+    group_override: false,
+    group_weight: 100,
+    probability: 100,
+    scan_depth: null,
+    case_sensitive: false,
+    match_whole_words: false,
+    automation_id: null,
+    use_regex: false,
+    prevent_recursion: true,
+    exclude_recursion: false,
+    delay_until_recursion: false,
+    priority: 10,
+    sticky: 0,
+    cooldown: 0,
+    delay: 0,
+    selective_logic: 0,
+    use_probability: true,
+    vectorized: false,
+    vector_index_status: "not_enabled",
+    vector_indexed_at: null,
+    vector_index_error: null,
+    extensions: {},
+    created_at: 0,
+    updated_at: 0,
+  };
+}
+
+const context = {
+  chatId: "chat",
+  characterId: "character",
+  messages: [],
+  chatTurn: 1,
+  chatMetadata: {},
+};
+
+describe("WorldInfoInterceptorChain activation capture", () => {
+  test("collects raw capture requests per extension without changing vote behavior", async () => {
+    const chain = new WorldInfoInterceptorChain();
+    chain.register({
+      extensionId: "one",
+      priority: 0,
+      handler: async () => ({
+        captured: ["a", "missing"],
+        disabled: ["a"],
+      }),
+    });
+    chain.register({
+      extensionId: "two",
+      priority: 1,
+      handler: async () => ({
+        captured: ["a", "b"],
+      }),
+    });
+
+    const result = await chain.run(
+      [makeEntry("a"), makeEntry("b")],
+      context,
+    );
+
+    expect(result.entries.map(({ id, disabled }) => ({ id, disabled }))).toEqual([
+      { id: "a", disabled: true },
+      { id: "b", disabled: false },
+    ]);
+    expect([...result.captureRequests.get("one")!]).toEqual(["a"]);
+    expect([...result.captureRequests.get("two")!]).toEqual(["a", "b"]);
+  });
+
+  test("retains an explicit empty request", async () => {
+    const chain = new WorldInfoInterceptorChain();
+    chain.register({
+      extensionId: "empty",
+      priority: 0,
+      handler: async () => ({ captured: [] }),
+    });
+
+    const result = await chain.run([makeEntry("a")], context);
+
+    expect(result.captureRequests.has("empty")).toBe(true);
+    expect([...result.captureRequests.get("empty")!]).toEqual([]);
+    expect(result.entries[0].disabled).toBe(false);
+  });
+});

--- a/src/spindle/world-info-interceptor.ts
+++ b/src/spindle/world-info-interceptor.ts
@@ -61,6 +61,12 @@ export interface WorldInfoInterceptorResultDTO {
   readonly enabled?: readonly string[];
   readonly forced?: readonly string[];
   readonly mutated?: readonly WorldInfoInterceptorMutationDTO[];
+  readonly captured?: readonly string[];
+}
+
+export interface WorldInfoInterceptorChainResult {
+  entries: WorldBookEntry[];
+  captureRequests: Map<string, Set<string>>;
 }
 
 export interface WorldInfoInterceptor {
@@ -72,7 +78,7 @@ export interface WorldInfoInterceptor {
   ) => Promise<WorldInfoInterceptorResultDTO | void>;
 }
 
-class WorldInfoInterceptorChain {
+export class WorldInfoInterceptorChain {
   private handlers: WorldInfoInterceptor[] = [];
 
   register(handler: WorldInfoInterceptor): () => void {
@@ -94,8 +100,10 @@ class WorldInfoInterceptorChain {
     ctx: Omit<WorldInfoInterceptorCtxDTO, "entries">,
     userId?: string | null,
     bookSourceMap?: ReadonlyMap<string, BookSource>
-  ): Promise<WorldBookEntry[]> {
-    if (this.handlers.length === 0) return [...entries];
+  ): Promise<WorldInfoInterceptorChainResult> {
+    if (this.handlers.length === 0) {
+      return { entries: [...entries], captureRequests: new Map() };
+    }
 
     const buildDto = (
       src: readonly WorldBookEntry[]
@@ -133,6 +141,8 @@ class WorldInfoInterceptorChain {
     const enabledByChain = new Set<string>();
     const forcedByChain = new Set<string>();
     const contentOverrides = new Map<string, string>();
+    const captureRequests = new Map<string, Set<string>>();
+    const candidateIds = new Set(entries.map((entry) => entry.id));
 
     let working: WorldBookEntry[] = [...entries];
 
@@ -162,6 +172,14 @@ class WorldInfoInterceptorChain {
         const enabledList = result?.enabled ?? [];
         const forcedList = result?.forced ?? [];
         const mutatedList = result?.mutated ?? [];
+        const capturedList = result?.captured;
+        if (capturedList !== undefined) {
+          const requested = captureRequests.get(handler.extensionId) ?? new Set<string>();
+          for (const id of capturedList) {
+            if (candidateIds.has(id)) requested.add(id);
+          }
+          captureRequests.set(handler.extensionId, requested);
+        }
         if (
           disabledList.length === 0 &&
           enabledList.length === 0 &&
@@ -189,7 +207,7 @@ class WorldInfoInterceptorChain {
       }
     }
 
-    return working;
+    return { entries: working, captureRequests };
   }
 
   get count(): number {


### PR DESCRIPTION
## Summary

Adds World Info activation capture to Spindle prompt assembly.

Extensions can identify the lorebook entries they care about during World Info interception. Lumiverse then determines which of those entries would have activated before extension changes were applied and returns the results only to the requesting extension.

This allows extensions such as LumiBooks to identify and replace the correct source messages without performing another expensive prompt assembly inside their three-second interceptor timeout.

Additional changes:

- Exposes source-message metadata only to extensions with `chat_mutation`.
- Prevents one extension from forging message provenance for another.
- Removes private fields before World Info results are sent to extensions.
- **Skips all vector-query preparation when no entries use vector matching.**
- **Reuses chat scans and vector-query work between activation passes.**
- **Limits how much plain chat text is processed for vector queries while preserving existing output.**
- **Stops processing repeated keyword matches after the first valid match.**
- Keeps capture randomness separate from normal activation and macros.
- Records timings for keyword matching, vector retrieval, merging, and capture.

Spindle: https://github.com/prolix-oc/lumiverse-spindle-types/pull/34

## Validation

Tests:
```text
bun test src/services/prompt-assembly-world-info-query.test.ts src/services/world-info-activation-scan-cache.test.ts src/spindle/world-info-capture.test.ts src/spindle/world-info-interceptor.test.ts src/spindle/source-message-metadata.test.ts

24 pass
0 fail
103 expect() calls
```

```text
bun test src/services/world-info-large-book.test.ts --test-name-pattern "world info RNG injection"

3 pass
32 filtered out
0 fail
13 expect() calls
```

Backend:
```text
bun test ./src

1334 pass
7 skip
7 fail
3402 expect() calls
Ran 1348 tests across 151 files. [10.65s]
```
7 failures pre-existing.

Typecheck:
```text
bun x tsc --noEmit
```

Frontend:

```text
cd frontend
bun run typecheck
bun run lint
```

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass.
  - Focused tests pass. The full suite retains seven unrelated platform-path failures described above.
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [x] Backend: `bun x tsc --noEmit`
    - The pinned TypeScript 5.9.3 and installed TypeScript 6 checks pass, but the exact unpinned command fails during Bun package bootstrap.
  - [x] Frontend: `cd frontend && bun run typecheck`, `bun run lint`

## UI changes (if applicable)

N/A

## Performance changes (if applicable)

- [x] I added or updated tests.
- [x] I included reproducible benchmarks and comparison results below.
- Benchmark commands and results:

Repeated-key regression:

```text
bun test src/services/world-info-activation-scan-cache.test.ts --test-name-pattern "saturates repeated shared-key outputs"

1 pass
0 fail
saturates repeated shared-key outputs after their first match [15.17ms]
```

This exercises 1,000 entries sharing one key against 100,000 occurrences. The test enforces a 1,000ms ceiling. Before saturation, the workload did not complete within 30 seconds.

Sanitizer comparison:

```powershell
$code = @'
import {
  __worldInfoVectorQueryTest,
  buildWorldInfoVectorQuery,
} from "./src/services/prompt-assembly.service.ts";

const content = "plain prose ".repeat(4_090_910);
const messages = [{
  id: "benchmark",
  chat_id: "benchmark",
  index: 0,
  is_user: true,
  name: "User",
  content,
  send_date: 0,
  extra: {},
}];

let started = performance.now();
const reference =
  await __worldInfoVectorQueryTest.buildReference(messages, null);
const referenceMs = performance.now() - started;

started = performance.now();
const bounded =
  await buildWorldInfoVectorQuery(messages, null, null);
const boundedMs = performance.now() - started;

console.log({
  inputChars: content.length,
  referenceMs,
  boundedMs,
  sameText: bounded.queryPreview === reference.text,
  sameTruncated:
    bounded.queryScope.tokenTruncated === reference.truncated,
  outputChars: bounded.queryPreview.length,
});
process.exit(0);
'@

bun -e $code
```

```text
Input:                 49,090,920 characters
**Historical sanitizer: 2,672.51ms
Bounded sanitizer:        7.01ms**
Output identical:      true
Truncation identical:  true
Output:                 24,000 characters
```

## Security-sensitive changes (if applicable)
This touches on spindle extension boundary, but nothing was added that could violate permission bypass, privilege escalation, cross-extension disclosure, provenance forgery, or private-data leakage.

## LLM-assisted work (if applicable)

- [x] I, as the human orchestrating this work, audited the submitted changes
      in a live environment.