### PR TITLE
fix: harden Spindle dock resizing

### DIFF
--- a/frontend/src/components/spindle/SpindleDockPanel.module.css
+++ b/frontend/src/components/spindle/SpindleDockPanel.module.css
@@ -10,6 +10,10 @@
   transition: width 0.2s ease, height 0.2s ease;
 }
 
+.panel.resizing {
+  transition: none;
+}
+
 /* ── Edge positions ── */
 
 .left {
@@ -143,46 +147,70 @@
 /* ── Resize handles ── */
 
 .resizeHandle {
-  position: absolute;
+  position: relative;
   z-index: 1;
+  flex-shrink: 0;
   touch-action: none;
+  outline: none;
 }
 
-.resize_left {
-  top: 0;
-  bottom: 0;
-  right: 0;
-  width: 4px;
+.resizeLeft,
+.resizeRight {
+  width: 12px;
+  min-width: 12px;
   cursor: ew-resize;
 }
 
-.resize_right {
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: 4px;
-  cursor: ew-resize;
-}
-
-.resize_top {
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: 4px;
+.resizeTop,
+.resizeBottom {
+  height: 12px;
+  min-height: 12px;
   cursor: ns-resize;
 }
 
-.resize_bottom {
-  left: 0;
-  right: 0;
-  top: 0;
-  height: 4px;
-  cursor: ns-resize;
+.resizeHandle::after {
+  content: '';
+  position: absolute;
+  background: transparent;
+  transition:
+    background var(--lumiverse-transition-fast),
+    opacity var(--lumiverse-transition-fast);
 }
 
-.resizeHandle:hover {
-  background: var(--lumiverse-accent);
-  opacity: 0.3;
+.resizeLeft::after,
+.resizeRight::after {
+  top: 0;
+  bottom: 0;
+  width: 2px;
+}
+
+.resizeLeft::after {
+  right: 0;
+}
+
+.resizeRight::after {
+  left: 0;
+}
+
+.resizeTop::after,
+.resizeBottom::after {
+  left: 0;
+  right: 0;
+  height: 2px;
+}
+
+.resizeTop::after {
+  bottom: 0;
+}
+
+.resizeBottom::after {
+  top: 0;
+}
+
+.resizeHandle:hover::after,
+.resizeHandle:focus-visible::after {
+  background: var(--lumiverse-primary);
+  opacity: 0.55;
 }
 
 /* ── Mobile ── */

--- a/frontend/src/components/spindle/SpindleDockPanel.tsx
+++ b/frontend/src/components/spindle/SpindleDockPanel.tsx
@@ -14,6 +14,13 @@ interface Props {
   panel: DockPanelState
 }
 
+const RESIZE_CLASS_BY_EDGE = {
+  left: styles.resizeLeft,
+  right: styles.resizeRight,
+  top: styles.resizeTop,
+  bottom: styles.resizeBottom,
+} as const
+
 export default function SpindleDockPanel({ panel }: Props) {
   const { t: tc } = useTranslation('common')
   const updateDockPanel = useStore((s) => s.updateDockPanel)
@@ -22,12 +29,19 @@ export default function SpindleDockPanel({ panel }: Props) {
   const isMobile = useIsMobile()
 
   const [currentSize, setCurrentSize] = useState(panel.size)
+  const [isResizing, setIsResizing] = useState(false)
+  const currentSizeRef = useRef(panel.size)
   const resizing = useRef(false)
   const startPos = useRef(0)
   const startSize = useRef(panel.size)
   const contentHostRef = useRef<HTMLDivElement | null>(null)
 
-  const effectiveEdge = resolveDockPanelEdge(panel.edge, dockPanelDesktopSide, isMobile)
+  const effectiveEdge = resolveDockPanelEdge(
+    panel.edge,
+    dockPanelDesktopSide,
+    isMobile,
+    panel.respectRequestedEdge,
+  )
   const effectiveHorizontal = effectiveEdge === 'left' || effectiveEdge === 'right'
 
   const handleToggle = useCallback(() => {
@@ -38,35 +52,103 @@ export default function SpindleDockPanel({ panel }: Props) {
     unregisterDockPanel(panel.id)
   }, [unregisterDockPanel, panel.id])
 
+  const commitResize = useCallback(
+    (requestedSize: number) => {
+      const size = Math.max(panel.minSize, Math.min(panel.maxSize, requestedSize))
+      currentSizeRef.current = size
+      setCurrentSize(size)
+      window.dispatchEvent(
+        new CustomEvent('spindle:dock-resize-end', {
+          detail: { panelId: panel.id, size },
+        }),
+      )
+    },
+    [panel.id, panel.minSize, panel.maxSize],
+  )
+
   const handleResizePointerDown = useCallback(
-    (e: React.PointerEvent) => {
+    (e: React.PointerEvent<HTMLDivElement>) => {
       if (!panel.resizable) return
       resizing.current = true
+      setIsResizing(true)
       startPos.current = effectiveHorizontal ? e.clientX : e.clientY
-      startSize.current = currentSize
-      ;(e.target as HTMLElement).setPointerCapture(e.pointerId)
+      startSize.current = currentSizeRef.current
+      e.currentTarget.setPointerCapture(e.pointerId)
       e.preventDefault()
     },
-    [panel.resizable, effectiveHorizontal, currentSize]
+    [panel.resizable, effectiveHorizontal],
   )
 
   const handleResizePointerMove = useCallback(
-    (e: React.PointerEvent) => {
+    (e: React.PointerEvent<HTMLDivElement>) => {
       if (!resizing.current) return
       const delta = effectiveHorizontal
         ? (effectiveEdge === 'left' ? e.clientX - startPos.current : startPos.current - e.clientX)
         : (effectiveEdge === 'top' ? e.clientY - startPos.current : startPos.current - e.clientY)
       const newSize = Math.max(panel.minSize, Math.min(panel.maxSize, startSize.current + delta))
+      currentSizeRef.current = newSize
       setCurrentSize(newSize)
     },
-    [effectiveHorizontal, effectiveEdge, panel.minSize, panel.maxSize]
+    [effectiveHorizontal, effectiveEdge, panel.minSize, panel.maxSize],
   )
 
-  const handleResizePointerUp = useCallback(() => {
-    if (!resizing.current) return
-    resizing.current = false
-    updateDockPanel(panel.id, { size: currentSize })
-  }, [updateDockPanel, panel.id, currentSize])
+  const handleResizePointerEnd = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!resizing.current) return
+      resizing.current = false
+      setIsResizing(false)
+
+      if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+        e.currentTarget.releasePointerCapture(e.pointerId)
+      }
+
+      commitResize(currentSizeRef.current)
+    },
+    [commitResize],
+  )
+
+  const handleResizeKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      let next: number | null = null
+
+      switch (e.key) {
+        case 'ArrowLeft':
+          if (!effectiveHorizontal) return
+          next = currentSizeRef.current + (effectiveEdge === 'right' ? 24 : -24)
+          break
+        case 'ArrowRight':
+          if (!effectiveHorizontal) return
+          next = currentSizeRef.current + (effectiveEdge === 'left' ? 24 : -24)
+          break
+        case 'ArrowUp':
+          if (effectiveHorizontal) return
+          next = currentSizeRef.current + (effectiveEdge === 'bottom' ? 24 : -24)
+          break
+        case 'ArrowDown':
+          if (effectiveHorizontal) return
+          next = currentSizeRef.current + (effectiveEdge === 'top' ? 24 : -24)
+          break
+        case 'Home':
+          next = panel.minSize
+          break
+        case 'End':
+          next = panel.maxSize
+          break
+        default:
+          return
+      }
+
+      e.preventDefault()
+      commitResize(next)
+    },
+    [commitResize, effectiveEdge, effectiveHorizontal, panel.minSize, panel.maxSize],
+  )
+
+  useEffect(() => {
+    if (resizing.current) return
+    currentSizeRef.current = panel.size
+    setCurrentSize(panel.size)
+  }, [panel.size])
 
   useEffect(() => {
     const host = contentHostRef.current
@@ -110,6 +192,7 @@ export default function SpindleDockPanel({ panel }: Props) {
         styles.panel,
         styles[effectiveEdge],
         panel.collapsed && styles.collapsed,
+        isResizing && styles.resizing,
       )}
       style={sizeStyle}
     >
@@ -121,13 +204,13 @@ export default function SpindleDockPanel({ panel }: Props) {
         >
           <CollapseIcon size={14} />
         </button>
+        {(!panel.collapsed || panel.showCollapsedTitle) && (
+          <span className={styles.title}>{panel.title}</span>
+        )}
         {!panel.collapsed && (
-          <>
-            <span className={styles.title}>{panel.title}</span>
-            <button className={styles.headerBtn} onClick={handleClose} title={tc('actions.close')}>
-              <X size={14} />
-            </button>
-          </>
+          <button className={styles.headerBtn} onClick={handleClose} title={tc('actions.close')}>
+            <X size={14} />
+          </button>
         )}
       </div>
 
@@ -137,10 +220,19 @@ export default function SpindleDockPanel({ panel }: Props) {
 
           {panel.resizable && (
             <div
-              className={clsx(styles.resizeHandle, styles[`resize_${effectiveEdge}`])}
+              className={clsx(styles.resizeHandle, RESIZE_CLASS_BY_EDGE[effectiveEdge])}
+              role="separator"
+              aria-orientation={effectiveHorizontal ? 'vertical' : 'horizontal'}
+              aria-label={panel.title}
+              aria-valuemin={panel.minSize}
+              aria-valuemax={panel.maxSize}
+              aria-valuenow={Math.round(currentSize)}
+              tabIndex={0}
               onPointerDown={handleResizePointerDown}
               onPointerMove={handleResizePointerMove}
-              onPointerUp={handleResizePointerUp}
+              onPointerUp={handleResizePointerEnd}
+              onPointerCancel={handleResizePointerEnd}
+              onKeyDown={handleResizeKeyDown}
             />
           )}
         </>

--- a/frontend/src/lib/spindle/dock-placement.test.ts
+++ b/frontend/src/lib/spindle/dock-placement.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test'
+import { resolveDockPanelEdge } from './dock-placement'
+
+describe('resolveDockPanelEdge', () => {
+  test('uses the desktop preference for ordinary horizontal docks', () => {
+    expect(resolveDockPanelEdge('right', 'left', false)).toBe('left')
+    expect(resolveDockPanelEdge('left', 'right', false)).toBe('right')
+  })
+
+  test('preserves an explicitly requested desktop edge', () => {
+    expect(resolveDockPanelEdge('right', 'left', false, true)).toBe('right')
+    expect(resolveDockPanelEdge('left', 'right', false, true)).toBe('left')
+  })
+
+  test('keeps the mobile safety remap even when the requested edge is respected', () => {
+    expect(resolveDockPanelEdge('right', 'left', true, true)).toBe('top')
+    expect(resolveDockPanelEdge('left', 'right', true, true)).toBe('top')
+  })
+
+  test('leaves vertical edges unchanged', () => {
+    expect(resolveDockPanelEdge('top', 'left', false, true)).toBe('top')
+    expect(resolveDockPanelEdge('bottom', 'right', true, false)).toBe('bottom')
+  })
+})

--- a/frontend/src/lib/spindle/dock-placement.ts
+++ b/frontend/src/lib/spindle/dock-placement.ts
@@ -6,12 +6,16 @@ export function resolveDockPanelEdge(
   edge: SpindleDockEdge,
   desktopSide: SpindleDockPanelDesktopSide,
   isMobile: boolean,
+  respectRequestedEdge = false,
 ): SpindleDockEdge {
   if (edge !== 'left' && edge !== 'right') {
     return edge
   }
   if (isMobile) {
     return 'top'
+  }
+  if (respectRequestedEdge) {
+    return edge
   }
   return desktopSide
 }

--- a/frontend/src/lib/spindle/frontend-context.geometry.runtime.test.ts
+++ b/frontend/src/lib/spindle/frontend-context.geometry.runtime.test.ts
@@ -58,12 +58,14 @@ describe('H6 frontend geometry runtime contract', () => {
       title: 'Geometry',
       size: 320,
       respectRequestedEdge: true,
+      showCollapsedTitle: true,
       persistGeometry: 'panel',
       onGeometryCommit: () => {},
     }
 
     expect(floatOptions.resizable).toBe(true)
     expect(dockOptions.respectRequestedEdge).toBe(true)
+    expect(dockOptions.showCollapsedTitle).toBe(true)
   })
 
   test('returns a disposer for the framework-free resize adapter', () => {

--- a/frontend/src/lib/spindle/frontend-context.ts
+++ b/frontend/src/lib/spindle/frontend-context.ts
@@ -64,6 +64,8 @@ export type FrontendFloatWidgetOptions = PublishedSpindleFloatWidgetOptions & {
 export type FrontendDockPanelOptions = PublishedSpindleDockPanelOptions & {
   persistGeometry?: string | false
   respectRequestedEdge?: boolean
+  /** Show the panel title while the dock is collapsed. Defaults to false. */
+  showCollapsedTitle?: boolean
   onGeometryCommit?(rect: SpindleGeometryRect): void
 }
 

--- a/frontend/src/lib/spindle/h6-placement.contract.isolated.ts
+++ b/frontend/src/lib/spindle/h6-placement.contract.isolated.ts
@@ -351,13 +351,20 @@ describe('H6 dock placement contract', () => {
       minSize: 120,
       maxSize: 480,
       respectRequestedEdge: true,
+      showCollapsedTitle: true,
       persistGeometry: 'dock-panel',
       onGeometryCommit: (rect: { x: number; y: number; width: number; height: number }) => commits.push(rect),
     } as any, () => {}, generation)
     handles.push(handle)
 
     const panel = placementStore.getState().dockPanels[0]
-    expect(panel).toMatchObject({ edge: 'left', size: 240, minSize: 120, maxSize: 480 })
+    expect(panel).toMatchObject({
+      edge: 'left',
+      size: 240,
+      minSize: 120,
+      maxSize: 480,
+      showCollapsedTitle: true,
+    })
     expect((panel as any)?.respectRequestedEdge).toBe(true)
 
     const extendedHandle = handle as any
@@ -368,6 +375,20 @@ describe('H6 dock placement contract', () => {
     extendedHandle.setSize(500)
     expect(placementStore.getState().dockPanels[0]?.size).toBe(320)
     expect(commits.at(-1)).toEqual({ x: 0, y: 0, width: 320, height: 320 })
+
+    fakeWindow.dispatchEvent(new FakeCustomEvent('spindle:dock-resize-end', {
+      detail: { panelId: handle.panelId, size: 310 },
+    }))
+    expect(placementStore.getState().dockPanels[0]?.size).toBe(310)
+    expect(commits.at(-1)).toEqual({ x: 0, y: 0, width: 310, height: 310 })
+    expect(JSON.parse(fakeWindow.localStorage.getItem('spindle:placementGeometry')!)).toEqual({
+      'spindle:placementGeometry:h6-placement-extension:dock:dock-panel': {
+        x: 0,
+        y: 0,
+        width: 310,
+        height: 310,
+      },
+    })
   })
 
   test('revokes only the ui-panels generation and leaves newer replay state alive', () => {
@@ -381,6 +402,10 @@ describe('H6 dock placement contract', () => {
 
     destroyPlacementsForExtensionPermission(extensionId, 'ui_panels', generation)
     expect(placementStore.getState().dockPanels.map((panel) => panel.title)).toEqual(['Newer'])
+    fakeWindow.dispatchEvent(new FakeCustomEvent('spindle:dock-resize-end', {
+      detail: { panelId: current.panelId, size: 400 },
+    }))
+    expect(placementStore.getState().dockPanels[0]?.size).toBe(240)
     expect(() => (current as any).setSize(280)).toThrow('PLACEMENT_DESTROYED')
     ;(newer as any).setSize(280)
     expect(placementStore.getState().dockPanels[0]?.size).toBe(280)

--- a/frontend/src/lib/spindle/placement-helper.ts
+++ b/frontend/src/lib/spindle/placement-helper.ts
@@ -237,6 +237,8 @@ type H6FloatWidgetOptions = SpindleFloatWidgetOptions & {
 type H6DockPanelOptions = SpindleDockPanelOptions & {
   persistGeometry?: string | false
   respectRequestedEdge?: boolean
+  /** Show the panel title while the dock is collapsed. Defaults to false. */
+  showCollapsedTitle?: boolean
   onGeometryCommit?: (rect: GeometryRect) => void
 }
 
@@ -1181,6 +1183,14 @@ export function createDockPanelHandle(
     }
     return size
   }
+  const handleResizeEndEvent = ((event: Event) => {
+    const detail = (event as CustomEvent<{ panelId?: unknown; size?: unknown }>).detail
+    if (detail?.panelId !== panelId) return
+    if (typeof detail.size !== 'number' || !Number.isFinite(detail.size)) return
+    commitSize(detail.size)
+  }) as EventListener
+  window.addEventListener('spindle:dock-resize-end', handleResizeEndEvent)
+
   const updateSizeBounds = () => {
     const nextSize = clampDockSize(size, minSize, maxSize)
     const changed = nextSize !== size
@@ -1198,6 +1208,7 @@ export function createDockPanelHandle(
     destroyed = true
     if (!registered) disposedDuringRegistration = true
     runCleanupSteps(
+      () => window.removeEventListener('spindle:dock-resize-end', handleResizeEndEvent),
       () => removePlacementRoot(root, unregisterRoot, extensionId, generation),
       () => { if (registered) getStore().unregisterDockPanel(panelId) },
       () => visibilityHandlers.clear(),
@@ -1220,6 +1231,7 @@ export function createDockPanelHandle(
       collapsed: dockOptions.startCollapsed ?? false,
       iconUrl: dockOptions.iconUrl,
       respectRequestedEdge: dockOptions.respectRequestedEdge === true,
+      showCollapsedTitle: dockOptions.showCollapsedTitle === true,
       persistGeometry: dockOptions.persistGeometry,
     } satisfies DockPanelState)
     registered = true

--- a/frontend/src/store/slices/spindle-placement.ts
+++ b/frontend/src/store/slices/spindle-placement.ts
@@ -157,6 +157,8 @@ export interface DockPanelState {
   iconUrl?: string
   /** Keep the requested edge instead of applying the user's dock preference. */
   respectRequestedEdge: boolean
+  /** Show the panel title while collapsed. */
+  showCollapsedTitle: boolean
   /** Extension-local persistence segment, or false to disable persistence. */
   persistGeometry?: string | false
 }


### PR DESCRIPTION
## Summary

Hardens native Spindle dock-panel resizing and fixes several related host-side geometry issues uncovered while validating extension half-docks.

The native resize affordance could resolve without its directional CSS-module class, leaving the handle with effectively no width/height, no resize cursor, and no visible hover indicator. Dock resizing also retained width/height transitions during an active drag, which caused the panel to trail behind the pointer.

This change:

* replaces the dynamic resize-edge CSS-module lookup with explicit edge-class mappings
* gives resize handles a 12px host-owned hit target with a 2px visual divider
* keeps the interactive area inside the dock boundary so adjacent page scrollbars do not consume most of the resize target
* disables dock size transitions while actively dragging
* synchronizes rendered dock size when `setSize()` changes placement state programmatically
* uses pointer capture consistently and handles pointer cancellation/release
* routes user resize commits through the placement geometry authority so persisted geometry and `onGeometryCommit` stay consistent with programmatic resizing
* adds keyboard-accessible separator semantics for dock resizing
* fixes `respectRequestedEdge` so explicitly positioned desktop docks are not remapped to the global dock-side preference
* adds an opt-in `showCollapsedTitle` dock option so collapsed docks can remain identifiable when multiple dock panels are present
* adds regression coverage for dock edge resolution, host resize commits, persistence, teardown, and the new local frontend dock option

The collapsed-title behavior remains opt-in, so existing docks keep their current compact collapsed appearance unless they request it.

## Validation

All applicable validation passed:

```text
bun test frontend/src/lib/spindle/dock-placement.test.ts frontend/src/lib/spindle/h6-placement.contract.isolated.ts frontend/src/lib/spindle/frontend-context.geometry.runtime.test.ts
# passed

bun x tsc --noEmit
# passed with no type errors or warnings

cd frontend
bun run lint
# passed

cd ..
git diff --check
# passed
```

Manual validation included:

* native dock resizing with the minimal isolated dock probe
* resize behavior with and without other dock extensions active
* programmatic `setSize()` updates at multiple widths
* persisted resize geometry and geometry commit callbacks
* requested left/right dock positioning
* collapsed title behavior
* resize interaction adjacent to a scrollable page
* Firefox and Chromium desktop validation
* Firefox and Chromium mobile validation
* mobile dock behavior using LumiScript, whose existing mobile dock interface integrated with the updated host behavior and remained resizable

## Required checklist

* [x] This pull request is based on the latest `staging` branch and targets
  `staging`, not `main`.
* [x] All applicable tests pass.
* [x] I ran the relevant type check(s) with no type errors or warnings:

  * [x] Backend: `bun x tsc --noEmit`
  * [x] Frontend: `cd frontend && bun run typecheck`
  * [x] Frontend: `bun run lint`

## UI changes (if applicable)

* [x] I validated this change in more than one browser.
* [x] I verified the integrated experience on a mobile interface or through
  the mobile PWA.
* Browsers, devices, and PWA coverage: Firefox and Chromium on desktop and mobile. Mobile dock integration was additionally validated with the existing LumiScript dock interface. No mobile-specific implementation was required; the host changes slotted into the existing responsive dock behavior.

## Performance changes (if applicable)

Not applicable as a benchmarked performance change. The resize path does remove width/height transition interpolation during active pointer dragging so native dock movement follows the pointer directly.

* [x] I added or updated tests.
* [ ] I included reproducible benchmarks and comparison results below.
* Benchmark commands and results: N/A.

## Security-sensitive changes (if applicable)

This changes Spindle host-side UI placement behavior but does not expand extension permissions or introduce new backend authority.

The resize commit path remains host-owned: user-driven resize completion is routed back through the existing placement geometry authority responsible for clamping, persistence, and `onGeometryCommit`. The new `showCollapsedTitle` option only affects host-rendered presentation of an already registered dock panel.

No security-sensitive backend changes are included.

## LLM-assisted work (if applicable)

* [x] I, as the human orchestrating this work, audited the submitted changes
  in a live environment.
