### PR TITLE
Add spindle display expression updates

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
         "hono": "^4.7.0",
         "js-tiktoken": "^1.0.16",
         "jsdom": "^29.0.1",
-        "lumiverse-spindle-types": "0.6.9",
+        "lumiverse-spindle-types": "0.6.10",
         "mute-stream": "^3.0.0",
         "sharp": "^0.34.5",
         "ssh2-sftp-client": "^12.1.1",
@@ -599,7 +599,7 @@
 
     "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
-    "lumiverse-spindle-types": ["lumiverse-spindle-types@0.6.9", "", {}, "sha512-KAoxNw/KhG136O3OLvgFDiMs5C2noIxL7hTc0u4wa/p5/lRXL06/gO/qxj0/5vUwp+wirvzSIqtWbaRqcciXeQ=="],
+    "lumiverse-spindle-types": ["lumiverse-spindle-types@0.6.10", "", {}, "sha512-0PPqBb0fFskdqsYSAcNYMswEsacKsxuAqJeAV47pKxeWdyk+eXjm5Y0rEPKLfGZ+kg1V1PA8+uu9SaFGXA2ZSw=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 

--- a/developer-docs/docs/frontend-api/display-resolver.md
+++ b/developer-docs/docs/frontend-api/display-resolver.md
@@ -108,4 +108,13 @@ ctx.display.invalidate(['*'])
 
 `invalidate` takes a list of `scope:name` strings, or `['*']` to clear everything. Use the wholesale form after a change you cannot express as a small set of variables, such as switching the chat your extension owns.
 
+Use `setExpression` when display resolution selects an expression image:
+
+```ts
+ctx.display.setExpression({ chatId, characterId, label, imageId })
+```
+
+The update is transient and frontend only. It is ignored when `chatId` is not
+the active chat.
+
 The hook is frontend only and requires no permission.

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -30,7 +30,7 @@
         "i18next": "^26.2.0",
         "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "^0.468.0",
-        "lumiverse-spindle-types": "0.6.9",
+        "lumiverse-spindle-types": "0.6.10",
         "marked": "^15.0.4",
         "motion": "^12.0.0",
         "react": "^19.2.6",
@@ -919,7 +919,7 @@
 
     "lucide-react": ["lucide-react@0.468.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA=="],
 
-    "lumiverse-spindle-types": ["lumiverse-spindle-types@0.6.9", "", {}, "sha512-KAoxNw/KhG136O3OLvgFDiMs5C2noIxL7hTc0u4wa/p5/lRXL06/gO/qxj0/5vUwp+wirvzSIqtWbaRqcciXeQ=="],
+    "lumiverse-spindle-types": ["lumiverse-spindle-types@0.6.10", "", {}, "sha512-0PPqBb0fFskdqsYSAcNYMswEsacKsxuAqJeAV47pKxeWdyk+eXjm5Y0rEPKLfGZ+kg1V1PA8+uu9SaFGXA2ZSw=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 

--- a/frontend/src/lib/spindle/loader.lifecycle.contract.isolated.ts
+++ b/frontend/src/lib/spindle/loader.lifecycle.contract.isolated.ts
@@ -240,6 +240,7 @@ function resetStore(): void {
     drawerTab: null,
     settingsModalOpen: false,
     settingsActiveView: 'general',
+    spindleSettings: { infoLoggingEnabled: false },
   } as never)
 }
 // The loader is intentionally loaded after boundary mocks so this test exercises
@@ -1159,6 +1160,7 @@ describe('retained non-UI context lifecycle', () => {
         ['messages.listMessageIds', () => firstContext.messages.listMessageIds()],
         ['display.registerResolver', () => firstContext.display.registerResolver({ resolveTemplates: async () => null, applyScripts: async () => null })],
         ['display.invalidate', () => firstContext.display.invalidate(['stale'])],
+        ['display.setExpression', () => firstContext.display.setExpression({ chatId: 'stale', characterId: 'stale', label: 'stale', imageId: 'stale' })],
         ['containers.registerContainer', () => firstContext.containers.registerContainer({ id: 'stale', side: 'left', element: document.createElement('div') })],
         ['containers.unregisterContainer', () => firstContext.containers.unregisterContainer('stale')],
         ['getActiveChat', () => firstContext.getActiveChat()],

--- a/frontend/src/lib/spindle/loader.ts
+++ b/frontend/src/lib/spindle/loader.ts
@@ -1624,6 +1624,15 @@ async function doLoadFrontendExtension(
           if (touchedVars.includes('*')) invalidateDisplayRegexCache()
           else invalidateDisplayRegexCacheForVars(new Set(touchedVars))
         },
+        setExpression({ chatId, characterId, label, imageId }) {
+          assertFrontendActive()
+          const state = useStore.getState()
+          if (state.activeChatId !== chatId) return
+          state.setActiveExpression(label, imageId, characterId)
+          if (state.isGroupChat) {
+            state.setGroupExpression(characterId, label, imageId)
+          }
+        },
       },
       containers: {
         registerContainer: (opts: { id: string; side: 'left' | 'right' | 'top' | 'bottom'; element: HTMLElement }) => {

--- a/frontend/src/lib/spindle/preset-editor-adapter.test.ts
+++ b/frontend/src/lib/spindle/preset-editor-adapter.test.ts
@@ -128,7 +128,7 @@ describe('preset editor draft adapter', () => {
       ...forgedSealedFields,
       id: 'new-block',
       name: 'Shared',
-    }
+    } as unknown as typeof firstDraftBlock
     draft.blocks = [forgedNewBlock, secondDraftBlock, firstDraftBlock]
     const next = applyPresetEditorDraft(current, draft)
 

--- a/frontend/src/lib/spindle/preset-editor-helper.test.ts
+++ b/frontend/src/lib/spindle/preset-editor-helper.test.ts
@@ -17,7 +17,7 @@ import type {
   SpindlePresetEditorState,
 } from './preset-editor-types'
 
-function sealedBlock(): PromptBlockDTO & Record<string, unknown> {
+function sealedBlock(): PromptBlockDTO {
   return {
     id: 'sealed-block',
     name: 'Sealed',
@@ -46,7 +46,7 @@ function sealedBlock(): PromptBlockDTO & Record<string, unknown> {
     sealedOriginPresetId: 'preset-1',
     sealedOriginVersion: '1',
     sealedSha256: 'hash',
-  }
+  } as unknown as PromptBlockDTO
 }
 
 

--- a/frontend/src/store/slices/spindle.ts
+++ b/frontend/src/store/slices/spindle.ts
@@ -294,6 +294,13 @@ export const createSpindleSlice: StateCreator<SpindleSlice> = (set, get) => ({
     })
   },
 
+  dismissTextEditor: (requestId: string) => {
+    set((state) => {
+      if (state.pendingTextEditor?.requestId !== requestId) return state
+      return { ...state, pendingTextEditor: null }
+    })
+  },
+
   openSpindleModal: (request) => {
     set({ pendingModal: request })
   },

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -960,6 +960,7 @@ export interface SpindleSlice {
   resolvePermissionRequest: (id: string, approved: boolean) => Promise<void>
   openTextEditor: (request: PendingTextEditorRequest) => void
   closeTextEditor: (requestId: string, text: string, cancelled: boolean) => void
+  dismissTextEditor: (requestId: string) => void
   openSpindleModal: (request: PendingModalRequest) => void
   closeSpindleModal: (requestId: string, dismissedBy: 'user' | 'extension' | 'cleanup') => void
   dismissSpindleModal: (requestId: string) => void

--- a/frontend/src/ws/useWebSocket.ts
+++ b/frontend/src/ws/useWebSocket.ts
@@ -1588,6 +1588,10 @@ export function useWebSocket() {
         store.getState().openTextEditor(payload)
       }),
 
+      wsClient.on(EventType.SPINDLE_TEXT_EDITOR_RESULT, (payload: { requestId: string }) => {
+        store.getState().dismissTextEditor(payload.requestId)
+      }),
+
       wsClient.on(EventType.SPINDLE_MODAL_OPEN, (payload: any) => {
         store.getState().openSpindleModal(payload)
       }),

--- a/src/services/prompt-assembly-runtime-world-info-placement.test.ts
+++ b/src/services/prompt-assembly-runtime-world-info-placement.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "bun:test";
+import type { LlmMessage } from "../llm/types";
+import type { WorldBookEntry } from "../types/world-book";
+import {
+  buildRuntimeWorldInfoChatPlacements,
+  insertRuntimeWorldInfoIntoTaggedHistory,
+  repositionRuntimeWorldInfoInTaggedHistory,
+  type RuntimeWorldInfoChatPlacementEntry,
+} from "./prompt-assembly.service";
+
+function history(content: string): LlmMessage {
+  return {
+    role: "user",
+    content,
+    __chatHistorySource: true,
+  } as unknown as LlmMessage;
+}
+
+function placement(
+  content: string,
+  depth: number,
+  direction: "from_start" | "from_end",
+): RuntimeWorldInfoChatPlacementEntry {
+  return {
+    id: content,
+    content,
+    entryLabel: content,
+    orderValue: 0,
+    placement: {
+      type: "chat_depth",
+      role: "system",
+      depth,
+      direction,
+    },
+  };
+}
+
+function entry(id: string, orderValue: number): WorldBookEntry {
+  return {
+    id,
+    world_book_id: "book",
+    uid: id,
+    outlet_name: null,
+    wi_marker: null,
+    wi_marker_side: null,
+    key: [id],
+    keysecondary: [],
+    content: id,
+    comment: id,
+    position: 0,
+    depth: 0,
+    role: null,
+    order_value: orderValue,
+    selective: false,
+    constant: false,
+    disabled: false,
+    group_name: "",
+    group_override: false,
+    group_weight: 1,
+    probability: 100,
+    scan_depth: null,
+    exclude_greeting: false,
+    case_sensitive: false,
+    match_whole_words: false,
+    automation_id: null,
+    use_regex: false,
+    prevent_recursion: false,
+    exclude_recursion: false,
+    delay_until_recursion: false,
+    priority: 0,
+    sticky: 0,
+    cooldown: 0,
+    delay: 0,
+    selective_logic: 0,
+    use_probability: false,
+    vectorized: false,
+    vector_index_status: "not_enabled",
+    vector_indexed_at: null,
+    vector_index_error: null,
+    extensions: {},
+    created_at: 0,
+    updated_at: 0,
+  };
+}
+
+describe("runtime world-info chat placement", () => {
+  test("uses only selected rows and restores final lore order", () => {
+    const placements = new Map([
+      ["later", placement("later", 1, "from_start").placement],
+      ["earlier", placement("earlier", 1, "from_start").placement],
+      ["equal-a", placement("equal-a", 1, "from_start").placement],
+      ["equal-b", placement("equal-b", 1, "from_start").placement],
+      ["dropped", placement("dropped", 1, "from_start").placement],
+    ]);
+
+    expect(
+      buildRuntimeWorldInfoChatPlacements(
+        [
+          entry("later", 20),
+          entry("earlier", 10),
+          entry("equal-a", 15),
+          entry("equal-b", 15),
+        ],
+        placements,
+      ).map(({ id }) => id),
+    ).toEqual(["earlier", "equal-b", "equal-a", "later"]);
+  });
+
+  test("matches sequential start and reverse splice behavior", () => {
+    const messages = [history("h0"), history("h1"), history("h2")];
+    insertRuntimeWorldInfoIntoTaggedHistory(messages, [
+      placement("start-a", 1, "from_start"),
+      placement("start-b", 1, "from_start"),
+      placement("end-a", 1, "from_end"),
+      placement("end-b", 1, "from_end"),
+    ]);
+
+    expect(messages.map(({ content }) => content)).toEqual([
+      "h0",
+      "start-b",
+      "start-a",
+      "h1",
+      "end-a",
+      "end-b",
+      "h2",
+    ]);
+  });
+
+  test("counts a tagged greeting in the selected prompt-history frame", () => {
+    const messages = [history("greeting"), history("user")];
+    insertRuntimeWorldInfoIntoTaggedHistory(messages, [
+      placement("after-greeting", 1, "from_start"),
+    ]);
+
+    expect(messages.map(({ content }) => content)).toEqual([
+      "greeting",
+      "after-greeting",
+      "user",
+    ]);
+  });
+
+  test("retains Array.splice negative-index behavior for oversized reverse depth", () => {
+    const messages = [
+      { role: "system", content: "prefix" } as LlmMessage,
+      history("h0"),
+      history("h1"),
+      history("h2"),
+      history("h3"),
+      { role: "system", content: "tail" } as LlmMessage,
+    ];
+    insertRuntimeWorldInfoIntoTaggedHistory(messages, [
+      placement("reverse-six", 6, "from_end"),
+    ]);
+
+    expect(messages.map(({ content }) => content)).toEqual([
+      "prefix",
+      "h0",
+      "h1",
+      "reverse-six",
+      "h2",
+      "h3",
+      "tail",
+    ]);
+  });
+
+  test("reapplies placement after older history is clipped", () => {
+    const messages = [
+      history("h0"),
+      history("h1"),
+      history("h2"),
+      history("h3"),
+    ];
+    const entries = [
+      placement("from-start", 1, "from_start"),
+      placement("from-end", 1, "from_end"),
+    ];
+    insertRuntimeWorldInfoIntoTaggedHistory(messages, entries);
+    messages.splice(
+      messages.findIndex(({ content }) => content === "h0"),
+      1,
+    );
+    repositionRuntimeWorldInfoInTaggedHistory(messages, entries);
+
+    expect(messages.map(({ content }) => content)).toEqual([
+      "h1",
+      "from-start",
+      "h2",
+      "from-end",
+      "h3",
+    ]);
+  });
+});

--- a/src/services/prompt-assembly.service.ts
+++ b/src/services/prompt-assembly.service.ts
@@ -25,7 +25,7 @@ import type {
   PromptVariableDef,
   PromptVariableValue,
 } from "../types/preset";
-import type { WorldInfoCache } from "../types/world-book";
+import type { WorldInfoCache, WorldBookEntry } from "../types/world-book";
 import type { Character } from "../types/character";
 import { getEffectiveCharacterName, makeAssistantCharacter } from "../types/character";
 import type { Persona } from "../types/persona";
@@ -49,13 +49,17 @@ import {
   applyWorldInfoGroupLogic,
   createWorldInfoActivationScanCache,
   finalizeActivatedWorldInfoEntries,
+  materializeWorldInfoCache,
   primeWorldInfoActivationScanCache,
   type WiState,
   type WorldInfoSettings,
   type FinalizedWorldInfoEntries,
   normalizeWorldInfoSettings,
 } from "./world-info-activation.service";
-import { worldInfoInterceptorChain } from "../spindle/world-info-interceptor";
+import {
+  worldInfoInterceptorChain,
+  type WorldInfoInterceptorPlacementDTO,
+} from "../spindle/world-info-interceptor";
 import { buildWorldInfoCaptureMap } from "../spindle/world-info-capture";
 import {
   getSourceMessageMetadata,
@@ -168,6 +172,7 @@ export type {
 
 const CHAT_HISTORY_KEY = "__chatHistorySource";
 const WORLD_INFO_KEY = "__worldInfoSource";
+const RUNTIME_WORLD_INFO_PLACEMENT_KEY = "__runtimeWorldInfoPlacementId";
 const SOURCE_ID_KEY = "__sourceMessageId";
 const SOURCE_INDEX_KEY = "__sourceIndexInChat";
 const CONTEXT_ANCHOR_PROTECTED_KEY = "__contextAnchorProtected";
@@ -203,6 +208,22 @@ function isContextAnchorProtected(msg: LlmMessage): boolean {
 function markAsWorldInfoEntry(msg: LlmMessage): LlmMessage {
   (msg as any)[WORLD_INFO_KEY] = true;
   return msg;
+}
+
+function markRuntimeWorldInfoPlacement(
+  msg: LlmMessage,
+  entryId: string,
+): LlmMessage {
+  markAsWorldInfoEntry(msg);
+  (msg as any)[RUNTIME_WORLD_INFO_PLACEMENT_KEY] = entryId;
+  return msg;
+}
+
+function getRuntimeWorldInfoPlacementId(
+  msg: LlmMessage,
+): string | undefined {
+  const value = (msg as any)[RUNTIME_WORLD_INFO_PLACEMENT_KEY];
+  return typeof value === "string" ? value : undefined;
 }
 
 export function isWorldInfoEntryMessage(msg: LlmMessage): boolean {
@@ -267,6 +288,153 @@ export function insertBlocksIntoTaggedHistory(
       content: block.content,
     });
   }
+}
+
+export interface RuntimeWorldInfoChatPlacementEntry {
+  readonly id: string;
+  content: string;
+  readonly entryLabel: string;
+  readonly orderValue: number;
+  readonly placement: WorldInfoInterceptorPlacementDTO;
+}
+
+export function buildRuntimeWorldInfoChatPlacements(
+  entries: readonly WorldBookEntry[],
+  placementByEntryId: ReadonlyMap<
+    string,
+    WorldInfoInterceptorPlacementDTO
+  >,
+): RuntimeWorldInfoChatPlacementEntry[] {
+  const placed: RuntimeWorldInfoChatPlacementEntry[] = [];
+  for (const entry of entries) {
+    const placement = placementByEntryId.get(entry.id);
+    if (!placement) continue;
+    placed.push({
+      id: entry.id,
+      content: entry.content,
+      entryLabel: getRuntimeWorldInfoEntryLabel(entry),
+      orderValue: entry.order_value,
+      placement,
+    });
+  }
+  // Selection is priority ordered. Restore semantic insertion order with the
+  // final reversal also applying to rows that share an order value.
+  placed.sort((a, b) => b.orderValue - a.orderValue).reverse();
+  return placed;
+}
+
+function placeRuntimeWorldInfoIntoTaggedHistory(
+  messages: LlmMessage[],
+  entries: readonly RuntimeWorldInfoChatPlacementEntry[],
+  messageByEntryId: ReadonlyMap<string, LlmMessage>,
+  fallbackIndex = messages.length,
+): void {
+  const historySequence = new Set<LlmMessage>(
+    messages.filter(isChatHistoryMessage),
+  );
+  const emptyHistoryFallback = Math.max(
+    0,
+    Math.min(Math.trunc(fallbackIndex), messages.length),
+  );
+
+  for (const entry of entries) {
+    const sequenceIndices: number[] = [];
+    for (let index = 0; index < messages.length; index++) {
+      if (historySequence.has(messages[index])) sequenceIndices.push(index);
+    }
+
+    const sequenceLength = sequenceIndices.length;
+    // Preserve sequential Array.splice semantics. Entries inserted earlier in
+    // this loop become part of the sequence used to place later entries.
+    const spliceStart =
+      entry.placement.direction === "from_start"
+        ? entry.placement.depth
+        : sequenceLength - entry.placement.depth;
+    // Array.splice treats a negative start as an offset from the current end.
+    const boundary =
+      spliceStart < 0
+        ? Math.max(sequenceLength + spliceStart, 0)
+        : Math.min(spliceStart, sequenceLength);
+    const insertAt =
+      sequenceLength === 0
+        ? emptyHistoryFallback
+        : boundary === sequenceLength
+          ? sequenceIndices[sequenceLength - 1] + 1
+          : sequenceIndices[boundary];
+    const message = messageByEntryId.get(entry.id);
+    if (!message) continue;
+    markRuntimeWorldInfoPlacement(message, entry.id);
+    messages.splice(insertAt, 0, message);
+    historySequence.add(message);
+  }
+}
+
+/**
+ * Apply prompt-local placement relative to tagged chat history.
+ */
+export function insertRuntimeWorldInfoIntoTaggedHistory(
+  messages: LlmMessage[],
+  entries: readonly RuntimeWorldInfoChatPlacementEntry[],
+  fallbackIndex = messages.length,
+): void {
+  const messageByEntryId = new Map<string, LlmMessage>();
+  for (const entry of entries) {
+    messageByEntryId.set(entry.id, {
+      role: entry.placement.role,
+      content: entry.content,
+    });
+  }
+  placeRuntimeWorldInfoIntoTaggedHistory(
+    messages,
+    entries,
+    messageByEntryId,
+    fallbackIndex,
+  );
+}
+
+/**
+ * Reapply placement after context clipping changes the selected history.
+ */
+export function repositionRuntimeWorldInfoInTaggedHistory(
+  messages: LlmMessage[],
+  entries: readonly RuntimeWorldInfoChatPlacementEntry[],
+): void {
+  if (entries.length === 0) return;
+  const entryIds = new Set(entries.map((entry) => entry.id));
+  const messageByEntryId = new Map<string, LlmMessage>();
+  let fallbackIndex = messages.length;
+  let write = 0;
+  for (let read = 0; read < messages.length; read++) {
+    const message = messages[read];
+    const entryId = getRuntimeWorldInfoPlacementId(message);
+    if (entryId && entryIds.has(entryId)) {
+      if (messageByEntryId.size === 0) fallbackIndex = write;
+      messageByEntryId.set(entryId, message);
+      continue;
+    }
+    messages[write++] = message;
+  }
+  if (messageByEntryId.size === 0) return;
+  messages.length = write;
+  placeRuntimeWorldInfoIntoTaggedHistory(
+    messages,
+    entries,
+    messageByEntryId,
+    fallbackIndex,
+  );
+}
+
+function getRuntimeWorldInfoEntryLabel(
+  entry: Pick<WorldBookEntry, "id" | "comment" | "key" | "keysecondary">,
+): string {
+  const comment = entry.comment?.trim();
+  if (comment) return comment;
+  const keys = [...(entry.key ?? []), ...(entry.keysecondary ?? [])]
+    .map((key) => key.trim())
+    .filter(Boolean);
+  return keys.length > 0
+    ? keys.join(", ")
+    : `(unnamed entry ${entry.id.slice(0, 8)})`;
 }
 
 // ---------------------------------------------------------------------------
@@ -1968,7 +2136,21 @@ export async function assemblePrompt(
       interception.selectionContentByEntryId,
     ),
   );
-  const wiCache = mergedWorldInfo.cache;
+  const runtimeWorldInfoPlacements = buildRuntimeWorldInfoChatPlacements(
+    mergedWorldInfo.activatedEntries,
+    interception.placementByEntryId,
+  );
+  const runtimePlacementIds = new Set(
+    runtimeWorldInfoPlacements.map((entry) => entry.id),
+  );
+  const wiCache =
+    runtimePlacementIds.size === 0
+      ? mergedWorldInfo.cache
+      : materializeWorldInfoCache(
+          mergedWorldInfo.activatedEntries.filter(
+            (entry) => !runtimePlacementIds.has(entry.id),
+          ),
+        );
   wiResult.activatedEntries = mergedWorldInfo.activatedEntries;
   const activatedWorldInfo = mergedWorldInfo.activatedWorldInfo;
   let spindleWorldInfoCaptures:
@@ -2532,6 +2714,7 @@ export async function assemblePrompt(
       wiCache.depth,
       wiCache.atMarker,
       wiCache.pinnedMarkers,
+      runtimeWorldInfoPlacements,
     ];
     let wiEvalCounter = 0;
     for (const bucket of allWiEntries) {
@@ -2548,6 +2731,11 @@ export async function assemblePrompt(
     }
   }
   pruneEmptyWorldInfoCacheEntries(wiCache);
+  for (let index = runtimeWorldInfoPlacements.length - 1; index >= 0; index--) {
+    if (runtimeWorldInfoPlacements[index].content.trim().length === 0) {
+      runtimeWorldInfoPlacements.splice(index, 1);
+    }
+  }
 
   // Populate {{wi_marker}} — all position-7 entries joined by double newlines
   if (wiCache.atMarker.length > 0) {
@@ -3255,6 +3443,23 @@ export async function assemblePrompt(
     });
   }
 
+  insertRuntimeWorldInfoIntoTaggedHistory(
+    result,
+    runtimeWorldInfoPlacements,
+    firstChatIdx >= 0 ? firstChatIdx : result.length,
+  );
+  for (const entry of runtimeWorldInfoPlacements) {
+    breakdown.push({
+      type: "world_info",
+      name: formatWorldInfoBreakdownName(
+        `WI Chat Depth ${entry.placement.direction} ${entry.placement.depth}`,
+        entry.entryLabel,
+      ),
+      role: entry.placement.role,
+      content: entry.content,
+    });
+  }
+
   // Position 7 (at marker): injected via {{wi_marker}} macro, add breakdown only
   for (const markerEntry of wiCache.atMarker) {
     breakdown.push({
@@ -3703,6 +3908,10 @@ export async function assemblePrompt(
       parameters.max_tokens as number | null | undefined,
       ctx.signal,
     )
+  );
+  repositionRuntimeWorldInfoInTaggedHistory(
+    result,
+    runtimeWorldInfoPlacements,
   );
 
   // Build memory stats for dry-run diagnostics

--- a/src/services/world-info-activation.service.ts
+++ b/src/services/world-info-activation.service.ts
@@ -516,7 +516,7 @@ export function finalizeActivatedWorldInfoEntries(
   const evictedByBudget = activatedBeforeBudget - activatedEntries.length;
 
   return {
-    cache: bucketByPosition(activatedEntries),
+    cache: materializeWorldInfoCache(activatedEntries),
     activatedEntries,
     activatedBeforeBudget,
     activatedAfterBudget: activatedEntries.length,
@@ -939,7 +939,9 @@ export function applyWorldInfoGroupLogic(
  *  4 = depth-based, 5 = EM before, 6 = EM after, 7 = at-marker,
  *  8 = outlet-only (excluded from all position buckets; surfaces only via {{outlet::name}})
  */
-function bucketByPosition(entries: WorldBookEntry[]): WorldInfoCache {
+export function materializeWorldInfoCache(
+  entries: WorldBookEntry[],
+): WorldInfoCache {
   const cache: WorldInfoCache = {
     before: [],
     after: [],

--- a/src/spindle/worker-host-content-api.ts
+++ b/src/spindle/worker-host-content-api.ts
@@ -1020,6 +1020,7 @@ export class WorkerHostContentApi {
       prevent_recursion: !!e.prevent_recursion,
       exclude_recursion: !!e.exclude_recursion,
       delay_until_recursion: !!e.delay_until_recursion,
+      exclude_greeting: !!e.exclude_greeting,
       priority: e.priority ?? 10,
       sticky: e.sticky ?? 0,
       cooldown: e.cooldown ?? 0,

--- a/src/spindle/worker-host-presentation-api.ts
+++ b/src/spindle/worker-host-presentation-api.ts
@@ -398,12 +398,15 @@ export class WorkerHostPresentationApi {
     value?: string,
     placeholder?: string,
     userId?: string,
+    callerEditorRequestId?: string,
   ): void {
     try {
       const resolvedUserId = this.resolveEffectiveUserId(userId);
       if (!resolvedUserId) throw new Error("userId is required for operator-scoped extensions");
 
-      const editorRequestId = `spindle-editor:${this.extensionId}:${requestId}`;
+      const editorRequestId = callerEditorRequestId
+        ? `spindle-editor:${this.extensionId}:${callerEditorRequestId}`
+        : `spindle-editor:${this.extensionId}:${requestId}`;
 
       // Listen for the result from the frontend
       const unsub = eventBus.on(EventType.SPINDLE_TEXT_EDITOR_RESULT, (msg) => {
@@ -431,6 +434,30 @@ export class WorkerHostPresentationApi {
         },
         resolvedUserId,
       );
+    } catch (err: any) {
+      this.postToWorker({ type: "response", requestId, error: err.message });
+    }
+  }
+
+  handleTextEditorClose(
+    requestId: string,
+    editorRequestId: string,
+    userId?: string,
+  ): void {
+    try {
+      const resolvedUserId = this.resolveEffectiveUserId(userId);
+      if (!resolvedUserId) throw new Error("userId is required for operator-scoped extensions");
+
+      eventBus.emit(
+        EventType.SPINDLE_TEXT_EDITOR_RESULT,
+        {
+          requestId: `spindle-editor:${this.extensionId}:${editorRequestId}`,
+          cancelled: true,
+        },
+        resolvedUserId,
+      );
+
+      this.postToWorker({ type: "response", requestId, result: undefined });
     } catch (err: any) {
       this.postToWorker({ type: "response", requestId, error: err.message });
     }

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -2284,7 +2284,10 @@ export class WorkerHost {
         break;
       // ─── Text Editor (free tier — no permission needed) ─────────────────
       case "text_editor_open":
-        this.presentationApi.handleTextEditorOpen(msg.requestId, msg.title, msg.value, msg.placeholder, msg.userId);
+        this.presentationApi.handleTextEditorOpen(msg.requestId, msg.title, msg.value, msg.placeholder, msg.userId, msg.editorRequestId);
+        break;
+      case "text_editor_close":
+        this.presentationApi.handleTextEditorClose(msg.requestId, msg.editorRequestId, msg.userId);
         break;
       // ─── Modal (free tier — no permission needed) ─────────────────────
       case "modal_open":

--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -3444,18 +3444,29 @@ const spindleApi: RuntimeSpindleAPI = {
       title?: string;
       value?: string;
       placeholder?: string;
+      editorRequestId?: string;
       userId?: string;
     }): Promise<{ text: string; cancelled: boolean }> {
       const requestId = crypto.randomUUID();
       const result = await request({
         type: "text_editor_open",
         requestId,
+        editorRequestId: options?.editorRequestId,
         title: options?.title,
         value: options?.value,
         placeholder: options?.placeholder,
         userId: options?.userId,
       } as any);
       return result as { text: string; cancelled: boolean };
+    },
+    async close(editorRequestId: string, userId?: string): Promise<void> {
+      const requestId = crypto.randomUUID();
+      await request({
+        type: "text_editor_close",
+        requestId,
+        editorRequestId,
+        userId,
+      } as any);
     },
   },
 

--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -3545,6 +3545,7 @@ const spindleApi: RuntimeSpindleAPI = {
   contracts: Object.freeze({
     preAssemblyGenerationContext: 1,
     worldInfoActivationCapture: 1,
+    worldInfoRuntimePlacement: 1,
   }),
 
   registerContextHandler(

--- a/src/spindle/world-info-interceptor.test.ts
+++ b/src/spindle/world-info-interceptor.test.ts
@@ -162,3 +162,65 @@ describe("world info interceptor activation settings", () => {
     expect(seen).toEqual([null, 7]);
   });
 });
+
+describe("world info interceptor runtime placement", () => {
+  test("chains validated prompt-local placement without changing stored rows", async () => {
+    const chain = new WorldInfoInterceptorChain();
+    let placementSeenBySecondHandler: unknown;
+    chain.register({
+      extensionId: "first",
+      priority: 0,
+      handler: async () => ({
+        mutated: [{
+          id: "a",
+          placement: {
+            type: "chat_depth",
+            role: "assistant",
+            depth: 3,
+            direction: "from_start",
+          },
+        }],
+      }),
+    });
+    chain.register({
+      extensionId: "second",
+      priority: 1,
+      handler: async (ctx) => {
+        placementSeenBySecondHandler = ctx.entries[0]?.placement;
+        return {
+          mutated: [{
+            id: "b",
+            placement: {
+              type: "chat_depth",
+              role: "system",
+              depth: -1,
+              direction: "from_end",
+            },
+          }],
+        };
+      },
+    });
+
+    const result = await chain.run(
+      [makeEntry("a"), makeEntry("b")],
+      context,
+    );
+
+    expect(placementSeenBySecondHandler).toEqual({
+      type: "chat_depth",
+      role: "assistant",
+      depth: 3,
+      direction: "from_start",
+    });
+    expect([...result.placementByEntryId]).toEqual([[
+      "a",
+      {
+        type: "chat_depth",
+        role: "assistant",
+        depth: 3,
+        direction: "from_start",
+      },
+    ]]);
+    expect(result.entries[0]?.position).toBe(0);
+  });
+});

--- a/src/spindle/world-info-interceptor.ts
+++ b/src/spindle/world-info-interceptor.ts
@@ -1,5 +1,8 @@
 import type { WorldBookEntry } from "../types/world-book";
 import type { BookSource } from "../services/world-info-sources.service";
+import type { WorldInfoInterceptorPlacementDTO } from "lumiverse-spindle-types";
+
+export type { WorldInfoInterceptorPlacementDTO } from "lumiverse-spindle-types";
 
 export interface WorldInfoInterceptorEntryDTO {
   readonly id: string;
@@ -12,6 +15,7 @@ export interface WorldInfoInterceptorEntryDTO {
   readonly keysecondary: readonly string[];
   readonly position: number;
   readonly depth: number;
+  readonly role: string | null;
   readonly priority: number;
   readonly probability: number;
   readonly use_probability: boolean;
@@ -19,6 +23,9 @@ export interface WorldInfoInterceptorEntryDTO {
   readonly automation_id: string | null;
   readonly selective: boolean;
   readonly selective_logic: number;
+  readonly group_name: string;
+  readonly group_override: boolean;
+  readonly group_weight: number;
   readonly match_whole_words: boolean;
   readonly case_sensitive: boolean;
   readonly use_regex: boolean;
@@ -28,6 +35,10 @@ export interface WorldInfoInterceptorEntryDTO {
   readonly exclude_greeting: boolean;
   readonly scan_depth: number | null;
   readonly order_value: number;
+  readonly sticky: number;
+  readonly cooldown: number;
+  readonly delay: number;
+  readonly placement?: WorldInfoInterceptorPlacementDTO;
   readonly book_source?: BookSource;
 }
 
@@ -69,6 +80,8 @@ export interface WorldInfoInterceptorMutationDTO {
   readonly content?: string;
   /** Prompt-local alternate used only by host selection and token accounting. */
   readonly selectionContent?: string;
+  /** Prompt-local placement relative to the selected chat history. */
+  readonly placement?: WorldInfoInterceptorPlacementDTO;
 }
 
 export interface WorldInfoInterceptorResultDTO {
@@ -85,6 +98,37 @@ export interface WorldInfoInterceptorChainResult {
   readonly captureRequests: Map<string, Set<string>>;
   readonly activationOverrides: WorldInfoActivationOverridesDTO;
   readonly selectionContentByEntryId: ReadonlyMap<string, string>;
+  readonly placementByEntryId: ReadonlyMap<
+    string,
+    WorldInfoInterceptorPlacementDTO
+  >;
+}
+
+function normalizePlacement(
+  value: unknown,
+): WorldInfoInterceptorPlacementDTO | null {
+  if (!value || typeof value !== "object") return null;
+  const candidate = value as Record<string, unknown>;
+  if (
+    candidate.type !== "chat_depth" ||
+    (candidate.role !== "system" &&
+      candidate.role !== "user" &&
+      candidate.role !== "assistant") ||
+    (candidate.direction !== "from_start" &&
+      candidate.direction !== "from_end") ||
+    typeof candidate.depth !== "number" ||
+    !Number.isFinite(candidate.depth) ||
+    !Number.isInteger(candidate.depth) ||
+    candidate.depth < 0
+  ) {
+    return null;
+  }
+  return {
+    type: "chat_depth",
+    role: candidate.role,
+    depth: candidate.depth,
+    direction: candidate.direction,
+  };
 }
 
 export interface WorldInfoInterceptor {
@@ -125,9 +169,14 @@ export class WorldInfoInterceptorChain {
         captureRequests: new Map(),
         activationOverrides: {},
         selectionContentByEntryId: new Map(),
+        placementByEntryId: new Map(),
       };
     }
 
+    const placementByEntryId = new Map<
+      string,
+      WorldInfoInterceptorPlacementDTO
+    >();
     const buildDto = (
       src: readonly WorldBookEntry[]
     ): WorldInfoInterceptorEntryDTO[] =>
@@ -142,6 +191,7 @@ export class WorldInfoInterceptorChain {
         keysecondary: e.keysecondary,
         position: e.position,
         depth: e.depth,
+        role: e.role,
         priority: e.priority,
         probability: e.probability,
         use_probability: e.use_probability,
@@ -149,6 +199,9 @@ export class WorldInfoInterceptorChain {
         automation_id: e.automation_id,
         selective: e.selective,
         selective_logic: e.selective_logic,
+        group_name: e.group_name,
+        group_override: e.group_override,
+        group_weight: e.group_weight,
         match_whole_words: e.match_whole_words,
         case_sensitive: e.case_sensitive,
         use_regex: e.use_regex,
@@ -158,6 +211,12 @@ export class WorldInfoInterceptorChain {
         exclude_greeting: e.exclude_greeting,
         scan_depth: e.scan_depth,
         order_value: e.order_value,
+        sticky: e.sticky,
+        cooldown: e.cooldown,
+        delay: e.delay,
+        ...(placementByEntryId.has(e.id)
+          ? { placement: placementByEntryId.get(e.id)! }
+          : {}),
         book_source: bookSourceMap?.get(e.world_book_id),
       }));
 
@@ -231,10 +290,13 @@ export class WorldInfoInterceptorChain {
         for (const id of enabledList) enabledByChain.add(id);
         for (const id of forcedList) forcedByChain.add(id);
         for (const m of mutatedList) {
+          if (!candidateIds.has(m.id)) continue;
           if (m.content !== undefined) contentOverrides.set(m.id, m.content);
           if (m.selectionContent !== undefined) {
             selectionContentByEntryId.set(m.id, m.selectionContent);
           }
+          const placement = normalizePlacement(m.placement);
+          if (placement) placementByEntryId.set(m.id, placement);
         }
         disableRecursion ||= disablesRecursion;
 
@@ -263,6 +325,7 @@ export class WorldInfoInterceptorChain {
         ...(disableRecursion ? { disableRecursion: true as const } : {}),
       },
       selectionContentByEntryId,
+      placementByEntryId,
     };
   }
 


### PR DESCRIPTION
Spindle PR: https://github.com/prolix-oc/lumiverse-spindle-types/pull/36

## Summary

Extensions could not update the active character expression directly during frontend display processing. Current Spindle types also exposed small mismatches in lore entry data, text editor cancellation, and test fixtures. World info interceptors also could not place selected entries at their intended message depth, especially when their depth was counted backward from the newest message.

To solve this, I added an active-chat expression update, completed the existing text editor cancellation contract, matched the affected data and tests with current Spindle types, and added role-aware world info placement that can count from either end of the chat.

## Validation

```text
bun x tsc --noEmit
Pass

cd frontend && bun run typecheck
Pass

cd frontend && bun run lint
Pass

cd frontend && bun test \
  src/lib/spindle/preset-editor-adapter.test.ts \
  src/lib/spindle/preset-editor-helper.test.ts \
  src/lib/spindle/loader.lifecycle.contract.test.ts
49 pass, 0 fail
```

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass.
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [x] Backend: `bun x tsc --noEmit`
  - [x] Frontend: `cd frontend && bun run typecheck`, `bun run lint`

## UI changes

N/A

## Performance changes

N/A

## Security-sensitive changes

N/A

## LLM-assisted work

N/A