### PR TITLE
Make big thing read in small chunk

### DIFF
--- a/developer-docs/docs/backend-api/uploads.md
+++ b/developer-docs/docs/backend-api/uploads.md
@@ -1,8 +1,8 @@
 # Uploads
 
-Receive large files from your extension's frontend without the WebSocket frame-size limits, then read the assembled bytes in the backend worker by id.
+Receive large files from your extension's frontend without the WebSocket frame-size limits, then read the staged upload in the backend worker by id.
 
-The browser streams the file to a resumable [tus](https://tus.io) endpoint on the host, which writes it straight to disk. The worker then pulls the bytes with `spindle.uploads.get(uploadId)`. This avoids base64-over-WebSocket inflation, the 4 MB `SPINDLE_BACKEND_MSG` cap, and buffering the whole file in browser memory at send time.
+The browser streams the file to a resumable [tus](https://tus.io) endpoint on the host, which writes it straight to disk. The worker can pull the complete bytes with `spindle.uploads.get(uploadId)` or read bounded pieces with `spindle.uploads.readChunk(uploadId, offset)`. This avoids base64-over-WebSocket inflation and the 4 MB `SPINDLE_BACKEND_MSG` cap.
 
 If your next step is a [`spindle.media.*`](media.md) transform, you usually do **not** need to call `spindle.uploads.get()` first. Pass `{ kind: "upload", upload_id }` directly to the media API and let the host read the staged file in place.
 
@@ -12,7 +12,7 @@ No permission is required. Each upload is scoped to the extension that created i
 
 1. The frontend uploads the file to `/api/v1/spindle-uploads` with the tus protocol, tagging it with your extension identifier.
 2. On success the frontend sends your own backend a small message carrying the returned `uploadId`.
-3. The worker calls `spindle.uploads.get(uploadId)`, processes the bytes, then calls `spindle.uploads.delete(uploadId)`.
+3. The worker calls `spindle.uploads.get(uploadId)` or repeatedly calls `spindle.uploads.readChunk(uploadId, offset)`, then deletes the upload.
 
 ### Frontend
 
@@ -39,6 +39,8 @@ upload.start()
 ```
 
 The `extension` metadata value must be your manifest identifier. The host stores it so only your worker can read the upload back. `filename` is optional and is returned to the worker.
+
+Uploads default to the existing 1 GiB limit. To opt into the 100 GiB limit, include `spindle_read_mode: 'chunked'` in the tus metadata and consume the upload with `spindle.uploads.readChunk()`.
 
 ### Backend
 
@@ -68,6 +70,14 @@ Read a completed upload's bytes. Returns `null` if the upload is missing, expire
 
 **Returns:** `Promise<SpindleUploadDTO | null>`
 
+### `spindle.uploads.readChunk(uploadId, offset, userId?)`
+
+Read at most 16 MiB from a completed upload, beginning at `offset`. Returns `null` if the upload is missing, expired, or belongs to another extension or user. Invalid offsets and incomplete uploads reject the request.
+
+Advance the next request by `result.data.byteLength` until `result.eof` is true. Each successful read refreshes the upload's inactivity timeout.
+
+**Returns:** `Promise<SpindleUploadChunkDTO | null>`
+
 ### `spindle.uploads.delete(uploadId, userId?)`
 
 Delete a staged upload and its on-disk file. Returns `false` if it was already gone. Call this once you have consumed the bytes so the file does not sit on disk until its TTL expires.
@@ -81,6 +91,14 @@ type SpindleUploadDTO = {
   fileName: string
   size: number
   data: Uint8Array
+}
+
+type SpindleUploadChunkDTO = {
+  fileName: string
+  size: number
+  offset: number
+  data: Uint8Array
+  eof: boolean
 }
 ```
 
@@ -101,13 +119,14 @@ The endpoint implements the tus 1.0.0 core protocol plus the `creation` extensio
 | `HEAD` | `/api/v1/spindle-uploads/:id` | Report the current `Upload-Offset` for resuming |
 | `PATCH` | `/api/v1/spindle-uploads/:id` | Append bytes at `Upload-Offset` |
 
-`Upload-Metadata` is a comma-separated list of `key base64(value)` pairs. The `extension` key is required. The `filename` key is optional.
+`Upload-Metadata` is a comma-separated list of `key base64(value)` pairs. The `extension` key is required. The `filename` key is optional. Set `spindle_read_mode` to `chunked` to opt into large uploads.
 
 ## Notes
 
-- The maximum upload size is 1 GB. `POST` rejects a larger `Upload-Length`, and `PATCH` stops a stream that exceeds the cap.
+- Uploads default to a 1 GiB maximum. `spindle_read_mode=chunked` raises the individual limit to 100 GiB. Staged uploads currently have no aggregate storage quota or free-space reservation.
 - Uploads expire after 30 minutes of inactivity and are swept from disk. Read and delete promptly.
 - `get` returns the full file as a `Uint8Array`, so size your processing for the byte length you expect.
+- `readChunk` never returns more than 16 MiB and does not load the complete staged file into host or worker memory.
 - The upload is bound to the extension identifier in `Upload-Metadata` and the signed-in user. Another extension cannot read it even with the id.
 
 !!! note

--- a/src/routes/uploads.routes.ts
+++ b/src/routes/uploads.routes.ts
@@ -25,7 +25,7 @@ app.options("*", () =>
     headers: tusHeaders({
       "Tus-Version": TUS_VERSION,
       "Tus-Extension": "creation",
-      "Tus-Max-Size": String(uploads.getMaxUploadBytes()),
+      "Tus-Max-Size": String(uploads.getMaxUploadBytes(true)),
     }),
   }),
 );
@@ -33,10 +33,11 @@ app.options("*", () =>
 app.post("/", (c) => {
   const userId = c.get("userId");
   const length = Number(c.req.header("Upload-Length"));
-  if (!Number.isInteger(length) || length < 0 || length > uploads.getMaxUploadBytes()) {
+  const meta = parseMetadata(c.req.header("Upload-Metadata"));
+  const maxBytes = uploads.getMaxUploadBytes(meta.spindle_read_mode === "chunked");
+  if (!Number.isInteger(length) || length < 0 || length > maxBytes) {
     return c.json({ error: "invalid Upload-Length" }, 400);
   }
-  const meta = parseMetadata(c.req.header("Upload-Metadata"));
   if (!meta.extension) return c.json({ error: "Upload-Metadata 'extension' is required" }, 400);
   let rec;
   try {

--- a/src/spindle/uploads.test.ts
+++ b/src/spindle/uploads.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { env } from "../env";
+import {
+  UPLOAD_READ_CHUNK_BYTES,
+  appendUpload,
+  createUpload,
+  deleteUpload,
+  getMaxUploadBytes,
+  readUploadChunk,
+} from "./uploads";
+
+const originalDataDir = env.dataDir;
+let dataDir = "";
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "lumiverse-upload-chunk-test-"));
+  env.dataDir = dataDir;
+});
+
+afterEach(() => {
+  env.dataDir = originalDataDir;
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("staged upload chunk reads", () => {
+  test("requires chunked reads for the 100 GiB cap", () => {
+    expect(getMaxUploadBytes()).toBe(1024 * 1024 * 1024);
+    expect(getMaxUploadBytes(true)).toBe(100 * 1024 * 1024 * 1024);
+  });
+
+  test("reads a completed upload in bounded chunks", async () => {
+    const bytes = new Uint8Array(UPLOAD_READ_CHUNK_BYTES + 3);
+    bytes[0] = 1;
+    bytes[UPLOAD_READ_CHUNK_BYTES - 1] = 2;
+    bytes[UPLOAD_READ_CHUNK_BYTES] = 3;
+    bytes[bytes.length - 1] = 4;
+    const upload = createUpload({
+      ownerUserId: "user-1",
+      extensionIdentifier: "extension.test",
+      fileName: "large.charx",
+      declaredSize: bytes.length,
+    });
+    await appendUpload(upload.uploadId, new Blob([bytes]).stream(), 0);
+
+    const first = await readUploadChunk(upload.uploadId, 0);
+    const second = await readUploadChunk(upload.uploadId, first.byteLength);
+
+    expect(first.byteLength).toBe(UPLOAD_READ_CHUNK_BYTES);
+    expect([first[0], first[first.length - 1]]).toEqual([1, 2]);
+    expect(Array.from(second)).toEqual([3, 0, 4]);
+    deleteUpload(upload.uploadId);
+  });
+
+  test("rejects incomplete uploads and invalid offsets", async () => {
+    const upload = createUpload({
+      ownerUserId: "user-1",
+      extensionIdentifier: "extension.test",
+      fileName: "partial.charx",
+      declaredSize: 2,
+    });
+    await appendUpload(upload.uploadId, new Blob([new Uint8Array([1])]).stream(), 0);
+    await expect(readUploadChunk(upload.uploadId, 0)).rejects.toThrow("upload is incomplete");
+
+    await appendUpload(upload.uploadId, new Blob([new Uint8Array([2])]).stream(), 1);
+    await expect(readUploadChunk(upload.uploadId, -1)).rejects.toThrow("invalid upload offset");
+    await expect(readUploadChunk(upload.uploadId, 3)).rejects.toThrow("invalid upload offset");
+    deleteUpload(upload.uploadId);
+  });
+
+  test("does not append beyond the declared upload size", async () => {
+    const upload = createUpload({
+      ownerUserId: "user-1",
+      extensionIdentifier: "extension.test",
+      fileName: "bounded.bin",
+      declaredSize: 1,
+    });
+    await expect(
+      appendUpload(upload.uploadId, new Blob([new Uint8Array([1, 2])]).stream(), 0),
+    ).rejects.toThrow("upload exceeds declared size");
+    deleteUpload(upload.uploadId);
+  });
+});

--- a/src/spindle/uploads.ts
+++ b/src/spindle/uploads.ts
@@ -17,12 +17,14 @@ export interface SpindleUploadRecord {
 
 const UPLOAD_TTL_MS = 30 * 60 * 1000;
 const SWEEP_INTERVAL_MS = 60_000;
-const MAX_UPLOAD_BYTES = 1024 * 1024 * 1024;
+const DEFAULT_MAX_UPLOAD_BYTES = 1024 * 1024 * 1024;
+const CHUNKED_MAX_UPLOAD_BYTES = 100 * DEFAULT_MAX_UPLOAD_BYTES;
+export const UPLOAD_READ_CHUNK_BYTES = 16 * 1024 * 1024;
 
 const uploads = new Map<string, SpindleUploadRecord>();
 
-export function getMaxUploadBytes(): number {
-  return MAX_UPLOAD_BYTES;
+export function getMaxUploadBytes(chunkedRead = false): number {
+  return chunkedRead ? CHUNKED_MAX_UPLOAD_BYTES : DEFAULT_MAX_UPLOAD_BYTES;
 }
 
 function dirFor(userId: string, uploadId: string): string {
@@ -76,7 +78,11 @@ export async function appendUpload(
   // Enforce the cap mid-stream so a client can't exceed it by lying about length.
   const cap = new Transform({
     transform(chunk: Buffer, _enc, cb) {
-      if (rec.offset + chunk.length > MAX_UPLOAD_BYTES) {
+      if (rec.offset + chunk.length > rec.declaredSize) {
+        cb(new Error("upload exceeds declared size"));
+        return;
+      }
+      if (rec.offset + chunk.length > CHUNKED_MAX_UPLOAD_BYTES) {
         cb(new Error("upload exceeds size cap"));
         return;
       }
@@ -112,6 +118,20 @@ export async function readUploadBytes(uploadId: string): Promise<Uint8Array> {
   const rec = uploads.get(uploadId);
   if (!rec) throw new Error("upload not found");
   return new Uint8Array(await Bun.file(rec.path).arrayBuffer());
+}
+
+export async function readUploadChunk(uploadId: string, offset: number): Promise<Uint8Array> {
+  const rec = getUpload(uploadId);
+  if (!rec) throw new Error("upload not found");
+  if (rec.offset !== rec.declaredSize) throw new Error("upload is incomplete");
+  if (!Number.isSafeInteger(offset) || offset < 0 || offset > rec.declaredSize) {
+    throw new Error("invalid upload offset");
+  }
+  rec.expiresAt = Date.now() + UPLOAD_TTL_MS;
+  const end = Math.min(offset + UPLOAD_READ_CHUNK_BYTES, rec.declaredSize);
+  const data = new Uint8Array(await Bun.file(rec.path).slice(offset, end).arrayBuffer());
+  if (data.byteLength !== end - offset) throw new Error("upload changed while reading");
+  return data;
 }
 
 export function deleteUpload(uploadId: string): void {

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -429,6 +429,7 @@ type RuntimeWorkerToHost =
       userId?: string;
     }
   | { type: "uploads_get"; requestId: string; uploadId: string; userId?: string }
+  | { type: "uploads_read_chunk"; requestId: string; uploadId: string; offset: number; userId?: string }
   | { type: "uploads_delete"; requestId: string; uploadId: string; userId?: string }
   | { type: "images_upload"; requestId: string; input: ImageUploadDTO; userId?: string }
   | {
@@ -2297,6 +2298,9 @@ export class WorkerHost {
       // ─── Resumable uploads (free tier) ────────────────────────────────
       case "uploads_get":
         this.handleUploadsGet(msg.requestId, msg.uploadId, msg.userId);
+        break;
+      case "uploads_read_chunk":
+        this.handleUploadsReadChunk(msg.requestId, msg.uploadId, msg.offset, msg.userId);
         break;
       case "uploads_delete":
         this.handleUploadsDelete(msg.requestId, msg.uploadId, msg.userId);
@@ -4464,6 +4468,33 @@ export class WorkerHost {
       }
       const data = await spindleUploads.readUploadBytes(uploadId);
       this.postToWorker({ type: "response", requestId, result: { fileName: rec.fileName, size: data.byteLength, data } });
+    } catch (err: any) {
+      this.postToWorker({ type: "response", requestId, error: err.message });
+    }
+  }
+
+  private async handleUploadsReadChunk(requestId: string, uploadId: string, offset: number, userId?: string): Promise<void> {
+    try {
+      const resolvedUserId = this.resolveEffectiveUserId(userId);
+      if (!resolvedUserId) throw new Error("userId is required for operator-scoped extensions");
+      this.enforceScopedUser(resolvedUserId);
+      const rec = spindleUploads.getUpload(uploadId);
+      if (!rec || rec.ownerUserId !== resolvedUserId || rec.extensionIdentifier !== this.manifest.identifier) {
+        this.postToWorker({ type: "response", requestId, result: null });
+        return;
+      }
+      const data = await spindleUploads.readUploadChunk(uploadId, offset);
+      this.postToWorker({
+        type: "response",
+        requestId,
+        result: {
+          fileName: rec.fileName,
+          size: rec.declaredSize,
+          offset,
+          data,
+          eof: offset + data.byteLength >= rec.declaredSize,
+        },
+      });
     } catch (err: any) {
       this.postToWorker({ type: "response", requestId, error: err.message });
     }

--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -347,6 +347,7 @@ type RuntimeWorkerToHost =
   | { type: "preset_blocks_delete"; requestId: string; presetId: string; blockId: string; userId?: string }
   | { type: "preset_categories_list"; requestId: string; presetId: string; userId?: string }
   | { type: "uploads_get"; requestId: string; uploadId: string; userId?: string }
+  | { type: "uploads_read_chunk"; requestId: string; uploadId: string; offset: number; userId?: string }
   | { type: "uploads_delete"; requestId: string; uploadId: string; userId?: string }
   | {
       type: "tokens_count_text";
@@ -767,6 +768,13 @@ type RuntimeSpindleAPI = Omit<SpindleAPI, "presets" | "imageGen" | "world_books"
   };
   uploads: {
     get(uploadId: string, userId?: string): Promise<{ fileName: string; size: number; data: Uint8Array } | null>;
+    readChunk(uploadId: string, offset: number, userId?: string): Promise<{
+      fileName: string;
+      size: number;
+      offset: number;
+      data: Uint8Array;
+      eof: boolean;
+    } | null>;
     delete(uploadId: string, userId?: string): Promise<boolean>;
   };
   media: {
@@ -2094,6 +2102,22 @@ const spindleApi: RuntimeSpindleAPI = {
       return (await request({ type: "uploads_get", requestId, uploadId, userId })) as
         | { fileName: string; size: number; data: Uint8Array }
         | null;
+    },
+    async readChunk(uploadId: string, offset: number, userId?: string): Promise<{
+      fileName: string;
+      size: number;
+      offset: number;
+      data: Uint8Array;
+      eof: boolean;
+    } | null> {
+      const requestId = crypto.randomUUID();
+      return (await request({ type: "uploads_read_chunk", requestId, uploadId, offset, userId })) as {
+        fileName: string;
+        size: number;
+        offset: number;
+        data: Uint8Array;
+        eof: boolean;
+      } | null;
     },
     async delete(uploadId: string, userId?: string): Promise<boolean> {
       const requestId = crypto.randomUUID();


### PR DESCRIPTION
## Summary

Big file. Big RAM. Tab sad. App go boom.

Not send big. Small chunk. Small RAM. Tab glad. Big thing go in.

Old path still work. No new type pack.

Big file. Then look. Small disk. Disk full. Bad. Know this. Next time fix.

## Validation

```text
bun x tsc --noEmit
Pass — no type errors or warnings.

bun test src/spindle/uploads.test.ts
Pass — 6 tests, 0 failures.

Stress test: Zero no Tsukaima Asset.risum
Pass — 1.047 GiB, 5,332 assets, 68 reads, 16 MiB maximum read.
Peak RSS was about 317 MiB.
```

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
  `staging`, not `main`.
- [x] All applicable tests pass.
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [x] Backend: `bun x tsc --noEmit`
  - [ ] `N/A` Frontend: `cd frontend && bun run typecheck`, `bun run lint`

## UI changes (if applicable)

N/A

Not applicable. No UI changes.

## Performance changes (if applicable)

- [x] I added or updated tests.
- [x] I included reproducible benchmarks and comparison results below.
- Benchmark commands and results:

A 1.047 GiB file with 5,332 assets was processed successfully. Reads were capped at 16 MiB, with about 317 MiB peak RSS.

## Security-sensitive changes (if applicable)

The 100 GiB limit is opt-in through upload metadata. There is no disk-space guard, so a large upload may fill the host disk.

## LLM-assisted work (if applicable)

- [x] I, as the human orchestrating this work, audited the submitted changes in a live environment.