### PR TITLE
feat(regex): expose sort order in the regex editor advanced options

### DIFF
--- a/frontend/src/components/modals/RegexEditorModal.tsx
+++ b/frontend/src/components/modals/RegexEditorModal.tsx
@@ -171,6 +171,7 @@ export default function RegexEditorModal() {
   const [repeatPosition, setRepeatPosition] = useState<RegexRepeatPosition>('end')
   const [repeatRawMatch, setRepeatRawMatch] = useState(false)
   const [trimStrings, setTrimStrings] = useState('')
+  const [sortOrder, setSortOrder] = useState('')
   const [runOnEdit, setRunOnEdit] = useState(false)
   const [description, setDescription] = useState('')
   const [folder, setFolder] = useState('')
@@ -208,6 +209,7 @@ export default function RegexEditorModal() {
       setRepeatPosition(readRepeatPosition(script.metadata, script.replace_string))
       setRepeatRawMatch(script.metadata?.repeat_raw_match === true)
       setTrimStrings(script.trim_strings.join(', '))
+      setSortOrder(script.sort_order != null ? String(script.sort_order) : '')
       setRunOnEdit(script.run_on_edit)
       setDescription(script.description)
       setFolder(script.folder || '')
@@ -281,6 +283,7 @@ export default function RegexEditorModal() {
           repeatRawMatch,
         ),
         trim_strings: trimStrings ? trimStrings.split(',').map((s) => s.trim()).filter(Boolean) : [],
+        sort_order: sortOrder === '' ? 0 : (parseInt(sortOrder, 10) || 0),
         run_on_edit: runOnEdit,
         description,
         folder,
@@ -289,7 +292,7 @@ export default function RegexEditorModal() {
     } catch (err: any) {
       toast.error(err.body?.error || err.message)
     }
-  }, [scriptId, script, activeCharacterId, activeChatId, name, userScriptId, findRegex, replaceString, actions, flags, placement, target, scope, minDepth, maxDepth, substituteMacros, moveBehavior, repeatBack, repeatPosition, repeatRawMatch, trimStrings, runOnEdit, description, folder, updateRegexScript, closeModal, tr])
+  }, [scriptId, script, activeCharacterId, activeChatId, name, userScriptId, findRegex, replaceString, actions, flags, placement, target, scope, minDepth, maxDepth, substituteMacros, moveBehavior, repeatBack, repeatPosition, repeatRawMatch, trimStrings, sortOrder, runOnEdit, description, folder, updateRegexScript, closeModal, tr])
 
   if (!script) return null
 
@@ -909,6 +912,13 @@ export default function RegexEditorModal() {
                     <span className={styles.fieldHint}>{tr('trimHint')}</span>
                   </label>
                   <input className={styles.fieldInput} value={trimStrings} onChange={(e) => setTrimStrings(e.target.value)} placeholder={tr('trimPlaceholder')} />
+                </div>
+                <div className={styles.field}>
+                  <label className={styles.fieldLabel}>
+                    {tr('sortOrder')}
+                    <span className={styles.fieldHint}>{tr('sortOrderHint')}</span>
+                  </label>
+                  <input className={styles.fieldInput} type="number" step="1" value={sortOrder} onChange={(e) => setSortOrder(e.target.value)} placeholder="0" />
                 </div>
                 <div className={styles.field}>
                   <label className={styles.fieldLabel}>{tr('notes')}</label>

--- a/frontend/src/i18n/locales/en/modals.json
+++ b/frontend/src/i18n/locales/en/modals.json
@@ -704,6 +704,8 @@
     "depthHint": "0 = latest",
     "trimStrings": "Trim strings",
     "trimHint": "comma separated",
+    "sortOrder": "Sort order",
+    "sortOrderHint": "Lower runs first; drag-reordering the list rewrites these",
     "scopeGlobal": "Global",
     "scopeCharacter": "Character",
     "scopeChat": "Chat",

--- a/frontend/src/i18n/locales/fr/modals.json
+++ b/frontend/src/i18n/locales/fr/modals.json
@@ -681,6 +681,8 @@
     "depthHint": "0 = dernières",
     "trimStrings": "Trim des chaînes",
     "trimHint": "séparées par des virgules",
+    "sortOrder": "Ordre de tri",
+    "sortOrderHint": "Le plus petit s'exécute en premier ; le glisser-déposer réécrit ces valeurs",
     "scopeGlobal": "Mondial",
     "scopeCharacter": "Personnage",
     "scopeChat": "Chat",

--- a/frontend/src/i18n/locales/it/modals.json
+++ b/frontend/src/i18n/locales/it/modals.json
@@ -681,6 +681,8 @@
     "depthHint": "0 = ultimi",
     "trimStrings": "Trim stringhe",
     "trimHint": "separati da virgole",
+    "sortOrder": "Ordine",
+    "sortOrderHint": "Prima il valore più basso; il riordino con trascinamento riscrive questi valori",
     "scopeGlobal": "Globale",
     "scopeCharacter": "Personaggio",
     "scopeChat": "Chat",

--- a/frontend/src/i18n/locales/ja/modals.json
+++ b/frontend/src/i18n/locales/ja/modals.json
@@ -681,6 +681,8 @@
     "depthHint": "0 = 最新",
     "trimStrings": "文字列をトリミング",
     "trimHint": "カンマ区切り",
+    "sortOrder": "並び順",
+    "sortOrderHint": "小さい値が先に実行されます。ドラッグで並べ替えると値は再割り当てされます",
     "scopeGlobal": "グローバル",
     "scopeCharacter": "キャラクター",
     "scopeChat": "チャット",

--- a/frontend/src/i18n/locales/zh-TW/modals.json
+++ b/frontend/src/i18n/locales/zh-TW/modals.json
@@ -681,6 +681,8 @@
     "depthHint": "0 = 最新",
     "trimStrings": "修剪字符串",
     "trimHint": "逗號分隔",
+    "sortOrder": "排序",
+    "sortOrderHint": "數值小的先執行；拖曳排序列表會改寫這些值",
     "scopeGlobal": "全局",
     "scopeCharacter": "角色",
     "scopeChat": "聊天",

--- a/frontend/src/i18n/locales/zh/modals.json
+++ b/frontend/src/i18n/locales/zh/modals.json
@@ -681,6 +681,8 @@
     "depthHint": "0 = 最新",
     "trimStrings": "修剪字符串",
     "trimHint": "逗号分隔",
+    "sortOrder": "排序",
+    "sortOrderHint": "数值小的先执行；拖拽排序列表会重写这些值",
     "scopeGlobal": "全局",
     "scopeCharacter": "角色",
     "scopeChat": "聊天",


### PR DESCRIPTION
## Summary

Adds explicit sort-order handling to the regex editor so regex scripts can be organized and reordered predictably without relying on incidental list order.

The change keeps ordering within the existing regex editing workflow and preserves the stored order used during processing.

## Validation

```text
git diff --check
cd frontend && bun x tsc --noEmit
cd frontend && bun run lint
cd frontend && bun run build

Manually tested regex ordering and persistence.
Validated the integrated UI in Chromium and Firefox on desktop and mobile.
````

## Required checklist

* [x] This pull request is based on the latest `staging` branch and targets
  `staging`, not `main`.
* [x] All applicable tests pass.
* [x] I ran the relevant type check(s) with no type errors or warnings:

  * [ ] Backend: not applicable; frontend-only change.
  * [x] Frontend: equivalent direct TypeScript check via `cd frontend && bun x tsc --noEmit`, plus `bun run lint`

## UI changes (if applicable)

* [x] I validated this change in more than one browser.
* [x] I verified the integrated experience on a mobile interface or through
  the mobile PWA.
* Browsers, devices, and PWA coverage: Chromium and Firefox on desktop and mobile.

## Performance changes (if applicable)

Not applicable.

## Security-sensitive changes (if applicable)

Not applicable. No Spindle capability or security boundary is changed.

## LLM-assisted work (if applicable)

* [x] I, as the human orchestrating this work, audited the submitted changes
  in a live environment.