### PR TITLE
feat/contextual guides

### DIFF
--- a/frontend/src/components/landing/LandingPage.tsx
+++ b/frontend/src/components/landing/LandingPage.tsx
@@ -3,7 +3,24 @@ import { useNavigate } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { motion, AnimatePresence, type Variants } from 'motion/react'
 import { useVirtualizer, type VirtualItem, type Virtualizer } from '@tanstack/react-virtual'
-import { MessageSquarePlus, MessageSquare, Trash2, Users, LogOut, FlaskConical, Gamepad2, Compass, EyeOff, Star, Pencil, Copy, GitBranch, Maximize2, Minimize2 } from 'lucide-react'
+import {
+  MessageSquarePlus,
+  MessageSquare,
+  Trash2,
+  Users,
+  LogOut,
+  FlaskConical,
+  Gamepad2,
+  Compass,
+  EyeOff,
+  Star,
+  Pencil,
+  Copy,
+  GitBranch,
+  Maximize2,
+  Minimize2,
+  BookOpen,
+} from 'lucide-react'
 import { Spinner } from '@/components/shared/Spinner'
 import { chatsApi, messagesApi } from '@/api/chats'
 import { charactersApi } from '@/api/characters'
@@ -19,6 +36,8 @@ import { prefetchImages } from '@/lib/imageDecodeCache'
 import { measureLayoutHeight, renderedPxToLayoutPx } from '@/lib/uiScale'
 import LazyImage from '@/components/shared/LazyImage'
 import ContextMenu, { type ContextMenuEntry, type ContextMenuPos } from '@/components/shared/ContextMenu'
+import { GuideViewer } from '@/components/shared/GuideViewer'
+import type { DrawerGuide } from '@/lib/drawer-tab-registry'
 import SearchField from '@/components/shared/SearchField'
 import { SortControl } from '@/components/shared/SortControl'
 import { useLongPress } from '@/hooks/useLongPress'
@@ -972,6 +991,12 @@ function VirtualizedChatRows({
   )
 }
 
+const FULL_GUIDES: DrawerGuide = {
+  kind: 'builtin',
+  path: 'index.md',
+  title: 'Lumiverse Guides',
+}
+
 export default function LandingPage() {
   const { t } = useTranslation('landing')
   const { t: tc } = useTranslation('common')
@@ -1029,6 +1054,7 @@ export default function LandingPage() {
   const [items, setItems] = useState<GroupedRecentChat[]>([])
   const [loading, setLoading] = useState(true)
   const [loadingMore, setLoadingMore] = useState(false)
+  const [guidesOpen, setGuidesOpen] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [total, setTotal] = useState(0)
   const [creatingTempChat, setCreatingTempChat] = useState(false)
@@ -1734,7 +1760,7 @@ export default function LandingPage() {
               </button>
             </div>
           </div>
-          <div className={styles.headerActions}>
+                    <div className={styles.headerActions}>
             {showMobileMotionEnable && mobileMotionPermission !== 'denied' && (
               <button
                 type="button"
@@ -1746,6 +1772,7 @@ export default function LandingPage() {
                 <Compass size={13} strokeWidth={1.5} />
               </button>
             )}
+
             <div className={styles.tempChatWrap} ref={tempChatMenuRef}>
               <button
                 type="button"
@@ -1765,21 +1792,49 @@ export default function LandingPage() {
                 </span>
                 <FlaskConical size={13} strokeWidth={1.5} />
               </button>
+
               {tempChatMenuOpen && (
                 <div className={styles.tempChatMenu}>
-                  <button type="button" className={styles.tempChatMenuItem} onClick={() => handleTempChat(false)}>
-                    <span className={styles.tempChatMenuLabel}>{t('tempChatMenu.withPreset')}</span>
+                  <button
+                    type="button"
+                    className={styles.tempChatMenuItem}
+                    onClick={() => handleTempChat(false)}
+                  >
+                    <span className={styles.tempChatMenuLabel}>
+                      {t('tempChatMenu.withPreset')}
+                    </span>
                     <span className={styles.tempChatMenuHint}>
                       {activePresetName || t('tempChatMenu.withPresetHint')}
                     </span>
                   </button>
-                  <button type="button" className={styles.tempChatMenuItem} onClick={() => handleTempChat(true)}>
-                    <span className={styles.tempChatMenuLabel}>{t('tempChatMenu.noPreset')}</span>
-                    <span className={styles.tempChatMenuHint}>{t('tempChatMenu.noPresetHint')}</span>
+
+                  <button
+                    type="button"
+                    className={styles.tempChatMenuItem}
+                    onClick={() => handleTempChat(true)}
+                  >
+                    <span className={styles.tempChatMenuLabel}>
+                      {t('tempChatMenu.noPreset')}
+                    </span>
+                    <span className={styles.tempChatMenuHint}>
+                      {t('tempChatMenu.noPresetHint')}
+                    </span>
                   </button>
                 </div>
               )}
             </div>
+
+            <button
+              type="button"
+              className={styles.accountBtn}
+              onClick={() => setGuidesOpen(true)}
+              title="Open Lumiverse guides"
+              aria-label="Open Lumiverse guides"
+            >
+              <span className={styles.accountName}>Guides</span>
+              <BookOpen size={13} strokeWidth={1.5} />
+            </button>
+
             <button
               type="button"
               className={styles.accountBtn}
@@ -1925,6 +1980,12 @@ export default function LandingPage() {
         </main>
       </motion.div>
     </div>
+    <GuideViewer
+     isOpen={guidesOpen}
+     onClose={() => setGuidesOpen(false)}
+     guide={FULL_GUIDES}
+     title="Lumiverse Guides"
+    />
     <ContextMenu
       position={contextMenu?.position ?? null}
       items={contextMenuItems}

--- a/frontend/src/components/landing/LandingPage.tsx
+++ b/frontend/src/components/landing/LandingPage.tsx
@@ -37,7 +37,7 @@ import { measureLayoutHeight, renderedPxToLayoutPx } from '@/lib/uiScale'
 import LazyImage from '@/components/shared/LazyImage'
 import ContextMenu, { type ContextMenuEntry, type ContextMenuPos } from '@/components/shared/ContextMenu'
 import { GuideViewer } from '@/components/shared/GuideViewer'
-import type { DrawerGuide } from '@/lib/drawer-tab-registry'
+import type { GuideDefinition } from '@/lib/guides/types'
 import SearchField from '@/components/shared/SearchField'
 import { SortControl } from '@/components/shared/SortControl'
 import { useLongPress } from '@/hooks/useLongPress'
@@ -991,7 +991,7 @@ function VirtualizedChatRows({
   )
 }
 
-const FULL_GUIDES: DrawerGuide = {
+const FULL_GUIDES: GuideDefinition = {
   kind: 'builtin',
   path: 'index.md',
   title: 'Lumiverse Guides',
@@ -1981,10 +1981,11 @@ export default function LandingPage() {
       </motion.div>
     </div>
     <GuideViewer
-     isOpen={guidesOpen}
-     onClose={() => setGuidesOpen(false)}
-     guide={FULL_GUIDES}
-     title="Lumiverse Guides"
+        isOpen={guidesOpen}
+        onClose={() => setGuidesOpen(false)}
+        guide={FULL_GUIDES}
+        title="Lumiverse Guides"
+        searchable
     />
     <ContextMenu
       position={contextMenu?.position ?? null}

--- a/frontend/src/components/panels/LoomBuilder.module.css
+++ b/frontend/src/components/panels/LoomBuilder.module.css
@@ -336,6 +336,52 @@
 }
 
 /* ============================================================================
+   GUIDE VIEWER - EXTENSION
+   ============================================================================ */
+
+.extensionTabRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.extensionTabRow .extensionTabBar {
+  flex: 1;
+  min-width: 0;
+}
+
+.extensionGuideButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+
+  width: 28px;
+  height: 28px;
+  padding: 0;
+
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+
+  color: var(--lumiverse-text-dim);
+  opacity: 0.42;
+  cursor: pointer;
+
+  transition:
+    opacity 120ms ease,
+    color 120ms ease,
+    background 120ms ease;
+}
+
+.extensionGuideButton:hover {
+  opacity: 1;
+  color: var(--lumiverse-text);
+  background: var(--lumiverse-fill-subtle);
+}
+
+/* ============================================================================
    SCROLL AREA
    ============================================================================ */
 

--- a/frontend/src/components/panels/LoomBuilder.tsx
+++ b/frontend/src/components/panels/LoomBuilder.tsx
@@ -58,10 +58,12 @@ import {
   Unlink,
   Shield,
   Archive,
+  CircleHelp,
 } from 'lucide-react'
 import clsx from 'clsx'
 import ExpandedTextEditor, { ExpandableTextarea } from '@/components/shared/ExpandedTextEditor'
 import { ModalShell } from '@/components/shared/ModalShell'
+import { GuideViewer } from '@/components/shared/GuideViewer'
 import { RangeSlider } from '@/components/shared/RangeSlider'
 import { resolveMacros as resolveMacrosApi } from '@/api/macros'
 import { useLoomBuilder } from '@/hooks/useLoomBuilder'
@@ -1931,6 +1933,7 @@ export default function LoomBuilder({
 
   const [view, setView] = useState<'list' | 'edit'>('list')
   const [activePresetEditorTab, setActivePresetEditorTab] = useState('preset')
+  const [guideOpen, setGuideOpen] = useState(false)
   const [editingBlock, setEditingBlock] = useState<PromptBlock | null>(null)
   const [blockValidationError, setBlockValidationError] = useState<string | null>(null)
   const [promptMenuOpen, setPromptMenuOpen] = useState(false)
@@ -2027,6 +2030,17 @@ export default function LoomBuilder({
     if (presetEditorTabs.some((tab) => tab.id === activePresetEditorTab)) return
     setActivePresetEditorTab('preset')
   }, [activePresetEditorTab, presetEditorTabs])
+
+  const activePresetExtensionTab = useMemo(
+  () =>
+    presetEditorTabs.find(
+      (tab) => tab.id === activePresetEditorTab,
+    ) ?? null,
+  [presetEditorTabs, activePresetEditorTab],
+)
+useEffect(() => {
+  setGuideOpen(false)
+}, [activePresetEditorTab])
 
   const configurableVariableCount = useMemo(() => {
     return (activePreset?.blocks ?? []).reduce((count, b) => {
@@ -2563,39 +2577,80 @@ export default function LoomBuilder({
         {presetEditorToolbar}
 
         {presetEditorTabs.length > 0 && (
-          <div className={s.extensionTabBar} role="tablist" aria-label={lb('editorTabs.ariaLabel')}>
+          <div className={s.extensionTabRow}>
+            <div
+              className={s.extensionTabBar}
+              role="tablist"
+              aria-label={lb('editorTabs.ariaLabel')}
+            >
             <button
               type="button"
               role="tab"
               aria-selected={activePresetEditorTab === 'preset'}
-              className={clsx(s.extensionTab, activePresetEditorTab === 'preset' && s.extensionTabActive)}
+              className={clsx(
+              s.extensionTab,
+              activePresetEditorTab === 'preset' &&
+              s.extensionTabActive,
+            )}
               onClick={() => setActivePresetEditorTab('preset')}
-            >
-              {lb('editorTabs.preset')}
-            </button>
-            {presetEditorTabs.map((tab) => (
-              <button
-                key={tab.id}
-                type="button"
-                role="tab"
-                aria-selected={activePresetEditorTab === tab.id}
-                className={clsx(s.extensionTab, activePresetEditorTab === tab.id && s.extensionTabActive)}
-                onClick={() => setActivePresetEditorTab(tab.id)}
-              >
-                {tab.title}
-              </button>
-            ))}
-          </div>
-        )}
+          >
+             {lb('editorTabs.preset')}
+          </button>
 
-      {activePresetEditorTab !== 'preset' && (() => {
-        const tab = presetEditorTabs.find((entry) => entry.id === activePresetEditorTab)
-        return tab ? (
-          <div className={s.extensionTabContent} role="tabpanel">
-            <SpindlePresetEditorTabContent tab={tab} />
-          </div>
-        ) : null
-      })()}
+          {presetEditorTabs.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              aria-selected={activePresetEditorTab === tab.id}
+              className={clsx(
+              s.extensionTab,
+              activePresetEditorTab === tab.id &&
+              s.extensionTabActive,
+          )}
+             onClick={() => setActivePresetEditorTab(tab.id)}
+            >
+              {tab.title}
+            </button>
+          ))}
+      </div>
+
+        {activePresetExtensionTab?.guide && (
+          <button
+            type="button"
+            className={s.extensionGuideButton}
+            onClick={() => setGuideOpen(true)}
+            aria-label={`Open guide for ${activePresetExtensionTab.title}`}
+            title="Open guide"
+          >
+            <CircleHelp size={15} strokeWidth={1.7} />
+          </button>
+        )}
+      </div>
+    )}
+
+      {activePresetExtensionTab && (
+      <div
+        className={s.extensionTabContent}
+        role="tabpanel"
+      >
+        <SpindlePresetEditorTabContent
+          tab={activePresetExtensionTab}
+        />
+      </div>
+    )}
+
+    {activePresetExtensionTab?.guide && (
+  <GuideViewer
+    isOpen={guideOpen}
+    onClose={() => setGuideOpen(false)}
+    guide={{
+      kind: 'markdown',
+      ...activePresetExtensionTab.guide,
+    }}
+    title={activePresetExtensionTab.title}
+  />
+)}
 
       <div style={{ display: activePresetEditorTab === 'preset' ? 'contents' : 'none' }}>
 

--- a/frontend/src/components/panels/ViewportDrawer.module.css
+++ b/frontend/src/components/panels/ViewportDrawer.module.css
@@ -359,6 +359,52 @@
   color: var(--lumiverse-text);
 }
 
+.panelHeaderMain {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  min-width: 0;
+}
+
+.guideButton {
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  padding: 0;
+
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+
+  color: var(--lumiverse-text-muted);
+  opacity: 0.38;
+
+  cursor: pointer;
+
+  transition:
+    opacity 0.15s ease,
+    color 0.15s ease,
+    background 0.15s ease;
+}
+
+.guideButton:hover {
+  opacity: 0.82;
+  color: var(--lumiverse-text);
+  background: var(--lumiverse-fill-subtle);
+}
+
+.guideButton:focus-visible {
+  opacity: 0.9;
+  outline: 1px solid var(--lumiverse-primary-050);
+  outline-offset: 1px;
+}
+
 .panelContent {
   flex: 1;
   min-height: 0;

--- a/frontend/src/components/panels/ViewportDrawer.tsx
+++ b/frontend/src/components/panels/ViewportDrawer.tsx
@@ -121,6 +121,10 @@ const activeTabTitle =
         )
       : t('panel', { defaultValue: 'Panel' })
 
+useEffect(() => {
+  setGuideOpen(false)
+}, [activeTab])
+
   useEffect(() => {
     if (drawerTab && drawerTab !== activeTab) {
       setDrawerTab(activeTab)

--- a/frontend/src/components/panels/ViewportDrawer.tsx
+++ b/frontend/src/components/panels/ViewportDrawer.tsx
@@ -1,10 +1,11 @@
 import { useRef, useState, useCallback, useEffect, useMemo } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
-import { Sparkles, Settings, Puzzle } from 'lucide-react'
+import { Sparkles, Settings, Puzzle, CircleHelp } from 'lucide-react'
 import { useStore } from '@/store'
 import useIsMobile from '@/hooks/useIsMobile'
 import ErrorBoundary from '@/components/shared/ErrorBoundary'
 import { CloseButton } from '@/components/shared/CloseButton'
+import { GuideViewer } from '@/components/shared/GuideViewer'
 import ContextMenu, { type ContextMenuEntry, type ContextMenuPos } from '@/components/shared/ContextMenu'
 import { useLongPress } from '@/hooks/useLongPress'
 import { DRAWER_TABS, adaptExtensionTabs, applyDrawerTabOrder, sanitizeDrawerTabOrder, sanitizeHiddenDrawerTabIds } from '@/lib/drawer-tab-registry'
@@ -53,6 +54,8 @@ export default function ViewportDrawer() {
   const panelContentRef = useRef<HTMLDivElement>(null)
   const [tabListScroll, setTabListScroll] = useState({ up: false, down: false })
   const [contextMenu, setContextMenu] = useState<ContextMenuPos | null>(null)
+  const [guideOpen, setGuideOpen] = useState(false)
+
 
   const updateTabListScroll = useCallback(() => {
     const el = tabListRef.current
@@ -107,6 +110,16 @@ export default function ViewportDrawer() {
   )
   const activeTab = allTabs.some((tab) => tab.id === requestedActiveTab) ? requestedActiveTab : 'profile'
   const activeTabConfig = allTabs.find((t) => t.id === activeTab) || DRAWER_TABS[0]
+const activeTabTitle =
+  activeTab === 'profile' && isGroupChat
+    ? t('group')
+    : activeTabConfig
+      ? translateDrawerField(
+          activeTabConfig.id,
+          'tabHeaderTitle',
+          activeTabConfig.tabHeaderTitle ?? activeTabConfig.tabName,
+        )
+      : t('panel', { defaultValue: 'Panel' })
 
   useEffect(() => {
     if (drawerTab && drawerTab !== activeTab) {
@@ -298,26 +311,42 @@ export default function ViewportDrawer() {
           </div>
 
           <div className={styles.panel}>
-            <div className={styles.panelHeader}>
-              <h2 className={styles.panelTitle}>
-                {activeTab === 'profile' && isGroupChat
-                  ? t('group')
-                  : activeTabConfig
-                    ? translateDrawerField(
-                        activeTabConfig.id,
-                        'tabHeaderTitle',
-                        activeTabConfig.tabHeaderTitle ?? activeTabConfig.tabName,
-                      )
-                    : t('panel', { defaultValue: 'Panel' })}
-              </h2>
-              <CloseButton onClick={closeDrawer} />
-            </div>
+           <div className={styles.panelHeader}>
+            <div className={styles.panelHeaderMain}>
+             <h2 className={styles.panelTitle}>
+               {activeTabTitle}
+             </h2>
+
+              {activeTabConfig.guide && (
+             <button
+               type="button"
+               className={styles.guideButton}
+               onClick={() => setGuideOpen(true)}
+               aria-label={`Open guide for ${activeTabTitle}`}
+               title="Open guide"
+             >
+               <CircleHelp size={15} strokeWidth={1.7} />
+            </button>
+           )}
+         </div>
+
+        <CloseButton onClick={closeDrawer} />
+      </div>
             <div className={clsx(styles.panelContent, (activeTab === 'loom' || activeTab === 'lumi' || activeTab === 'browser' || activeTab === 'lorebook') && styles.panelContentFull)} ref={panelContentRef}>
               <TabPanelContent tabId={activeTab} location={{ kind: 'main-drawer' }} />
             </div>
           </div>
         </div>
       </div>
+
+{activeTabConfig.guide && (
+  <GuideViewer
+    isOpen={guideOpen}
+    onClose={() => setGuideOpen(false)}
+    guide={activeTabConfig.guide}
+    title={activeTabTitle}
+  />
+)}
 
       <ContextMenu
         position={contextMenu}

--- a/frontend/src/components/panels/character-browser/CharacterEditorPage.module.css
+++ b/frontend/src/components/panels/character-browser/CharacterEditorPage.module.css
@@ -198,6 +198,49 @@
   flex-shrink: 0;
 }
 
+/* Guide */
+.tabBarRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.tabBarRow .tabBar {
+  flex: 1;
+  min-width: 0;
+}
+
+.extensionGuideButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+
+  width: 28px;
+  height: 28px;
+  padding: 0;
+
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+
+  color: var(--lumiverse-text-dim);
+  opacity: 0.42;
+  cursor: pointer;
+
+  transition:
+    opacity 120ms ease,
+    color 120ms ease,
+    background 120ms ease;
+}
+
+.extensionGuideButton:hover {
+  opacity: 1;
+  color: var(--lumiverse-text);
+  background: var(--lumiverse-fill-subtle);
+}
+
 /* Tab bar */
 .tabBar {
   display: flex;

--- a/frontend/src/components/panels/character-browser/CharacterEditorPage.tsx
+++ b/frontend/src/components/panels/character-browser/CharacterEditorPage.tsx
@@ -4,7 +4,24 @@ import { useVirtualizer } from '@tanstack/react-virtual'
 
 import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'motion/react'
-import { X, Upload, Trash2, Copy, MessageSquare, User, UserPlus, Plus, ImagePlus, Download, Code2, GripVertical, ExternalLink, Hash, MoreHorizontal } from 'lucide-react'
+import {
+  X,
+  Upload,
+  Trash2,
+  Copy,
+  MessageSquare,
+  User,
+  UserPlus,
+  Plus,
+  ImagePlus,
+  Download,
+  Code2,
+  GripVertical,
+  ExternalLink,
+  Hash,
+  MoreHorizontal,
+  CircleHelp,
+} from 'lucide-react'
 import {
   DndContext,
   closestCenter,
@@ -76,6 +93,7 @@ import AlternateFieldEditor from './AlternateFieldEditor'
 import AlternateAvatarManager from './AlternateAvatarManager'
 import type { AlternateAvatarEntry } from './AlternateAvatarManager'
 import CharacterTokenReportModal, { type CharacterTokenReportItem } from './CharacterTokenReportModal'
+import { GuideViewer } from '@/components/shared/GuideViewer'
 
 const DEBOUNCE_MS = 2000
 const MAX_PERSPECTIVE_LAYERS = 5
@@ -400,6 +418,7 @@ export default function CharacterEditorPage() {
   const [fields, setFields] = useState<Record<string, string>>({})
   const [tags, setTags] = useState<string[]>([])
   const [newTag, setNewTag] = useState('')
+  const [guideOpen, setGuideOpen] = useState(false)
   const [alternateGreetings, setAlternateGreetings] = useState<string[]>([])
   const [alternateCharacterName, setAlternateCharacterName] = useState('')
   const [extensionsJson, setExtensionsJson] = useState('')
@@ -453,6 +472,11 @@ export default function CharacterEditorPage() {
     document.addEventListener('keydown', handleEscape)
     return () => document.removeEventListener('keydown', handleEscape)
   }, [isOpen, close])
+
+  /// Guide Viewer 
+  useEffect(() => {
+  setGuideOpen(false)
+}, [activeTab])
 
   // Reset tab and force re-sync when switching to a different character.
   // Keyed on editingCharacterId (a stable string) so store-driven object
@@ -1857,16 +1881,19 @@ export default function CharacterEditorPage() {
                 {/* Tab bar */}
                 <div className={styles.tabBar}>
                   {tabs.map((tab) => (
-                    <button
-                      key={tab.id}
-                      type="button"
-                      className={clsx(styles.tab, activeTab === tab.id && styles.tabActive)}
-                      onClick={() => setActiveTab(tab.id)}
-                    >
-                      {tab.label}
-                    </button>
-                  ))}
-                </div>
+                  <button
+                    key={tab.id}
+                    type="button"
+                    className={clsx(
+                    styles.tab,
+                      activeTab === tab.id && styles.tabActive,
+                  )}
+                    onClick={() => setActiveTab(tab.id)}
+                >
+                 {tab.label}
+                </button>
+               ))}
+              </div>
 
                 {/* Tab content */}
                 <div className={styles.tabContent}>
@@ -2449,8 +2476,26 @@ export default function CharacterEditorPage() {
                   )}
 
                   {activeExtensionTab && (
-                    <SpindleCharacterEditorTabContent tab={activeExtensionTab} />
+                    <div className={styles.extensionTabShell}>
+                  {activeExtensionTab.guide && (
+                    <div className={styles.extensionGuideRow}>
+                      <button
+                        type="button"
+                        className={styles.extensionGuideButton}
+                        onClick={() => setGuideOpen(true)}
+                        aria-label={`Open guide for ${activeExtensionTab.title}`}
+                        title="Open guide"
+                      >
+                        <CircleHelp size={15} strokeWidth={1.7} />
+                      </button>
+                    </div>
                   )}
+
+                    <SpindleCharacterEditorTabContent
+                      tab={activeExtensionTab}
+                    />
+                  </div>
+                )}
                 </div>
               </>
             )}
@@ -2467,6 +2512,17 @@ export default function CharacterEditorPage() {
       onClose={() => setGalleryContextMenu(null)}
     />
     <ImageLightbox src={galleryLightboxSrc} onClose={() => setGalleryLightboxSrc(null)} />
+    {activeExtensionTab?.guide && (
+  <GuideViewer
+    isOpen={guideOpen}
+    onClose={() => setGuideOpen(false)}
+    guide={{
+      kind: 'markdown',
+      ...activeExtensionTab.guide,
+    }}
+    title={activeExtensionTab.title}
+  />
+)}
 
     {character && (
       <CharacterTokenReportModal

--- a/frontend/src/components/shared/GuideViewer.module.css
+++ b/frontend/src/components/shared/GuideViewer.module.css
@@ -42,6 +42,48 @@
   white-space: nowrap;
 }
 
+.headerLeading {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+
+  min-width: 0;
+}
+
+.backButton {
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  padding: 0;
+
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+
+  color: var(--lumiverse-text-muted);
+
+  cursor: pointer;
+
+  transition:
+    color 0.15s ease,
+    background 0.15s ease;
+}
+
+.backButton:hover {
+  color: var(--lumiverse-text);
+  background: var(--lumiverse-fill-subtle);
+}
+
+.backButton:focus-visible {
+  outline: 1px solid var(--lumiverse-primary-050);
+  outline-offset: 1px;
+}
+
 .body {
   flex: 1;
   min-height: 0;

--- a/frontend/src/components/shared/GuideViewer.module.css
+++ b/frontend/src/components/shared/GuideViewer.module.css
@@ -84,6 +84,133 @@
   outline-offset: 1px;
 }
 
+.searchArea {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+
+  margin: -18px -20px 18px;
+  padding: 12px 20px;
+
+  border-bottom: 1px solid var(--lumiverse-border);
+  background: var(--lumiverse-bg-deep);
+}
+
+.searchInputWrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  width: 100%;
+  padding: 0 10px;
+
+  border: 1px solid var(--lumiverse-border);
+  border-radius: var(--lumiverse-radius-md);
+
+  background: var(--lumiverse-bg);
+  color: var(--lumiverse-text-muted);
+}
+
+.searchInputWrap:focus-within {
+  border-color: var(--lumiverse-primary-050);
+}
+
+.searchInput {
+  flex: 1;
+  min-width: 0;
+
+  padding: 9px 0;
+
+  border: 0;
+  outline: 0;
+  background: transparent;
+
+  color: var(--lumiverse-text);
+  font: inherit;
+  font-size: calc(12px * var(--lumiverse-font-scale, 1));
+}
+
+.searchInput::placeholder {
+  color: var(--lumiverse-text-dim);
+}
+
+.searchClear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 24px;
+  height: 24px;
+  padding: 0;
+
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+
+  color: var(--lumiverse-text-dim);
+  cursor: pointer;
+}
+
+.searchClear:hover {
+  background: var(--lumiverse-fill-subtle);
+  color: var(--lumiverse-text);
+}
+
+.searchResults {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+
+  margin-top: 8px;
+}
+
+.searchResult {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+
+  width: 100%;
+  padding: 8px 10px;
+
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+
+  color: var(--lumiverse-text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.searchResult:hover {
+  background: var(--lumiverse-primary-010);
+}
+
+.searchResultTitle {
+  font-size: calc(12px * var(--lumiverse-font-scale, 1));
+  font-weight: 600;
+}
+
+.searchResultPath {
+  color: var(--lumiverse-text-dim);
+
+  font-size: calc(10px * var(--lumiverse-font-scale, 1));
+}
+
+.searchEmpty {
+  padding: 12px 10px;
+
+  color: var(--lumiverse-text-dim);
+  font-size: calc(12px * var(--lumiverse-font-scale, 1));
+}
+
+@media (max-width: 600px) {
+  .searchArea {
+    margin: -14px -14px 14px;
+    padding: 10px 14px;
+  }
+}
+
 .body {
   flex: 1;
   min-height: 0;

--- a/frontend/src/components/shared/GuideViewer.module.css
+++ b/frontend/src/components/shared/GuideViewer.module.css
@@ -1,0 +1,245 @@
+.modal {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+
+  padding: 12px 16px;
+
+  border-bottom: 1px solid var(--lumiverse-border);
+  background: var(--lumiverse-bg);
+
+  flex-shrink: 0;
+}
+
+.headerTitle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  min-width: 0;
+
+  color: var(--lumiverse-text);
+  font-size: calc(14px * var(--lumiverse-font-scale, 1));
+  font-weight: 600;
+}
+
+.headerTitle svg {
+  flex-shrink: 0;
+  color: var(--lumiverse-primary);
+}
+
+.headerTitle span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.body {
+  flex: 1;
+  min-height: 0;
+
+  padding: 18px 20px 24px;
+
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
+
+  background: var(--lumiverse-bg-deep);
+}
+
+.status,
+.error {
+  padding: 24px 8px;
+
+  font-size: calc(13px * var(--lumiverse-font-scale, 1));
+  line-height: 1.5;
+}
+
+.status {
+  color: var(--lumiverse-text-dim);
+}
+
+.error {
+  color: var(--lumiverse-danger);
+}
+
+.prose {
+  color: var(--lumiverse-text-muted);
+
+  font-size: calc(13px * var(--lumiverse-font-scale, 1));
+  line-height: 1.65;
+}
+
+.prose > :first-child {
+  margin-top: 0;
+}
+
+.prose > :last-child {
+  margin-bottom: 0;
+}
+
+.prose h1,
+.prose h2,
+.prose h3,
+.prose h4 {
+  color: var(--lumiverse-text);
+  line-height: 1.3;
+}
+
+.prose h1 {
+  margin: 0 0 14px;
+
+  font-size: calc(22px * var(--lumiverse-font-scale, 1));
+  font-weight: 700;
+}
+
+.prose h2 {
+  margin: 26px 0 10px;
+
+  font-size: calc(17px * var(--lumiverse-font-scale, 1));
+  font-weight: 650;
+}
+
+.prose h3 {
+  margin: 20px 0 8px;
+
+  font-size: calc(15px * var(--lumiverse-font-scale, 1));
+  font-weight: 600;
+}
+
+.prose h4 {
+  margin: 16px 0 6px;
+
+  font-size: calc(13px * var(--lumiverse-font-scale, 1));
+  font-weight: 600;
+}
+
+.prose p {
+  margin: 0 0 12px;
+}
+
+.prose ul,
+.prose ol {
+  margin: 8px 0 14px;
+  padding-left: 24px;
+}
+
+.prose li {
+  margin: 4px 0;
+}
+
+.prose strong {
+  color: var(--lumiverse-text);
+  font-weight: 650;
+}
+
+.prose a {
+  color: var(--lumiverse-primary);
+  text-decoration: underline;
+  text-decoration-color: var(--lumiverse-primary-050);
+  text-underline-offset: 2px;
+}
+
+.prose a:hover {
+  text-decoration-color: currentColor;
+}
+
+.prose code {
+  padding: 1px 5px;
+
+  border-radius: 5px;
+  background: var(--lumiverse-fill-subtle);
+
+  color: var(--lumiverse-text);
+
+  font-family: var(--lumiverse-font-mono);
+  font-size: 0.9em;
+}
+
+.prose pre {
+  margin: 12px 0 16px;
+  padding: 12px 14px;
+
+  overflow-x: auto;
+
+  border: 1px solid var(--lumiverse-border);
+  border-radius: var(--lumiverse-radius-md);
+  background: var(--lumiverse-bg);
+
+  color: var(--lumiverse-text);
+}
+
+.prose pre code {
+  padding: 0;
+  background: transparent;
+
+  font-size: calc(12px * var(--lumiverse-font-scale, 1));
+}
+
+.prose blockquote {
+  margin: 14px 0;
+  padding: 8px 14px;
+
+  border-left: 3px solid var(--lumiverse-primary-050);
+
+  color: var(--lumiverse-text-dim);
+}
+
+.prose table {
+  display: block;
+
+  width: 100%;
+  margin: 14px 0;
+
+  overflow-x: auto;
+
+  border-collapse: collapse;
+}
+
+.prose th,
+.prose td {
+  padding: 8px 10px;
+
+  border: 1px solid var(--lumiverse-border);
+
+  text-align: left;
+  vertical-align: top;
+}
+
+.prose th {
+  background: var(--lumiverse-fill-subtle);
+
+  color: var(--lumiverse-text);
+  font-weight: 600;
+}
+
+.prose hr {
+  margin: 22px 0;
+
+  border: 0;
+  border-top: 1px solid var(--lumiverse-border);
+}
+
+.prose img {
+  display: block;
+
+  max-width: 100%;
+  height: auto;
+  margin: 14px auto;
+
+  border-radius: var(--lumiverse-radius-md);
+}
+
+@media (max-width: 600px) {
+  .body {
+    padding: 14px 14px 20px;
+  }
+}

--- a/frontend/src/components/shared/GuideViewer.module.css
+++ b/frontend/src/components/shared/GuideViewer.module.css
@@ -174,7 +174,24 @@
   padding-left: 24px;
 }
 
+.prose ul {
+  list-style: disc;
+}
+
+.prose ol {
+  list-style: decimal;
+}
+
+.prose ul ul {
+  list-style: circle;
+}
+
+.prose ul ul ul {
+  list-style: square;
+}
+
 .prose li {
+  display: list-item;
   margin: 4px 0;
 }
 
@@ -278,6 +295,121 @@
   margin: 14px auto;
 
   border-radius: var(--lumiverse-radius-md);
+}
+
+.prose :global(.guide-admonition) {
+  margin: 16px 0;
+  padding: 12px 14px;
+
+  border: 1px solid var(--lumiverse-border);
+  border-left: 3px solid var(--lumiverse-primary);
+  border-radius: var(--lumiverse-radius-md);
+
+  background: var(--lumiverse-fill-subtle);
+}
+
+.prose :global(.guide-admonition-title) {
+  margin-bottom: 6px;
+
+  color: var(--lumiverse-text);
+  font-weight: 650;
+}
+
+.prose :global(.guide-admonition) > :last-child {
+  margin-bottom: 0;
+}
+
+.prose :global(.guide-content-tabs) {
+  margin: 16px 0;
+
+  border: 1px solid var(--lumiverse-border);
+  border-radius: var(--lumiverse-radius-md);
+
+  overflow: hidden;
+  background: var(--lumiverse-bg);
+}
+
+.prose :global(.guide-content-tab-list) {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+
+  padding: 6px;
+
+  border-bottom: 1px solid var(--lumiverse-border);
+  background: var(--lumiverse-fill-subtle);
+}
+
+.prose :global(.guide-content-tab) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  min-height: 30px;
+  padding: 5px 10px;
+
+  border: 1px solid transparent;
+  border-radius: 7px;
+
+  background: transparent;
+  color: var(--lumiverse-text-muted);
+
+  font: inherit;
+  font-size: calc(12px * var(--lumiverse-font-scale, 1));
+  font-weight: 500;
+
+  cursor: pointer;
+
+  transition:
+    color var(--lumiverse-transition-fast),
+    border-color var(--lumiverse-transition-fast),
+    background var(--lumiverse-transition-fast);
+}
+
+.prose :global(.guide-content-tab:hover) {
+  color: var(--lumiverse-text);
+  background: var(--lumiverse-fill);
+}
+
+.prose
+  :global(.guide-content-tab[aria-selected='true']) {
+  color: var(--lumiverse-text);
+
+  border-color: var(--lumiverse-primary-050);
+  background: var(--lumiverse-primary-015);
+}
+
+.prose :global(.guide-content-tab:focus-visible) {
+  outline: 1px solid var(--lumiverse-primary);
+  outline-offset: 1px;
+}
+
+.prose :global(.guide-content-tab code) {
+  padding: 0;
+  background: transparent;
+
+  color: inherit;
+  font-size: inherit;
+}
+
+.prose :global(.guide-content-tab-panel) {
+  padding: 14px 16px;
+}
+
+.prose
+  :global(.guide-content-tab-panel[data-active='false']) {
+  display: none;
+}
+
+.prose
+  :global(.guide-content-tab-panel > :first-child) {
+  margin-top: 0;
+}
+
+.prose
+  :global(.guide-content-tab-panel > :last-child) {
+  margin-bottom: 0;
 }
 
 @media (max-width: 600px) {

--- a/frontend/src/components/shared/GuideViewer.navigation.test.tsx
+++ b/frontend/src/components/shared/GuideViewer.navigation.test.tsx
@@ -1,0 +1,272 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  test,
+} from 'bun:test'
+import {
+  act,
+  createElement,
+  type ReactNode,
+} from 'react'
+import { createRoot } from 'react-dom/client'
+import { JSDOM } from 'jsdom'
+
+const dom = new JSDOM(
+  '<!doctype html><html><body></body></html>',
+  {
+    url: 'http://localhost/',
+    pretendToBeVisual: true,
+  },
+)
+
+const originalWindow = globalThis.window
+const originalDocument = globalThis.document
+const originalElement = globalThis.Element
+const originalHTMLElement = globalThis.HTMLElement
+const originalNode = globalThis.Node
+const originalEvent = globalThis.Event
+const originalMouseEvent = globalThis.MouseEvent
+const originalDOMParser = globalThis.DOMParser
+const originalNavigator = globalThis.navigator
+const originalFetch = globalThis.fetch
+
+mock.module('@/components/shared/ModalShell', () => ({
+  ModalShell: ({
+    isOpen,
+    children,
+  }: {
+    isOpen: boolean
+    children: ReactNode
+  }) =>
+    isOpen
+      ? createElement(
+          'div',
+          { 'data-testid': 'guide-modal' },
+          children,
+        )
+      : null,
+}))
+
+mock.module('@/components/shared/CloseButton', () => ({
+  CloseButton: ({
+    onClick,
+  }: {
+    onClick: () => void
+  }) =>
+    createElement(
+      'button',
+      {
+        type: 'button',
+        onClick,
+        'aria-label': 'Close',
+      },
+      'Close',
+    ),
+}))
+
+let GuideViewer:
+  typeof import('./GuideViewer').GuideViewer
+
+beforeAll(async () => {
+  const domWindow =
+    dom.window as unknown as Window & typeof globalThis
+
+  Object.assign(globalThis, {
+    window: domWindow,
+    document: domWindow.document,
+    Element: domWindow.Element,
+    HTMLElement: domWindow.HTMLElement,
+    Node: domWindow.Node,
+    Event: domWindow.Event,
+    MouseEvent: domWindow.MouseEvent,
+    DOMParser: domWindow.DOMParser,
+  })
+
+  Object.defineProperty(
+    globalThis,
+    'navigator',
+    {
+      configurable: true,
+      value: domWindow.navigator,
+    },
+  )
+
+  ;(
+    globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT: boolean
+    }
+  ).IS_REACT_ACT_ENVIRONMENT = true
+
+  ;({ GuideViewer } = await import('./GuideViewer'))
+})
+
+afterAll(() => {
+  Object.assign(globalThis, {
+    window: originalWindow,
+    document: originalDocument,
+    Element: originalElement,
+    HTMLElement: originalHTMLElement,
+    Node: originalNode,
+    Event: originalEvent,
+    MouseEvent: originalMouseEvent,
+    DOMParser: originalDOMParser,
+    fetch: originalFetch,
+  })
+
+  Object.defineProperty(
+    globalThis,
+    'navigator',
+    {
+      configurable: true,
+      value: originalNavigator,
+    },
+  )
+})
+
+async function waitForText(
+  container: HTMLElement,
+  text: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (container.textContent?.includes(text)) {
+      return
+    }
+
+    await act(async () => {
+      await new Promise((resolve) =>
+        setTimeout(resolve, 0),
+      )
+    })
+  }
+
+  throw new Error(
+    `Timed out waiting for "${text}". ` +
+      `Rendered: ${container.textContent}`,
+  )
+}
+
+describe('GuideViewer builtin navigation', () => {
+  test(
+    'allows internal navigation but resets when the builtin guide changes',
+    async () => {
+      const responses = [
+        [
+          '# CHARACTERS ROOT BODY',
+          '',
+          '[Open child](child.md)',
+        ].join('\n'),
+        '# CHARACTERS CHILD BODY',
+        '# REGEX ROOT BODY',
+      ]
+
+      const requestedUrls: string[] = []
+
+      globalThis.fetch = (async (input) => {
+        requestedUrls.push(String(input))
+
+        const markdown = responses.shift()
+
+        if (!markdown) {
+          throw new Error(
+            `Unexpected guide request: ${String(input)}`,
+          )
+        }
+
+        return new Response(markdown, {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/markdown',
+          },
+        })
+      }) as typeof fetch
+
+      const container =
+        document.createElement('div')
+
+      document.body.append(container)
+
+      const root = createRoot(container)
+
+      try {
+        await act(async () => {
+          root.render(
+            createElement(GuideViewer, {
+              isOpen: true,
+              onClose: () => {},
+              guide: {
+                kind: 'builtin',
+                path: 'characters/index.md',
+              },
+              title: 'Characters',
+            }),
+          )
+        })
+
+        await waitForText(
+          container,
+          'CHARACTERS ROOT BODY',
+        )
+
+        const childLink =
+          container.querySelector('a')
+
+        expect(childLink).not.toBeNull()
+
+        await act(async () => {
+          childLink!.dispatchEvent(
+            new dom.window.MouseEvent(
+              'click',
+              {
+                bubbles: true,
+                cancelable: true,
+              },
+            ),
+          )
+        })
+
+        await waitForText(
+          container,
+          'CHARACTERS CHILD BODY',
+        )
+
+        expect(container.textContent).not.toContain(
+          'CHARACTERS ROOT BODY',
+        )
+
+        await act(async () => {
+          root.render(
+            createElement(GuideViewer, {
+              isOpen: true,
+              onClose: () => {},
+              guide: {
+                kind: 'builtin',
+                path: 'customization/regex-scripts.md',
+              },
+              title: 'Regex',
+            }),
+          )
+        })
+
+        await waitForText(
+          container,
+          'REGEX ROOT BODY',
+        )
+
+        expect(container.textContent).not.toContain(
+          'CHARACTERS CHILD BODY',
+        )
+
+        expect(requestedUrls).toHaveLength(3)
+      } finally {
+        await act(async () => {
+          root.unmount()
+        })
+
+        container.remove()
+      }
+    },
+  )
+})

--- a/frontend/src/components/shared/GuideViewer.tsx
+++ b/frontend/src/components/shared/GuideViewer.tsx
@@ -358,6 +358,22 @@ export function GuideViewer({
   )
 
   const [history, setHistory] = useState<string[]>([])
+
+  const builtinPath =
+  guide.kind === 'builtin'
+    ? guide.path
+    : null
+
+useEffect(() => {
+  if (!isOpen || builtinPath === null) {
+    return
+  }
+
+  setCurrentPath(builtinPath)
+  setHistory([])
+  setError(null)
+}, [isOpen, builtinPath])
+
   const inlineMarkdown =
   guide.kind === 'markdown'
     ? guide.markdown

--- a/frontend/src/components/shared/GuideViewer.tsx
+++ b/frontend/src/components/shared/GuideViewer.tsx
@@ -26,6 +26,207 @@ interface ResolvedGuideLink {
   hash: string
 }
 
+
+function transformAdmonitions(markdown: string): string {
+  const lines = markdown.split(/\r?\n/)
+  const output: string[] = []
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const match = lines[i].match(
+      /^!!!\s+([a-zA-Z0-9_-]+)(?:\s+"([^"]*)")?\s*$/,
+    )
+
+    if (!match) {
+      output.push(lines[i])
+      continue
+    }
+
+    const [, type, customTitle] = match
+    const body: string[] = []
+
+    i += 1
+
+    while (i < lines.length) {
+      const line = lines[i]
+
+      if (/^( {4}|\t)/.test(line)) {
+        body.push(line.replace(/^( {4}|\t)/, ''))
+        i += 1
+        continue
+      }
+
+      if (line.trim() === '' && body.length > 0) {
+        body.push('')
+        i += 1
+        continue
+      }
+
+      break
+    }
+stripFrontMatter 
+    i -= 1
+
+    const title =
+  customTitle ||
+  type.charAt(0).toUpperCase() + type.slice(1)
+
+const titleHtml = marked.parseInline(
+  title,
+  { async: false },
+) as string
+
+    output.push(
+  `<div class="guide-admonition guide-admonition-${type}">`,
+  `<div class="guide-admonition-title">${title}</div>`,
+  '',
+  body.join('\n'),
+  '',
+  '</div>',
+  '',
+)
+  }
+
+  return output.join('\n')
+}
+
+function transformContentTabs(markdown: string): string {
+  const lines = markdown.split(/\r?\n/)
+  const output: string[] = []
+  const tabPattern = /^===\s+"([^"]+)"\s*$/
+
+  let i = 0
+
+  while (i < lines.length) {
+    const firstMatch = lines[i].match(tabPattern)
+
+    if (!firstMatch) {
+      output.push(lines[i])
+      i += 1
+      continue
+    }
+
+    const tabs: Array<{
+      label: string
+      body: string
+    }> = []
+
+    while (i < lines.length) {
+      const headerMatch = lines[i].match(tabPattern)
+
+      if (!headerMatch) break
+
+      const label = headerMatch[1]
+
+      i += 1
+
+      // Zensical normally leaves a blank line after === "Label".
+      if (i < lines.length && lines[i].trim() === '') {
+        i += 1
+      }
+
+      const bodyLines: string[] = []
+
+      while (i < lines.length) {
+        const line = lines[i]
+
+        // Next sibling tab starts here.
+        if (tabPattern.test(line)) {
+          break
+        }
+
+        // Blank lines belong to the current tab body.
+        if (line.trim() === '') {
+          bodyLines.push('')
+          i += 1
+          continue
+        }
+
+        // Tab contents are indented one Markdown level.
+        if (/^( {4}|\t)/.test(line)) {
+          bodyLines.push(
+            line.replace(/^( {4}|\t)/, ''),
+          )
+          i += 1
+          continue
+        }
+
+        // Non-indented content means the tab group is over.
+        break
+      }
+
+      tabs.push({
+        label,
+        body: bodyLines.join('\n').trimEnd(),
+      })
+
+      if (
+        i >= lines.length ||
+        !tabPattern.test(lines[i])
+      ) {
+        break
+      }
+    }
+
+    const buttons = tabs
+      .map((tab, index) => {
+        const labelHtml = marked.parseInline(
+          tab.label,
+          { async: false },
+        ) as string
+
+        return `
+<button
+  type="button"
+  class="guide-content-tab"
+  data-guide-tab-button="${index}"
+  aria-selected="${index === 0 ? 'true' : 'false'}"
+>
+  ${labelHtml}
+</button>`
+      })
+      .join('')
+
+    const panels = tabs
+      .map((tab, index) => {
+        /*
+         * The tab body has now been dedented by four spaces.
+         * This turns nested constructs like:
+         *
+         *     !!! warning
+         *         body
+         *
+         * into normal top-level admonition syntax for our
+         * existing transformer.
+         */
+        const bodyHtml = marked.parse(
+          transformAdmonitions(tab.body),
+          { async: false },
+        ) as string
+
+        return `
+<div
+  class="guide-content-tab-panel"
+  data-guide-tab-panel="${index}"
+  data-active="${index === 0 ? 'true' : 'false'}"
+>
+  ${bodyHtml}
+</div>`
+      })
+      .join('')
+
+    output.push(
+      '',
+      '<div class="guide-content-tabs" data-guide-tab-group>',
+      `<div class="guide-content-tab-list">${buttons}</div>`,
+      `<div class="guide-content-tab-panels">${panels}</div>`,
+      '</div>',
+      '',
+    )
+  }
+
+  return output.join('\n')
+}
+
 function stripFrontMatter(markdown: string): string {
   return markdown.replace(
     /^\uFEFF?---\r?\n[\s\S]*?\r?\n---\r?\n?/,
@@ -49,11 +250,23 @@ function getFrontMatterTitle(markdown: string): string | null {
     .replace(/^["']|["']$/g, '')
 }
 
-function encodeGuidePath(path: string): string {
-  return path
-    .split('/')
-    .map((segment) => encodeURIComponent(segment))
-    .join('/')
+function encodeDocumentKey(path: string): string {
+  const bytes = new TextEncoder().encode(path)
+
+  let binary = ''
+
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '')
+}
+
+function documentUrl(path: string): string {
+  return `/api/v1/docs/file/${encodeDocumentKey(path)}`
 }
 
 function resolveGuideLink(
@@ -108,9 +321,9 @@ function rewriteGuideAssetUrls(
       const resolved = resolveGuideLink(currentPath, src)
 
       image.setAttribute(
-        'src',
-        `/api/v1/docs/${encodeGuidePath(resolved.path)}`,
-      )
+  'src',
+  documentUrl(resolved.path),
+)
     },
   )
 
@@ -135,81 +348,71 @@ export function GuideViewer({
 
   const [history, setHistory] = useState<string[]>([])
 
-  useEffect(() => {
-    if (!isOpen) return
+useEffect(() => {
+  if (
+    !isOpen ||
+    guide.kind !== 'builtin' ||
+    !currentPath
+  ) {
+    return
+  }
 
-    setHistory([])
-    setError(null)
+  const controller = new AbortController()
 
-    if (guide.kind === 'markdown') {
-      setCurrentPath(null)
-      setContent(guide.markdown)
-      setLoading(false)
-      return
-    }
+  setContent('')
+  setError(null)
+  setLoading(true)
 
-    setContent('')
-    setCurrentPath(guide.path)
-  }, [isOpen, guide])
+  const guideUrl = documentUrl(currentPath)
 
-  useEffect(() => {
-    if (
-      !isOpen ||
-      guide.kind !== 'builtin' ||
-      !currentPath
-    ) {
-      return
-    }
-
-    const controller = new AbortController()
-
-    setContent('')
-    setError(null)
-    setLoading(true)
-
-    void fetch(
-      `/api/v1/docs/${encodeGuidePath(currentPath)}`,
-      { signal: controller.signal },
-    )
-      .then(async (response) => {
-        if (!response.ok) {
-          throw new Error(
-            `Guide request failed (${response.status})`,
-          )
-        }
-
-        return response.text()
-      })
-      .then((text) => {
-        setContent(text)
-      })
-      .catch((err: unknown) => {
-        if (controller.signal.aborted) return
-
-        setError(
-          err instanceof Error
-            ? err.message
-            : 'Unable to load this guide.',
+  void fetch(
+    guideUrl,
+    { signal: controller.signal },
+  )
+    .then(async (response) => {
+      if (!response.ok) {
+        throw new Error(
+          `Guide request failed (${response.status})`,
         )
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) {
-          setLoading(false)
-        }
-      })
+      }
 
-    return () => {
-      controller.abort()
-    }
-  }, [isOpen, guide.kind, currentPath])
+      return response.text()
+    })
+    .then((text) => {
+      setContent(text)
+    })
+    .catch((err: unknown) => {
+      if (controller.signal.aborted) return
+
+      const message =
+        err instanceof Error
+          ? err.message
+          : 'Unable to load this guide.'
+
+      setError(message)
+    })
+    .finally(() => {
+      if (!controller.signal.aborted) {
+        setLoading(false)
+      }
+    })
+
+  return () => {
+    controller.abort()
+  }
+}, [isOpen, guide.kind, currentPath])
 
   const renderedHtml = useMemo(() => {
     if (!content) return ''
 
-    const parsed = marked.parse(
-      stripFrontMatter(content),
-      { async: false },
-    ) as string
+    const preparedMarkdown = transformContentTabs(
+  stripFrontMatter(content),
+)
+
+const parsed = marked.parse(
+  transformAdmonitions(preparedMarkdown),
+  { async: false },
+) as string
 
     const sanitized = DOMPurify.sanitize(parsed)
 
@@ -242,6 +445,8 @@ export function GuideViewer({
     const target = event.target
 
     if (!(target instanceof Element)) return
+
+
 
     const anchor = target.closest('a')
 

--- a/frontend/src/components/shared/GuideViewer.tsx
+++ b/frontend/src/components/shared/GuideViewer.tsx
@@ -1,5 +1,10 @@
-import { useEffect, useMemo, useState } from 'react'
-import { BookOpen } from 'lucide-react'
+import {
+  type MouseEvent,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+import { ArrowLeft, BookOpen } from 'lucide-react'
 import DOMPurify from 'dompurify'
 import { marked } from 'marked'
 
@@ -16,6 +21,11 @@ interface GuideViewerProps {
   title: string
 }
 
+interface ResolvedGuideLink {
+  path: string
+  hash: string
+}
+
 function stripFrontMatter(markdown: string): string {
   return markdown.replace(
     /^\uFEFF?---\r?\n[\s\S]*?\r?\n---\r?\n?/,
@@ -23,11 +33,88 @@ function stripFrontMatter(markdown: string): string {
   )
 }
 
+function getFrontMatterTitle(markdown: string): string | null {
+  const frontMatter = markdown.match(
+    /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/,
+  )
+
+  if (!frontMatter) return null
+
+  const title = frontMatter[1].match(/^title:\s*(.+?)\s*$/m)
+
+  if (!title) return null
+
+  return title[1]
+    .trim()
+    .replace(/^["']|["']$/g, '')
+}
+
 function encodeGuidePath(path: string): string {
   return path
     .split('/')
     .map((segment) => encodeURIComponent(segment))
     .join('/')
+}
+
+function resolveGuideLink(
+  basePath: string,
+  href: string,
+): ResolvedGuideLink {
+  const url = new URL(
+    href,
+    `https://lumiverse.guide/${basePath}`,
+  )
+
+  return {
+    path: decodeURIComponent(url.pathname.replace(/^\/+/, '')),
+    hash: url.hash,
+  }
+}
+
+function isExternalHref(href: string): boolean {
+  return (
+    /^[a-z][a-z0-9+.-]*:/i.test(href) ||
+    href.startsWith('//')
+  )
+}
+
+function rewriteGuideAssetUrls(
+  html: string,
+  currentPath: string | null,
+): string {
+  if (!currentPath || typeof DOMParser === 'undefined') {
+    return html
+  }
+
+  const document = new DOMParser().parseFromString(
+    html,
+    'text/html',
+  )
+
+  document.querySelectorAll<HTMLImageElement>('img[src]').forEach(
+    (image) => {
+      const src = image.getAttribute('src')
+
+      if (
+        !src ||
+        src.startsWith('#') ||
+        src.startsWith('/') ||
+        isExternalHref(src) ||
+        src.startsWith('data:')
+      ) {
+        return
+      }
+
+      const resolved = resolveGuideLink(currentPath, src)
+
+      image.setAttribute(
+        'src',
+        `/api/v1/docs/${encodeGuidePath(resolved.path)}`,
+      )
+    },
+  )
+
+  return document.body.innerHTML
 }
 
 export function GuideViewer({
@@ -40,29 +127,55 @@ export function GuideViewer({
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  const [currentPath, setCurrentPath] = useState<string | null>(
+    guide.kind === 'builtin'
+      ? guide.path
+      : null,
+  )
+
+  const [history, setHistory] = useState<string[]>([])
+
   useEffect(() => {
     if (!isOpen) return
 
+    setHistory([])
     setError(null)
 
     if (guide.kind === 'markdown') {
+      setCurrentPath(null)
       setContent(guide.markdown)
       setLoading(false)
+      return
+    }
+
+    setContent('')
+    setCurrentPath(guide.path)
+  }, [isOpen, guide])
+
+  useEffect(() => {
+    if (
+      !isOpen ||
+      guide.kind !== 'builtin' ||
+      !currentPath
+    ) {
       return
     }
 
     const controller = new AbortController()
 
     setContent('')
+    setError(null)
     setLoading(true)
 
     void fetch(
-      `/api/v1/docs/${encodeGuidePath(guide.path)}`,
+      `/api/v1/docs/${encodeGuidePath(currentPath)}`,
       { signal: controller.signal },
     )
       .then(async (response) => {
         if (!response.ok) {
-          throw new Error(`Guide request failed (${response.status})`)
+          throw new Error(
+            `Guide request failed (${response.status})`,
+          )
         }
 
         return response.text()
@@ -88,7 +201,7 @@ export function GuideViewer({
     return () => {
       controller.abort()
     }
-  }, [isOpen, guide])
+  }, [isOpen, guide.kind, currentPath])
 
   const renderedHtml = useMemo(() => {
     if (!content) return ''
@@ -98,13 +211,91 @@ export function GuideViewer({
       { async: false },
     ) as string
 
-    return DOMPurify.sanitize(parsed)
-  }, [content])
+    const sanitized = DOMPurify.sanitize(parsed)
 
-  const resolvedTitle =
-    guide.kind === 'markdown' && guide.title
-      ? guide.title
-      : title
+    return rewriteGuideAssetUrls(
+      sanitized,
+      currentPath,
+    )
+  }, [content, currentPath])
+
+  const documentTitle = useMemo(() => {
+    if (guide.kind === 'markdown' && guide.title) {
+      return guide.title
+    }
+
+    return getFrontMatterTitle(content) ?? title
+  }, [content, guide, title])
+
+  const handleBack = () => {
+    const previousPath = history.at(-1)
+
+    if (!previousPath) return
+
+    setHistory((current) => current.slice(0, -1))
+    setCurrentPath(previousPath)
+  }
+
+  const handleContentClick = (
+    event: MouseEvent<HTMLDivElement>,
+  ) => {
+    const target = event.target
+
+    if (!(target instanceof Element)) return
+
+    const anchor = target.closest('a')
+
+    if (
+      !anchor ||
+      !event.currentTarget.contains(anchor)
+    ) {
+      return
+    }
+
+    const href = anchor.getAttribute('href')
+
+    if (!href) return
+
+    if (href.startsWith('#')) {
+      event.preventDefault()
+
+      const id = decodeURIComponent(href.slice(1))
+
+      const heading = event.currentTarget.querySelector(
+        `#${CSS.escape(id)}`,
+      )
+
+      heading?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+      })
+
+      return
+    }
+
+    if (
+      guide.kind !== 'builtin' ||
+      !currentPath ||
+      isExternalHref(href)
+    ) {
+      return
+    }
+
+    const resolved = resolveGuideLink(currentPath, href)
+
+    if (!/\.md$/i.test(resolved.path)) {
+      return
+    }
+
+    event.preventDefault()
+
+    setHistory((current) => [
+      ...current,
+      currentPath,
+    ])
+
+    setCurrentPath(resolved.path)
+  }
 
   return (
     <ModalShell
@@ -115,9 +306,23 @@ export function GuideViewer({
       className={styles.modal}
     >
       <div className={styles.header}>
-        <div className={styles.headerTitle}>
-          <BookOpen size={17} strokeWidth={1.7} />
-          <span>{resolvedTitle}</span>
+        <div className={styles.headerLeading}>
+          {history.length > 0 && (
+            <button
+              type="button"
+              className={styles.backButton}
+              onClick={handleBack}
+              aria-label="Back to previous guide"
+              title="Back"
+            >
+              <ArrowLeft size={17} strokeWidth={1.7} />
+            </button>
+          )}
+
+          <div className={styles.headerTitle}>
+            <BookOpen size={17} strokeWidth={1.7} />
+            <span>{documentTitle}</span>
+          </div>
         </div>
 
         <CloseButton onClick={onClose} />
@@ -125,13 +330,20 @@ export function GuideViewer({
 
       <div className={styles.body}>
         {loading ? (
-          <div className={styles.status}>Loading guide…</div>
+          <div className={styles.status}>
+            Loading guide…
+          </div>
         ) : error ? (
-          <div className={styles.error}>{error}</div>
+          <div className={styles.error}>
+            {error}
+          </div>
         ) : (
           <div
             className={styles.prose}
-            dangerouslySetInnerHTML={{ __html: renderedHtml }}
+            onClick={handleContentClick}
+            dangerouslySetInnerHTML={{
+              __html: renderedHtml,
+            }}
           />
         )}
       </div>

--- a/frontend/src/components/shared/GuideViewer.tsx
+++ b/frontend/src/components/shared/GuideViewer.tsx
@@ -220,12 +220,12 @@ export function GuideViewer({
   }, [content, currentPath])
 
   const documentTitle = useMemo(() => {
-    if (guide.kind === 'markdown' && guide.title) {
+    if (guide.title) {
       return guide.title
-    }
+  }
 
-    return getFrontMatterTitle(content) ?? title
-  }, [content, guide, title])
+     return getFrontMatterTitle(content) ?? title
+    }, [content, guide, title])
 
   const handleBack = () => {
     const previousPath = history.at(-1)

--- a/frontend/src/components/shared/GuideViewer.tsx
+++ b/frontend/src/components/shared/GuideViewer.tsx
@@ -8,9 +8,9 @@ import { ArrowLeft, BookOpen, Search, X } from 'lucide-react'
 import DOMPurify from 'dompurify'
 import { marked } from 'marked'
 
+import type { GuideDefinition } from '@/lib/guides/types'
 import { ModalShell } from '@/components/shared/ModalShell'
 import { CloseButton } from '@/components/shared/CloseButton'
-import type { DrawerGuide } from '@/lib/drawer-tab-registry'
 
 import styles from './GuideViewer.module.css'
 
@@ -23,7 +23,7 @@ interface GuideCatalogEntry {
 interface GuideViewerProps {
   isOpen: boolean
   onClose: () => void
-  guide: DrawerGuide
+  guide: GuideDefinition
   title: string
   searchable?: boolean
 }
@@ -358,6 +358,22 @@ export function GuideViewer({
   )
 
   const [history, setHistory] = useState<string[]>([])
+  const inlineMarkdown =
+  guide.kind === 'markdown'
+    ? guide.markdown
+    : null
+
+    useEffect(() => {
+  if (!isOpen || inlineMarkdown === null) {
+    return
+  }
+
+  setContent(inlineMarkdown)
+  setError(null)
+  setLoading(false)
+  setCurrentPath(null)
+  setHistory([])
+}, [isOpen, inlineMarkdown])
 
   useEffect(() => {
   if (!isOpen || !searchable || catalog.length > 0) {

--- a/frontend/src/components/shared/GuideViewer.tsx
+++ b/frontend/src/components/shared/GuideViewer.tsx
@@ -4,7 +4,7 @@ import {
   useMemo,
   useState,
 } from 'react'
-import { ArrowLeft, BookOpen } from 'lucide-react'
+import { ArrowLeft, BookOpen, Search, X } from 'lucide-react'
 import DOMPurify from 'dompurify'
 import { marked } from 'marked'
 
@@ -14,11 +14,18 @@ import type { DrawerGuide } from '@/lib/drawer-tab-registry'
 
 import styles from './GuideViewer.module.css'
 
+
+interface GuideCatalogEntry {
+  path: string
+  title: string
+}
+
 interface GuideViewerProps {
   isOpen: boolean
   onClose: () => void
   guide: DrawerGuide
   title: string
+  searchable?: boolean
 }
 
 interface ResolvedGuideLink {
@@ -335,10 +342,14 @@ export function GuideViewer({
   onClose,
   guide,
   title,
+  searchable = false,
 }: GuideViewerProps) {
   const [content, setContent] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [catalog, setCatalog] = useState<GuideCatalogEntry[]>([])
+  const [searchQuery, setSearchQuery] = useState('')
+  const [catalogLoading, setCatalogLoading] = useState(false)
 
   const [currentPath, setCurrentPath] = useState<string | null>(
     guide.kind === 'builtin'
@@ -347,6 +358,108 @@ export function GuideViewer({
   )
 
   const [history, setHistory] = useState<string[]>([])
+
+  useEffect(() => {
+  if (!isOpen || !searchable || catalog.length > 0) {
+    return
+  }
+
+  const controller = new AbortController()
+
+  setCatalogLoading(true)
+
+  void fetch('/api/v1/docs/catalog', {
+    signal: controller.signal,
+  })
+    .then(async (response) => {
+      if (!response.ok) {
+        throw new Error(
+          `Guide catalog request failed (${response.status})`,
+        )
+      }
+
+      return response.json() as Promise<GuideCatalogEntry[]>
+    })
+    .then((entries) => {
+      setCatalog(entries)
+    })
+    .catch((error: unknown) => {
+      if (controller.signal.aborted) return
+
+      console.error(
+        '[GuideViewer] failed to load guide catalog',
+        error,
+      )
+    })
+    .finally(() => {
+      if (!controller.signal.aborted) {
+        setCatalogLoading(false)
+      }
+    })
+
+  return () => {
+    controller.abort()
+  }
+}, [isOpen, searchable, catalog.length])
+
+useEffect(() => {
+  if (isOpen) {
+    setSearchQuery('')
+  }
+}, [isOpen])
+
+const searchResults = useMemo(() => {
+  const query = searchQuery.trim().toLowerCase()
+
+  if (!query) return []
+
+  const terms = query
+    .split(/\s+/)
+    .filter(Boolean)
+
+  return catalog
+    .map((entry) => {
+      const title = entry.title.toLowerCase()
+      const path = entry.path
+        .replace(/\.md$/i, '')
+        .replace(/[-_/]+/g, ' ')
+        .toLowerCase()
+
+      let score = 0
+
+      for (const term of terms) {
+        if (title === term) score += 100
+        else if (title.startsWith(term)) score += 40
+        else if (title.includes(term)) score += 20
+
+        if (path.includes(term)) score += 5
+      }
+
+      return {
+        ...entry,
+        score,
+      }
+    })
+    .filter((entry) => entry.score > 0)
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        a.title.localeCompare(b.title),
+    )
+    .slice(0, 20)
+}, [catalog, searchQuery])
+
+const openSearchResult = (entry: GuideCatalogEntry) => {
+  if (currentPath && currentPath !== entry.path) {
+    setHistory((current) => [
+      ...current,
+      currentPath,
+    ])
+  }
+
+  setCurrentPath(entry.path)
+  setSearchQuery('')
+}
 
 useEffect(() => {
   if (
@@ -532,9 +645,70 @@ const parsed = marked.parse(
 
         <CloseButton onClick={onClose} />
       </div>
+      {searchable && (
+  <div className={styles.searchArea}>
+    <div className={styles.searchInputWrap}>
+      <Search size={15} strokeWidth={1.7} />
 
+      <input
+        type="text"
+        role="searchbox"
+        className={styles.searchInput}
+        value={searchQuery}
+        onChange={(event) =>
+          setSearchQuery(event.target.value)
+        }
+        placeholder="Search guides…"
+        aria-label="Search Lumiverse guides"
+      />
+
+      {searchQuery && (
+        <button
+          type="button"
+          className={styles.searchClear}
+          onClick={() => setSearchQuery('')}
+          aria-label="Clear guide search"
+          title="Clear"
+        >
+          <X size={14} strokeWidth={1.7} />
+        </button>
+      )}
+    </div>
+
+    {searchQuery.trim() && (
+      <div className={styles.searchResults}>
+        {catalogLoading ? (
+          <div className={styles.searchEmpty}>
+            Loading guides…
+          </div>
+        ) : searchResults.length > 0 ? (
+          searchResults.map((entry) => (
+            <button
+              key={entry.path}
+              type="button"
+              className={styles.searchResult}
+              onClick={() => openSearchResult(entry)}
+            >
+              <span className={styles.searchResultTitle}>
+                {entry.title}
+              </span>
+
+              <span className={styles.searchResultPath}>
+                {entry.path.replace(/\.md$/i, '')}
+              </span>
+            </button>
+          ))
+        ) : (
+          <div className={styles.searchEmpty}>
+            No matching guides
+          </div>
+        )}
+      </div>
+    )}
+  </div>
+)}
       <div className={styles.body}>
-        {loading ? (
+        {searchable && searchQuery.trim() ? null : loading ? (
           <div className={styles.status}>
             Loading guide…
           </div>

--- a/frontend/src/components/shared/GuideViewer.tsx
+++ b/frontend/src/components/shared/GuideViewer.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useMemo, useState } from 'react'
+import { BookOpen } from 'lucide-react'
+import DOMPurify from 'dompurify'
+import { marked } from 'marked'
+
+import { ModalShell } from '@/components/shared/ModalShell'
+import { CloseButton } from '@/components/shared/CloseButton'
+import type { DrawerGuide } from '@/lib/drawer-tab-registry'
+
+import styles from './GuideViewer.module.css'
+
+interface GuideViewerProps {
+  isOpen: boolean
+  onClose: () => void
+  guide: DrawerGuide
+  title: string
+}
+
+function stripFrontMatter(markdown: string): string {
+  return markdown.replace(
+    /^\uFEFF?---\r?\n[\s\S]*?\r?\n---\r?\n?/,
+    '',
+  )
+}
+
+function encodeGuidePath(path: string): string {
+  return path
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/')
+}
+
+export function GuideViewer({
+  isOpen,
+  onClose,
+  guide,
+  title,
+}: GuideViewerProps) {
+  const [content, setContent] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    setError(null)
+
+    if (guide.kind === 'markdown') {
+      setContent(guide.markdown)
+      setLoading(false)
+      return
+    }
+
+    const controller = new AbortController()
+
+    setContent('')
+    setLoading(true)
+
+    void fetch(
+      `/api/v1/docs/${encodeGuidePath(guide.path)}`,
+      { signal: controller.signal },
+    )
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Guide request failed (${response.status})`)
+        }
+
+        return response.text()
+      })
+      .then((text) => {
+        setContent(text)
+      })
+      .catch((err: unknown) => {
+        if (controller.signal.aborted) return
+
+        setError(
+          err instanceof Error
+            ? err.message
+            : 'Unable to load this guide.',
+        )
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setLoading(false)
+        }
+      })
+
+    return () => {
+      controller.abort()
+    }
+  }, [isOpen, guide])
+
+  const renderedHtml = useMemo(() => {
+    if (!content) return ''
+
+    const parsed = marked.parse(
+      stripFrontMatter(content),
+      { async: false },
+    ) as string
+
+    return DOMPurify.sanitize(parsed)
+  }, [content])
+
+  const resolvedTitle =
+    guide.kind === 'markdown' && guide.title
+      ? guide.title
+      : title
+
+  return (
+    <ModalShell
+      isOpen={isOpen}
+      onClose={onClose}
+      maxWidth="min(760px, calc(100vw - 24px))"
+      maxHeight="86vh"
+      className={styles.modal}
+    >
+      <div className={styles.header}>
+        <div className={styles.headerTitle}>
+          <BookOpen size={17} strokeWidth={1.7} />
+          <span>{resolvedTitle}</span>
+        </div>
+
+        <CloseButton onClick={onClose} />
+      </div>
+
+      <div className={styles.body}>
+        {loading ? (
+          <div className={styles.status}>Loading guide…</div>
+        ) : error ? (
+          <div className={styles.error}>{error}</div>
+        ) : (
+          <div
+            className={styles.prose}
+            dangerouslySetInnerHTML={{ __html: renderedHtml }}
+          />
+        )}
+      </div>
+    </ModalShell>
+  )
+}

--- a/frontend/src/components/shared/GuideViewer.tsx
+++ b/frontend/src/components/shared/GuideViewer.tsx
@@ -70,7 +70,7 @@ function transformAdmonitions(markdown: string): string {
 
       break
     }
-stripFrontMatter 
+
     i -= 1
 
     const title =

--- a/frontend/src/lib/drawer-tab-registry.tsx
+++ b/frontend/src/lib/drawer-tab-registry.tsx
@@ -44,17 +44,7 @@ import MemoryCortexPanel from '@/components/panels/memory-cortex/MemoryCortexPan
 import DatabankPanel from '@/components/panels/databank/DatabankPanel'
 import MultiplayerPanel from '@/components/panels/multiplayer/MultiplayerPanel'
 
-export type DrawerGuide =
-  | {
-      kind: 'builtin'
-      path: string
-      title?: string
-    }
-  | {
-      kind: 'markdown'
-      title?: string
-      markdown: string
-    }
+import type { GuideDefinition } from '@/lib/guides/types'
 
 export interface DrawerTabEntry {
   id: string
@@ -69,7 +59,7 @@ export interface DrawerTabEntry {
   /** Title shown in the panel header navbar. Falls back to tabName if omitted. */
   tabHeaderTitle?: string
   /** Contextual documentation available from the panel header. */
-  guide?: DrawerGuide
+  guide?: GuideDefinition
   /** Keywords for command palette fuzzy search */
   keywords: string[]
   /** Optional scope restriction for command palette filtering */
@@ -481,12 +471,29 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
 export function adaptExtensionTabs(tabs: DrawerTabState[]): DrawerTabEntry[] {
   return tabs.map((dt) => ({
     id: dt.id,
-    shortName: dt.shortName ?? (dt.title.length > 8 ? dt.title.slice(0, 7) + '\u2026' : dt.title),
+    shortName:
+      dt.shortName ??
+      (dt.title.length > 8
+        ? dt.title.slice(0, 7) + '\u2026'
+        : dt.title),
     tabName: dt.title,
-    tabDescription: dt.description ?? `Open ${dt.title} extension tab`,
+    tabDescription:
+      dt.description ??
+      `Open ${dt.title} extension tab`,
     tabIcon: Puzzle,
     tabHeaderTitle: dt.headerTitle,
-    keywords: ['extension', 'spindle', dt.extensionId, ...(dt.keywords ?? [])],
+    guide: dt.guide
+      ? {
+          ...dt.guide,
+          kind: 'markdown',
+        }
+      : undefined,
+    keywords: [
+      'extension',
+      'spindle',
+      dt.extensionId,
+      ...(dt.keywords ?? []),
+    ],
     mount: () => () => {},
   }))
 }

--- a/frontend/src/lib/drawer-tab-registry.tsx
+++ b/frontend/src/lib/drawer-tab-registry.tsx
@@ -45,6 +45,7 @@ import DatabankPanel from '@/components/panels/databank/DatabankPanel'
 import MultiplayerPanel from '@/components/panels/multiplayer/MultiplayerPanel'
 
 import type { GuideDefinition } from '@/lib/guides/types'
+import { adaptSpindleGuide } from './guides/adapt-spindle-guide'
 
 export interface DrawerTabEntry {
   id: string
@@ -482,12 +483,7 @@ export function adaptExtensionTabs(tabs: DrawerTabState[]): DrawerTabEntry[] {
       `Open ${dt.title} extension tab`,
     tabIcon: Puzzle,
     tabHeaderTitle: dt.headerTitle,
-    guide: dt.guide
-      ? {
-          ...dt.guide,
-          kind: 'markdown',
-        }
-      : undefined,
+    guide: adaptSpindleGuide(dt.guide),
     keywords: [
       'extension',
       'spindle',

--- a/frontend/src/lib/drawer-tab-registry.tsx
+++ b/frontend/src/lib/drawer-tab-registry.tsx
@@ -44,6 +44,16 @@ import MemoryCortexPanel from '@/components/panels/memory-cortex/MemoryCortexPan
 import DatabankPanel from '@/components/panels/databank/DatabankPanel'
 import MultiplayerPanel from '@/components/panels/multiplayer/MultiplayerPanel'
 
+export type DrawerGuide =
+  | {
+      kind: 'builtin'
+      path: string
+    }
+  | {
+      kind: 'markdown'
+      title?: string
+      markdown: string
+    }
 export interface DrawerTabEntry {
   id: string
   /** Short label shown beneath the icon in the sidebar */
@@ -56,6 +66,8 @@ export interface DrawerTabEntry {
   tabIcon: ComponentType<{ size?: number; strokeWidth?: number; className?: string }>
   /** Title shown in the panel header navbar. Falls back to tabName if omitted. */
   tabHeaderTitle?: string
+  /** Contextual documentation available from the panel header. */
+  guide?: DrawerGuide
   /** Keywords for command palette fuzzy search */
   keywords: string[]
   /** Optional scope restriction for command palette filtering */
@@ -277,15 +289,19 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     keywords: ['composition', 'compose', 'lumia', 'loom', 'sovereign hand', 'context filters', 'narrative', 'selection', 'modes'],
     mount: (root) => mountReactComponent(root, <PromptPanel />),
   },
-  {
-    id: 'council',
-    shortName: 'Council',
-    tabName: 'Council',
-    tabDescription: 'Configure the Lumia Council and tool functions',
-    tabIcon: IconUsersGroup,
-    keywords: ['council', 'tools', 'agents', 'lumia', 'functions', 'tool use', 'sidecar', 'function calling'],
-    mount: (root) => mountReactComponent(root, <CouncilManager />),
+{
+  id: 'council',
+  shortName: 'Council',
+  tabName: 'Council',
+  tabDescription: 'Configure the Lumia Council and tool functions',
+  tabIcon: IconUsersGroup,
+  guide: {
+    kind: 'builtin',
+    path: 'council/index.md',
   },
+  keywords: ['council', 'tools', 'agents', 'lumia', 'functions', 'tool use', 'sidecar', 'function calling'],
+  mount: (root) => mountReactComponent(root, <CouncilManager />),
+},
   {
     id: 'summary',
     shortName: 'Summary',

--- a/frontend/src/lib/drawer-tab-registry.tsx
+++ b/frontend/src/lib/drawer-tab-registry.tsx
@@ -48,12 +48,14 @@ export type DrawerGuide =
   | {
       kind: 'builtin'
       path: string
+      title?: string
     }
   | {
       kind: 'markdown'
       title?: string
       markdown: string
     }
+
 export interface DrawerTabEntry {
   id: string
   /** Short label shown beneath the icon in the sidebar */
@@ -134,6 +136,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'Profile',
     tabDescription: 'View and edit the active character',
     tabIcon: User,
+    guide: {
+  kind: 'builtin',
+  path: 'characters/index.md',
+},
     keywords: ['character', 'avatar', 'info', 'edit', 'card', 'description', 'bio', 'greeting', 'first message'],
     mount: (root) => mountReactComponent(root, <CharacterProfile />),
   },
@@ -143,6 +149,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'Reasoning',
     tabDescription: 'Configure reasoning, chain-of-thought, and prompt behavior',
     tabIcon: Wand2,
+    guide: {
+  kind: 'builtin',
+  path: 'presets/index.md',
+},
     tabHeaderTitle: 'Reasoning',
     keywords: ['reasoning', 'cot', 'chain of thought', 'thinking', 'reasoning effort', 'api reasoning', 'prompt bias', 'start reply with', 'prefix', 'suffix'],
     mount: (root) => mountReactComponent(root, <PresetManager />),
@@ -153,6 +163,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'Loom',
     tabDescription: 'Configure narrative structure and story beats',
     tabIcon: GitFork,
+    guide: {
+  kind: 'builtin',
+  path: 'presets/index.md',
+},
     keywords: ['narrative', 'story', 'lore', 'structure', 'beats', 'loom', 'pacing', 'plot', 'sovereign hand', 'director'],
     mount: (root) => mountReactComponent(root, <LoomBuilder compact />),
   },
@@ -162,6 +176,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'Weaver',
     tabDescription: 'Craft a character from your idea',
     tabIcon: Feather,
+    guide: {
+  kind: 'builtin',
+  path: 'weaver/index.md',
+},
     keywords: ['weaver', 'dream', 'character', 'create', 'ai'],
     mount: (root) => mountReactComponent(root, <WeaverPanel />),
   },
@@ -171,6 +189,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'Connections',
     tabDescription: 'Manage API connections and providers',
     tabIcon: Link2,
+    guide: {
+  kind: 'builtin',
+  path: 'connections/index.md',
+},
     tabHeaderTitle: 'Connections',
     keywords: ['api', 'provider', 'key', 'openai', 'anthropic', 'model', 'endpoint', 'google', 'vertex', 'claude', 'gemini', 'openrouter', 'deepseek', 'url', 'secret'],
     mount: (root) => mountReactComponent(root, (
@@ -197,6 +219,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'Pack Browser',
     tabDescription: 'Browse and manage content packs',
     tabIcon: Package,
+    guide: {
+  kind: 'builtin',
+  path: 'packs/index.md',
+},
     tabHeaderTitle: 'Browser',
     keywords: ['packs', 'content', 'download', 'browse', 'browser', 'install', 'marketplace', 'library', 'search'],
     mount: (root) => mountReactComponent(root, <PackBrowser />),
@@ -207,6 +233,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'Characters',
     tabDescription: 'Browse and manage your character cards',
     tabIcon: Users,
+    guide: {
+  kind: 'builtin',
+  path: 'characters/index.md',
+},
     tabHeaderTitle: 'Characters',
     keywords: ['character', 'list', 'import', 'card', 'browse', 'export', 'png', 'charx', 'gallery', 'switch', 'select'],
     mount: (root) => mountReactComponent(root, <CharacterBrowser />),
@@ -217,6 +247,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'Personas',
     tabDescription: 'Manage your user personas',
     tabIcon: Drama,
+    guide: {
+  kind: 'builtin',
+  path: 'personas/index.md',
+},
     keywords: ['persona', 'identity', 'user', 'avatar', 'name', 'sender', 'you', 'addons'],
     mount: (root) => mountReactComponent(root, <PersonaManager />),
   },
@@ -236,6 +270,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'Lorebook',
     tabDescription: 'Edit world book and lorebook entries',
     tabIcon: Library,
+    guide: {
+  kind: 'builtin',
+  path: 'world-books/index.md',
+},
     tabHeaderTitle: 'Lorebook',
     keywords: ['lorebook', 'world', 'lore', 'book', 'entries', 'worldbook', 'world info', 'wi', 'keywords', 'triggers', 'knowledge'],
     mount: (root) => mountReactComponent(root, <WorldBookPanel />),
@@ -246,6 +284,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'Memory Cortex',
     tabDescription: 'View and manage memory cortex entries',
     tabIcon: Brain,
+    guide: {
+  kind: 'builtin',
+  path: 'chatting/memory-cortex.md',
+},
     tabHeaderTitle: 'Memory',
     keywords: ['memory', 'cortex', 'embeddings', 'recall', 'brain', 'entities', 'relationships', 'salience', 'vector', 'long term', 'ltcm', 'facts'],
     mount: (root) => mountReactComponent(root, <MemoryCortexPanel />),
@@ -256,6 +298,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'Databank',
     tabDescription: 'Upload and manage reference documents for AI context',
     tabIcon: Database,
+    guide: {
+  kind: 'builtin',
+  path: 'chatting/databank.md',
+},
     tabHeaderTitle: 'Databank',
     keywords: ['databank', 'knowledge', 'documents', 'upload', 'files', 'bank', 'reference', 'data', 'rag'],
     mount: (root) => mountReactComponent(root, <DatabankPanel />),
@@ -276,6 +322,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'OOC',
     tabDescription: 'Out-of-character comment display settings',
     tabIcon: MessageCircle,
+    guide: {
+  kind: 'builtin',
+  path: 'chatting/ooc.md',
+},
     keywords: ['ooc', 'out of character', 'comments', 'irc', 'social', 'chat', 'meta', 'parentheses', 'brackets'],
     mount: (root) => mountReactComponent(root, <OOCPanel />),
   },
@@ -308,6 +358,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'Summary',
     tabDescription: 'Configure context summarization and truncation',
     tabIcon: ScrollText,
+    guide: {
+  kind: 'builtin',
+  path: 'chatting/loom-summary.md',
+},
     keywords: ['summary', 'context', 'truncation', 'compress', 'summarize', 'shorten', 'overflow', 'window', 'limit'],
     mount: (root) => mountReactComponent(root, <SummaryEditor />),
   },
@@ -317,6 +371,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'Council Feedback',
     tabDescription: 'View the latest council execution results',
     tabIcon: MessageSquareReply,
+    guide: {
+  kind: 'builtin',
+  path: 'council/council-tools.md',
+},
     tabHeaderTitle: 'Feedback',
     keywords: ['feedback', 'council', 'results', 'tools', 'output', 'debug', 'log', 'response', 'execution', 'trace'],
     mount: (root) => mountReactComponent(root, <CouncilFeedback />),
@@ -327,6 +385,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'World Info',
     tabDescription: 'View currently activated world info entries',
     tabIcon: Globe,
+    guide: {
+  kind: 'builtin',
+  path: 'world-books/keywords-and-activation.md',
+},
     tabHeaderTitle: 'World Info',
     keywords: ['world info', 'activation', 'lorebook', 'active', 'entries', 'triggered', 'wi', 'matched', 'fired'],
     mount: (root) => mountReactComponent(root, <WorldInfoFeedback />),
@@ -337,6 +399,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'Image Generation',
     tabDescription: 'Configure and control AI scene generation',
     tabIcon: Image,
+    guide: {
+  kind: 'builtin',
+  path: 'image-generation/index.md',
+},
     tabHeaderTitle: 'Image Gen',
     keywords: ['image', 'generation', 'scene', 'art', 'picture', 'ai', 'background', 'novelai', 'nai', 'dalle', 'illustration'],
     mount: (root) => mountReactComponent(root, <ImageGenPanel />),
@@ -347,6 +413,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'Wallpaper',
     tabDescription: 'Set global or per-chat background wallpapers',
     tabIcon: Wallpaper,
+    guide: {
+  kind: 'builtin',
+  path: 'customization/wallpapers.md',
+},
     keywords: ['wallpaper', 'background', 'backdrop', 'image', 'video', 'animated', 'mp4', 'webm', 'gif', 'scenery', 'chat background'],
     mount: (root) => mountReactComponent(root, <WallpaperPanel />),
   },
@@ -356,6 +426,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'Regex Scripts',
     tabDescription: 'Create and manage regex find/replace scripts',
     tabIcon: Replace,
+    guide: {
+  kind: 'builtin',
+  path: 'customization/regex-scripts.md',
+},
     tabHeaderTitle: 'Regex',
     keywords: ['regex', 'find', 'replace', 'script', 'transform', 'filter', 'pattern', 'substitution', 'text', 'output', 'display', 'rewrite', 'format'],
     mount: (root) => mountReactComponent(root, <RegexPanel />),
@@ -366,6 +440,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'Branch Tree',
     tabDescription: 'View and navigate the chat branch history',
     tabIcon: GitBranch,
+    guide: {
+  kind: 'builtin',
+  path: 'chatting/branching.md',
+},
     tabHeaderTitle: 'Branches',
     keywords: ['branch', 'fork', 'history', 'tree', 'navigate', 'alternate', 'swipe', 'undo', 'timeline', 'rewind', 'path'],
     mount: (root) => mountReactComponent(root, <BranchTreePanel />),
@@ -376,6 +454,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'Theme',
     tabDescription: 'Customize colors, accent, and visual style',
     tabIcon: Palette,
+    guide: {
+  kind: 'builtin',
+  path: 'customization/themes.md',
+},
     keywords: ['theme', 'colors', 'accent', 'appearance', 'dark', 'light', 'glass', 'radius', 'font', 'css', 'style', 'customize', 'ui', 'mode'],
     mount: (root) => mountReactComponent(root, <ThemePanel />),
   },
@@ -385,6 +467,10 @@ export const DRAWER_TABS: DrawerTabEntry[] = [
     tabName: 'Extensions',
     tabDescription: 'Manage Spindle extensions',
     tabIcon: Puzzle,
+    guide: {
+  kind: 'builtin',
+  path: 'extensions/index.md',
+},
     tabHeaderTitle: 'Extensions',
     keywords: ['extensions', 'spindle', 'plugins', 'addons', 'install', 'manage', 'enable', 'disable', 'uninstall', 'github'],
     mount: (root) => mountReactComponent(root, <SpindlePanel />),

--- a/frontend/src/lib/guides/adapt-spindle-guide.test.ts
+++ b/frontend/src/lib/guides/adapt-spindle-guide.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test'
+import { adaptSpindleGuide } from './adapt-spindle-guide'
+
+describe('adaptSpindleGuide', () => {
+  test('converts Spindle guide metadata into a native markdown guide', () => {
+    expect(
+      adaptSpindleGuide({
+        title: 'Test guide',
+        markdown: '# Hello from Spindle',
+      }),
+    ).toEqual({
+      kind: 'markdown',
+      title: 'Test guide',
+      markdown: '# Hello from Spindle',
+    })
+  })
+
+  test('returns undefined when no guide is provided', () => {
+    expect(adaptSpindleGuide(undefined)).toBeUndefined()
+  })
+})

--- a/frontend/src/lib/guides/adapt-spindle-guide.ts
+++ b/frontend/src/lib/guides/adapt-spindle-guide.ts
@@ -1,0 +1,15 @@
+import type { SpindleGuideDefinition } from 'lumiverse-spindle-types'
+import type { MarkdownGuideDefinition } from './types'
+
+export function adaptSpindleGuide(
+  guide: SpindleGuideDefinition | undefined,
+): MarkdownGuideDefinition | undefined {
+  if (!guide) {
+    return undefined
+  }
+
+  return {
+    ...guide,
+    kind: 'markdown',
+  }
+}

--- a/frontend/src/lib/guides/types.ts
+++ b/frontend/src/lib/guides/types.ts
@@ -1,0 +1,16 @@
+import type { SpindleGuideDefinition } from 'lumiverse-spindle-types'
+
+export interface BuiltinGuideDefinition {
+  kind: 'builtin'
+  path: string
+  title?: string
+}
+
+export type MarkdownGuideDefinition =
+  SpindleGuideDefinition & {
+    kind: 'markdown'
+  }
+
+export type GuideDefinition =
+  | BuiltinGuideDefinition
+  | MarkdownGuideDefinition

--- a/frontend/src/lib/spindle/character-editor-types.ts
+++ b/frontend/src/lib/spindle/character-editor-types.ts
@@ -4,11 +4,15 @@
  * Core can adopt the new API shape immediately, before the published
  * `lumiverse-spindle-types` package version used by this repo is bumped.
  */
-import type { SpindleFrontendContext } from 'lumiverse-spindle-types'
+import type {
+  SpindleFrontendContext,
+  SpindleGuideDefinition,
+} from 'lumiverse-spindle-types'
 
 export interface SpindleCharacterEditorTabOptions {
   id: string
   title: string
+  guide?: SpindleGuideDefinition
 }
 
 export interface SpindleCharacterEditorTabHandle {

--- a/frontend/src/lib/spindle/placement-helper.isolated.ts
+++ b/frontend/src/lib/spindle/placement-helper.isolated.ts
@@ -227,6 +227,68 @@ describe('preset editor toolbar registration', () => {
 })
 
 describe('non-preset placement lifecycle', () => {
+      test('preserves contextual guide metadata across tab registrations', () => {
+    const guide = {
+      title: 'Test guide',
+      markdown: '# Hello from Spindle',
+    }
+
+    const drawer = createDrawerTabHandle(
+      extensionId,
+      {
+        id: 'guided-drawer',
+        title: 'Guided Drawer',
+        guide,
+      },
+      undefined,
+      generation,
+    )
+
+    const character = createCharacterEditorTabHandle(
+      extensionId,
+      {
+        id: 'guided-character',
+        title: 'Guided Character',
+        guide,
+      },
+      undefined,
+      generation,
+    )
+
+    const preset = createPresetEditorTabHandle(
+      extensionId,
+      {
+        id: 'guided-preset',
+        title: 'Guided Preset',
+        guide,
+      },
+      () => {},
+      generation,
+    )
+
+    expect(
+      placementStore.getState().drawerTabs.find(
+        (tab) => tab.id === drawer.tabId,
+      )?.guide,
+    ).toEqual(guide)
+
+    expect(
+      placementStore.getState().characterEditorTabs.find(
+        (tab) => tab.id === character.tabId,
+      )?.guide,
+    ).toEqual(guide)
+
+    expect(
+      placementStore.getState().presetEditorTabs.find(
+        (tab) => tab.id === preset.tabId,
+      )?.guide,
+    ).toEqual(guide)
+
+    drawer.destroy()
+    character.destroy()
+    preset.destroy()
+  })
+
   test('explicit destroy is idempotent and removes its unload disposer', () => {
     const hostId = 'placement-disposer-host'
     const otherId = 'placement-disposer-other'

--- a/frontend/src/lib/spindle/placement-helper.ts
+++ b/frontend/src/lib/spindle/placement-helper.ts
@@ -627,11 +627,17 @@ export function createCharacterEditorTabHandle(
   try {
     assertActive()
     getStore().registerCharacterEditorTab({
-      id: tabId,
-      extensionId,
-      title: options.title,
-      root,
-    })
+    id: tabId,
+    extensionId,
+    title: options.title,
+    guide: options.guide
+      ? {
+          markdown: options.guide.markdown,
+          title: options.guide.title,
+        }
+      : undefined,
+    root,
+  })
     registered = true
     if (disposedDuringRegistration) {
       getStore().unregisterCharacterEditorTab(tabId)
@@ -778,7 +784,18 @@ export function createPresetEditorTabHandle(
 
   try {
     assertActive()
-    getStore().registerPresetEditorTab({ id: tabId, extensionId, title: options.title, root })
+      getStore().registerPresetEditorTab({
+    id: tabId,
+    extensionId,
+    title: options.title,
+    guide: options.guide
+      ? {
+          markdown: options.guide.markdown,
+          title: options.guide.title,
+        }
+      : undefined,
+    root,
+  })
     registered = true
     if (disposedDuringRegistration) {
       getStore().unregisterPresetEditorTab(tabId)

--- a/frontend/src/lib/spindle/placement-helper.ts
+++ b/frontend/src/lib/spindle/placement-helper.ts
@@ -419,18 +419,24 @@ export function createDrawerTabHandle(
   try {
     assertActive()
     getStore().registerDrawerTab({
-      id: tabId,
-      extensionId,
-      title: options.title,
-      shortName: options.shortName,
-      description: options.description,
-      keywords: options.keywords,
-      headerTitle: options.headerTitle,
-      iconUrl: options.iconUrl,
-      iconSvg: options.iconSvg,
-      badge: null,
-      root,
-    })
+    id: tabId,
+    extensionId,
+    title: options.title,
+    shortName: options.shortName,
+    description: options.description,
+    keywords: options.keywords,
+    headerTitle: options.headerTitle,
+    guide: options.guide
+      ? {
+          markdown: options.guide.markdown,
+          title: options.guide.title,
+        }
+      : undefined,
+    iconUrl: options.iconUrl,
+    iconSvg: options.iconSvg,
+    badge: null,
+    root,
+  })
     registered = true
     if (disposedDuringRegistration) {
       getStore().unregisterDrawerTab(tabId)

--- a/frontend/src/lib/spindle/preset-editor-types.ts
+++ b/frontend/src/lib/spindle/preset-editor-types.ts
@@ -2,12 +2,14 @@ import type {
   PromptBlockDTO,
   PromptVariableValuesDTO,
   SpindleFrontendContext,
+  SpindleGuideDefinition,
   SpindlePresetEditorDraft as PublishedSpindlePresetEditorDraft,
 } from 'lumiverse-spindle-types'
 
 export interface SpindlePresetEditorTabOptions {
   id: string
   title: string
+  guide?: SpindleGuideDefinition
 }
 
 export interface SpindlePresetEditorTabHandle {

--- a/frontend/src/store/slices/spindle-placement.ts
+++ b/frontend/src/store/slices/spindle-placement.ts
@@ -4,7 +4,11 @@ import type {
   SpindlePlacementSlice,
   SurfaceRectPrefs,
 } from '@/types/store'
-import type { SpindleDockEdge, SpindleTabLocation as TabLocation } from 'lumiverse-spindle-types'
+import type {
+  SpindleDockEdge,
+  SpindleGuideDefinition,
+  SpindleTabLocation as TabLocation,
+} from 'lumiverse-spindle-types'
 
 // ── Capacity limits ──
 
@@ -27,14 +31,22 @@ export interface DrawerTabState {
   id: string
   extensionId: string
   title: string
+
   /** Short label for below the sidebar icon (max ~8 chars). Falls back to title. */
   shortName?: string
+
   /** Description shown in command palette. Falls back to "Open {title} extension tab". */
   description?: string
+
   /** Keywords for command palette search. Extension name added automatically. */
   keywords?: string[]
+
   /** Title for the panel header navbar. Falls back to title. */
   headerTitle?: string
+
+  /** Contextual documentation supplied by the owning extension. */
+  guide?: SpindleGuideDefinition
+
   iconUrl?: string
   iconSvg?: string
   badge: string | null
@@ -69,6 +81,7 @@ export interface CharacterEditorTabState {
   id: string
   extensionId: string
   title: string
+  guide?: SpindleGuideDefinition
   root: HTMLElement
 }
 
@@ -85,6 +98,7 @@ export interface PresetEditorTabState {
   id: string
   extensionId: string
   title: string
+  guide?: SpindleGuideDefinition
   root: HTMLElement
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -42,6 +42,7 @@ import { stMigrationRoutes } from "./routes/st-migration.routes";
 import { googleDriveRoutes } from "./routes/google-drive.routes";
 import { dropboxRoutes } from "./routes/dropbox.routes";
 import { presetProfilesRoutes } from "./routes/preset-profiles.routes";
+import { docsRoutes } from "./routes/docs.routes";
 import { loadoutsRoutes } from "./routes/loadouts.routes";
 import { regexScriptsRoutes } from "./routes/regex-scripts.routes";
 import { expressionsRoutes } from "./routes/expressions.routes";
@@ -460,6 +461,7 @@ app.get("/api/v1/runtime-config", (c) => {
 app.use("/api/v1/*", requireAuth);
 
 app.route("/api/v1/settings", settingsRoutes);
+app.route("/api/v1/docs", docsRoutes);
 app.route("/api/v1/characters", charactersRoutes);
 app.route("/api/v1/chats", chatsRoutes);
 app.route("/api/v1/personas", personasRoutes);

--- a/src/routes/docs.routes.ts
+++ b/src/routes/docs.routes.ts
@@ -1,0 +1,41 @@
+import { Hono } from "hono";
+import { resolve, sep } from "node:path";
+
+const docsRoutes = new Hono();
+
+const DOCS_ROOT = resolve(import.meta.dir, "../../user-docs/docs");
+
+docsRoutes.get("/*", async (c) => {
+  const prefix = "/api/v1/docs/";
+  const requestPath = decodeURIComponent(c.req.path.slice(prefix.length))
+    .replace(/^[/\\]+/, "");
+
+  if (!requestPath) {
+    return c.json({ error: "Document path required" }, 400);
+  }
+
+  const filePath = resolve(DOCS_ROOT, requestPath);
+
+  // Never allow ../ traversal outside user-docs/docs.
+  if (
+    filePath !== DOCS_ROOT &&
+    !filePath.startsWith(`${DOCS_ROOT}${sep}`)
+  ) {
+    return c.json({ error: "Invalid document path" }, 400);
+  }
+
+  const file = Bun.file(filePath);
+
+  if (!(await file.exists())) {
+    return c.json({ error: "Document not found" }, 404);
+  }
+
+  return new Response(file, {
+    headers: {
+      "Content-Type": file.type || "application/octet-stream",
+      "Cache-Control": "no-cache",
+    },
+  });
+});
+
+export { docsRoutes };

--- a/src/routes/docs.routes.ts
+++ b/src/routes/docs.routes.ts
@@ -1,41 +1,113 @@
 import { Hono } from "hono";
+import { Buffer } from "node:buffer";
 import { resolve, sep } from "node:path";
 
 const docsRoutes = new Hono();
 
 const DOCS_ROOT = resolve(import.meta.dir, "../../user-docs/docs");
 
-docsRoutes.get("/*", async (c) => {
-  const prefix = "/api/v1/docs/";
-  const requestPath = decodeURIComponent(c.req.path.slice(prefix.length))
-    .replace(/^[/\\]+/, "");
+function resolveDocumentPath(requestPath: string): string | null {
+  const cleanPath = requestPath.replace(/^[/\\]+/, "");
 
-  if (!requestPath) {
-    return c.json({ error: "Document path required" }, 400);
+  if (!cleanPath) {
+    return null;
   }
 
-  const filePath = resolve(DOCS_ROOT, requestPath);
+  const filePath = resolve(DOCS_ROOT, cleanPath);
 
-  // Never allow ../ traversal outside user-docs/docs.
   if (
     filePath !== DOCS_ROOT &&
     !filePath.startsWith(`${DOCS_ROOT}${sep}`)
   ) {
-    return c.json({ error: "Invalid document path" }, 400);
+    return null;
+  }
+
+  return filePath;
+}
+
+async function documentResponse(
+  requestPath: string,
+): Promise<Response> {
+  const filePath = resolveDocumentPath(requestPath);
+
+  if (!filePath) {
+    return Response.json(
+      { error: "Invalid document path" },
+      { status: 400 },
+    );
   }
 
   const file = Bun.file(filePath);
 
   if (!(await file.exists())) {
-    return c.json({ error: "Document not found" }, 404);
+    return Response.json(
+      { error: "Document not found" },
+      { status: 404 },
+    );
   }
 
   return new Response(file, {
     headers: {
-      "Content-Type": file.type || "application/octet-stream",
+      "Content-Type":
+        file.type || "application/octet-stream",
       "Cache-Control": "no-cache",
     },
   });
+}
+
+/**
+ * Opaque document endpoint used by the in-app guide viewer.
+ *
+ * Encoding the path keeps document names out of the request URL,
+ * avoiding false positives from browser content blockers.
+ */
+docsRoutes.get("/file/:encoded", async (c) => {
+  const encoded = c.req.param("encoded");
+
+  if (!/^[A-Za-z0-9_-]+$/.test(encoded)) {
+    return c.json(
+      { error: "Invalid document key" },
+      400,
+    );
+  }
+
+  const requestPath = Buffer.from(
+    encoded,
+    "base64url",
+  ).toString("utf8");
+
+  if (!requestPath) {
+    return c.json(
+      { error: "Invalid document key" },
+      400,
+    );
+  }
+
+  return documentResponse(requestPath);
+});
+
+/**
+ * Human-readable/raw endpoint.
+ *
+ * Kept for direct access and debugging.
+ */
+docsRoutes.get("/*", async (c) => {
+  const prefix = "/api/v1/docs/";
+
+  let requestPath: string;
+
+  try {
+    requestPath = decodeURIComponent(
+      c.req.path.slice(prefix.length),
+    );
+  } catch {
+    return c.json(
+      { error: "Invalid document path" },
+      400,
+    );
+  }
+
+  return documentResponse(requestPath);
 });
 
 export { docsRoutes };

--- a/src/routes/docs.routes.ts
+++ b/src/routes/docs.routes.ts
@@ -1,3 +1,4 @@
+import { Glob } from "bun";
 import { Hono } from "hono";
 import { Buffer } from "node:buffer";
 import { resolve, sep } from "node:path";
@@ -5,6 +6,76 @@ import { resolve, sep } from "node:path";
 const docsRoutes = new Hono();
 
 const DOCS_ROOT = resolve(import.meta.dir, "../../user-docs/docs");
+
+interface GuideCatalogEntry {
+  path: string;
+  title: string;
+}
+
+function extractDocumentTitle(
+  markdown: string,
+  path: string,
+): string {
+  const frontMatter = markdown.match(
+    /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/,
+  );
+
+  if (frontMatter) {
+    const titleMatch = frontMatter[1].match(
+      /^title:\s*(.+?)\s*$/m,
+    );
+
+    if (titleMatch) {
+      return titleMatch[1]
+        .trim()
+        .replace(/^["']|["']$/g, "");
+    }
+  }
+
+  const heading = markdown.match(/^#\s+(.+?)\s*$/m);
+
+  if (heading) {
+    return heading[1].trim();
+  }
+
+  const filename =
+    path.split("/").at(-1)?.replace(/\.md$/i, "") ??
+    path;
+
+  return filename
+    .replace(/[-_]+/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+async function buildGuideCatalog(): Promise<GuideCatalogEntry[]> {
+  const glob = new Glob("**/*.md");
+  const entries: GuideCatalogEntry[] = [];
+
+  for await (const relativePath of glob.scan({
+    cwd: DOCS_ROOT,
+    absolute: false,
+  })) {
+    const normalizedPath = relativePath.replace(/\\/g, "/");
+
+    const file = Bun.file(
+      resolve(DOCS_ROOT, relativePath),
+    );
+
+    const markdown = await file.text();
+
+    entries.push({
+      path: normalizedPath,
+      title: extractDocumentTitle(
+        markdown,
+        normalizedPath,
+      ),
+    });
+  }
+
+  return entries.sort((a, b) =>
+    a.title.localeCompare(b.title),
+  );
+}
 
 function resolveDocumentPath(requestPath: string): string | null {
   const cleanPath = requestPath.replace(/^[/\\]+/, "");
@@ -54,6 +125,14 @@ async function documentResponse(
     },
   });
 }
+
+docsRoutes.get("/catalog", async (c) => {
+  const entries = await buildGuideCatalog();
+
+  return c.json(entries, 200, {
+    "Cache-Control": "no-cache",
+  });
+});
 
 /**
  * Opaque document endpoint used by the in-app guide viewer.


### PR DESCRIPTION
## Summary

Adds native contextual documentation throughout Lumiverse and extends the same guide system to Spindle extension surfaces.

### Native contextual guides

- Adds contextual guide buttons to supported drawer tabs.
- Adds native guide navigation with internal Markdown links and back history.
- Adds a full Guides browser accessible from the landing page.
- Adds bundled user-document serving through the backend.
- Adds guide catalog search.
- Supports relative guide assets through the bundled document route.
- Supports YAML frontmatter titles while stripping frontmatter from rendered content.
- Supports Zensical-style admonitions and content tabs.
- Sanitizes rendered Markdown before display.
- Fixes GuideViewer state synchronization so switching between built-in guides does not retain the previously opened guide path.

### Spindle contextual guides

Adds native contextual guide support for Spindle extensions using the guide metadata introduced in `lumiverse-spindle-types@0.6.14`.

Extensions may provide:

```ts
guide: {
  title?: string
  markdown: string
}
````

Supported extension surfaces:

* Drawer tabs
* Character editor tabs
* Preset editor tabs

Lumiverse owns the rendering, sanitization, navigation, and presentation of extension-provided guide Markdown. Extensions only provide the guide content and optional title.

### Why

Context-sensitive documentation lets users reach the relevant guide directly from the UI instead of having to locate the matching documentation manually.

For extensions, this provides a common host-native documentation surface without requiring extensions to implement their own modals, Markdown rendering, or help UI.

## Validation

Frontend typecheck:

```text
cd frontend
bun run typecheck
```

Result: passed with no type errors.

Contextual guide regression suite:

```text
bun test \
  ./src/lib/spindle/placement-helper.isolated.ts \
  ./src/lib/guides/adapt-spindle-guide.test.ts \
  ./src/components/shared/GuideViewer.navigation.test.tsx
```

Result:

```text
25 pass
0 fail
135 expect() calls
```

Production frontend build:

```text
cd frontend
bun run build
```

Result: passed.

Repository validation:

```text
git diff --check
```

Result: passed with no whitespace errors.

Full checklist:
```bun x tsc --noEmit
cd frontend && bun run typecheck
cd frontend && bun run lint
bun test \
  ./src/lib/spindle/placement-helper.isolated.ts \
  ./src/lib/guides/adapt-spindle-guide.test.ts \
  ./src/components/shared/GuideViewer.navigation.test.tsx
cd frontend && bun run build
git diff --check
```

The final validation was performed against the published `lumiverse-spindle-types@0.6.14` package rather than the local development link.

## Required checklist

* [x] This pull request is based on the latest `staging` branch and targets
  `staging`, not `main`.
* [x] All applicable tests pass.
* [x] I ran the relevant type check(s) with no type errors or warnings:

  * [x] Backend: `bun x tsc --noEmit`
  * [x] Frontend: `cd frontend && bun run typecheck`
  * [x] Frontend: `bun run lint`

## UI changes (if applicable)

* [x] I validated this change in more than one browser.
* [x] I verified the integrated experience on a mobile interface or through
  the mobile PWA.
* Browsers, devices, and PWA coverage:

  * Firefox — desktop
  * Firefox — mobile
  * Chromium — desktop
  * Chromium — mobile

Validated native contextual guides, guide navigation, search, bundled Markdown rendering, and Spindle-provided guides across the supported extension surfaces.

## Performance changes (if applicable)

Not applicable. This change does not introduce a performance-sensitive execution path or materially alter generation/runtime performance.

* [x] I added or updated tests.
* [x] I included reproducible benchmarks and comparison results below.
* Benchmark commands and results: N/A

## Security-sensitive changes (if applicable)

This change extends Spindle tab metadata with optional contextual guide content but does not add new Spindle execution capabilities, permissions, or privileged extension APIs.

Extension-provided guide content is rendered by Lumiverse rather than by the extension and is sanitized by the host before display.

Bundled documentation endpoints are read-only and are used to serve Lumiverse user documentation and associated guide assets.

No extension-provided filesystem path is accepted for Spindle guides; extensions provide inline Markdown only.

## LLM-assisted work (if applicable)

* [x] I, as the human orchestrating this work, audited the submitted changes
  in a live environment.