### PR TITLE
Fix mobile Spindle widget scaling

### DIFF
--- a/frontend/src/components/spindle/SpindleFloatWidget.tsx
+++ b/frontend/src/components/spindle/SpindleFloatWidget.tsx
@@ -7,6 +7,7 @@ import ContextMenu, { type ContextMenuPos, type ContextMenuEntry } from '@/compo
 import { useLongPress } from '@/hooks/useLongPress'
 import { getLiveRootRecordExact } from '@/lib/spindle/live-root-registry'
 import { scheduleSpindleDomTask } from '@/lib/spindle/browser-scheduler'
+import { resolveFloatWidgetStyle } from './spindle-float-widget-layout'
 import styles from './SpindleFloatWidget.module.css'
 
 interface Props {
@@ -162,9 +163,7 @@ export default function SpindleFloatWidget({ widget }: Props) {
 
   if (!widget.visible) return null
 
-  const widgetStyle = isFullscreen
-    ? { left: 0, top: 0, width: window.innerWidth, height: window.innerHeight }
-    : { left: pos.x, top: pos.y, width: size.width, height: size.height }
+  const widgetStyle = resolveFloatWidgetStyle(isFullscreen, pos, size)
 
   return (
     <>

--- a/frontend/src/components/spindle/spindle-float-widget-layout.test.ts
+++ b/frontend/src/components/spindle/spindle-float-widget-layout.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test'
+import { FULLSCREEN_FLOAT_WIDGET_STYLE, resolveFloatWidgetStyle } from './spindle-float-widget-layout'
+
+describe('Spindle float widget layout', () => {
+  test('uses scale-compensated viewport dimensions in fullscreen mode', () => {
+    expect(resolveFloatWidgetStyle(true, { x: 24, y: 96 }, { width: 40, height: 40 })).toEqual({
+      left: 0,
+      top: 0,
+      width: 'var(--app-scaled-viewport-width, calc(100vw / var(--lumiverse-ui-scale, 1)))',
+      height: 'var(--app-scaled-viewport-height, calc(100vh / var(--lumiverse-ui-scale, 1)))',
+    })
+    expect(FULLSCREEN_FLOAT_WIDGET_STYLE.width).not.toContain('window.innerWidth')
+    expect(FULLSCREEN_FLOAT_WIDGET_STYLE.height).not.toContain('window.innerHeight')
+  })
+
+  test('preserves pixel positioning for regular draggable widgets', () => {
+    expect(resolveFloatWidgetStyle(false, { x: 24, y: 96 }, { width: 320, height: 148 })).toEqual({
+      left: 24,
+      top: 96,
+      width: 320,
+      height: 148,
+    })
+  })
+})

--- a/frontend/src/components/spindle/spindle-float-widget-layout.ts
+++ b/frontend/src/components/spindle/spindle-float-widget-layout.ts
@@ -1,0 +1,23 @@
+import type { CSSProperties } from 'react'
+
+export const FULLSCREEN_FLOAT_WIDGET_STYLE = {
+  left: 0,
+  top: 0,
+  width: 'var(--app-scaled-viewport-width, calc(100vw / var(--lumiverse-ui-scale, 1)))',
+  height: 'var(--app-scaled-viewport-height, calc(100vh / var(--lumiverse-ui-scale, 1)))',
+} satisfies CSSProperties
+
+export function resolveFloatWidgetStyle(
+  fullscreen: boolean,
+  position: { x: number; y: number },
+  size: { width: number; height: number },
+): CSSProperties {
+  if (fullscreen) return FULLSCREEN_FLOAT_WIDGET_STYLE
+
+  return {
+    left: position.x,
+    top: position.y,
+    width: size.width,
+    height: size.height,
+  }
+}


### PR DESCRIPTION
## Summary

Fixed fullscreen Spindle float widgets under scaled UI settings. Fullscreen dimensions now use scale-aware CSS viewport variables instead of raw browser pixel dimensions, while regular draggable widgets retain their existing pixel-based positioning. Added focused regression coverage for both fullscreen and regular widget layouts

## Validation

```
git diff --check
PASS

git fetch --no-tags upstream staging
git merge-base --is-ancestor upstream/staging HEAD
PASS — be130430 contains the latest upstream/staging commit.

bun install --frozen-lockfile
PASS — dependencies restored without lockfile changes.

bun x tsc --noEmit
PASS — no backend type errors or warnings.

cd frontend && bun run typecheck
PASS — no frontend type errors or warnings.

cd frontend && bun run lint
PASS — ESLint completed successfully.

bun test frontend/src/components/spindle/spindle-float-widget-layout.test.ts
PASS in a clean local clone:
2 pass
0 fail
4 expect() calls
```

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass.
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [x] Backend: `bun x tsc --noEmit`
  - [x] Frontend: `cd frontend && bun run typecheck`, `bun run lint`

## UI changes (if applicable)

- [x] I validated this change in more than one browser.
- [x] I verified the integrated experience on a mobile interface or through
      the mobile PWA.
- Browsers, devices, and PWA coverage:

## Performance changes (if applicable)

- [x] I added or updated tests.
- [ ] I included reproducible benchmarks and comparison results below.
- Benchmark commands and results:

## Security-sensitive changes (if applicable)

No security-sensitive impact. This is a client-side layout change for the Spindle float widget and does not modify authentication, authorization, sandboxing, iframe isolation, data handling, or backend behavior. A separate security audit is not required.

## LLM-assisted work (if applicable)

- [x] I, as the human orchestrating this work, audited the submitted changes
      in a live environment.