### PR TITLE
feat(loom): blanket enable/disable control for categories

### DIFF
--- a/frontend/src/components/panels/LoomBuilder.tsx
+++ b/frontend/src/components/panels/LoomBuilder.tsx
@@ -245,12 +245,14 @@ interface SortableCategoryItemProps {
   onEdit: (block: PromptBlock) => void
   onDelete: (id: string) => void
   onToggle: (id: string) => void
+  /** Blanket enable/disable of the category and all of its children. */
+  onToggleChildren: (id: string) => void
   childCount: number
   dragDisabled?: boolean
 }
 
 function SortableCategoryItem({
-  block, isCollapsed, onToggleCollapse, onEdit, onDelete, onToggle, childCount, dragDisabled = false,
+  block, isCollapsed, onToggleCollapse, onEdit, onDelete, onToggle, onToggleChildren, childCount, dragDisabled = false,
 }: SortableCategoryItemProps) {
   const { t } = useLb()
   const { attributes, listeners, setNodeRef: setSortableRef, transform, transition, isDragging } = useSortable({ id: block.id, disabled: dragDisabled })
@@ -290,6 +292,9 @@ function SortableCategoryItem({
       </div>
       <Button size="icon-sm" variant="ghost" onClick={() => onToggle(block.id)} title={block.enabled ? t('category.disable') : t('category.enable')}>
         {block.enabled ? <Eye size={14} /> : <EyeOff size={14} />}
+      </Button>
+      <Button size="icon-sm" variant="ghost" onClick={() => onToggleChildren(block.id)} title={block.enabled ? t('category.disableAll') : t('category.enableAll')}>
+        <Layers size={14} />
       </Button>
       <Button size="icon-sm" variant="ghost" onClick={() => onEdit(block)} title={t('category.rename')}>
         <Edit2 size={14} />
@@ -371,14 +376,14 @@ function SortableBlockItem({ block, effectiveRole, onEdit, onDelete, onToggle, o
       <Button size="icon-sm" variant="ghost" onClick={() => onToggle(block.id)} title={block.enabled ? t('block.disable') : t('block.enable')}>
         {block.enabled ? <Eye size={14} /> : <EyeOff size={14} />}
       </Button>
-      <Button size="icon-sm" variant="ghost" onClick={() => onEdit(block)} title={tc('actions.edit')}>
-        <Edit2 size={14} />
-      </Button>
       {!isMarker && !block.stashId && onStash && (
         <Button size="icon-sm" variant="ghost" onClick={() => onStash(block)} title={t('actions.addToStash')}>
           <Archive size={14} />
         </Button>
       )}
+      <Button size="icon-sm" variant="ghost" onClick={() => onEdit(block)} title={tc('actions.edit')}>
+        <Edit2 size={14} />
+      </Button>
       {!block.isLocked && (
         <Button size="icon-sm" variant="danger-ghost" onClick={() => onDelete(block.id)} title={tc('actions.delete')}>
           <Trash2 size={14} />
@@ -1793,6 +1798,7 @@ export default function LoomBuilder({
     removeBlock,
     updateBlock,
     toggleBlock,
+    toggleCategoryChildren,
     saveSamplerOverrides,
     savePromptBehavior,
     saveCompletionSettings,
@@ -2945,6 +2951,7 @@ useEffect(() => {
                         onEdit={handleEdit}
                         onDelete={handleDelete}
                         onToggle={toggleBlock}
+                        onToggleChildren={toggleCategoryChildren}
                         childCount={group.children.length}
                         dragDisabled={isSearchActive}
                       />

--- a/frontend/src/hooks/useLoomBuilder.ts
+++ b/frontend/src/hooks/useLoomBuilder.ts
@@ -29,6 +29,7 @@ import {
   sanitizeLumiHubSealedBlocksForExport,
   normalizeCategoryBlockState,
   toggleBlockWithCategoryRules,
+  toggleCategoryWithChildren,
   coerceImportedLoomPreset,
   detectImportedPresetKind,
   reconcilePromptVariableValues,
@@ -584,6 +585,15 @@ export function useLoomBuilder() {
     saveBlocks(blocks)
   }, [saveBlocks])
 
+  // Blanket category toggle: disable captures each child's enabled state on
+  // the category block; enable restores that exact snapshot.
+  const toggleCategoryChildren = useCallback((categoryId: string) => {
+    const current = effectiveActivePresetRef.current
+    if (!current) return
+    const blocks = toggleCategoryWithChildren(current.blocks, categoryId)
+    saveBlocks(blocks)
+  }, [saveBlocks])
+
   const reorderBlocks = useCallback((fromIndex: number, toIndex: number) => {
     const current = effectiveActivePresetRef.current
     if (!current) return
@@ -826,6 +836,7 @@ export function useLoomBuilder() {
     removeBlock,
     updateBlock,
     toggleBlock,
+    toggleCategoryChildren,
     reorderBlocks,
 
     // Sampler settings

--- a/frontend/src/i18n/locales/en/panels.json
+++ b/frontend/src/i18n/locales/en/panels.json
@@ -3332,9 +3332,11 @@
       "collapseAll": "Collapse all",
       "bulkUnavailableSearch": "Clear the prompt search to expand or collapse all categories",
       "pickOne": "pick one",
+      "enableAll": "Enable category and contents",
+      "disableAll": "Disable category and contents",
       "multi": "multi",
-      "enable": "Enable category",
-      "disable": "Disable category",
+      "enable": "Enable category block",
+      "disable": "Disable category block",
       "rename": "Rename",
       "deleteCategory": "Delete category"
     },

--- a/frontend/src/i18n/locales/fr/panels.json
+++ b/frontend/src/i18n/locales/fr/panels.json
@@ -3072,9 +3072,11 @@
       "expand": "Agrandir la catégorie",
       "collapse": "Réduire la catégorie",
       "pickOne": "en choisir un",
+      "enableAll": "Activer la catégorie et son contenu",
+      "disableAll": "Désactiver la catégorie et son contenu",
       "multi": "multi",
-      "enable": "Activer la catégorie",
-      "disable": "Désactiver la catégorie",
+      "enable": "Activer le bloc de catégorie",
+      "disable": "Désactiver le bloc de catégorie",
       "rename": "Rebaptiser",
       "deleteCategory": "Supprimer la catégorie"
     },

--- a/frontend/src/i18n/locales/it/panels.json
+++ b/frontend/src/i18n/locales/it/panels.json
@@ -3080,9 +3080,11 @@
       "expand": "Espandi categoria",
       "collapse": "Comprimi categoria",
       "pickOne": "scegli uno",
+      "enableAll": "Attiva categoria e contenuti",
+      "disableAll": "Disattiva categoria e contenuti",
       "multi": "multi",
-      "enable": "Abilita categoria",
-      "disable": "Disabilita categoria",
+      "enable": "Attiva blocco categoria",
+      "disable": "Disattiva blocco categoria",
       "rename": "Rinomina",
       "deleteCategory": "Elimina categoria"
     },

--- a/frontend/src/i18n/locales/ja/panels.json
+++ b/frontend/src/i18n/locales/ja/panels.json
@@ -3072,9 +3072,11 @@
       "expand": "カテゴリを展開",
       "collapse": "カテゴリを折りたたむ",
       "pickOne": "1 つ選択",
+      "enableAll": "カテゴリと内容を有効化",
+      "disableAll": "カテゴリと内容を無効化",
       "multi": "マルチ",
-      "enable": "カテゴリを有効にする",
-      "disable": "カテゴリを無効にする",
+      "enable": "カテゴリブロックを有効化",
+      "disable": "カテゴリブロックを無効化",
       "rename": "名前変更",
       "deleteCategory": "カテゴリを削除"
     },

--- a/frontend/src/i18n/locales/zh-TW/panels.json
+++ b/frontend/src/i18n/locales/zh-TW/panels.json
@@ -3072,9 +3072,11 @@
       "expand": "展開類別",
       "collapse": "摺疊類別",
       "pickOne": "單選",
+      "enableAll": "啟用分類及內容",
+      "disableAll": "停用分類及內容",
       "multi": "多選",
-      "enable": "啟用類別",
-      "disable": "禁用類別",
+      "enable": "啟用分類區塊",
+      "disable": "停用分類區塊",
       "rename": "重命名",
       "deleteCategory": "刪除類別"
     },

--- a/frontend/src/i18n/locales/zh/panels.json
+++ b/frontend/src/i18n/locales/zh/panels.json
@@ -3072,9 +3072,11 @@
       "expand": "展开类别",
       "collapse": "折叠类别",
       "pickOne": "单选",
+      "enableAll": "启用分类及内容",
+      "disableAll": "禁用分类及内容",
       "multi": "多选",
-      "enable": "启用类别",
-      "disable": "禁用类别",
+      "enable": "启用分类块",
+      "disable": "禁用分类块",
       "rename": "重命名",
       "deleteCategory": "删除类别"
     },

--- a/frontend/src/lib/loom/service.prompt-variables.test.ts
+++ b/frontend/src/lib/loom/service.prompt-variables.test.ts
@@ -5,6 +5,7 @@ import {
   reconcilePromptVariableValues,
   resolvePromptBlockPlacements,
   toggleBlockWithCategoryRules,
+  toggleCategoryWithChildren,
   validatePromptVariableSchema,
 } from './service'
 import type {
@@ -382,6 +383,72 @@ describe('Loom prompt-variable schema and value reconciliation', () => {
     const switched = toggleBlockWithCategoryRules(normalized, 'second')
     expect(switched.filter((entry) => entry.group === 'category' && entry.enabled).map((entry) => entry.id))
       .toEqual(['second'])
+  })
+
+  test('blanket-disabling a category turns the marker and children off; re-enabling restores them', () => {
+    const category = { ...block('category'), marker: 'category', categoryMode: 'checkbox' as const }
+    const first = { ...block('first'), group: 'category' }
+    const second = { ...block('second'), group: 'category' }
+    const outside = block('outside')
+
+    const disabled = toggleCategoryWithChildren([category, first, second, outside], 'category')
+    expect(disabled.find((entry) => entry.id === 'category')?.enabled).toBe(false)
+    expect(disabled.filter((entry) => entry.group === 'category').every((entry) => !entry.enabled)).toBe(true)
+    expect(disabled.find((entry) => entry.id === 'outside')?.enabled).toBe(true)
+
+    const reEnabled = toggleCategoryWithChildren(disabled, 'category')
+    expect(reEnabled.find((entry) => entry.id === 'category')?.enabled).toBe(true)
+    expect(reEnabled.filter((entry) => entry.group === 'category').every((entry) => entry.enabled)).toBe(true)
+    expect(reEnabled.find((entry) => entry.id === 'outside')?.enabled).toBe(true)
+    // The snapshot is consumed on restore.
+    expect(reEnabled.find((entry) => entry.id === 'category')?.savedChildEnabled).toBeUndefined()
+  })
+
+  test('blanket re-enable restores a mixed child state instead of enabling everything', () => {
+    const category = { ...block('category'), marker: 'category', categoryMode: 'checkbox' as const }
+    const first = { ...block('first'), group: 'category' }
+    const second = { ...block('second'), group: 'category', enabled: false }
+    const third = { ...block('third'), group: 'category', enabled: false }
+
+    const disabled = toggleCategoryWithChildren([category, first, second, third], 'category')
+    expect(disabled.filter((entry) => entry.group === 'category').every((entry) => !entry.enabled)).toBe(true)
+    expect(disabled.find((entry) => entry.id === 'category')?.savedChildEnabled)
+      .toEqual({ first: true, second: false, third: false })
+
+    const restored = toggleCategoryWithChildren(disabled, 'category')
+    expect(restored.find((entry) => entry.id === 'first')?.enabled).toBe(true)
+    expect(restored.find((entry) => entry.id === 'second')?.enabled).toBe(false)
+    expect(restored.find((entry) => entry.id === 'third')?.enabled).toBe(false)
+  })
+
+  test('blanket re-enabling a radio category still restores exactly one active child', () => {
+    const category = { ...block('category'), marker: 'category', categoryMode: 'radio' as const }
+    const first = { ...block('first'), group: 'category' }
+    const second = { ...block('second'), group: 'category' }
+
+    const disabled = toggleCategoryWithChildren([category, first, second], 'category')
+    expect(disabled.every((entry) => !entry.enabled)).toBe(true)
+
+    const reEnabled = toggleCategoryWithChildren(disabled, 'category')
+    expect(reEnabled.find((entry) => entry.id === 'category')?.enabled).toBe(true)
+    expect(reEnabled.filter((entry) => entry.group === 'category' && entry.enabled).map((entry) => entry.id))
+      .toEqual(['first'])
+  })
+
+  test('the category eye toggle only flips the marker block, never its children', () => {
+    const category = { ...block('category'), marker: 'category', categoryMode: 'checkbox' as const }
+    const first = { ...block('first'), group: 'category' }
+    const second = { ...block('second'), group: 'category', enabled: false }
+
+    const toggled = toggleBlockWithCategoryRules([category, first, second], 'category')
+    expect(toggled.find((entry) => entry.id === 'category')?.enabled).toBe(false)
+    expect(toggled.find((entry) => entry.id === 'first')?.enabled).toBe(true)
+    expect(toggled.find((entry) => entry.id === 'second')?.enabled).toBe(false)
+
+    const toggledBack = toggleBlockWithCategoryRules(toggled, 'category')
+    expect(toggledBack.find((entry) => entry.id === 'category')?.enabled).toBe(true)
+    expect(toggledBack.find((entry) => entry.id === 'first')?.enabled).toBe(true)
+    expect(toggledBack.find((entry) => entry.id === 'second')?.enabled).toBe(false)
   })
 })
 

--- a/frontend/src/lib/loom/service.ts
+++ b/frontend/src/lib/loom/service.ts
@@ -222,6 +222,10 @@ function migratePreset(preset: LoomPreset): LoomPreset {
       block.categoryMode = block.marker === 'category'
         ? coerceCategoryMode(block.categoryMode)
         : null
+      // Blanket-disable snapshots only make sense on category blocks.
+      block.savedChildEnabled = block.marker === 'category' && isRecord(block.savedChildEnabled)
+        ? Object.fromEntries(Object.entries(block.savedChildEnabled).filter((entry): entry is [string, boolean] => typeof entry[0] === 'string' && typeof entry[1] === 'boolean'))
+        : undefined
       if (block.sealedSource === 'lumihub') {
         block.sealed = true
       }
@@ -441,6 +445,51 @@ export function toggleBlockWithCategoryRules(
     if (!categoryGroup.children.some((child) => child.id === block.id)) return block
     return { ...block, enabled: block.id === blockId }
   })
+}
+
+/**
+ * Blanket enable/disable for a category and all of its children — the
+ * distinct category-row control beside the marker's own eye toggle.
+ *
+ * Disabling snapshots every child's enabled state onto the category block
+ * (`savedChildEnabled`, persisted with the preset) and turns the marker and
+ * all children off. Enabling restores that exact snapshot — a mixed
+ * child state comes back mixed — instead of enabling everything
+ * indiscriminately. Children missing from the snapshot (added while the
+ * category was blanket-disabled) keep their current state. The result runs
+ * through category normalization so a radio category still ends with at
+ * most one active child even when the snapshot predates that rule.
+ */
+export function toggleCategoryWithChildren(
+  blocks: PromptBlock[],
+  categoryId: string,
+): PromptBlock[] {
+  const category = blocks.find((block) => block.id === categoryId && block.marker === 'category')
+  if (!category) return blocks
+
+  const group = computeGroups(blocks).find((candidate) => candidate.categoryBlock?.id === categoryId)
+  const childIds = new Set((group?.children ?? []).map((child) => child.id))
+  const disabling = category.enabled
+  const snapshot = category.savedChildEnabled
+
+  const toggled = blocks.map((block) => {
+    if (block.id === categoryId) {
+      return {
+        ...block,
+        enabled: !disabling,
+        // Capture on disable; consume on enable.
+        savedChildEnabled: disabling
+          ? Object.fromEntries((group?.children ?? []).map((child) => [child.id, child.enabled === true]))
+          : undefined,
+      }
+    }
+    if (!childIds.has(block.id)) return block
+    if (disabling) return { ...block, enabled: false }
+    if (!snapshot || !(block.id in snapshot)) return block
+    return { ...block, enabled: snapshot[block.id] === true }
+  })
+
+  return normalizeCategoryBlockState(toggled)
 }
 
 // ============================================================================

--- a/frontend/src/lib/loom/types.ts
+++ b/frontend/src/lib/loom/types.ts
@@ -105,6 +105,12 @@ export interface PromptBlock {
   characterTagTrigger?: string[]
   group?: string | null
   categoryMode?: 'radio' | 'checkbox' | null
+  /**
+   * Child enablement snapshot captured when the category was blanket-
+   * disabled via the category-row "and contents" control, restored on the
+   * blanket re-enable. Category blocks only.
+   */
+  savedChildEnabled?: Record<string, boolean>
   variables?: PromptVariableDef[]
   placementBinding?: PromptBlockPlacementBinding
   /** Stable identity of a user-owned stash entry shared across presets. */

--- a/frontend/src/lib/spindle/loom-dto.ts
+++ b/frontend/src/lib/spindle/loom-dto.ts
@@ -37,6 +37,7 @@ type UnknownRecord = Record<string, unknown>
 export const HOST_ONLY_BLOCK_FIELDS = [
   'stashId',
   'placementBinding',
+  'savedChildEnabled',
   'sealed',
   'sealedKey',
   'sealedSource',


### PR DESCRIPTION
## Summary

Adds a separate blanket visibility control for Loom categories while preserving the existing category-block visibility control.

The existing Eye action continues to toggle only the category marker itself. A new Layers action toggles the category and all of its children together.

When blanket-disabled, the category records the exact enabled state of each child. Re-enabling restores that snapshot rather than simply enabling everything.

Additional behavior:

- Mixed child states round-trip correctly.
- Radio categories are normalized so exactly one child remains active.
- Category collapse remains visual-only and does not alter enabled state.
- The saved child-state snapshot survives save/reload.
- The snapshot is treated as host-only Loom state and stripped at the public Spindle preset-editor boundary.
- Action ordering was adjusted so category and normal prompt rows remain visually aligned.

## Validation

```text
git diff --check
cd frontend && bun x tsc --noEmit
cd frontend && bun run lint
cd frontend && bun run build

Manual testing:
- Eye toggles category marker only
- Layers toggles category + contents
- Mixed child states restore exactly
- Save/reload while blanket-disabled preserves restoration state
- Radio category restores to exactly one active child
- Collapse does not affect enabled state
- Preset editor accepts Loom state without exposing host-only snapshot data

Validated in Chromium and Firefox on desktop and mobile.
````

## Required checklist

* [x] This pull request is based on the latest `staging` branch and targets
  `staging`, not `main`.
* [x] All applicable tests pass.
* [x] I ran the relevant type check(s) with no type errors or warnings:

  * [ ] Backend: not applicable; frontend-only change.
  * [x] Frontend: equivalent direct TypeScript check via `cd frontend && bun x tsc --noEmit`, plus `bun run lint`

## UI changes (if applicable)

* [x] I validated this change in more than one browser.
* [x] I verified the integrated experience on a mobile interface or through
  the mobile PWA.
* Browsers, devices, and PWA coverage: Chromium and Firefox on desktop and mobile.

## Performance changes (if applicable)

Not applicable.

## Security-sensitive changes (if applicable)

No security boundary is expanded. `savedChildEnabled` is host-internal Loom state and is stripped before the public Spindle preset-editor DTO boundary.

## LLM-assisted work (if applicable)

* [x] I, as the human orchestrating this work, audited the submitted changes
  in a live environment.
