### PR TITLE
Feat/regex action queue

### DIFF
--- a/frontend/src/components/chat/BubbleMessageDefault.tsx
+++ b/frontend/src/components/chat/BubbleMessageDefault.tsx
@@ -260,10 +260,30 @@ export default function BubbleMessageDefault({
     },
   })
 
+  const isRegexActionEvent = useCallback((e: React.SyntheticEvent) => {
+    const path = typeof e.nativeEvent.composedPath === 'function'
+      ? e.nativeEvent.composedPath()
+      : [e.target]
+
+    return path.some((node) => (
+      node instanceof Element
+      && node.hasAttribute('data-lumiverse-regex-action')
+    ))
+  }, [])
+
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
     if (!canOpenContextMenu) return
+    if (isRegexActionEvent(e)) {
+      e.preventDefault()
+      return
+    }
     longPress.onContextMenu(e)
-  }, [canOpenContextMenu, longPress])
+  }, [canOpenContextMenu, isRegexActionEvent, longPress])
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    if (!canOpenContextMenu || isRegexActionEvent(e)) return
+    longPress.onTouchStart(e)
+  }, [canOpenContextMenu, isRegexActionEvent, longPress])
 
   const contextMenuItems: ContextMenuEntry[] = useMemo(() => [
     {
@@ -354,7 +374,7 @@ export default function BubbleMessageDefault({
       data-message-id={message.id}
       onClick={isSelectMode ? onToggleSelect : undefined}
       onContextMenu={handleContextMenu}
-      onTouchStart={canOpenContextMenu ? longPress.onTouchStart : undefined}
+      onTouchStart={canOpenContextMenu ? handleTouchStart : undefined}
       onTouchMove={canOpenContextMenu ? longPress.onTouchMove : undefined}
       onTouchEnd={canOpenContextMenu ? longPress.onTouchEnd : undefined}
     >

--- a/frontend/src/components/chat/InputArea.tsx
+++ b/frontend/src/components/chat/InputArea.tsx
@@ -1998,6 +1998,21 @@ export default function InputArea({ chatId, onNavigateHome, onOpenChatFind }: In
         toast.info(t('toast.regexActionClaimFailed'))
         return
       }
+      // Ctrl/cmd-click or right-click queues the send-action content into
+      // the composer as an editable draft. Nothing is claimed server-side;
+      // the action stays usable until the user sends the drafted message.
+      if (action.queue && !action.multi_select && action.type === 'send') {
+        setText((current) => applyRegexActionDraft(current, { content: action.content, mode: 'append' }))
+        requestAnimationFrame(() => {
+          resizeTextarea(textareaRef.current)
+          textareaRef.current?.focus()
+        })
+        toast.info(action.subtitle || t('toast.regexActionDraftQueued'), {
+          title: action.title || t('toast.regexActionSelected'),
+          duration: 2500,
+        })
+        return
+      }
       regexActionHandlingRef.current = true
       try {
         if (action.multi_select) {

--- a/frontend/src/components/chat/MessageContent.tsx
+++ b/frontend/src/components/chat/MessageContent.tsx
@@ -37,6 +37,7 @@ import {
   type RegexActionActivation,
   type ResolvedRegexActionPayload,
 } from '@/lib/regex/actionBus'
+import { attachRegexActionLongPress } from '@/lib/regex/actionLongPress'
 import { toast } from '@/lib/toast'
 import { OOCBlock as OOCBlockComponent, OOCIrcChatRoom } from './ooc'
 import type { IrcEntry } from './ooc'
@@ -1583,14 +1584,24 @@ export default function MessageContent({
     const container = containerRef.current
     if (!container || isStreaming || !chatId) return
 
-    const activate = (event: MouseEvent | KeyboardEvent) => {
-      if (event instanceof KeyboardEvent && event.key !== 'Enter' && event.key !== ' ') return
-      const target = event.composedPath().find((node): node is Element => (
+    const findActionTarget = (event: Event): Element | null => (
+      event.composedPath().find((node): node is Element => (
         node instanceof Element && node.hasAttribute('data-lumiverse-regex-action')
-      ))
-      if (!target) return
+      )) ?? null
+    )
+
+    type ConfiguredAction = (typeof regexScripts)[number]['actions'][number]
+    type ResolvedAction = { payload: ResolvedRegexActionPayload; configured: ConfiguredAction }
+
+    const findConfiguredAction = (payload: Partial<ResolvedRegexActionPayload>) => regexScripts
+      .find((script) => script.id === payload.scriptId && !script.disabled && script.target.includes('display'))
+      ?.actions.find((action) => action.id === payload.id)
+
+    // Shared shape/config validation — silently ignores anything that is not
+    // a well-formed, currently-configured regex action.
+    const resolveConfigured = (target: Element): ResolvedAction | null => {
       const encoded = target.getAttribute('data-lumiverse-regex-action')
-      if (!encoded) return
+      if (!encoded) return null
       try {
         const payload = JSON.parse(decodeURIComponent(encoded)) as Partial<ResolvedRegexActionPayload>
         if (
@@ -1601,61 +1612,115 @@ export default function MessageContent({
           typeof payload.cost !== 'number' || !Number.isFinite(payload.cost) || payload.cost <= 0 ||
           typeof payload.limit !== 'number' || !Number.isFinite(payload.limit) || payload.limit < 0 ||
           typeof payload.content !== 'string' || (payload.type !== 'effects' && !payload.content.trim())
-        ) return
-        if (regexActionsSuperseded) {
-          event.preventDefault()
-          event.stopPropagation()
-          toast.info(t('toast.regexActionExpired'))
-          return
-        }
-        const configured = regexScripts
-          .find((script) => script.id === payload.scriptId && !script.disabled && script.target.includes('display'))
-          ?.actions.find((action) => action.id === payload.id)
-        if (
-          !configured ||
-          configured.type !== payload.type ||
-          configured.multi_select !== payload.multi_select
-        ) return
+        ) return null
+        const configured = findConfiguredAction(payload)
+        if (!configured) return null
+        if (configured.type !== payload.type || configured.multi_select !== payload.multi_select) return null
+        return { payload: payload as ResolvedRegexActionPayload, configured }
+      } catch {
+        return null
+      }
+    }
+
+    const isUsedOrDisabled = (target: Element, configured: ConfiguredAction, payload: ResolvedRegexActionPayload): boolean => {
+      const usageKey = configured.multi_select ? `${payload.instanceId}:${payload.id}` : payload.instanceId
+      const blockHasSelection = Object.keys(actionUsage || {}).some((key) => (
+        key === payload.instanceId || key.startsWith(`${payload.instanceId}:`)
+      ))
+      const alreadyUsed = configured.multi_select
+        ? !!actionUsage?.[payload.instanceId] || !!actionUsage?.[usageKey]
+        : blockHasSelection
+      return target.getAttribute('aria-disabled') === 'true' || alreadyUsed
+    }
+
+    const dispatchActivation = (resolved: ResolvedAction, queue: boolean): void => {
+      const { payload, configured } = resolved
+      dispatchRegexAction({
+        id: payload.id,
+        type: payload.type,
+        multi_select: configured.multi_select,
+        cost: payload.cost,
+        limit: payload.limit,
+        title: typeof payload.title === 'string' ? payload.title : '',
+        subtitle: typeof payload.subtitle === 'string' ? payload.subtitle : '',
+        content: payload.content,
+        scriptId: payload.scriptId,
+        instanceId: payload.instanceId,
+        chatId,
+        messageId,
+        ...(configured.effects?.length ? { effects: configured.effects } : {}),
+        ...(queue ? { queue: true } : {}),
+      })
+    }
+
+    // Ctrl/cmd-click or right-click queues the action content into the
+    // composer instead of claiming and sending it, so the user can build on
+    // top of it. Plain clicks and keyboard activation keep sending.
+    const queueIntent = (event: MouseEvent | KeyboardEvent): boolean => (
+      event instanceof MouseEvent && (event.type === 'contextmenu' || event.ctrlKey || event.metaKey)
+    )
+
+    // Touch/pen long-press produces the same queue activation. The
+    // controller suppresses the synthetic click (and any synthesized
+    // contextmenu) that follow the hold, so the gesture queues exactly once.
+    const longPress = attachRegexActionLongPress({
+      container,
+      findTarget: findActionTarget,
+      isQueueable: (target) => {
+        const resolved = resolveConfigured(target)
+        if (!resolved) return false
+        const { payload, configured } = resolved
+        if (configured.multi_select || payload.type !== 'send') return false
+        if (regexActionsSuperseded) return false
+        if (isUser && configured.effects?.length) return false
+        return !isUsedOrDisabled(target, configured, payload)
+      },
+      onQueue: (target) => {
+        const resolved = resolveConfigured(target)
+        if (!resolved) return
+        dispatchActivation(resolved, true)
+      },
+    })
+
+    const activate = (event: MouseEvent | KeyboardEvent) => {
+      if (event instanceof KeyboardEvent && event.key !== 'Enter' && event.key !== ' ') return
+      const target = findActionTarget(event)
+      if (!target) return
+      if (longPress.shouldSuppressEvent(event, target)) {
         event.preventDefault()
         event.stopPropagation()
-        if (isUser && configured.effects?.length) {
-          toast.info(t('toast.regexActionAssistantOnly'))
-          return
-        }
-        const usageKey = configured.multi_select ? `${payload.instanceId}:${payload.id}` : payload.instanceId
-        const blockHasSelection = Object.keys(actionUsage || {}).some((key) => (
-          key === payload.instanceId || key.startsWith(`${payload.instanceId}:`)
-        ))
-        const alreadyUsed = configured.multi_select
-          ? !!actionUsage?.[payload.instanceId] || !!actionUsage?.[usageKey]
-          : blockHasSelection
-        if (target.getAttribute('aria-disabled') === 'true' || alreadyUsed) {
-          toast.info(t('toast.regexActionAlreadyUsed'))
-          return
-        }
-        dispatchRegexAction({
-          id: payload.id,
-          type: payload.type,
-          multi_select: configured.multi_select,
-          cost: payload.cost,
-          limit: payload.limit,
-          title: typeof payload.title === 'string' ? payload.title : '',
-          subtitle: typeof payload.subtitle === 'string' ? payload.subtitle : '',
-          content: payload.content,
-          scriptId: payload.scriptId,
-          instanceId: payload.instanceId,
-          chatId,
-          messageId,
-          ...(configured.effects?.length ? { effects: configured.effects } : {}),
-        })
-      } catch {}
+        return
+      }
+      const resolved = resolveConfigured(target)
+      if (!resolved) return
+      const { payload, configured } = resolved
+      if (regexActionsSuperseded) {
+        event.preventDefault()
+        event.stopPropagation()
+        toast.info(t('toast.regexActionExpired'))
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      if (isUser && configured.effects?.length) {
+        toast.info(t('toast.regexActionAssistantOnly'))
+        return
+      }
+      if (isUsedOrDisabled(target, configured, payload)) {
+        toast.info(t('toast.regexActionAlreadyUsed'))
+        return
+      }
+      dispatchActivation(resolved, queueIntent(event))
     }
 
     container.addEventListener('click', activate)
     container.addEventListener('keydown', activate)
+    container.addEventListener('contextmenu', activate)
     return () => {
       container.removeEventListener('click', activate)
       container.removeEventListener('keydown', activate)
+      container.removeEventListener('contextmenu', activate)
+      longPress.destroy()
     }
   }, [chatId, messageId, isUser, isStreaming, regexScripts, actionUsage, regexActionsSuperseded, t, regexSelectionVersion])
 

--- a/frontend/src/components/chat/MinimalMessageDefault.tsx
+++ b/frontend/src/components/chat/MinimalMessageDefault.tsx
@@ -251,10 +251,30 @@ export default function MinimalMessageDefault({
     },
   })
 
+  const isRegexActionEvent = useCallback((e: React.SyntheticEvent) => {
+    const path = typeof e.nativeEvent.composedPath === 'function'
+      ? e.nativeEvent.composedPath()
+      : [e.target]
+
+    return path.some((node) => (
+      node instanceof Element
+      && node.hasAttribute('data-lumiverse-regex-action')
+    ))
+  }, [])
+
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
     if (!canOpenContextMenu) return
+    if (isRegexActionEvent(e)) {
+      e.preventDefault()
+      return
+    }
     longPress.onContextMenu(e)
-  }, [canOpenContextMenu, longPress])
+  }, [canOpenContextMenu, isRegexActionEvent, longPress])
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    if (!canOpenContextMenu || isRegexActionEvent(e)) return
+    longPress.onTouchStart(e)
+  }, [canOpenContextMenu, isRegexActionEvent, longPress])
 
   const contextMenuItems: ContextMenuEntry[] = useMemo(() => [
     {
@@ -344,7 +364,7 @@ export default function MinimalMessageDefault({
       data-message-id={message.id}
       onClick={isSelectMode ? onToggleSelect : undefined}
       onContextMenu={handleContextMenu}
-      onTouchStart={canOpenContextMenu ? longPress.onTouchStart : undefined}
+      onTouchStart={canOpenContextMenu ? handleTouchStart : undefined}
       onTouchMove={canOpenContextMenu ? longPress.onTouchMove : undefined}
       onTouchEnd={canOpenContextMenu ? longPress.onTouchEnd : undefined}
     >

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -205,6 +205,7 @@
     "failedQueueMessage": "Failed to queue message",
     "regexActionSelected": "Choice selected",
     "regexActionQueued": "This choice will be appended invisibly to your next message.",
+    "regexActionDraftQueued": "Queued to input — edit and send when ready.",
     "regexActionAlreadyUsed": "That choice block has already been used.",
     "regexActionExpired": "That choice is no longer available because you already replied.",
     "regexActionAssistantOnly": "State-changing choices are only available on assistant messages.",

--- a/frontend/src/lib/regex/actionBus.ts
+++ b/frontend/src/lib/regex/actionBus.ts
@@ -19,6 +19,12 @@ export interface ResolvedRegexActionPayload {
 export interface RegexActionActivation extends ResolvedRegexActionPayload {
   chatId: string
   messageId?: string
+  /**
+   * Queue intent: the activation came from a ctrl/cmd-click or right-click
+   * and the content should land in the composer as an editable draft
+   * instead of being claimed and sent.
+   */
+  queue?: boolean
 }
 
 export interface PendingRegexSelection extends RegexActionActivation {

--- a/frontend/src/lib/regex/actionLongPress.test.ts
+++ b/frontend/src/lib/regex/actionLongPress.test.ts
@@ -1,0 +1,315 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { JSDOM } from 'jsdom'
+import {
+  attachRegexActionLongPress,
+  type RegexActionLongPressController,
+} from './actionLongPress'
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost/' })
+
+const TEST_LONG_PRESS_MS = 20
+const TEST_GRACE_MS = 120
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+interface Harness {
+  container: HTMLElement
+  action: HTMLElement
+  otherAction: HTMLElement
+  queued: Element[]
+  delegatedClicks: number
+  delegatedContextMenus: number
+  queueable: boolean
+  controller: RegexActionLongPressController
+  destroy(): void
+}
+
+function findActionTarget(event: Event): Element | null {
+  return event.composedPath().find((node): node is Element => (
+    node instanceof Element && node.hasAttribute('data-lumiverse-regex-action')
+  )) ?? null
+}
+
+function createController(
+  harness: Harness,
+  graceWindowMs = TEST_GRACE_MS,
+): RegexActionLongPressController {
+  return attachRegexActionLongPress({
+    container: harness.container,
+    findTarget: findActionTarget,
+    isQueueable: () => harness.queueable,
+    onQueue: (target) => { harness.queued.push(target) },
+    longPressMs: TEST_LONG_PRESS_MS,
+    movementSlopPx: 12,
+    graceWindowMs,
+  })
+}
+
+function createHarness({ graceWindowMs = TEST_GRACE_MS }: { graceWindowMs?: number } = {}): Harness {
+  const document = dom.window.document
+  const container = document.createElement('div')
+  const action = document.createElement('button')
+  action.setAttribute('data-lumiverse-regex-action', `encoded-${Math.random()}`)
+  const otherAction = document.createElement('button')
+  otherAction.setAttribute('data-lumiverse-regex-action', `other-${Math.random()}`)
+  container.append(action, otherAction)
+  document.body.append(container)
+
+  const harness: Harness = {
+    container,
+    action,
+    otherAction,
+    queued: [],
+    delegatedClicks: 0,
+    delegatedContextMenus: 0,
+    queueable: true,
+    controller: null as unknown as RegexActionLongPressController,
+    destroy: () => {
+      harness.controller?.destroy()
+      container.remove()
+    },
+  }
+
+  harness.controller = createController(harness, graceWindowMs)
+
+  const delegated = (event: Event) => {
+    const target = findActionTarget(event)
+    if (harness.controller.shouldSuppressEvent(event, target)) {
+      event.preventDefault()
+      event.stopPropagation()
+      return
+    }
+
+    if (event.type === 'click') harness.delegatedClicks += 1
+    if (event.type === 'contextmenu') harness.delegatedContextMenus += 1
+  }
+
+  container.addEventListener('click', delegated)
+  container.addEventListener('contextmenu', delegated)
+
+  return harness
+}
+
+function pointerEvent(
+  type: 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel',
+  init: {
+    pointerType?: string
+    isPrimary?: boolean
+    pointerId?: number
+    clientX?: number
+    clientY?: number
+  } = {},
+): Event {
+  const event = new dom.window.MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    clientX: init.clientX ?? 0,
+    clientY: init.clientY ?? 0,
+  })
+  Object.defineProperties(event, {
+    pointerType: { value: init.pointerType ?? 'touch' },
+    isPrimary: { value: init.isPrimary ?? true },
+    pointerId: { value: init.pointerId ?? 1 },
+  })
+  return event
+}
+
+function clickEvent(): Event {
+  return new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, composed: true })
+}
+
+function contextmenuEvent(): Event {
+  return new dom.window.MouseEvent('contextmenu', { bubbles: true, cancelable: true, composed: true })
+}
+
+const harnesses: Harness[] = []
+const track = (harness: Harness): Harness => {
+  harnesses.push(harness)
+  return harness
+}
+
+afterEach(() => {
+  for (const harness of harnesses.splice(0)) harness.destroy()
+})
+
+describe('regex action long-press queue gesture', () => {
+  test('queues once and suppresses contextmenu while the finger remains held', async () => {
+    const harness = track(createHarness())
+
+    harness.action.dispatchEvent(pointerEvent('pointerdown'))
+    await wait(TEST_LONG_PRESS_MS + 10)
+
+    expect(harness.queued).toEqual([harness.action])
+
+    harness.action.dispatchEvent(contextmenuEvent())
+    harness.action.dispatchEvent(contextmenuEvent())
+
+    expect(harness.queued).toHaveLength(1)
+    expect(harness.delegatedContextMenus).toBe(0)
+  })
+
+  test('suppresses a contextmenu that races the hold timer', async () => {
+    const harness = track(createHarness())
+
+    harness.action.dispatchEvent(pointerEvent('pointerdown'))
+    harness.action.dispatchEvent(contextmenuEvent())
+
+    expect(harness.delegatedContextMenus).toBe(0)
+    expect(harness.queued).toHaveLength(0)
+
+    await wait(TEST_LONG_PRESS_MS + 10)
+    expect(harness.queued).toEqual([harness.action])
+  })
+
+  test('suppresses release click and trailing contextmenu after a successful hold', async () => {
+    const harness = track(createHarness())
+
+    harness.action.dispatchEvent(pointerEvent('pointerdown'))
+    await wait(TEST_LONG_PRESS_MS + 10)
+    harness.action.dispatchEvent(pointerEvent('pointerup'))
+
+    harness.action.dispatchEvent(clickEvent())
+    harness.action.dispatchEvent(contextmenuEvent())
+
+    expect(harness.queued).toHaveLength(1)
+    expect(harness.delegatedClicks).toBe(0)
+    expect(harness.delegatedContextMenus).toBe(0)
+  })
+
+  test('consumed suppression survives controller teardown and re-attachment', async () => {
+    const harness = track(createHarness())
+
+    harness.action.dispatchEvent(pointerEvent('pointerdown'))
+    await wait(TEST_LONG_PRESS_MS + 10)
+    expect(harness.queued).toHaveLength(1)
+
+    harness.controller.destroy()
+    harness.controller = createController(harness)
+
+    harness.action.dispatchEvent(contextmenuEvent())
+    harness.action.dispatchEvent(clickEvent())
+
+    expect(harness.queued).toHaveLength(1)
+    expect(harness.delegatedContextMenus).toBe(0)
+    expect(harness.delegatedClicks).toBe(0)
+  })
+
+  test('pointercancel after firing is not treated as physical release', async () => {
+    const harness = track(createHarness())
+
+    harness.action.dispatchEvent(pointerEvent('pointerdown', { pointerId: 4 }))
+    await wait(TEST_LONG_PRESS_MS + 10)
+    harness.action.dispatchEvent(pointerEvent('pointercancel', { pointerId: 4 }))
+    await wait(TEST_GRACE_MS + 40)
+
+    harness.action.dispatchEvent(contextmenuEvent())
+
+    expect(harness.queued).toHaveLength(1)
+    expect(harness.delegatedContextMenus).toBe(0)
+  })
+
+  test('short tap stays on the normal click path', async () => {
+    const harness = track(createHarness())
+
+    harness.action.dispatchEvent(pointerEvent('pointerdown'))
+    harness.action.dispatchEvent(pointerEvent('pointerup'))
+    await wait(TEST_LONG_PRESS_MS + 10)
+    harness.action.dispatchEvent(clickEvent())
+
+    expect(harness.queued).toHaveLength(0)
+    expect(harness.delegatedClicks).toBe(1)
+  })
+
+  test('movement beyond slop cancels the hold', async () => {
+    const harness = track(createHarness())
+
+    harness.action.dispatchEvent(pointerEvent('pointerdown', { clientX: 0, clientY: 0 }))
+    harness.action.dispatchEvent(pointerEvent('pointermove', { clientX: 30, clientY: 0 }))
+    await wait(TEST_LONG_PRESS_MS + 10)
+    harness.action.dispatchEvent(contextmenuEvent())
+
+    expect(harness.queued).toHaveLength(0)
+    expect(harness.delegatedContextMenus).toBe(1)
+  })
+
+  test('movement within slop keeps the hold alive', async () => {
+    const harness = track(createHarness())
+
+    harness.action.dispatchEvent(pointerEvent('pointerdown', { clientX: 0, clientY: 0 }))
+    harness.action.dispatchEvent(pointerEvent('pointermove', { clientX: 5, clientY: 5 }))
+    await wait(TEST_LONG_PRESS_MS + 10)
+
+    expect(harness.queued).toEqual([harness.action])
+  })
+
+  test('pointercancel before firing cancels the hold', async () => {
+    const harness = track(createHarness())
+
+    harness.action.dispatchEvent(pointerEvent('pointerdown'))
+    harness.action.dispatchEvent(pointerEvent('pointercancel'))
+    await wait(TEST_LONG_PRESS_MS + 10)
+    harness.action.dispatchEvent(clickEvent())
+
+    expect(harness.queued).toHaveLength(0)
+    expect(harness.delegatedClicks).toBe(1)
+  })
+
+  test('mouse, secondary pointers, and non-queueable actions never arm', async () => {
+    const harness = track(createHarness())
+
+    harness.action.dispatchEvent(pointerEvent('pointerdown', { pointerType: 'mouse' }))
+    harness.action.dispatchEvent(pointerEvent('pointerdown', { pointerId: 2, isPrimary: false }))
+
+    harness.queueable = false
+    harness.action.dispatchEvent(pointerEvent('pointerdown', { pointerId: 3 }))
+
+    await wait(TEST_LONG_PRESS_MS + 10)
+
+    expect(harness.queued).toHaveLength(0)
+  })
+
+  test('suppression is scoped to the held action', async () => {
+    const harness = track(createHarness())
+
+    harness.action.dispatchEvent(pointerEvent('pointerdown'))
+    await wait(TEST_LONG_PRESS_MS + 10)
+
+    harness.otherAction.dispatchEvent(contextmenuEvent())
+
+    expect(harness.queued).toHaveLength(1)
+    expect(harness.delegatedContextMenus).toBe(1)
+  })
+
+  test('a fresh primary press clears stale consumed state', async () => {
+    const harness = track(createHarness())
+
+    harness.action.dispatchEvent(pointerEvent('pointerdown', { pointerId: 1 }))
+    await wait(TEST_LONG_PRESS_MS + 10)
+    harness.action.dispatchEvent(pointerEvent('pointercancel', { pointerId: 1 }))
+    harness.action.dispatchEvent(contextmenuEvent())
+    expect(harness.delegatedContextMenus).toBe(0)
+
+    harness.action.dispatchEvent(pointerEvent('pointerdown', { pointerId: 2 }))
+    harness.action.dispatchEvent(pointerEvent('pointerup', { pointerId: 2 }))
+    harness.action.dispatchEvent(clickEvent())
+
+    expect(harness.queued).toHaveLength(1)
+    expect(harness.delegatedClicks).toBe(1)
+  })
+
+  test('destroy before the timer fires clears pending state', async () => {
+    const harness = track(createHarness())
+
+    harness.action.dispatchEvent(pointerEvent('pointerdown'))
+    harness.controller.destroy()
+    await wait(TEST_LONG_PRESS_MS + 10)
+
+    harness.controller = createController(harness)
+    harness.action.dispatchEvent(clickEvent())
+    harness.action.dispatchEvent(contextmenuEvent())
+
+    expect(harness.queued).toHaveLength(0)
+    expect(harness.delegatedClicks).toBe(1)
+    expect(harness.delegatedContextMenus).toBe(1)
+  })
+})

--- a/frontend/src/lib/regex/actionLongPress.ts
+++ b/frontend/src/lib/regex/actionLongPress.ts
@@ -1,0 +1,221 @@
+/**
+ * Touch/pen long-press -> queue gesture for regex send-actions.
+ *
+ * The controller owns only the action-level gesture. Message-level long-press
+ * menus are excluded separately by the message renderers using composedPath().
+ *
+ * Guards live at module scope so a consumed hold survives MessageContent
+ * effect teardown/re-attachment after the draft is inserted.
+ */
+
+export interface RegexActionLongPressOptions {
+  container: HTMLElement
+  findTarget(event: Event): Element | null
+  isQueueable(target: Element): boolean
+  onQueue(target: Element): void
+  longPressMs?: number
+  movementSlopPx?: number
+  graceWindowMs?: number
+  maxHeldMs?: number
+}
+
+export interface RegexActionLongPressController {
+  shouldSuppressEvent(event: Event, target: Element | null): boolean
+  destroy(): void
+}
+
+type GuardPhase = 'pending' | 'consumed'
+
+interface GestureGuard {
+  owner: symbol
+  phase: GuardPhase
+  expiresAt: number
+  graceWindowMs: number
+}
+
+const guards = new WeakMap<Element, GestureGuard>()
+
+function activeGuard(target: Element): GestureGuard | null {
+  const guard = guards.get(target)
+  if (!guard) return null
+
+  if (Date.now() > guard.expiresAt) {
+    guards.delete(target)
+    return null
+  }
+
+  return guard
+}
+
+export function attachRegexActionLongPress(
+  options: RegexActionLongPressOptions,
+): RegexActionLongPressController {
+  const { container, findTarget, isQueueable, onQueue } = options
+  const longPressMs = options.longPressMs ?? 500
+  const movementSlopPx = options.movementSlopPx ?? 12
+  const graceWindowMs = options.graceWindowMs ?? 750
+  const maxHeldMs = options.maxHeldMs ?? 10_000
+  const owner = Symbol('regex-action-long-press')
+
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let pressTarget: Element | null = null
+  let pressPointerId: number | null = null
+  let pressOrigin: { x: number; y: number } | null = null
+  let destroyed = false
+
+  const pointerListeners: Array<[string, EventListener]> = []
+
+  const detachPointerListeners = (): void => {
+    for (const [type, handler] of pointerListeners) {
+      container.removeEventListener(type, handler)
+    }
+    pointerListeners.length = 0
+  }
+
+  const resetLocal = (): void => {
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+    }
+    detachPointerListeners()
+    pressTarget = null
+    pressPointerId = null
+    pressOrigin = null
+  }
+
+  const clearPendingGuard = (target: Element | null): void => {
+    if (!target) return
+    const guard = guards.get(target)
+    if (guard?.owner === owner && guard.phase === 'pending') {
+      guards.delete(target)
+    }
+  }
+
+  const cancelPending = (): void => {
+    clearPendingGuard(pressTarget)
+    resetLocal()
+  }
+
+  const handlePointerMove = (event: PointerEvent): void => {
+    if (timer === null || pressOrigin === null || pressPointerId === null) return
+    if (event.pointerId !== pressPointerId) return
+
+    const dx = event.clientX - pressOrigin.x
+    const dy = event.clientY - pressOrigin.y
+    if (dx * dx + dy * dy > movementSlopPx * movementSlopPx) cancelPending()
+  }
+
+  const handlePointerUp = (event: PointerEvent): void => {
+    if (pressPointerId === null || event.pointerId !== pressPointerId) return
+
+    const target = pressTarget
+    const guard = target ? activeGuard(target) : null
+
+    if (guard?.owner === owner && guard.phase === 'consumed') {
+      guard.expiresAt = Date.now() + graceWindowMs
+      resetLocal()
+      return
+    }
+
+    cancelPending()
+  }
+
+  const handlePointerCancel = (event: PointerEvent): void => {
+    if (pressPointerId === null || event.pointerId !== pressPointerId) return
+
+    const guard = pressTarget ? activeGuard(pressTarget) : null
+    if (guard?.owner === owner && guard.phase === 'consumed') {
+      // Mobile browsers may emit pointercancel while the finger is still held.
+      // Keep the consumed guard alive until click/release evidence or timeout.
+      return
+    }
+
+    cancelPending()
+  }
+
+  const handlePointerDown = (event: PointerEvent): void => {
+    if (destroyed || event.pointerType === 'mouse' || event.isPrimary === false) return
+
+    const target = findTarget(event)
+    if (!target || !isQueueable(target)) return
+
+    // A fresh primary press proves any stale hold on this action is over.
+    guards.delete(target)
+    cancelPending()
+
+    pressTarget = target
+    pressPointerId = event.pointerId
+    pressOrigin = { x: event.clientX, y: event.clientY }
+
+    guards.set(target, {
+      owner,
+      phase: 'pending',
+      expiresAt: Date.now() + maxHeldMs,
+      graceWindowMs,
+    })
+
+    pointerListeners.push(
+      ['pointermove', handlePointerMove as EventListener],
+      ['pointerup', handlePointerUp as EventListener],
+      ['pointercancel', handlePointerCancel as EventListener],
+    )
+    for (const [type, handler] of pointerListeners) {
+      container.addEventListener(type, handler)
+    }
+
+    timer = setTimeout(() => {
+      timer = null
+
+      const target = pressTarget
+      if (!target || destroyed || !isQueueable(target)) {
+        cancelPending()
+        return
+      }
+
+      const guard = activeGuard(target)
+      if (!guard || guard.owner !== owner || guard.phase !== 'pending') {
+        cancelPending()
+        return
+      }
+
+      guard.phase = 'consumed'
+      guard.expiresAt = Date.now() + maxHeldMs
+      onQueue(target)
+    }, longPressMs)
+  }
+
+  container.addEventListener('pointerdown', handlePointerDown)
+
+  return {
+    shouldSuppressEvent(event: Event, target: Element | null): boolean {
+      if (!target || (event.type !== 'click' && event.type !== 'contextmenu')) return false
+
+      const guard = activeGuard(target)
+      if (!guard) return false
+
+      // While waiting for the hold timer, only contextmenu is ours. A quick
+      // tap's click must still follow the normal send path.
+      if (guard.phase === 'pending') return event.type === 'contextmenu'
+
+      // A synthesized click can be the only release evidence after a browser
+      // emits pointercancel during long-press recognition.
+      if (event.type === 'click') {
+        guard.expiresAt = Date.now() + guard.graceWindowMs
+      }
+
+      return true
+    },
+
+    destroy() {
+      if (destroyed) return
+      destroyed = true
+
+      // Pending state belongs to this controller. Consumed state intentionally
+      // survives teardown so the next MessageContent effect can suppress the
+      // release click/contextmenu from the same physical hold.
+      clearPendingGuard(pressTarget)
+      resetLocal()
+      container.removeEventListener('pointerdown', handlePointerDown)
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Adds a queue-to-composer action for regex editor actions so generated/transformed content can be inserted into the composer as an editable draft instead of being sent immediately.

Interaction is input-aware:

- Ctrl/Cmd-click queues the action on desktop.
- Right-click queues the action.
- Touch/pen long-press queues once without sending on release.
- Normal action behavior remains available without the modifier/gesture.
- Gesture handling tolerates small pointer movement and avoids duplicate activation.

The message-menu integration uses the native composed event path so regex actions continue to work correctly across component/shadow boundaries.

## Validation

```text
git diff --check
cd frontend && bun x tsc --noEmit
cd frontend && bun run lint
cd frontend && bun run build

Manual testing:
- Ctrl/Cmd-click queue-to-composer
- Right-click queue-to-composer
- Touch/pen long-press
- Movement tolerance during long-press
- Release does not send after a successful long-press
- Composer receives an editable draft
- Existing normal action behavior remains intact

Validated in Chromium and Firefox on desktop and mobile.
````

## Required checklist

* [x] This pull request is based on the latest `staging` branch and targets
  `staging`, not `main`.
* [x] All applicable tests pass.
* [x] I ran the relevant type check(s) with no type errors or warnings:

  * [ ] Backend: not applicable; frontend-only change.
  * [x] Frontend: equivalent direct TypeScript check via `cd frontend && bun x tsc --noEmit`, plus `bun run lint`

## UI changes (if applicable)

* [x] I validated this change in more than one browser.
* [x] I verified the integrated experience on a mobile interface or through
  the mobile PWA.
* Browsers, devices, and PWA coverage: Chromium and Firefox on desktop and mobile, including touch/long-press interaction.

## Performance changes (if applicable)

Not applicable.

## Security-sensitive changes (if applicable)

Not applicable. The change alters local interaction/queue behavior and does not add a new Spindle capability or security boundary.

## LLM-assisted work (if applicable)

* [x] I, as the human orchestrating this work, audited the submitted changes
  in a live environment.
