### PR TITLE
feat(spindle): let extensions opt out of the base64 imageDataUrl payload

### DIFF
--- a/developer-docs/docs/backend-api/image-generation.md
+++ b/developer-docs/docs/backend-api/image-generation.md
@@ -16,6 +16,24 @@ const result = await spindle.imageGen.generate({
 // result: { imageDataUrl: "data:image/png;base64,...", model: "...", provider: "..." }
 ```
 
+When the extension only needs the persisted image (`imageId` / `imageUrl`), pass
+`includeDataUrl: false` to omit the base64 `imageDataUrl` from the result. The
+host still persists the image (so `imageId` / `imageUrl` remain available) but
+skips shipping the largest per-image RPC payload back to the worker:
+
+```ts
+const result = await spindle.imageGen.generate({
+  prompt: 'A serene mountain landscape at sunset, anime style',
+  connection_id: 'optional-connection-id',
+  includeDataUrl: false,
+})
+// result: { imageId: "img-...", imageUrl: "/api/v1/image-gen/results/img-...", model: "...", provider: "..." }
+```
+
+The default (`includeDataUrl` omitted or `true`) keeps the data URL for
+backward compatibility.
+
+
 You can override the model and pass provider-specific parameters:
 
 ```ts

--- a/src/spindle/worker-host-image-gen-api.test.ts
+++ b/src/spindle/worker-host-image-gen-api.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import type { ImageProvider } from "../image-gen/provider";
 import {
+  applyDataUrlInclusion,
   WorkerHostImageGenApi,
   supportsWebSocketPreviewStreaming,
 } from "./worker-host-image-gen-api";
@@ -75,3 +76,44 @@ test("streaming requests retain the image_gen permission gate", async () => {
     }),
   ]);
 });
+
+
+test("applyDataUrlInclusion keeps the base64 payload by default", () => {
+  const result = {
+    imageDataUrl: "data:image/png;base64,AAAA",
+    imageId: "img-1",
+    imageUrl: "/api/v1/image-gen/results/img-1",
+    model: "test",
+    provider: "test",
+  };
+  expect(applyDataUrlInclusion(result, true)).toEqual(result);
+});
+
+test("applyDataUrlInclusion strips the base64 payload when opted out", () => {
+  const result = {
+    imageDataUrl: "data:image/png;base64,AAAA",
+    imageId: "img-1",
+    imageUrl: "/api/v1/image-gen/results/img-1",
+    model: "test",
+    provider: "test",
+  };
+  expect(applyDataUrlInclusion(result, false)).toEqual({
+    imageId: "img-1",
+    imageUrl: "/api/v1/image-gen/results/img-1",
+    model: "test",
+    provider: "test",
+  });
+});
+
+test("applyDataUrlInclusion does not mutate the source result", () => {
+  const result = {
+    imageDataUrl: "data:image/png;base64,AAAA",
+    imageId: "img-1",
+    imageUrl: "/api/v1/image-gen/results/img-1",
+  };
+  const stripped = applyDataUrlInclusion(result, false);
+  expect(stripped).not.toBe(result);
+  expect(result.imageDataUrl).toBe("data:image/png;base64,AAAA");
+  expect("imageDataUrl" in stripped).toBe(false);
+});
+

--- a/src/spindle/worker-host-image-gen-api.ts
+++ b/src/spindle/worker-host-image-gen-api.ts
@@ -45,6 +45,25 @@ type WebSocketPreviewImageProvider = ImageProvider & {
  * `generateStream` alone is not enough: an extension-facing stream promises
  * WebSocket previews and status, so providers must explicitly advertise both.
  */
+
+/**
+ * Shapes the result returned to an extension.
+ *
+ * The base64 `imageDataUrl` is the largest per-image RPC field. It is required
+ * host-side (to persist the image into the images table), but extensions that
+ * only consume `imageId` / `imageUrl` can opt out of receiving it by passing
+ * `includeDataUrl: false` in the generate request. The default keeps the data
+ * URL for backward compatibility.
+ */
+export function applyDataUrlInclusion(
+  result: Record<string, unknown>,
+  includeDataUrl: boolean,
+): Record<string, unknown> {
+  if (includeDataUrl) return result;
+  const { imageDataUrl: _omitted, ...rest } = result;
+  return rest;
+}
+
 export function supportsWebSocketPreviewStreaming(
   provider: ImageProvider,
 ): provider is WebSocketPreviewImageProvider {
@@ -160,7 +179,9 @@ export class WorkerHostImageGenApi {
       }
     }
 
-    return { ...result, imageId, imageUrl };
+    // Persisting already consumed the data URL; the extension-facing result
+    // can drop it when the caller opts out of the base64 payload.
+    return applyDataUrlInclusion({ ...result, imageId, imageUrl }, input?.includeDataUrl !== false);
   }
 
   async handleGenerate(requestId: string, input: any): Promise<void> {


### PR DESCRIPTION
## Summary

`spindle.imageGen.generate()` always returns the full base64 `imageDataUrl` in the result — the largest per-image RPC field (multi-MB per PNG). Extensions like inlay-illustrator only consume `imageId`/`imageUrl` and never read the data URL, so every generated image ships that payload back to the worker for nothing.

Adds `includeDataUrl: false` to generate requests:
- The host still needs the data URL to persist the image into the images table, so persistence is unchanged and `imageId`/`imageUrl` stay populated.
- Only the extension-facing response drops the base64 field (`applyDataUrlInclusion` in `worker-host-image-gen-api.ts`).
- Default behavior (omitted or `true`) is unchanged — existing extensions keep receiving the data URL. Applies to both `generate` and the stream `done` event (shared `persistResult`); preview frames are unaffected.

## Validation

- `bun test src/spindle/worker-host-image-gen-api.test.ts` — 5 pass, 0 fail (3 new tests: default keeps payload, opt-out strips it, source not mutated)
- `bunx tsc --noEmit -p tsconfig.json` — no errors

## Required checklist

- [x] Based on the latest `staging` branch and targets `staging`, not `main`.
- [x] All applicable tests pass.
- [x] Backend type check with no errors.

## Performance changes (if applicable)

- [x] Added/updated tests (`worker-host-image-gen-api.test.ts`).
- [ ] Reproducible benchmarks: none run — impact is per-image RPC payload reduction (base64 ≈ 1.33× PNG bytes, dropped from the worker response); measurable via existing `image_generation_completed` timings.

## LLM-assisted work (if applicable)

- [x] I, as the human orchestrating this work, audited the submitted changes in a live environment.