### PR TITLE
fix(swarmui): gracefully close generation websocket

### DIFF
--- a/src/image-gen/providers/swarmui.ts
+++ b/src/image-gen/providers/swarmui.ts
@@ -3,7 +3,7 @@ import type { ImageProviderCapabilities, ImageParameterSchemaMap } from "../para
 import type { ImageGenRequest, ImageGenResponse } from "../types"
 import { applyRawOverride } from "../types"
 import { parseProviderErrorBody, ProviderRequestError, readBoundedText, throwProviderResponseError } from "../../utils/provider-errors"
-import { openWebSocket } from "./ws-helpers"
+import { closeWebSocketGracefully, openWebSocket } from "./ws-helpers"
 import { executeComfyWorkflow, executeComfyWorkflowStream } from "./comfy-runner"
 
 const PARAMETERS: ImageParameterSchemaMap = {
@@ -773,7 +773,10 @@ export class SwarmUIImageProvider implements ImageProvider {
       }
     } finally {
       request.signal?.removeEventListener("abort", abortHandler)
-      ws.close()
+      await closeWebSocketGracefully(
+        ws,
+        request.signal?.aborted ? 100 : 1_000,
+      )
     }
 
     if (!imagePath) {

--- a/src/image-gen/providers/ws-helpers.ts
+++ b/src/image-gen/providers/ws-helpers.ts
@@ -57,3 +57,46 @@ export async function openWebSocket(
   })
   return ws
 }
+
+async function waitForWebSocketClose(ws: WebSocket, timeoutMs: number): Promise<boolean> {
+  if (ws.readyState === WebSocket.CLOSED) return true
+  return new Promise<boolean>((resolve) => {
+    let settled = false
+    const finish = (closed: boolean) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      ws.removeEventListener("close", onClose)
+      resolve(closed)
+    }
+    const onClose = () => finish(true)
+    const timer = setTimeout(() => finish(false), Math.max(0, timeoutMs))
+    ws.addEventListener("close", onClose, { once: true })
+  })
+}
+
+/**
+ * Initiate a normal WebSocket close handshake and briefly await the peer's
+ * acknowledgement. Awaiting the close event gives Bun time to flush the close
+ * frame instead of letting the request tear down the transport immediately
+ * after `ws.close()`.
+ *
+ * If the peer has already started closing, just wait for that handshake to
+ * finish rather than issuing a second close.
+ */
+export async function closeWebSocketGracefully(
+  ws: WebSocket,
+  closeTimeoutMs = 1_000,
+): Promise<void> {
+  if (ws.readyState === WebSocket.CLOSED) return
+
+  if (ws.readyState === WebSocket.OPEN) {
+    try {
+      ws.close(1000, "complete")
+    } catch {
+      return
+    }
+  }
+
+  await waitForWebSocketClose(ws, closeTimeoutMs)
+}

--- a/tests/swarmui-websocket-close.test.ts
+++ b/tests/swarmui-websocket-close.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test"
+import { closeWebSocketGracefully } from "../src/image-gen/providers/ws-helpers"
+
+class FakeWebSocket extends EventTarget {
+  readyState = WebSocket.OPEN
+  readonly closeCalls: Array<{ code?: number; reason?: string }> = []
+
+  constructor(private readonly closeDelayMs = 0) {
+    super()
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closeCalls.push({ code, reason })
+    this.readyState = WebSocket.CLOSING
+    setTimeout(() => this.finishClose(), this.closeDelayMs)
+  }
+
+  beginRemoteClose(delayMs = 0): void {
+    this.readyState = WebSocket.CLOSING
+    setTimeout(() => this.finishClose(), delayMs)
+  }
+
+  finishClose(): void {
+    if (this.readyState === WebSocket.CLOSED) return
+    this.readyState = WebSocket.CLOSED
+    this.dispatchEvent(new Event("close"))
+  }
+}
+
+function asWebSocket(socket: FakeWebSocket): WebSocket {
+  return socket as unknown as WebSocket
+}
+
+describe("closeWebSocketGracefully", () => {
+  test("returns immediately when already closed", async () => {
+    const socket = new FakeWebSocket()
+    socket.finishClose()
+
+    await closeWebSocketGracefully(asWebSocket(socket), 50)
+
+    expect(socket.readyState).toBe(WebSocket.CLOSED)
+    expect(socket.closeCalls).toEqual([])
+  })
+
+  test("awaits a close already initiated by the peer", async () => {
+    const socket = new FakeWebSocket()
+    socket.beginRemoteClose(10)
+
+    await closeWebSocketGracefully(asWebSocket(socket), 50)
+
+    expect(socket.readyState).toBe(WebSocket.CLOSED)
+    expect(socket.closeCalls).toEqual([])
+  })
+
+  test("initiates a normal client close and awaits the handshake", async () => {
+    const socket = new FakeWebSocket(20)
+    let resolved = false
+
+    const closing = closeWebSocketGracefully(asWebSocket(socket), 100).then(() => {
+      resolved = true
+    })
+
+    expect(socket.closeCalls).toEqual([{ code: 1000, reason: "complete" }])
+    expect(socket.readyState).toBe(WebSocket.CLOSING)
+    expect(resolved).toBe(false)
+
+    await closing
+    expect(socket.readyState).toBe(WebSocket.CLOSED)
+    expect(resolved).toBe(true)
+  })
+
+  test("does not hang forever if the peer never acknowledges close", async () => {
+    class NeverClosingWebSocket extends FakeWebSocket {
+      override close(code?: number, reason?: string): void {
+        this.closeCalls.push({ code, reason })
+        this.readyState = WebSocket.CLOSING
+      }
+    }
+
+    const socket = new NeverClosingWebSocket()
+    const started = performance.now()
+
+    await closeWebSocketGracefully(asWebSocket(socket), 20)
+
+    expect(socket.closeCalls).toEqual([{ code: 1000, reason: "complete" }])
+    expect(socket.readyState).toBe(WebSocket.CLOSING)
+    expect(performance.now() - started).toBeGreaterThanOrEqual(15)
+  })
+
+  test("supports a short timeout for explicit interruption", async () => {
+    const socket = new FakeWebSocket(500)
+    const started = performance.now()
+
+    await closeWebSocketGracefully(asWebSocket(socket), 20)
+
+    expect(socket.closeCalls).toEqual([{ code: 1000, reason: "complete" }])
+    expect(performance.now() - started).toBeLessThan(200)
+  })
+})


### PR DESCRIPTION
## Summary

Gracefully closes the SwarmUI generation WebSocket after a generation completes instead of allowing the transport to disappear before the WebSocket close handshake finishes.

Previously Lumiverse could successfully receive and display the generated image while SwarmUI still logged a server-side `WebSocketException` reporting that the remote party closed the connection without completing the close handshake.

The new helper:

- Returns immediately for an already-closed socket.
- Waits when the peer has already started closing.
- Initiates a normal WebSocket close (`1000`) when the client is still open.
- Briefly waits for the peer's close acknowledgement.
- Uses a bounded timeout so cleanup cannot hang indefinitely.
- Uses a shorter timeout for explicit cancellation/interruption.

This does not change the generation result or user-facing image flow; it cleans up the transport after the result has already been received.

## Validation

```text
git diff --check
bun x tsc --noEmit

bun test tests/swarmui-websocket-close.test.ts

5 pass
0 fail
14 expect() calls
````

Manual integration testing:

```text
- Normal SwarmUI generation completes and the image appears as before.
- Base Lumiverse no longer produces the incomplete WebSocket close-handshake error in SwarmUI.
- Cancellation remains responsive.
```

## Required checklist

* [x] This pull request is based on the latest `staging` branch and targets
  `staging`, not `main`.
* [x] All applicable tests pass.
* [x] I ran the relevant type check(s) with no type errors or warnings:

  * [x] Backend: `bun x tsc --noEmit`
  * [ ] Frontend: not applicable; no frontend changes.

## UI changes (if applicable)

Not applicable. This is transport cleanup after generation completion and does not alter the generated-image UI.

## Performance changes (if applicable)

Not a performance feature. The graceful close wait is bounded and normally resolves as soon as the peer acknowledges the close frame. Explicit interruption uses a shorter timeout.

## Security-sensitive changes (if applicable)

Not applicable. No authentication, authorization, or Spindle security boundary changes.

## LLM-assisted work (if applicable)

* [x] I, as the human orchestrating this work, audited the submitted changes
  in a live environment.

