### PR TITLE
Fix Android PWA lorebook field focus scroll jump

### DIFF
--- a/frontend/src/components/panels/world-book/WorldBookPanel.module.css
+++ b/frontend/src/components/panels/world-book/WorldBookPanel.module.css
@@ -33,6 +33,17 @@
   padding-bottom: calc(12px + max(var(--worldbook-footer-height, 0px), var(--app-keyboard-inset-bottom, 0px)));
 }
 
+/* Chromium/Android PWAs use interactive-widget=resizes-content, so the layout
+   viewport already ends above the software keyboard. Do not reserve the same
+   keyboard height again inside the lorebook scroller. */
+:global(html[data-pwa][data-resizes-content]) .panelScroll {
+  scroll-padding-block: 12px calc(12px + var(--worldbook-footer-height, 0px));
+}
+
+:global(html[data-pwa][data-resizes-content]) .panelBody {
+  padding-bottom: calc(12px + var(--worldbook-footer-height, 0px));
+}
+
 .panelMobile .panelScroll {
   gap: 10px;
   padding: 10px 10px 0;
@@ -57,12 +68,10 @@
   display: none;
 }
 
-/* Keep the docked pagination physically pinned to the screen bottom.
-   Chromium/Android shrinks the viewport above the keyboard, while iOS PWA can
-   pan the visual viewport upward when an editor is focused. In both cases we
-   pull the footer's margin box down by the live keyboard inset so it stays
-   behind the keyboard instead of riding up with the focused field. */
-:global(html[data-resizes-content]) .panelFooter,
+/* iOS PWA can pan the visual viewport upward when an editor is focused. Pull
+   the footer's margin box down by the live keyboard inset so it stays behind
+   the keyboard instead of riding up with the focused field. Chromium/Android
+   uses the naturally resized viewport and must not receive this correction. */
 :global(html[data-ios-pwa]) .panelFooter {
   margin-bottom: calc(-1 * var(--app-keyboard-inset-bottom, 0px));
 }

--- a/frontend/src/components/shared/WorldBookEntriesSection.mobile-focus.test.ts
+++ b/frontend/src/components/shared/WorldBookEntriesSection.mobile-focus.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test'
+
+const entriesSource = await Bun.file(new URL('./WorldBookEntriesSection.tsx', import.meta.url)).text()
+const panelStyles = await Bun.file(
+  new URL('../panels/world-book/WorldBookPanel.module.css', import.meta.url),
+).text()
+
+describe('Android PWA lorebook field focus contract', () => {
+  test('defers to the browser-resized viewport and performs one settled fallback', () => {
+    expect(entriesSource).toContain("root.hasAttribute('data-pwa') && root.hasAttribute('data-resizes-content')")
+    expect(entriesSource).toContain('ENTRY_FIELD_RESIZED_VIEWPORT_SETTLE_DELAY')
+    expect(entriesSource).toContain('focusRevealTimersRef.current = [window.setTimeout(')
+    expect(entriesSource).toContain('if (usesBrowserResizedKeyboardViewport()) return')
+  })
+
+  test('does not count the keyboard inset twice in the Android PWA panel', () => {
+    expect(panelStyles).toContain(':global(html[data-pwa][data-resizes-content]) .panelScroll')
+    expect(panelStyles).toContain('scroll-padding-block: 12px calc(12px + var(--worldbook-footer-height, 0px));')
+    expect(panelStyles).toContain(':global(html[data-pwa][data-resizes-content]) .panelBody')
+    expect(panelStyles).toContain('padding-bottom: calc(12px + var(--worldbook-footer-height, 0px));')
+  })
+
+  test('keeps the negative keyboard footer correction exclusive to iOS', () => {
+    expect(panelStyles).not.toContain(':global(html[data-resizes-content]) .panelFooter')
+    expect(panelStyles).toContain(':global(html[data-ios-pwa]) .panelFooter')
+  })
+})

--- a/frontend/src/components/shared/WorldBookEntriesSection.tsx
+++ b/frontend/src/components/shared/WorldBookEntriesSection.tsx
@@ -100,6 +100,7 @@ const CUSTOM_PAGE_SIZE = 200 as const
 const ENTRY_FIELD_VISIBLE_TOP_GUTTER = 12
 const ENTRY_FIELD_KEYBOARD_GUTTER = 72
 const ENTRY_FIELD_REVEAL_THRESHOLD = 10
+const ENTRY_FIELD_RESIZED_VIEWPORT_SETTLE_DELAY = 160
 const ENTRY_FIELD_FOCUS_SETTLE_DELAYS = [40, 180, 360, 520] as const
 const TOKEN_PREFETCH_DWELL_MS = 180
 
@@ -190,9 +191,17 @@ function parseCssPx(value: string): number {
   return Number.isFinite(parsed) ? parsed : 0
 }
 
+function usesBrowserResizedKeyboardViewport(): boolean {
+  const root = document.documentElement
+  return root.hasAttribute('data-pwa') && root.hasAttribute('data-resizes-content')
+}
+
 function getEntryFieldBottomGutter(container: HTMLElement): number {
   const style = getComputedStyle(container)
   const footerHeight = parseCssPx(style.getPropertyValue('--worldbook-footer-height'))
+  if (usesBrowserResizedKeyboardViewport()) {
+    return footerHeight + ENTRY_FIELD_VISIBLE_TOP_GUTTER
+  }
   return Math.max(ENTRY_FIELD_KEYBOARD_GUTTER, footerHeight + ENTRY_FIELD_VISIBLE_TOP_GUTTER)
 }
 
@@ -795,6 +804,20 @@ export default function WorldBookEntriesSection({
   const scheduleEntryFieldFocusCorrection = useCallback((target: HTMLElement) => {
     focusedEntryFieldRef.current = target
     clearFocusRevealTimers()
+
+    // Chromium/Android PWAs opt into `interactive-widget=resizes-content`, so
+    // the browser has already resized the layout viewport above the keyboard.
+    // Wait until that resize settles, then perform at most one minimal fallback
+    // correction. Running the immediate + multi-timer path here counts the
+    // keyboard twice and visibly throws the lorebook panel upward.
+    if (usesBrowserResizedKeyboardViewport()) {
+      focusRevealTimersRef.current = [window.setTimeout(
+        () => scheduleEntryFieldReveal(target),
+        ENTRY_FIELD_RESIZED_VIEWPORT_SETTLE_DELAY,
+      )]
+      return
+    }
+
     scheduleEntryFieldReveal(target)
     focusRevealTimersRef.current = ENTRY_FIELD_FOCUS_SETTLE_DELAYS.map((delay) =>
       window.setTimeout(() => scheduleEntryFieldReveal(target), delay)
@@ -820,11 +843,18 @@ export default function WorldBookEntriesSection({
     const handleInput = (event: Event) => {
       if (!isEditableEntryField(event.target)) return
       focusedEntryFieldRef.current = event.target
+      if (usesBrowserResizedKeyboardViewport()) return
       scheduleEntryFieldReveal(event.target)
     }
 
     const handleViewportChange = () => {
-      scheduleEntryFieldReveal()
+      const target = focusedEntryFieldRef.current
+      if (!target) return
+      if (usesBrowserResizedKeyboardViewport()) {
+        scheduleEntryFieldFocusCorrection(target)
+      } else {
+        scheduleEntryFieldReveal(target)
+      }
     }
 
     root.addEventListener('focusin', handleFocusIn)


### PR DESCRIPTION
## Summary

Fix the lorebook editor jumping upward when a text field receives focus in an Android standalone PWA.

Chromium already resizes the layout viewport above the software keyboard when `interactive-widget=resizes-content` is active. The lorebook panel was also applying its own keyboard inset and repeated focus/viewport scroll corrections, effectively compensating for the keyboard twice.

This change:

- avoids repeated focus correction while the browser-managed viewport resize is settling;
- performs one minimal fallback correction after the resize;
- removes duplicate keyboard inset spacing from the Android PWA lorebook scroller;
- keeps the negative footer correction exclusive to iOS PWA behavior.

## Validation

```text
cd frontend

bun test src/components/shared/WorldBookEntriesSection.mobile-focus.test.ts
# 3 pass, 0 fail

bun run typecheck
# Passed with no type errors or warnings

bun run lint
# Passed
```

Manual validation:

- Reproduced the original jump in the installed Android PWA before rebuilding with the patch.
- Verified the fix in the rebuilt standalone PWA on a Samsung Galaxy A35.
- Verified that the same lorebook fields continue to behave normally in regular Android Chrome outside standalone PWA mode.

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass.
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [ ] Backend: `bun x tsc --noEmit` — not applicable; this is a frontend-only change.
  - [x] Frontend: `cd frontend && bun run typecheck`, `bun run lint`

## UI changes (if applicable)

- [ ] I validated this change in more than one browser. Both tested modes used Chrome/Chromium.
- [x] I verified the integrated experience on a mobile interface or through
      the mobile PWA.
- Browsers, devices, and PWA coverage: Samsung Galaxy A35; regular Android Chrome and installed standalone PWA.

## Performance changes (if applicable)

Not applicable. This change does not target performance behavior.

## Security-sensitive changes (if applicable)

None. This is limited to frontend focus/viewport behavior and does not affect Spindle, backend code, authentication, or other security systems.

## LLM-assisted work (if applicable)

- [x] I, as the human orchestrating this work, audited the submitted changes
      in a live environment.