### PR TITLE
Spindle world info and runtime hooks

### DIFF
--- a/developer-docs/docs/backend-api/macro-interceptor.md
+++ b/developer-docs/docs/backend-api/macro-interceptor.md
@@ -37,6 +37,12 @@ interface MacroInterceptorCtx {
 
 `env` is a structured-clone snapshot. Persist state via `spindle.variables.*`, not the snapshot.
 
+`env.character.firstMessage` is the selected greeting stored in the chat, including edits.
+
+`env.character.alternateGreetings` contains the card's alternate greetings.
+
+`env.chat.greetingIndex` is `0` for the default greeting, `1` for the first alternate, and so on.
+
 `env.dynamicMacros` carries per-call macro overrides supplied by the caller (`Record<string, string>`). The display-regex pipeline (`phase: "display"`) sets `chat_index` to the rendered message's index in the chat, which lets handlers compute per-message context that registered macros cannot reach on their own. Other callers may set additional fields.
 
 ## Composition Order

--- a/developer-docs/docs/backend-api/message-content-processor.md
+++ b/developer-docs/docs/backend-api/message-content-processor.md
@@ -30,6 +30,7 @@ interface MessageContentProcessorCtx {
   chatId: string
   messageId?: string                              // undefined for "create"
   content: string
+  isUser: boolean                                 // true for a user-authored row
   extra?: Record<string, unknown>                 // populated with { role, is_user } for "render"
   origin: "create" | "update" | "swipe_add" | "swipe_update" | "render"
   swipeIndex?: number                             // set for "swipe_update"

--- a/developer-docs/docs/backend-api/world-books.md
+++ b/developer-docs/docs/backend-api/world-books.md
@@ -143,6 +143,7 @@ const entryDeleted = await spindle.world_books.entries.delete(newEntry.id)
   group_weight: number         // weight for group selection
   probability: number          // activation probability (0-100)
   scan_depth: number | null    // how many messages to scan for keywords
+  exclude_greeting: boolean    // exclude the opening greeting from keyword scans
   case_sensitive: boolean      // case-sensitive keyword matching
   match_whole_words: boolean   // match whole words only
   automation_id: string | null // automation identifier
@@ -178,6 +179,7 @@ All fields are optional. Common fields you'll typically set:
 | `selective` | `boolean` | Require secondary keys to also match |
 | `constant` | `boolean` | Always active regardless of keywords |
 | `disabled` | `boolean` | Disable this entry |
+| `exclude_greeting` | `boolean` | Exclude the opening greeting from keyword scans |
 | `order_value` | `number` | Sort order within position bucket (default 100) |
 | `priority` | `number` | Activation priority (default 10) |
 

--- a/developer-docs/docs/backend-api/world-info-interceptor.md
+++ b/developer-docs/docs/backend-api/world-info-interceptor.md
@@ -36,6 +36,10 @@ interface WorldInfoInterceptorCtx {
   messages: WorldInfoInterceptorMessage[]
   chatTurn: number
   chatMetadata: Record<string, unknown>
+  activationSettings: {
+    globalScanDepth: number | null
+    maxRecursionPasses: number
+  }
 }
 
 interface WorldInfoInterceptorEntry {
@@ -63,6 +67,7 @@ interface WorldInfoInterceptorEntry {
   prevent_recursion: boolean
   exclude_recursion: boolean
   delay_until_recursion: boolean
+  exclude_greeting: boolean
   scan_depth: number | null
   order_value: number
   // Which attachment scope contributed the entry's book to this chat.
@@ -86,6 +91,8 @@ interface WorldInfoInterceptorMessage {
 
 `chatMetadata` is the chat-level metadata blob. Persist cross-turn state here via `spindle.chats.update`; the snapshot is read-only.
 
+`activationSettings` contains the host scan depth and recursion limit for this prompt. A null scan depth uses all available messages. A recursion limit of `0` disables recursion.
+
 ## Return Value
 
 ```ts
@@ -93,18 +100,27 @@ interface WorldInfoInterceptorResult {
   disabled?: string[]
   enabled?: string[]
   forced?: string[]
-  mutated?: { id: string; content?: string }[]
+  mutated?: {
+    id: string
+    content?: string
+    selectionContent?: string
+  }[]
+  activationOverrides?: {
+    disableRecursion?: true
+  }
 }
 ```
 
-Return `void` (or omit all arrays) for a no-op pass-through. The four axes are independent:
+Return `void` or omit all fields for a no-op pass-through. The fields are independent:
 
 | Field | Effect |
 | --- | --- |
 | `disabled` | Forces `disabled: true`. Wins against any `enabled`/`forced` vote anywhere in the chain. |
 | `enabled` | Un-flips a stored `disabled: true`. No effect on entries already enabled or on entries any handler voted to disable. |
 | `forced` | Sets `constant: true` for this turn (activates regardless of key match). No effect if any handler voted to disable. Independent of `enabled`. To force a stored-disabled entry, vote both `enabled` and `forced`. |
-| `mutated` | Replaces `content` for this turn only; the stored entry is unchanged. Applies regardless of activation state. |
+| `mutated.content` | Replaces the content inserted for this prompt. The stored entry is unchanged. |
+| `mutated.selectionContent` | Replaces content only for selection, duplicate checks, and token limits. |
+| `activationOverrides.disableRecursion` | Disables recursive activation for this prompt. |
 
 Mutating an entry that another interceptor disabled is allowed but inert.
 
@@ -114,7 +130,9 @@ Multiple interceptors run in priority order (lower first), with registration ord
 
 Vote-off precedence is the chain's invariant: once any handler votes `disabled` for an entry, no later handler's `enabled` or `forced` can revive it. This makes per-handler reasoning order-independent on the disable axis.
 
-Content overrides accumulate last-write-wins: if two handlers set `content` for the same entry, the higher-priority handler (later in the chain) wins.
+Content and selection overrides use the last value returned for each entry.
+
+After one interceptor disables recursion, later interceptors receive `maxRecursionPasses: 0`.
 
 ## Permission Scope
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
     "i18next": "^26.2.0",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^0.468.0",
-    "lumiverse-spindle-types": "0.6.9",
+    "lumiverse-spindle-types": "0.6.10",
     "marked": "^15.0.4",
     "motion": "^12.0.0",
     "react": "^19.2.6",

--- a/frontend/src/components/shared/WorldBookEntryEditor.tsx
+++ b/frontend/src/components/shared/WorldBookEntryEditor.tsx
@@ -313,6 +313,11 @@ export default function WorldBookEntryEditor({ entry, onUpdate, onImmediateUpdat
             label={t('toggles.matchWholeWords')}
           />
           <Toggle.Checkbox
+            checked={entry.exclude_greeting}
+            onChange={() => onImmediateUpdate(entry.id, { exclude_greeting: !entry.exclude_greeting })}
+            label={t('toggles.excludeGreeting')}
+          />
+          <Toggle.Checkbox
             checked={entry.use_regex}
             onChange={() => onImmediateUpdate(entry.id, { use_regex: !entry.use_regex })}
             label={t('toggles.useRegex')}

--- a/frontend/src/hooks/useDisplayRegex.ts
+++ b/frontend/src/hooks/useDisplayRegex.ts
@@ -31,6 +31,9 @@ interface DisplayRegexContentCacheEntry {
 export interface DisplayPreprocessOpts {
   messageId: string
   role: 'user' | 'assistant' | 'system'
+  depth?: number
+  messageIndex?: number
+  dynamicMacros?: Record<string, string>
 }
 
 interface ResolvedTemplatesState {
@@ -54,6 +57,9 @@ interface DisplayPreprocessBody {
   messageId: string
   role: string
   rawContent: string
+  depth?: number
+  messageIndex?: number
+  dynamicMacros?: Record<string, string>
 }
 
 interface DisplayPreprocessOutcome {
@@ -223,9 +229,11 @@ function fetchDisplayPreprocess(chatId: string, body: DisplayPreprocessBody): Pr
           context: {
             chatId,
             isUser: body.role === 'user',
-            depth: 0,
+            depth: body.depth ?? 0,
             messageId: body.messageId,
             role: body.role,
+            ...(typeof body.messageIndex === 'number' ? { messageIndex: body.messageIndex } : {}),
+            ...(body.dynamicMacros ? { dynamicMacros: body.dynamicMacros } : {}),
           },
         })
         .then((local) => {
@@ -267,8 +275,8 @@ function useDisplayPreprocessedState(
 
   const key = useMemo(() => {
     if (!opts?.messageId || !chatId) return null
-    return `${chatId}|${opts.messageId}|${opts.role}|${content.length}|${fnv1a(content)}`
-  }, [content, opts?.messageId, opts?.role, chatId])
+    return `${chatId}|${opts.messageId}|${opts.role}|${opts.depth ?? 0}|${opts.messageIndex ?? -1}|${JSON.stringify(opts.dynamicMacros ?? {})}|${content.length}|${fnv1a(content)}`
+  }, [content, opts?.messageId, opts?.role, opts?.depth, opts?.messageIndex, opts?.dynamicMacros, chatId])
 
   const cached = key ? displayPreprocessCache.get(key)?.value : undefined
   const [state, setState] = useState<{ key: string; value: string; ok: boolean } | null>(() =>
@@ -300,6 +308,9 @@ function useDisplayPreprocessedState(
         messageId: opts.messageId,
         role: opts.role,
         rawContent: content,
+        ...(typeof opts.depth === 'number' ? { depth: opts.depth } : {}),
+        ...(typeof opts.messageIndex === 'number' ? { messageIndex: opts.messageIndex } : {}),
+        ...(opts.dynamicMacros ? { dynamicMacros: opts.dynamicMacros } : {}),
       })
         .then((next) => {
           if (displayPreprocessCache.get(key)?.promise === assignedPromise) {
@@ -330,7 +341,17 @@ function useDisplayPreprocessedState(
     }
     displayPreprocessCache.get(key)?.promise?.then(apply)
     return () => { cancelled = true }
-  }, [key, opts?.messageId, opts?.role, chatId, content, cvSnapshot])
+  }, [
+    key,
+    opts?.messageId,
+    opts?.role,
+    opts?.depth,
+    opts?.messageIndex,
+    opts?.dynamicMacros,
+    chatId,
+    content,
+    cvSnapshot,
+  ])
 
   if (!key) return { value: content, ready: true }
   if (cached !== undefined) return { value: cached, ready: true }
@@ -509,7 +530,22 @@ export function useDisplayRegex(
   }, [messageIndex])
   const macroCharacterId = activeGroupCharacterId ?? activeCharacterId
 
-  const { value: content, ready: preprocessReady } = useDisplayPreprocessedState(rawContent, activeChatId, preprocessOpts)
+  const displayPreprocessOpts = useMemo(
+    () => preprocessOpts
+      ? {
+          ...preprocessOpts,
+          depth,
+          ...(messageIndex >= 0 ? { messageIndex } : {}),
+          ...(dynamicMacros ? { dynamicMacros } : {}),
+        }
+      : undefined,
+    [preprocessOpts, depth, messageIndex, dynamicMacros],
+  )
+  const { value: content, ready: preprocessReady } = useDisplayPreprocessedState(
+    rawContent,
+    activeChatId,
+    displayPreprocessOpts,
+  )
   const pendingSlowReportsRef = useRef<SlowRegexReport[]>([])
 
   // When an extension owns display, regex runs on preprocessed content only.

--- a/frontend/src/hooks/useDisplayRegex.ts
+++ b/frontend/src/hooks/useDisplayRegex.ts
@@ -548,8 +548,9 @@ export function useDisplayRegex(
   )
   const pendingSlowReportsRef = useRef<SlowRegexReport[]>([])
 
+  const displayOwned = !!activeChatId && isDisplayChatOwned(activeChatId)
   // When an extension owns display, regex runs on preprocessed content only.
-  const regexGated = !!activeChatId && isDisplayChatOwned(activeChatId) && !preprocessReady
+  const regexGated = displayOwned && !preprocessReady
 
   const displayScripts = useMemo(
     () =>
@@ -723,10 +724,10 @@ export function useDisplayRegex(
   }, [fallbackContent])
 
   const hasAsyncMacroScripts = useMemo(
-    () => displayScripts.some(
+    () => displayOwned || displayScripts.some(
       (s) => s.substitute_macros === 'raw' || s.substitute_macros === 'after',
     ),
-    [displayScripts],
+    [displayOwned, displayScripts],
   )
 
   const resolvedTemplateKey = useMemo(

--- a/frontend/src/i18n/locales/en/panels.json
+++ b/frontend/src/i18n/locales/en/panels.json
@@ -1724,6 +1724,7 @@
         "disabled": "Disabled",
         "caseSensitive": "Case Sensitive",
         "matchWholeWords": "Match Whole Words",
+        "excludeGreeting": "Exclude Greeting",
         "useRegex": "Use Regex",
         "useProbability": "Use Probability",
         "vectorized": "Vectorized",

--- a/frontend/src/i18n/locales/fr/panels.json
+++ b/frontend/src/i18n/locales/fr/panels.json
@@ -1577,6 +1577,7 @@
         "disabled": "Désactivé",
         "caseSensitive": "Sensible aux majuscules et minuscules",
         "matchWholeWords": "Faire correspondre des mots entiers",
+        "excludeGreeting": "Exclure le message d'accueil",
         "useRegex": "Utiliser Regex",
         "useProbability": "Utiliser Probabilité",
         "vectorized": "Vectorisé",

--- a/frontend/src/i18n/locales/it/panels.json
+++ b/frontend/src/i18n/locales/it/panels.json
@@ -1578,6 +1578,7 @@
         "disabled": "Disabilitato",
         "caseSensitive": "Sensitive case",
         "matchWholeWords": "Corrispondenza parole intere",
+        "excludeGreeting": "Escludi il messaggio di saluto",
         "useRegex": "Usa Regex",
         "useProbability": "Usa probabilità",
         "vectorized": "Vettorizzato",

--- a/frontend/src/i18n/locales/ja/panels.json
+++ b/frontend/src/i18n/locales/ja/panels.json
@@ -1577,6 +1577,7 @@
         "disabled": "無効",
         "caseSensitive": "大文字と小文字を区別",
         "matchWholeWords": "単語全体と一致",
+        "excludeGreeting": "挨拶メッセージを除外",
         "useRegex": "正規表現を使用する",
         "useProbability": "確率を使用",
         "vectorized": "ベクトル化",

--- a/frontend/src/i18n/locales/zh-TW/panels.json
+++ b/frontend/src/i18n/locales/zh-TW/panels.json
@@ -1577,6 +1577,7 @@
         "disabled": "已禁用",
         "caseSensitive": "區分大小寫",
         "matchWholeWords": "整詞匹配",
+        "excludeGreeting": "排除問候訊息",
         "useRegex": "使用正則",
         "useProbability": "使用概率",
         "vectorized": "向量化",

--- a/frontend/src/i18n/locales/zh/panels.json
+++ b/frontend/src/i18n/locales/zh/panels.json
@@ -1577,6 +1577,7 @@
         "disabled": "已禁用",
         "caseSensitive": "区分大小写",
         "matchWholeWords": "整词匹配",
+        "excludeGreeting": "排除问候消息",
         "useRegex": "使用正则",
         "useProbability": "使用概率",
         "vectorized": "向量化",

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -855,6 +855,7 @@ export interface WorldBookEntry {
   group_weight: number;
   probability: number;
   scan_depth: number | null;
+  exclude_greeting: boolean;
   case_sensitive: boolean;
   match_whole_words: boolean;
   automation_id: string | null;
@@ -1082,6 +1083,7 @@ export interface CreateWorldBookEntryInput {
   group_weight?: number;
   probability?: number;
   scan_depth?: number;
+  exclude_greeting?: boolean;
   case_sensitive?: boolean;
   match_whole_words?: boolean;
   automation_id?: string;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "hono": "^4.7.0",
     "js-tiktoken": "^1.0.16",
     "jsdom": "^29.0.1",
-    "lumiverse-spindle-types": "0.6.9",
+    "lumiverse-spindle-types": "0.6.10",
     "mute-stream": "^3.0.0",
     "sharp": "^0.34.5",
     "ssh2-sftp-client": "^12.1.1"

--- a/src/db/migrations/098_world_book_entry_exclude_greeting.sql
+++ b/src/db/migrations/098_world_book_entry_exclude_greeting.sql
@@ -1,0 +1,1 @@
+ALTER TABLE world_book_entries ADD COLUMN exclude_greeting INTEGER NOT NULL DEFAULT 0;

--- a/src/macros/MacroEnv.test.ts
+++ b/src/macros/MacroEnv.test.ts
@@ -124,6 +124,56 @@ describe("buildEnv firstMessage", () => {
 
     expect(env.character.firstMessage).toBe("Group greeting");
   });
+
+  test("exposes the selected greeting identity without matching message text", () => {
+    const env = buildEnv({
+      character: {
+        ...baseCharacter,
+        alternate_greetings: ["Alternate one", "Alternate two"],
+      },
+      persona: null,
+      chat: {
+        ...baseChat,
+        metadata: { activeGreetingIndex: 2 },
+      },
+      messages: [
+        makeMessage({
+          content: "Edited selected greeting",
+          extra: { greeting: true, greeting_index: 0 },
+        }),
+      ],
+      generationType: "normal",
+      connection: null,
+    });
+
+    expect(env.character.firstMessage).toBe("Edited selected greeting");
+    expect(env.character.alternateGreetings).toEqual([
+      "Alternate one",
+      "Alternate two",
+    ]);
+    expect(env.chat.greetingIndex).toBe(2);
+  });
+
+  test("falls back to the persisted greeting message index", () => {
+    const env = buildEnv({
+      character: {
+        ...baseCharacter,
+        alternate_greetings: ["Alternate one"],
+      },
+      persona: null,
+      chat: baseChat,
+      messages: [
+        makeMessage({
+          content: "Alternate one",
+          extra: { greeting: true, greeting_index: 1 },
+        }),
+      ],
+      generationType: "normal",
+      connection: null,
+    });
+
+    expect(env.chat.greetingIndex).toBe(1);
+  });
 });
 
 describe("buildEnv persona pronouns", () => {

--- a/src/macros/MacroEnv.ts
+++ b/src/macros/MacroEnv.ts
@@ -121,6 +121,7 @@ export function buildEnv(ctx: BuildEnvContext): MacroEnv {
       version: (character.extensions?.version as string) || "",
       creator: character.creator || "",
       firstMessage: resolveChatGreeting(character, chat, messages),
+      alternateGreetings: [...(character.alternate_greetings || [])],
     },
     chat: {
       id: chat.id,
@@ -134,6 +135,7 @@ export function buildEnv(ctx: BuildEnvContext): MacroEnv {
       lastSwipeId: lastMsg?.swipes ? lastMsg.swipes.length - 1 : 0,
       currentSwipeId: lastMsg?.swipe_id ?? 0,
       rejectedSwipe: ctx.rejectedSwipe ?? "",
+      greetingIndex: resolveChatGreetingIndex(character, chat, messages),
     },
     system: {
       model: connection?.model || "",
@@ -254,6 +256,29 @@ function resolveChatGreeting(character: Character, chat: Chat, messages: Message
   if (openingMessage && !openingMessage.is_user) return openingMessage.content;
 
   return character.first_mes || "";
+}
+
+function resolveChatGreetingIndex(
+  character: Character,
+  chat: Chat,
+  messages: Message[],
+): number {
+  const metadataIndex = chat.metadata?.activeGreetingIndex;
+  if (Number.isInteger(metadataIndex) && metadataIndex >= 0) {
+    return metadataIndex;
+  }
+
+  const taggedGreeting = chat.metadata?.group
+    ? messages.find((message) =>
+        !message.is_user
+        && message.extra?.greeting === true
+        && message.extra?.greeting_character_id === character.id,
+      )
+    : messages.find((message) =>
+        !message.is_user && message.extra?.greeting === true,
+      );
+  const storedIndex = taggedGreeting?.extra?.greeting_index;
+  return Number.isInteger(storedIndex) && storedIndex >= 0 ? storedIndex : 0;
 }
 
 export function mergeDynamicMacros(

--- a/src/macros/definitions/persona-card.ts
+++ b/src/macros/definitions/persona-card.ts
@@ -1,7 +1,12 @@
 import { registry } from "../MacroRegistry";
 
 function getFocusedCharacterField(
-  ctx: { env: { extra?: Record<string, any>; character: Record<string, string> } },
+  ctx: {
+    env: {
+      extra?: Record<string, any>;
+      character: { description: string; personality: string };
+    };
+  },
   field: "description" | "personality",
 ): string {
   const focused = ctx.env.extra?.groupFocusedCharacter as

--- a/src/macros/types.ts
+++ b/src/macros/types.ts
@@ -175,6 +175,8 @@ export interface MacroEnv {
     version: string;
     creator: string;
     firstMessage: string;
+    /** Card-defined alternatives, excluding the default first message. */
+    alternateGreetings?: string[];
   };
   chat: {
     id: string;
@@ -188,6 +190,8 @@ export interface MacroEnv {
     lastSwipeId: number;
     currentSwipeId: number;
     rejectedSwipe: string;
+    /** Selected index in [default greeting, ...alternate greetings]. */
+    greetingIndex?: number;
   };
   system: {
     model: string;

--- a/src/routes/chats.routes.ts
+++ b/src/routes/chats.routes.ts
@@ -47,6 +47,7 @@ async function processChatGreeting(userId: string, chat: { id: string }) {
     chatId: chat.id,
     messageId: greeting.id,
     content: greeting.content,
+    isUser: false,
     extra: greeting.extra,
     origin: "create",
     userId,
@@ -102,6 +103,7 @@ async function runDisplayPreprocessItem(
     ? await messageContentProcessorChain.run({
         chatId,
         content: item.rawContent,
+        isUser: item.role === "user",
         origin: "render",
         userId,
         ...(item.messageId ? { messageId: item.messageId } : {}),
@@ -742,7 +744,14 @@ app.post("/:chatId/messages", async (c) => {
   }
 
   const processed = await runMessageContentProcessors(
-    { chatId, content: body.content, extra: body.extra, origin: "create", userId },
+    {
+      chatId,
+      content: body.content,
+      isUser: body.is_user === true,
+      extra: body.extra,
+      origin: "create",
+      userId,
+    },
     userId,
     c.req.raw.signal,
   );
@@ -894,11 +903,13 @@ app.put("/:chatId/messages/:id", async (c) => {
   const body = await c.req.json();
 
   if (body.content !== undefined) {
+    const existing = svc.getMessage(userId, messageId);
     const processed = await runMessageContentProcessors(
       {
         chatId,
         messageId,
         content: body.content,
+        isUser: existing?.is_user === true,
         extra: body.extra,
         origin: "update",
         userId,
@@ -916,7 +927,6 @@ app.put("/:chatId/messages/:id", async (c) => {
         chatId,
       });
       if (editScripts.length > 0) {
-        const existing = svc.getMessage(userId, messageId);
         const placement = existing?.is_user ? "user_input" as const : "ai_output" as const;
         body.content = await regexScriptsSvc.applyRegexScripts(
           body.content,
@@ -966,11 +976,13 @@ app.post("/:chatId/messages/:id/swipe", async (c) => {
   if (body.direction === "left" || body.direction === "right") {
     msg = svc.cycleSwipe(userId, messageId, body.direction);
   } else if (body.content !== undefined) {
+    const existing = svc.getMessage(userId, messageId);
     const processed = await runMessageContentProcessors(
       {
         chatId,
         messageId,
         content: body.content,
+        isUser: existing?.is_user === true,
         origin: "swipe_add",
         userId,
       },
@@ -993,12 +1005,14 @@ app.put("/:chatId/messages/:id/swipe/:idx", async (c) => {
   const body = await c.req.json();
   if (body.content === undefined) return c.json({ error: "content is required" }, 400);
   const idx = parseInt(c.req.param("idx"), 10);
+  const existing = svc.getMessage(userId, messageId);
 
   const processed = await runMessageContentProcessors(
     {
       chatId,
       messageId,
       content: body.content,
+      isUser: existing?.is_user === true,
       origin: "swipe_update",
       swipeIndex: idx,
       userId,
@@ -1015,7 +1029,6 @@ app.put("/:chatId/messages/:id/swipe/:idx", async (c) => {
       chatId,
     });
     if (editScripts.length > 0) {
-      const existing = svc.getMessage(userId, messageId);
       const placement = existing?.is_user ? "user_input" as const : "ai_output" as const;
       finalContent = await regexScriptsSvc.applyRegexScripts(
         finalContent,

--- a/src/services/chats.service.test.ts
+++ b/src/services/chats.service.test.ts
@@ -3,6 +3,7 @@ import { closeDatabase, getDb, initDatabase } from "../db/connection";
 import {
   addSwipe,
   convertSoloChatToGroup,
+  createChat,
   deleteChats,
   getChat,
   cycleSwipe,
@@ -153,6 +154,28 @@ beforeEach(() => {
 
 afterEach(() => {
   closeDatabase();
+});
+
+describe("chat greeting selection", () => {
+  test("persists the selected greeting index on the chat and greeting message", () => {
+    getDb()
+      .query("UPDATE characters SET first_mes = ?, alternate_greetings = ? WHERE id = ?")
+      .run(
+        "Default greeting",
+        JSON.stringify(["Alternate one", "Alternate two"]),
+        "c1",
+      );
+
+    const chat = createChat("u1", {
+      character_id: "c1",
+      greeting_index: 2,
+    });
+    const greeting = getMessages("u1", chat.id)[0];
+
+    expect(chat.metadata.activeGreetingIndex).toBe(2);
+    expect(greeting?.content).toBe("Alternate two");
+    expect(greeting?.extra.greeting_index).toBe(2);
+  });
 });
 
 describe("chat message search", () => {

--- a/src/services/chats.service.ts
+++ b/src/services/chats.service.ts
@@ -1002,6 +1002,15 @@ export function getChat(userId: string, id: string): Chat | null {
 export function createChat(userId: string, input: CreateChatInput): Chat {
   const id = crypto.randomUUID();
   const now = Math.floor(Date.now() / 1000);
+  const requestedGreetingIndex = input.greeting_index
+    ?? input.metadata?.activeGreetingIndex;
+  const greetingIndex =
+    Number.isInteger(requestedGreetingIndex) && requestedGreetingIndex >= 0
+      ? requestedGreetingIndex
+      : 0;
+  const metadata = input.character_id
+    ? { ...(input.metadata || {}), activeGreetingIndex: greetingIndex }
+    : (input.metadata || {});
 
   // Auto-name with character name
   let chatName = input.name || "";
@@ -1012,14 +1021,14 @@ export function createChat(userId: string, input: CreateChatInput): Chat {
 
   getDb()
     .query("INSERT INTO chats (id, user_id, character_id, name, metadata, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)")
-    .run(id, userId, input.character_id ?? null, chatName, JSON.stringify(input.metadata || {}), now, now);
+    .run(id, userId, input.character_id ?? null, chatName, JSON.stringify(metadata), now, now);
 
   // Insert the character's greeting as the opening message
   const character = input.character_id ? getCharacter(userId, input.character_id) : null;
   if (character) {
     let greeting = character.first_mes;
-    if (input.greeting_index && input.greeting_index >= 1 && character.alternate_greetings?.length) {
-      const altIdx = input.greeting_index - 1;
+    if (greetingIndex >= 1 && character.alternate_greetings?.length) {
+      const altIdx = greetingIndex - 1;
       if (altIdx < character.alternate_greetings.length) {
         greeting = character.alternate_greetings[altIdx];
       }
@@ -1032,7 +1041,7 @@ export function createChat(userId: string, input: CreateChatInput): Chat {
         extra: {
           greeting: true,
           greeting_character_id: character.id,
-          greeting_index: input.greeting_index ?? 0,
+          greeting_index: greetingIndex,
         },
       }, userId);
     }

--- a/src/services/display-regex.service.ts
+++ b/src/services/display-regex.service.ts
@@ -237,6 +237,7 @@ export async function applyDisplayRegex(input: ApplyDisplayRegexInput): Promise<
         {
           chatId: input.context.chat_id,
           content,
+          isUser: input.context.is_user,
           origin: "render",
           userId: input.userId,
           ...(input.context.message_id ? { messageId: input.context.message_id } : {}),

--- a/src/services/embeddings-world-book-index-race.test.ts
+++ b/src/services/embeddings-world-book-index-race.test.ts
@@ -29,6 +29,7 @@ function makeEntry(overrides: Partial<WorldBookEntry> = {}): WorldBookEntry {
     group_weight: 100,
     probability: 100,
     scan_depth: null,
+    exclude_greeting: false,
     case_sensitive: false,
     match_whole_words: false,
     automation_id: null,

--- a/src/services/prompt-assembly-outlets.test.ts
+++ b/src/services/prompt-assembly-outlets.test.ts
@@ -100,6 +100,7 @@ function makeEntry(partial: Partial<WorldBookEntry>): WorldBookEntry {
     group_weight: 0,
     probability: 100,
     scan_depth: null,
+    exclude_greeting: false,
     case_sensitive: false,
     match_whole_words: false,
     automation_id: null,

--- a/src/services/prompt-assembly-vector-cache.test.ts
+++ b/src/services/prompt-assembly-vector-cache.test.ts
@@ -35,6 +35,7 @@ function entry(overrides: Partial<WorldBookEntry> = {}): WorldBookEntry {
     group_weight: 100,
     probability: 100,
     scan_depth: null,
+    exclude_greeting: false,
     case_sensitive: false,
     match_whole_words: false,
     automation_id: null,

--- a/src/services/prompt-assembly.service.ts
+++ b/src/services/prompt-assembly.service.ts
@@ -1812,6 +1812,7 @@ export async function assemblePrompt(
       chatTurn: messages.length,
       chatMetadata: chat.metadata ?? {},
       activationSettings: {
+        globalScanDepth: normalizedWorldInfoSettings.globalScanDepth,
         maxRecursionPasses: normalizedWorldInfoSettings.maxRecursionPasses,
       },
     },

--- a/src/services/prompt-assembly.service.ts
+++ b/src/services/prompt-assembly.service.ts
@@ -1850,6 +1850,7 @@ export async function assemblePrompt(
       wiState,
       settings: worldInfoSettings,
       scanCache: activationScanCache,
+      selectionContentByEntryId: interception.selectionContentByEntryId,
     }),
   );
 
@@ -1962,6 +1963,8 @@ export async function assemblePrompt(
       worldInfoSettings,
       wiSources.bookSourceMap,
       wiSources.bookNameMap,
+      undefined,
+      interception.selectionContentByEntryId,
     ),
   );
   const wiCache = mergedWorldInfo.cache;
@@ -4201,6 +4204,7 @@ export function selectMergedWorldInfoEntries(
   settingsInput?: Partial<WorldInfoSettings>,
   bookSourceMap?: Map<string, BookSource>,
   random?: () => number,
+  selectionContentByEntryId?: ReadonlyMap<string, string>,
 ): WorldInfoMergeSelection {
   const settings = normalizeWorldInfoSettings(settingsInput);
   const mergedEntries: WorldBookEntryModel[] = [];
@@ -4236,7 +4240,24 @@ export function selectMergedWorldInfoEntries(
     sources.set(item.entry.id, { source: "vector", score: item.finalScore });
   }
 
-  const dedupResult = deduplicateWorldInfoEntries(mergedEntries, sources, bookSourceMap);
+  const entriesForDedup = selectionContentByEntryId?.size
+    ? mergedEntries.map((entry) => {
+        const content = selectionContentByEntryId.get(entry.id);
+        return content === undefined ? entry : { ...entry, content };
+      })
+    : mergedEntries;
+  const selectedDedupResult = deduplicateWorldInfoEntries(
+    entriesForDedup,
+    sources,
+    bookSourceMap,
+  );
+  const mergedEntryById = new Map(mergedEntries.map((entry) => [entry.id, entry]));
+  const dedupResult = {
+    ...selectedDedupResult,
+    entries: selectedDedupResult.entries.map(
+      (entry) => mergedEntryById.get(entry.id) ?? entry,
+    ),
+  };
   for (const removed of dedupResult.removed) {
     sources.delete(removed.removedEntryId);
     if (vectorEntryIds.has(removed.removedEntryId)) {
@@ -4301,6 +4322,7 @@ export function selectMergedWorldInfoEntries(
     skipGroupLogic: true,
     preserveOrder: !hasBudget,
     budgetPriorityById,
+    selectionContentByEntryId,
   });
   const activatedIds = new Set(finalized.activatedEntries.map((entry) => entry.id));
   for (const item of vectorEntries) {
@@ -4324,6 +4346,7 @@ export function mergeActivatedWorldInfoEntries(
   bookSourceMap?: Map<string, BookSource>,
   bookNameMap?: Map<string, string>,
   random?: () => number,
+  selectionContentByEntryId?: ReadonlyMap<string, string>,
 ): MergedWorldInfoEntriesResult {
   const mergeStartedAt = performance.now();
   const selection = selectMergedWorldInfoEntries(
@@ -4332,6 +4355,7 @@ export function mergeActivatedWorldInfoEntries(
     settingsInput,
     bookSourceMap,
     random,
+    selectionContentByEntryId,
   );
   const { finalized, sources, dedupResult, dispositions } = selection;
 

--- a/src/services/prompt-assembly.service.ts
+++ b/src/services/prompt-assembly.service.ts
@@ -1776,12 +1776,15 @@ export async function assemblePrompt(
     for (const bookId of mpWorldInfo.bookIds) wiSources.bookSourceMap.set(bookId, "peer");
   }
   const wiState: WiState = (chat.metadata?.wi_state as WiState) ?? {};
-  const worldInfoSettings =
+  const configuredWorldInfoSettings =
     pf?.allSettings.get("worldInfoSettings") ??
     (settingsSvc.getSetting(ctx.userId, "worldInfoSettings")?.value as
       | Partial<WorldInfoSettings>
       | undefined) ??
     {};
+  const normalizedWorldInfoSettings = normalizeWorldInfoSettings(
+    configuredWorldInfoSettings,
+  );
   const interception = await worldInfoInterceptorChain.run(
     wiEntries,
     {
@@ -1808,10 +1811,20 @@ export async function assemblePrompt(
       }),
       chatTurn: messages.length,
       chatMetadata: chat.metadata ?? {},
+      activationSettings: {
+        maxRecursionPasses: normalizedWorldInfoSettings.maxRecursionPasses,
+      },
     },
     ctx.userId,
     wiSources.bookSourceMap
   );
+  const worldInfoSettings: WorldInfoSettings = {
+    ...normalizedWorldInfoSettings,
+    maxRecursionPasses:
+      interception.activationOverrides.disableRecursion === true
+        ? 0
+        : normalizedWorldInfoSettings.maxRecursionPasses,
+  };
   const intercepted = interception.entries;
   const hasCaptureRequests = interception.captureRequests.size > 0;
   const hasCapturedIds = [...interception.captureRequests.values()].some(

--- a/src/services/world-books-wi-marker.test.ts
+++ b/src/services/world-books-wi-marker.test.ts
@@ -17,6 +17,17 @@ async function applyBaseline(): Promise<void> {
   const db = getDb();
   db.run("PRAGMA foreign_keys = OFF");
   db.run(await Bun.file(join(import.meta.dir, "..", "db", "baseline.sql")).text());
+  db.run(
+    await Bun.file(
+      join(
+        import.meta.dir,
+        "..",
+        "db",
+        "migrations",
+        "098_world_book_entry_exclude_greeting.sql",
+      ),
+    ).text(),
+  );
 }
 
 function readRawExtensions(id: string): Record<string, any> {

--- a/src/services/world-books.service.ts
+++ b/src/services/world-books.service.ts
@@ -188,6 +188,7 @@ function rowToEntry(row: any): WorldBookEntry {
     prevent_recursion: !!row.prevent_recursion,
     exclude_recursion: !!row.exclude_recursion,
     delay_until_recursion: !!row.delay_until_recursion,
+    exclude_greeting: !!row.exclude_greeting,
     use_probability: !!row.use_probability,
     vectorized: !!row.vectorized,
     vector_index_status: vectorIndexStatus,
@@ -345,6 +346,7 @@ export function normalizeImportedEntryInput(raw: any, index: number): CreateWorl
     "constant", "case_sensitive", "caseSensitive", "match_whole_words", "matchWholeWords",
     "group", "group_name", "group_override", "groupOverride",
     "group_weight", "groupWeight", "probability", "scan_depth", "scanDepth",
+    "exclude_greeting", "excludeGreeting",
     "automation_id", "automationId", "selectiveLogic", "selective_logic",
     "useProbability", "use_probability", "use_regex", "useRegex",
     "prevent_recursion", "preventRecursion", "exclude_recursion", "excludeRecursion",
@@ -380,6 +382,7 @@ export function normalizeImportedEntryInput(raw: any, index: number): CreateWorl
     group_weight: importValue(raw, ext, "group_weight", "groupWeight") ?? 100,
     probability: importValue(raw, ext, "probability") ?? 100,
     scan_depth: importValue(raw, ext, "scan_depth", "scanDepth") ?? undefined,
+    exclude_greeting: importValue(raw, ext, "exclude_greeting", "excludeGreeting") ?? false,
     automation_id: importValue(raw, ext, "automation_id", "automationId") || undefined,
     selective_logic: importValue(raw, ext, "selectiveLogic", "selective_logic") ?? 0,
     use_probability: importValue(raw, ext, "useProbability", "use_probability") ?? true,
@@ -429,6 +432,7 @@ export function materializeCharacterBookEntriesForRuntime(
       group_weight: input.group_weight ?? 100,
       probability: input.probability ?? 100,
       scan_depth: input.scan_depth ?? null,
+      exclude_greeting: !!input.exclude_greeting,
       case_sensitive: !!input.case_sensitive,
       match_whole_words: !!input.match_whole_words,
       automation_id: input.automation_id ?? null,
@@ -1165,12 +1169,13 @@ export function createEntry(
         id, world_book_id, uid, key, keysecondary, content, comment,
         position, depth, role, order_value, selective, constant, disabled,
         group_name, group_override, group_weight, probability, scan_depth,
+        exclude_greeting,
         case_sensitive, match_whole_words, automation_id,
         use_regex, prevent_recursion, exclude_recursion, delay_until_recursion,
         priority, sticky, cooldown, delay, selective_logic, use_probability,
         vectorized, vector_index_status, vector_indexed_at, vector_index_error,
         extensions, created_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     .run(
       id, worldBookId, uid,
@@ -1190,6 +1195,7 @@ export function createEntry(
       input.group_weight ?? 100,
       input.probability ?? 100,
       input.scan_depth ?? null,
+      input.exclude_greeting ? 1 : 0,
       input.case_sensitive ? 1 : 0,
       input.match_whole_words ? 1 : 0,
       input.automation_id || null,
@@ -1242,7 +1248,7 @@ export function updateEntry(userId: string, id: string, input: UpdateWorldBookEn
     if (input[f] !== undefined) { fields.push(`${f} = ?`); values.push(input[f]); }
   }
 
-  const boolFields = ["selective", "constant", "disabled", "group_override", "case_sensitive", "match_whole_words", "use_regex", "prevent_recursion", "exclude_recursion", "delay_until_recursion", "use_probability", "vectorized"] as const;
+  const boolFields = ["selective", "constant", "disabled", "group_override", "case_sensitive", "match_whole_words", "use_regex", "prevent_recursion", "exclude_recursion", "delay_until_recursion", "exclude_greeting", "use_probability", "vectorized"] as const;
   for (const f of boolFields) {
     if (input[f] !== undefined) { fields.push(`${f} = ?`); values.push(input[f] ? 1 : 0); }
   }
@@ -1348,6 +1354,7 @@ export function duplicateEntry(userId: string, entryId: string, input?: Duplicat
     group_weight: existing.group_weight,
     probability: existing.probability,
     scan_depth: existing.scan_depth ?? undefined,
+    exclude_greeting: existing.exclude_greeting,
     case_sensitive: existing.case_sensitive,
     match_whole_words: existing.match_whole_words,
     automation_id: existing.automation_id || undefined,
@@ -1668,12 +1675,13 @@ function bulkInsertEntries(
       id, world_book_id, uid, key, keysecondary, content, comment,
       position, depth, role, order_value, selective, constant, disabled,
       group_name, group_override, group_weight, probability, scan_depth,
+      exclude_greeting,
       case_sensitive, match_whole_words, automation_id,
       use_regex, prevent_recursion, exclude_recursion, delay_until_recursion,
       priority, sticky, cooldown, delay, selective_logic, use_probability,
       vectorized, vector_index_status, vector_indexed_at, vector_index_error,
       extensions, created_at, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   );
 
   let aborted = false;
@@ -1721,6 +1729,7 @@ function bulkInsertEntries(
           input.group_weight ?? 100,
           input.probability ?? 100,
           input.scan_depth ?? null,
+          input.exclude_greeting ? 1 : 0,
           input.case_sensitive ? 1 : 0,
           input.match_whole_words ? 1 : 0,
           input.automation_id || null,
@@ -1949,6 +1958,7 @@ function entryToCharacterBookSpec(entry: WorldBookEntry, index: number): Record<
     group_weight: entry.group_weight,
     probability: entry.probability,
     scan_depth: entry.scan_depth,
+    exclude_greeting: entry.exclude_greeting,
     automation_id: entry.automation_id,
     vectorized: entry.vectorized,
     uid: entry.uid,
@@ -2012,6 +2022,7 @@ function exportSillyTavern(book: WorldBook, entries: WorldBookEntry[]): Record<s
           group_weight: entry.group_weight,
           probability: entry.probability,
           scan_depth: entry.scan_depth,
+          exclude_greeting: entry.exclude_greeting,
           automation_id: entry.automation_id,
           selectiveLogic: entry.selective_logic,
           useProbability: entry.use_probability,

--- a/src/services/world-info-activation-scan-cache.test.ts
+++ b/src/services/world-info-activation-scan-cache.test.ts
@@ -32,6 +32,7 @@ function entry(overrides: Partial<WorldBookEntry> = {}): WorldBookEntry {
     group_weight: 100,
     probability: 100,
     scan_depth: null,
+    exclude_greeting: false,
     case_sensitive: false,
     match_whole_words: false,
     automation_id: null,

--- a/src/services/world-info-activation.service.ts
+++ b/src/services/world-info-activation.service.ts
@@ -229,7 +229,11 @@ function computeMessageSignature(messages: readonly Message[]): string {
   const hasher = new Bun.CryptoHasher("sha256");
   for (const message of messages) {
     hasher.update(
-      JSON.stringify({ id: message.id, content: message.content }),
+      JSON.stringify({
+        id: message.id,
+        content: message.content,
+        greeting: message.extra?.greeting === true,
+      }),
     );
     hasher.update("\0");
   }
@@ -238,9 +242,9 @@ function computeMessageSignature(messages: readonly Message[]): string {
 
 function computeWiActivationCacheKey(input: ActivationInput): string {
   const entries = input.entries;
-  const messages = input.messages;
   const wiState = input.wiState;
   const settings = normalizeWorldInfoSettings(input.settings);
+  const messages = input.messages;
   const hasher = new Bun.CryptoHasher("sha256");
   for (const e of entries) {
     hasher.update(JSON.stringify({
@@ -262,6 +266,7 @@ function computeWiActivationCacheKey(input: ActivationInput): string {
       group_weight: e.group_weight,
       probability: e.probability,
       scan_depth: e.scan_depth,
+      exclude_greeting: e.exclude_greeting,
       case_sensitive: e.case_sensitive,
       match_whole_words: e.match_whole_words,
       use_regex: e.use_regex,
@@ -622,6 +627,7 @@ function scanEntryCacheValue(entry: WorldBookEntry): object {
     key: entry.key,
     keysecondary: entry.keysecondary,
     scan_depth: entry.scan_depth,
+    exclude_greeting: entry.exclude_greeting,
     case_sensitive: entry.case_sensitive,
     match_whole_words: entry.match_whole_words,
     use_regex: entry.use_regex,
@@ -639,28 +645,40 @@ function scanBaseState(
   settings: WorldInfoSettings,
 ): ScanState {
   const state = makeScanState();
-  const depthBuckets = new Map<string, Set<string>>();
-  const depthKey = (d: number | null) => (d === null ? "all" : String(d));
+  // Pass 0 base: scan messages once per unique effective scan_depth.
+  // Pre-compute scan text per depth key and memoize so entries sharing the
+  // same effective depth don't rebuild the same concatenated string.
+  const depthBuckets = new Map<string, { scope: Set<string>; excludeGreeting: boolean; depth: number | null }>();
+  const depthKey = (d: number | null, excludeGreeting: boolean) =>
+    `${excludeGreeting ? "without-greeting" : "all-messages"}:${d === null ? "all" : String(d)}`;
+  let needsGreetingExcludedScan = false;
   for (const e of conditional) {
     if (e.key.length === 0) continue;
     const d = e.scan_depth ?? settings.globalScanDepth;
-    const k = depthKey(d);
-    let set = depthBuckets.get(k);
-    if (!set) {
-      set = new Set();
-      depthBuckets.set(k, set);
+    needsGreetingExcludedScan ||= e.exclude_greeting;
+    const k = depthKey(d, e.exclude_greeting);
+    let bucket = depthBuckets.get(k);
+    if (!bucket) {
+      bucket = { scope: new Set(), excludeGreeting: e.exclude_greeting, depth: d };
+      depthBuckets.set(k, bucket);
     }
-    set.add(e.uid);
+    bucket.scope.add(e.uid);
   }
+  const messagesWithoutGreeting = needsGreetingExcludedScan
+    ? messages.filter((message) => message.extra?.greeting !== true)
+    : messages;
   const scanTextCache = new Map<string, string>();
-  for (const [k, scope] of depthBuckets) {
-    const d = k === "all" ? null : Number(k);
+  for (const [k, bucket] of depthBuckets) {
     let text = scanTextCache.get(k);
     if (text === undefined) {
-      text = buildScanText(messages, d, "");
+      text = buildScanText(
+        bucket.excludeGreeting ? messagesWithoutGreeting : messages,
+        bucket.depth,
+        "",
+      );
       scanTextCache.set(k, text);
     }
-    matcher.scanChunk(text, state, scope);
+    matcher.scanChunk(text, state, bucket.scope);
   }
   return state;
 }

--- a/src/services/world-info-activation.service.ts
+++ b/src/services/world-info-activation.service.ts
@@ -96,6 +96,7 @@ export interface ActivationInput {
   settings?: Partial<WorldInfoSettings>;
   scanCache?: WorldInfoActivationScanCache;
   random?: () => number;
+  selectionContentByEntryId?: ReadonlyMap<string, string>;
 }
 
 export interface WorldInfoActivationScanCache {
@@ -185,6 +186,8 @@ export interface FinalizeWorldInfoOptions {
   random?: () => number;
   /** Internal competition priorities used only for budget ordering. */
   budgetPriorityById?: ReadonlyMap<string, number>;
+  /** Prompt-local content used only for selection and token accounting. */
+  selectionContentByEntryId?: ReadonlyMap<string, string>;
 }
 
 // ─── Activation cache (short-TTL for rapid dry-run optimization) ───
@@ -282,6 +285,13 @@ function computeWiActivationCacheKey(input: ActivationInput): string {
       vectorized: e.vectorized,
     }));
     hasher.update("\0");
+  }
+  for (const entry of entries) {
+    const content = input.selectionContentByEntryId?.get(entry.id);
+    if (content !== undefined && content !== entry.content) {
+      hasher.update(JSON.stringify([entry.id, content]));
+      hasher.update("\0");
+    }
   }
   const readsMessages = entries.some(
     (entry) =>
@@ -449,6 +459,7 @@ export function activateWorldInfo(input: ActivationInput): ActivationResult {
 
   const finalized = finalizeActivatedWorldInfoEntries(activated, settings, {
     random: input.random,
+    selectionContentByEntryId: input.selectionContentByEntryId,
   });
 
   const stats: ActivationStats = {
@@ -481,7 +492,11 @@ export function finalizeActivatedWorldInfoEntries(
   const afterGroups = options.skipGroupLogic
     ? [...entries]
     : applyWorldInfoGroupLogic([...entries], options.random);
-  const insertableEntries = afterGroups.filter(hasMeaningfulWorldInfoContent);
+  const insertableEntries = afterGroups.filter((entry) =>
+    hasMeaningfulWorldInfoContent({
+      content: selectionContentFor(entry, options.selectionContentByEntryId),
+    }),
+  );
 
   if (!options.preserveOrder) {
     insertableEntries.sort((a, b) => {
@@ -493,7 +508,11 @@ export function finalizeActivatedWorldInfoEntries(
   }
 
   const activatedBeforeBudget = insertableEntries.length;
-  const activatedEntries = enforceBudget(insertableEntries, settings);
+  const activatedEntries = enforceBudget(
+    insertableEntries,
+    settings,
+    options.selectionContentByEntryId,
+  );
   const evictedByBudget = activatedBeforeBudget - activatedEntries.length;
 
   return {
@@ -502,7 +521,10 @@ export function finalizeActivatedWorldInfoEntries(
     activatedBeforeBudget,
     activatedAfterBudget: activatedEntries.length,
     evictedByBudget,
-    estimatedTokens: estimateTokens(activatedEntries),
+    estimatedTokens: estimateTokens(
+      activatedEntries,
+      options.selectionContentByEntryId,
+    ),
   };
 }
 
@@ -515,10 +537,21 @@ function estimateEntryTokens(content: string): number {
   return Math.ceil(content.length / 4);
 }
 
-function estimateTokens(entries: WorldBookEntry[]): number {
+function selectionContentFor(
+  entry: Pick<WorldBookEntry, "id" | "content">,
+  selectionContentByEntryId?: ReadonlyMap<string, string>,
+): string {
+  return selectionContentByEntryId?.get(entry.id) ?? entry.content;
+}
+
+function estimateTokens(
+  entries: WorldBookEntry[],
+  selectionContentByEntryId?: ReadonlyMap<string, string>,
+): number {
   let total = 0;
   for (const e of entries) {
-    if (e.content) total += estimateEntryTokens(e.content);
+    const content = selectionContentFor(e, selectionContentByEntryId);
+    if (content) total += estimateEntryTokens(content);
   }
   return total;
 }
@@ -528,7 +561,11 @@ function estimateTokens(entries: WorldBookEntry[]): number {
  * Entries are already sorted by priority desc, order_value asc.
  * Constants are never evicted — they take priority over conditional entries.
  */
-function enforceBudget(entries: WorldBookEntry[], settings: WorldInfoSettings): WorldBookEntry[] {
+function enforceBudget(
+  entries: WorldBookEntry[],
+  settings: WorldInfoSettings,
+  selectionContentByEntryId?: ReadonlyMap<string, string>,
+): WorldBookEntry[] {
   let result = entries;
 
   // Max activated entries cap
@@ -552,7 +589,8 @@ function enforceBudget(entries: WorldBookEntry[], settings: WorldInfoSettings): 
     // Constants first (never evicted)
     for (const e of result) {
       if (e.constant) {
-        totalTokens += e.content ? estimateEntryTokens(e.content) : 0;
+        const content = selectionContentFor(e, selectionContentByEntryId);
+        totalTokens += content ? estimateEntryTokens(content) : 0;
         kept.push(e);
       }
     }
@@ -560,7 +598,8 @@ function enforceBudget(entries: WorldBookEntry[], settings: WorldInfoSettings): 
     // Non-constants in priority order until budget exhausted
     for (const e of result) {
       if (e.constant) continue;
-      const tokens = e.content ? estimateEntryTokens(e.content) : 0;
+      const content = selectionContentFor(e, selectionContentByEntryId);
+      const tokens = content ? estimateEntryTokens(content) : 0;
       if (totalTokens + tokens > settings.maxTokenBudget) continue;
       totalTokens += tokens;
       kept.push(e);

--- a/src/services/world-info-large-book.test.ts
+++ b/src/services/world-info-large-book.test.ts
@@ -684,6 +684,71 @@ describe("mergeActivatedWorldInfoEntries — user-shape (9000+ entries, keys=[],
   });
 });
 
+describe("prompt-local world-info selection content", () => {
+  test("filters a raw constant whose selection view is empty without caching the empty result", () => {
+    const entry = makeEntry({
+      id: crypto.randomUUID(),
+      uid: crypto.randomUUID(),
+      constant: true,
+      content: "{{runtime condition}}large hidden payload{{/runtime condition}}",
+      vectorized: false,
+    });
+
+    const hidden = activateWorldInfo({
+      entries: [entry],
+      messages: [],
+      chatTurn: 0,
+      wiState: {},
+      settings: {},
+      selectionContentByEntryId: new Map([[entry.id, ""]]),
+    });
+    const visible = activateWorldInfo({
+      entries: [entry],
+      messages: [],
+      chatTurn: 0,
+      wiState: {},
+      settings: {},
+      selectionContentByEntryId: new Map([[entry.id, "visible"]]),
+    });
+
+    expect(hidden.activatedEntries).toEqual([]);
+    expect(visible.activatedEntries).toEqual([entry]);
+  });
+
+  test("uses selection content for budget and dedup while returning raw content", () => {
+    const first = makeEntry({
+      content: "A".repeat(4_000),
+      priority: 20,
+      vectorized: false,
+    });
+    const duplicate = makeEntry({
+      content: "B".repeat(4_000),
+      priority: 10,
+      vectorized: false,
+    });
+    const selectionContentByEntryId = new Map([
+      [first.id, "same"],
+      [duplicate.id, "same"],
+    ]);
+
+    const result = mergeActivatedWorldInfoEntries(
+      [first, duplicate],
+      [],
+      { maxTokenBudget: 1 },
+      undefined,
+      undefined,
+      undefined,
+      selectionContentByEntryId,
+    );
+
+    expect(result.activatedEntries).toEqual([first]);
+    expect(result.activatedEntries[0]?.content).toBe(first.content);
+    expect(result.cache.before[0]?.content).toBe(first.content);
+    expect(result.estimatedTokens).toBe(1);
+    expect(result.deduplicated).toBe(1);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Scenario 2: equal priority + high order_value loses even when budget has room
 // ---------------------------------------------------------------------------

--- a/src/services/world-info-large-book.test.ts
+++ b/src/services/world-info-large-book.test.ts
@@ -68,6 +68,7 @@ function makeEntry(overrides: Partial<WorldBookEntry> = {}): WorldBookEntry {
     group_weight: 100,
     probability: 100,
     scan_depth: null,
+    exclude_greeting: false,
     case_sensitive: false,
     match_whole_words: false,
     automation_id: null,

--- a/src/services/world-info-large-book.test.ts
+++ b/src/services/world-info-large-book.test.ts
@@ -1,23 +1,9 @@
 /**
- * Regression suite for the "9000+ entry lorebook fires no entries" bug.
- *
- * Production log that motivated this suite:
- *   [embeddings] WI vector search: 0 rows from LanceDB for book=17c52a6c (limit=30)
- *   [prompt-assembly] Vector WI retrieval: eligible=9251, hits=57,
- *                     afterThreshold=57, afterRerank=57, shortlisted=15 (topK=15)
- *   [WI merge] vector candidates=15 → accepted=0,
- *              skipped: dedup=0, minPriority=0, group=0, budgetCap=15, budgetSim=0
- *
- * The merge/activation pipeline is deterministic and pure, so we exercise it
- * directly with entries shaped like the user's import. The vector-search half
- * of the pipeline (LanceDB) is stubbed — we feed the merge function synthetic
- * `VectorActivatedEntry[]` that mirror what `collectVectorActivatedWorldInfoDetailed`
- * would have produced.
+ * Portable regression coverage for world-info activation and merge behavior.
+ * Vector retrieval is represented with synthetic candidates so the suite has
+ * no external data dependency.
  */
 import { describe, test, expect } from "bun:test";
-import { readFileSync, existsSync } from "node:fs";
-import path from "node:path";
-import os from "node:os";
 
 import type { WorldBookEntry } from "../types/world-book";
 import type { Message } from "../types/message";
@@ -35,8 +21,6 @@ import {
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
-
-const LOREBOOK_PATH = path.join(os.homedir(), "Downloads", "memories_lorebook.json");
 
 let __counter = 0;
 function makeEntry(overrides: Partial<WorldBookEntry> = {}): WorldBookEntry {
@@ -112,12 +96,12 @@ function makeMessage(content: string): Message {
   };
 }
 
-/** Wrap a WorldBookEntry as a VectorActivatedEntry with realistic scoring. */
+/** Wrap a WorldBookEntry as a VectorActivatedEntry with representative scoring. */
 function asVectorCandidate(entry: WorldBookEntry, finalScore = 0.8): VectorActivatedEntry {
   return {
     entry,
     score: finalScore,
-    distance: Number.POSITIVE_INFINITY, // FTS-only, mirroring the production log
+    distance: Number.POSITIVE_INFINITY,
     finalScore,
     lexicalCandidateScore: 10,
     matchedPrimaryKeys: [],
@@ -548,13 +532,10 @@ describe("global keyword matching overrides", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Scenario 1: the "as-imported" shape — keys=[], vectorized=true, no constants.
-// This is the exact profile of memories_lorebook.json. With default settings
-// (maxActivatedEntries=0=unlimited, maxTokenBudget=0=unlimited) ALL 15 vector
-// candidates MUST be accepted.
+// Vector and keyword competition with default and configured limits.
 // ---------------------------------------------------------------------------
 
-describe("mergeActivatedWorldInfoEntries — user-shape (9000+ entries, keys=[], vectorized)", () => {
+describe("mergeActivatedWorldInfoEntries — vector and keyword competition", () => {
   test("includes the source book name in activated entry summaries", () => {
     const entry = makeEntry({ world_book_id: "book-lore" });
 
@@ -600,10 +581,8 @@ describe("mergeActivatedWorldInfoEntries — user-shape (9000+ entries, keys=[],
   });
 
   test("FIXED: score-boosted vectors can now displace equal-priority keyword entries at a full cap", () => {
-    // This is the production bug reproducer. Before the fix: all 15 vector
-    // candidates were rejected with `budgetCap=15`. After the fix: vectors
-    // with meaningful finalScore receive a bounded priority uplift and beat
-    // equal-priority keyword entries on the order_value tiebreaker.
+    // Meaningful vector scores can beat equal-priority keyword entries while
+    // the configured entry cap remains in force.
     const keywordEntries = Array.from({ length: 15 }, (_, i) =>
       makeEntry({ world_book_id: "other-book", key: ["x"], order_value: i + 1, comment: `kw-${i}` }),
     );
@@ -617,10 +596,10 @@ describe("mergeActivatedWorldInfoEntries — user-shape (9000+ entries, keys=[],
       { maxActivatedEntries: 15 },
     );
 
-    // At least some vectors must now fire — that is the bug fix.
+    // At least some vectors must activate.
     expect(result.vectorActivated).toBeGreaterThan(0);
     expect(result.totalActivated).toBe(15);
-    // The output must still respect the user's cap.
+    // The output must still respect the configured cap.
     expect(result.activatedEntries.length).toBe(15);
   });
 
@@ -678,8 +657,7 @@ describe("mergeActivatedWorldInfoEntries — user-shape (9000+ entries, keys=[],
       maxTokenBudget: 100,
     });
 
-    // This is a SEPARATE failure mode from the user's log. Verifies the
-    // budgetCap vs budgetSim counters discriminate correctly.
+    // Token limits and entry-count limits report separate outcomes.
     expect(result.vectorActivated).toBe(0);
   });
 });
@@ -851,160 +829,5 @@ describe("mergeActivatedWorldInfoEntries — unified finalization", () => {
     } finally {
       Math.random = originalRandom;
     }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Scenario 3: replay against the real 9239-entry user file
-// ---------------------------------------------------------------------------
-
-describe("mergeActivatedWorldInfoEntries — real 9239-entry user lorebook", () => {
-  const available = existsSync(LOREBOOK_PATH);
-  const skip = available ? test : test.skip;
-
-  // Load once, reuse across tests. Maps each ST-style raw entry to our
-  // WorldBookEntry model using the same defaults createEntry/importWorldBook
-  // would apply (priority=10 when unset, order_value from displayIndex/order).
-  function loadRealEntries(): WorldBookEntry[] {
-    const raw = JSON.parse(readFileSync(LOREBOOK_PATH, "utf8"));
-    const rawEntries: any[] = Array.isArray(raw.entries)
-      ? raw.entries
-      : Object.values(raw.entries);
-    return rawEntries.map((e: any, i: number) =>
-      makeEntry({
-        id: `real-${i}`,
-        uid: `real-uid-${i}`,
-        world_book_id: "memories-book",
-        content: String(e.content || ""),
-        comment: String(e.comment || ""),
-        key: Array.isArray(e.key) ? e.key : [],
-        keysecondary: Array.isArray(e.keysecondary) ? e.keysecondary : [],
-        order_value: e.displayIndex ?? e.order ?? i + 1,
-        priority: e.priority ?? 10,
-        position: e.position ?? 0,
-        depth: e.depth ?? 4,
-        selective: e.selective ?? true,
-        constant: e.constant ?? false,
-        disabled: !!e.disable,
-        probability: e.probability ?? 100,
-        use_probability: e.useProbability ?? true,
-        vectorized: e.vectorized ?? true,
-      }),
-    );
-  }
-
-  skip("invariants: >9000 entries, all empty keys, all vectorized, no constants, none disabled", () => {
-    const entries = loadRealEntries();
-    expect(entries.length).toBeGreaterThan(9000);
-    expect(entries.every((e) => e.key.length === 0)).toBe(true);
-    expect(entries.every((e) => e.vectorized === true)).toBe(true);
-    expect(entries.every((e) => !e.constant)).toBe(true);
-    expect(entries.every((e) => !e.disabled)).toBe(true);
-  });
-
-  skip("end-to-end: only this book + default settings + any subset as vector hits → every hit wins", () => {
-    const entries = loadRealEntries();
-    // Simulate LanceDB returning 30 arbitrary entries as candidates.
-    const hitIndexes = [3, 47, 120, 500, 987, 1234, 2200, 3500, 4815, 5000, 6666, 7777, 8000, 8500, 9000, 100, 250, 450, 700, 900, 1100, 1300, 1500, 1700, 1900, 2100, 2300, 2500, 2700, 2900];
-    const vectorCandidates = hitIndexes.map((idx, rank) =>
-      asVectorCandidate(entries[idx], 1.0 - rank * 0.02),
-    );
-
-    const result = mergeActivatedWorldInfoEntries([], vectorCandidates, {});
-    expect(result.vectorActivated).toBe(vectorCandidates.length);
-    expect(result.keywordActivated).toBe(0);
-  });
-
-  skip("full-scale merge: 9239 entries + 15 vector hits + maxActivatedEntries=15 + zero keyword competition → all 15 vectors accepted", () => {
-    const entries = loadRealEntries();
-    const vectorCandidates = entries.slice(0, 15).map((e, i) =>
-      asVectorCandidate(e, 1.2 - i * 0.05),
-    );
-
-    const result = mergeActivatedWorldInfoEntries([], vectorCandidates, { maxActivatedEntries: 15 });
-    expect(result.vectorActivated).toBe(15);
-  });
-
-  skip("post-fix production-log replay: 15 keyword competitors + cap=15 + real book content → vectors now fire", () => {
-    const entries = loadRealEntries();
-    // Another source contributes 15 keyword matches at default priority.
-    const keywordCompetitors = Array.from({ length: 15 }, (_, i) =>
-      makeEntry({ world_book_id: "other-book", key: ["trigger"], order_value: i + 1, priority: 10 }),
-    );
-    const vectorHits = entries.slice(0, 15).map((e, i) =>
-      asVectorCandidate(e, 0.9 - i * 0.03),
-    );
-
-    const result = mergeActivatedWorldInfoEntries(
-      keywordCompetitors,
-      vectorHits,
-      { maxActivatedEntries: 15 },
-    );
-
-    // Before the fix: vectorActivated=0, budgetCap=15.
-    // After the fix: vectorActivated > 0 and the total still respects cap.
-    expect(result.vectorActivated).toBeGreaterThan(0);
-    expect(result.totalActivated).toBe(15);
-  });
-
-  skip("realistic pipeline: varying maxActivatedEntries × retrieval_top_k combinations", () => {
-    const entries = loadRealEntries();
-
-    for (const topK of [4, 15, 30, 50]) {
-      for (const cap of [0, 15, 30, 100]) {
-        const vectorCandidates = entries.slice(0, topK).map((e, i) =>
-          asVectorCandidate(e, 1.0 - i * (0.8 / topK)),
-        );
-        const result = mergeActivatedWorldInfoEntries([], vectorCandidates, {
-          maxActivatedEntries: cap,
-        });
-        const expected = cap === 0 ? topK : Math.min(topK, cap);
-        // Content-level dedup may trim a few near-duplicates; allow wiggle.
-        expect(result.vectorActivated).toBeGreaterThanOrEqual(
-          Math.max(0, expected - 3),
-        );
-        expect(result.vectorActivated).toBeLessThanOrEqual(expected);
-      }
-    }
-  });
-
-  skip("stress test: 9239 entries through full pipeline completes in under 2 seconds", () => {
-    const entries = loadRealEntries();
-    const vectorCandidates = entries.slice(0, 30).map((e, i) =>
-      asVectorCandidate(e, 1.0 - i * 0.02),
-    );
-
-    const t0 = performance.now();
-    const result = mergeActivatedWorldInfoEntries([], vectorCandidates, {
-      maxActivatedEntries: 30,
-    });
-    const elapsed = performance.now() - t0;
-
-    expect(result.vectorActivated).toBeGreaterThan(0);
-    expect(elapsed).toBeLessThan(2000);
-  });
-
-  skip("dedup sanity: real-content duplicates across books are collapsed but don't zero out vectors", () => {
-    const entries = loadRealEntries();
-    // Duplicate the first entry into a separate book (simulates two books
-    // with overlapping content, which is what triggers dedup).
-    const duplicate = makeEntry({
-      id: "dupe-1",
-      world_book_id: "other-book",
-      content: entries[0].content,
-      comment: entries[0].comment,
-      priority: 10,
-    });
-
-    const vector = [
-      asVectorCandidate(entries[0], 0.9),
-      asVectorCandidate(duplicate, 0.9),
-      ...entries.slice(1, 15).map((e, i) => asVectorCandidate(e, 0.85 - i * 0.01)),
-    ];
-
-    const result = mergeActivatedWorldInfoEntries([], vector, {});
-    // One dedup hit expected (the intentional duplicate).
-    expect(result.deduplicated).toBeGreaterThanOrEqual(1);
-    expect(result.vectorActivated).toBeGreaterThan(10);
   });
 });

--- a/src/services/world-info-marker-pin.test.ts
+++ b/src/services/world-info-marker-pin.test.ts
@@ -49,6 +49,7 @@ function makeEntry(partial: Partial<WorldBookEntry>): WorldBookEntry {
     group_weight: 0,
     probability: 100,
     scan_depth: null,
+    exclude_greeting: false,
     case_sensitive: false,
     match_whole_words: false,
     automation_id: null,

--- a/src/services/world-info-outlet-only.test.ts
+++ b/src/services/world-info-outlet-only.test.ts
@@ -43,6 +43,7 @@ function makeEntry(overrides: Partial<WorldBookEntry> = {}): WorldBookEntry {
     group_weight: 100,
     probability: 100,
     scan_depth: null,
+    exclude_greeting: false,
     case_sensitive: false,
     match_whole_words: false,
     automation_id: null,

--- a/src/services/world-info-vector-ranking.test.ts
+++ b/src/services/world-info-vector-ranking.test.ts
@@ -33,6 +33,7 @@ function makeEntry(overrides: Partial<WorldBookEntry>): WorldBookEntry {
     group_weight: 100,
     probability: 100,
     scan_depth: null,
+    exclude_greeting: false,
     case_sensitive: false,
     match_whole_words: false,
     automation_id: null,

--- a/src/spindle/message-content-processor.test.ts
+++ b/src/spindle/message-content-processor.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { messageContentProcessorChain } from "./message-content-processor";
+
+describe("message content processor context", () => {
+  test("preserves the message author flag through the chain", async () => {
+    const seen: boolean[] = [];
+    const unregister = messageContentProcessorChain.register({
+      extensionId: "test-author-flag",
+      priority: 100,
+      handler: async (ctx) => {
+        seen.push(ctx.isUser);
+      },
+    });
+
+    try {
+      await messageContentProcessorChain.run({
+        chatId: "chat",
+        content: "user",
+        isUser: true,
+        origin: "create",
+        userId: "user",
+      });
+      await messageContentProcessorChain.run({
+        chatId: "chat",
+        content: "assistant",
+        isUser: false,
+        origin: "create",
+        userId: "user",
+      });
+    } finally {
+      unregister();
+    }
+
+    expect(seen).toEqual([true, false]);
+  });
+});

--- a/src/spindle/message-content-processor.ts
+++ b/src/spindle/message-content-processor.ts
@@ -11,6 +11,7 @@ export interface MessageContentProcessorCtx {
   chatId: string;
   messageId?: string;
   content: string;
+  isUser: boolean;
   extra?: Record<string, unknown>;
   origin: MessageContentProcessorOrigin;
   swipeIndex?: number;

--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -585,6 +585,7 @@ type RuntimeSpindleAPI = Omit<SpindleAPI, "presets" | "imageGen"> & {
       chatId: string;
       messageId?: string;
       content: string;
+      isUser: boolean;
       extra?: Record<string, unknown>;
       origin: "create" | "update" | "swipe_add" | "swipe_update" | "render";
       swipeIndex?: number;

--- a/src/spindle/world-info-interceptor.test.ts
+++ b/src/spindle/world-info-interceptor.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type { WorldBookEntry } from "../types/world-book";
-import { WorldInfoInterceptorChain } from "./world-info-interceptor";
+import {
+  WorldInfoInterceptorChain,
+  worldInfoInterceptorChain,
+  type WorldInfoInterceptor,
+} from "./world-info-interceptor";
 
 function makeEntry(id: string): WorldBookEntry {
   return {
@@ -57,6 +61,7 @@ const context = {
   chatTurn: 1,
   chatMetadata: {},
   activationSettings: {
+    globalScanDepth: null,
     maxRecursionPasses: 3,
   },
 };
@@ -106,5 +111,54 @@ describe("WorldInfoInterceptorChain activation capture", () => {
     expect(result.captureRequests.has("empty")).toBe(true);
     expect([...result.captureRequests.get("empty")!]).toEqual([]);
     expect(result.entries[0].disabled).toBe(false);
+  });
+});
+
+describe("world info interceptor activation settings", () => {
+  test("passes the normalized global scan depth to each handler", async () => {
+    const seen: Array<number | null> = [];
+    const interceptor: WorldInfoInterceptor = {
+      extensionId: "world-info-settings-test",
+      priority: 0,
+      handler: async (ctx) => {
+        seen.push(ctx.activationSettings.globalScanDepth);
+      },
+    };
+    const unregister = worldInfoInterceptorChain.register(interceptor);
+
+    try {
+      await worldInfoInterceptorChain.run(
+        [],
+        {
+          chatId: "chat-1",
+          characterId: "character-1",
+          messages: [],
+          chatTurn: 0,
+          chatMetadata: {},
+          activationSettings: {
+            globalScanDepth: null,
+            maxRecursionPasses: 3,
+          },
+        },
+      );
+      await worldInfoInterceptorChain.run(
+        [],
+        {
+          chatId: "chat-1",
+          characterId: "character-1",
+          messages: [],
+          chatTurn: 0,
+          chatMetadata: {},
+          activationSettings: {
+            globalScanDepth: 7,
+            maxRecursionPasses: 3,
+          },
+        },
+      );
+    } finally {
+      unregister();
+    }
+
+    expect(seen).toEqual([null, 7]);
   });
 });

--- a/src/spindle/world-info-interceptor.test.ts
+++ b/src/spindle/world-info-interceptor.test.ts
@@ -26,6 +26,7 @@ function makeEntry(id: string): WorldBookEntry {
     group_weight: 100,
     probability: 100,
     scan_depth: null,
+    exclude_greeting: false,
     case_sensitive: false,
     match_whole_words: false,
     automation_id: null,
@@ -55,6 +56,9 @@ const context = {
   messages: [],
   chatTurn: 1,
   chatMetadata: {},
+  activationSettings: {
+    maxRecursionPasses: 3,
+  },
 };
 
 describe("WorldInfoInterceptorChain activation capture", () => {

--- a/src/spindle/world-info-interceptor.ts
+++ b/src/spindle/world-info-interceptor.ts
@@ -25,6 +25,7 @@ export interface WorldInfoInterceptorEntryDTO {
   readonly prevent_recursion: boolean;
   readonly exclude_recursion: boolean;
   readonly delay_until_recursion: boolean;
+  readonly exclude_greeting: boolean;
   readonly scan_depth: number | null;
   readonly order_value: number;
   readonly book_source?: BookSource;
@@ -147,6 +148,7 @@ export class WorldInfoInterceptorChain {
         prevent_recursion: e.prevent_recursion,
         exclude_recursion: e.exclude_recursion,
         delay_until_recursion: e.delay_until_recursion,
+        exclude_greeting: e.exclude_greeting,
         scan_depth: e.scan_depth,
         order_value: e.order_value,
         book_source: bookSourceMap?.get(e.world_book_id),

--- a/src/spindle/world-info-interceptor.ts
+++ b/src/spindle/world-info-interceptor.ts
@@ -43,6 +43,8 @@ export interface WorldInfoInterceptorMessageDTO {
 }
 
 export interface WorldInfoActivationSettingsDTO {
+  /** Default entry scan depth, or null to scan all available messages. */
+  readonly globalScanDepth: number | null;
   readonly maxRecursionPasses: number;
 }
 
@@ -195,6 +197,7 @@ export class WorldInfoInterceptorChain {
           ...ctx,
           entries: buildDto(working),
           activationSettings: {
+            globalScanDepth: ctx.activationSettings.globalScanDepth,
             maxRecursionPasses: disableRecursion
               ? 0
               : ctx.activationSettings.maxRecursionPasses,

--- a/src/spindle/world-info-interceptor.ts
+++ b/src/spindle/world-info-interceptor.ts
@@ -41,6 +41,14 @@ export interface WorldInfoInterceptorMessageDTO {
   readonly index_in_chat: number;
 }
 
+export interface WorldInfoActivationSettingsDTO {
+  readonly maxRecursionPasses: number;
+}
+
+export interface WorldInfoActivationOverridesDTO {
+  readonly disableRecursion?: true;
+}
+
 export interface WorldInfoInterceptorCtxDTO {
   readonly chatId: string;
   readonly characterId: string;
@@ -49,6 +57,7 @@ export interface WorldInfoInterceptorCtxDTO {
   readonly messages: readonly WorldInfoInterceptorMessageDTO[];
   readonly chatTurn: number;
   readonly chatMetadata: Readonly<Record<string, unknown>>;
+  readonly activationSettings: WorldInfoActivationSettingsDTO;
 }
 
 export interface WorldInfoInterceptorMutationDTO {
@@ -62,11 +71,13 @@ export interface WorldInfoInterceptorResultDTO {
   readonly forced?: readonly string[];
   readonly mutated?: readonly WorldInfoInterceptorMutationDTO[];
   readonly captured?: readonly string[];
+  readonly activationOverrides?: WorldInfoActivationOverridesDTO;
 }
 
 export interface WorldInfoInterceptorChainResult {
-  entries: WorldBookEntry[];
-  captureRequests: Map<string, Set<string>>;
+  readonly entries: WorldBookEntry[];
+  readonly captureRequests: Map<string, Set<string>>;
+  readonly activationOverrides: WorldInfoActivationOverridesDTO;
 }
 
 export interface WorldInfoInterceptor {
@@ -102,7 +113,11 @@ export class WorldInfoInterceptorChain {
     bookSourceMap?: ReadonlyMap<string, BookSource>
   ): Promise<WorldInfoInterceptorChainResult> {
     if (this.handlers.length === 0) {
-      return { entries: [...entries], captureRequests: new Map() };
+      return {
+        entries: [...entries],
+        captureRequests: new Map(),
+        activationOverrides: {},
+      };
     }
 
     const buildDto = (
@@ -143,6 +158,7 @@ export class WorldInfoInterceptorChain {
     const contentOverrides = new Map<string, string>();
     const captureRequests = new Map<string, Set<string>>();
     const candidateIds = new Set(entries.map((entry) => entry.id));
+    let disableRecursion = false;
 
     let working: WorldBookEntry[] = [...entries];
 
@@ -167,7 +183,15 @@ export class WorldInfoInterceptorChain {
     for (const handler of this.handlers) {
       if (handler.userId && handler.userId !== userId) continue;
       try {
-        const result = await handler.handler({ ...ctx, entries: buildDto(working) });
+        const result = await handler.handler({
+          ...ctx,
+          entries: buildDto(working),
+          activationSettings: {
+            maxRecursionPasses: disableRecursion
+              ? 0
+              : ctx.activationSettings.maxRecursionPasses,
+          },
+        });
         const disabledList = result?.disabled ?? [];
         const enabledList = result?.enabled ?? [];
         const forcedList = result?.forced ?? [];
@@ -180,11 +204,14 @@ export class WorldInfoInterceptorChain {
           }
           captureRequests.set(handler.extensionId, requested);
         }
+        const activationOverrides = result?.activationOverrides;
+        const disablesRecursion = activationOverrides?.disableRecursion === true;
         if (
           disabledList.length === 0 &&
           enabledList.length === 0 &&
           forcedList.length === 0 &&
-          mutatedList.length === 0
+          mutatedList.length === 0 &&
+          !disablesRecursion
         ) {
           continue;
         }
@@ -195,8 +222,16 @@ export class WorldInfoInterceptorChain {
         for (const m of mutatedList) {
           if (m.content !== undefined) contentOverrides.set(m.id, m.content);
         }
+        disableRecursion ||= disablesRecursion;
 
-        working = rebuildWorking();
+        if (
+          disabledList.length > 0 ||
+          enabledList.length > 0 ||
+          forcedList.length > 0 ||
+          mutatedList.length > 0
+        ) {
+          working = rebuildWorking();
+        }
       } catch (err) {
         console.error(
           `[Spindle] World-info interceptor error from ${handler.extensionId}: ${err instanceof Error ? err.message : String(err)}`
@@ -207,7 +242,13 @@ export class WorldInfoInterceptorChain {
       }
     }
 
-    return { entries: working, captureRequests };
+    return {
+      entries: working,
+      captureRequests,
+      activationOverrides: {
+        ...(disableRecursion ? { disableRecursion: true as const } : {}),
+      },
+    };
   }
 
   get count(): number {

--- a/src/spindle/world-info-interceptor.ts
+++ b/src/spindle/world-info-interceptor.ts
@@ -63,7 +63,10 @@ export interface WorldInfoInterceptorCtxDTO {
 
 export interface WorldInfoInterceptorMutationDTO {
   readonly id: string;
+  /** Prompt-local replacement used for final insertion. */
   readonly content?: string;
+  /** Prompt-local alternate used only by host selection and token accounting. */
+  readonly selectionContent?: string;
 }
 
 export interface WorldInfoInterceptorResultDTO {
@@ -79,6 +82,7 @@ export interface WorldInfoInterceptorChainResult {
   readonly entries: WorldBookEntry[];
   readonly captureRequests: Map<string, Set<string>>;
   readonly activationOverrides: WorldInfoActivationOverridesDTO;
+  readonly selectionContentByEntryId: ReadonlyMap<string, string>;
 }
 
 export interface WorldInfoInterceptor {
@@ -118,6 +122,7 @@ export class WorldInfoInterceptorChain {
         entries: [...entries],
         captureRequests: new Map(),
         activationOverrides: {},
+        selectionContentByEntryId: new Map(),
       };
     }
 
@@ -160,6 +165,7 @@ export class WorldInfoInterceptorChain {
     const contentOverrides = new Map<string, string>();
     const captureRequests = new Map<string, Set<string>>();
     const candidateIds = new Set(entries.map((entry) => entry.id));
+    const selectionContentByEntryId = new Map<string, string>();
     let disableRecursion = false;
 
     let working: WorldBookEntry[] = [...entries];
@@ -223,6 +229,9 @@ export class WorldInfoInterceptorChain {
         for (const id of forcedList) forcedByChain.add(id);
         for (const m of mutatedList) {
           if (m.content !== undefined) contentOverrides.set(m.id, m.content);
+          if (m.selectionContent !== undefined) {
+            selectionContentByEntryId.set(m.id, m.selectionContent);
+          }
         }
         disableRecursion ||= disablesRecursion;
 
@@ -250,6 +259,7 @@ export class WorldInfoInterceptorChain {
       activationOverrides: {
         ...(disableRecursion ? { disableRecursion: true as const } : {}),
       },
+      selectionContentByEntryId,
     };
   }
 

--- a/src/types/world-book.ts
+++ b/src/types/world-book.ts
@@ -33,6 +33,8 @@ export interface WorldBookEntry {
   group_weight: number;
   probability: number;
   scan_depth: number | null;
+  /** Exclude the synthetic character greeting from this entry's lexical activation scan. */
+  exclude_greeting: boolean;
   case_sensitive: boolean;
   match_whole_words: boolean;
   automation_id: string | null;
@@ -272,6 +274,8 @@ export interface CreateWorldBookEntryInput {
   group_weight?: number;
   probability?: number;
   scan_depth?: number;
+  /** Exclude the synthetic character greeting from this entry's lexical activation scan. */
+  exclude_greeting?: boolean;
   case_sensitive?: boolean;
   match_whole_words?: boolean;
   automation_id?: string;


### PR DESCRIPTION
# Spindle Types PR: https://github.com/prolix-oc/lumiverse-spindle-types/pull/35

## Summary
There were several deficiencies found when developing an extension for finer lorebook and regex resolution (guess):
- Extensions could not adjust recursion or distinguish content used for lorebook selection from content ultimately inserted into the prompt, resulting in all or nothing, usually blowing up activation.
- Frontend display resolution could lose message-specific context or bypass an extension-owned resolver.
- Message processors could not reliably distinguish user and assistant messages.
- Macro evaluation did not expose the selected alternate greeting consistently.

### Solution
- Added a per-entry **Exclude Greeting** option to the lorebook editor, persistence layer, import/export paths, and keyword activation.
- Expanded the world-info interceptor with the active scan settings, prompt-local recursion control, and selection-only content.
- Preserved message depth, index, role, and dynamic macro context through frontend display resolution.
- Ensured extension-owned display scripts continue through the frontend resolver without adding backend IPC.
- Added message authorship to message-content processor context.
- Exposed and persisted the selected greeting index and alternate greetings for deterministic macro evaluation.

Existing default behaviors remain unchanged.

## Validation

```text
bun x tsc --noEmit

bun frontend/node_modules/typescript/bin/tsc --noEmit -p tsconfig.json

cd frontend && bun run typecheck

cd frontend && bun run lint

bun test \
  src/macros/MacroEnv.test.ts \
  src/services/chats.service.test.ts \
  src/services/embeddings-world-book-index-race.test.ts \
  src/services/prompt-assembly-outlets.test.ts \
  src/services/prompt-assembly-vector-cache.test.ts \
  src/services/world-books-wi-marker.test.ts \
  src/services/world-info-activation-scan-cache.test.ts \
  src/services/world-info-large-book.test.ts \
  src/services/world-info-marker-pin.test.ts \
  src/services/world-info-outlet-only.test.ts \
  src/services/world-info-vector-ranking.test.ts \
  src/spindle/message-content-processor.test.ts \
  src/spindle/world-info-interceptor.test.ts

127 passed, 0 failed.
445 assertions across 13 files in 1.31 seconds.
```

## Required checklist
- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass.
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [x] Backend: `bun x tsc --noEmit`
  - [x] Frontend: `cd frontend && bun run typecheck`, `bun run lint`

## UI changes (if applicable)
- [x] I validated this change in more than one browser.
- [x] I verified the integrated experience on a mobile interface or through
      the mobile PWA.
- Browsers, devices, and PWA coverage: Chrome, Firefox on PC, Android.

## Performance changes (if applicable)

- [x] I added or updated tests.
- [ ] I included reproducible benchmarks and comparison results below.
- Benchmark commands and results: N/A

## Security-sensitive changes (if applicable)

N/A

## LLM-assisted work (if applicable)

- [x] I, as the human orchestrating this work, audited the submitted changes
      in a live environment.