### PR TITLE
Add spindle support for opening world book editor at a specific lorebook and entry

### DIFF
--- a/frontend/src/components/shared/WorldBookEntriesSection.token-count.test.tsx
+++ b/frontend/src/components/shared/WorldBookEntriesSection.token-count.test.tsx
@@ -267,6 +267,19 @@ afterAll(() => {
 })
 
 describe('WorldBookEntriesSection token-count invalidation', () => {
+  test('moves to the page containing a pending deep-linked entry', async () => {
+    const entries = Array.from({ length: 75 }, (_, index) => entry(`entry-${String(index + 1).padStart(2, '0')}`))
+    storeState.pendingWorldBookEditEntryId = 'entry-60'
+    const { root, host } = await render(entries)
+    try {
+      expect(storeState.pendingWorldBookEditEntryId).toBeNull()
+      expect(host.querySelector('[data-entry-id="entry-60"]')).not.toBeNull()
+      expect(host.querySelector('[data-entry-id="entry-01"]')).toBeNull()
+    } finally {
+      unmount(root)
+    }
+  })
+
   test('renders stable row and token-cell anchors with an immediate estimate', async () => {
     const { root, host } = await render([entry('entry-anchor', '12345678')])
     try {

--- a/frontend/src/components/shared/WorldBookEntriesSection.tsx
+++ b/frontend/src/components/shared/WorldBookEntriesSection.tsx
@@ -1228,16 +1228,18 @@ export default function WorldBookEntriesSection({
 
   useEffect(() => {
     if (!pendingWorldBookEditEntryId) return
-    if (!entries.some((entry) => entry.id === pendingWorldBookEditEntryId)) return
+    const targetIndex = filteredEntries.findIndex((entry) => entry.id === pendingWorldBookEditEntryId)
+    if (targetIndex < 0) return
+    if (pageSize != null) setEntryPage(Math.floor(targetIndex / pageSize) + 1)
     setSelectedEntryId(pendingWorldBookEditEntryId)
     setPendingWorldBookEditEntryId(null)
-  }, [entries, pendingWorldBookEditEntryId, setPendingWorldBookEditEntryId])
+  }, [filteredEntries, pageSize, pendingWorldBookEditEntryId, setPendingWorldBookEditEntryId])
 
   useEffect(() => {
     if (!selectedEntryId) return
     const element = entryListRef.current?.querySelector<HTMLElement>(`[data-entry-id="${CSS.escape(selectedEntryId)}"]`)
     element?.scrollIntoView({ block: 'nearest' })
-  }, [selectedEntryId])
+  }, [entryPage, selectedEntryId])
 
   const refetchCurrentPage = useCallback(async () => {
     await loadEntries(selectedBookId)

--- a/frontend/src/lib/spindle/host-actions.test.ts
+++ b/frontend/src/lib/spindle/host-actions.test.ts
@@ -17,7 +17,7 @@ function runtime(overrides: Partial<HostActionRuntime> = {}) {
     runCommand: (id) => { calls.push(['runCommand', id]) },
     navigate: (path) => { calls.push(['navigate', path]) },
     setEditingCharacterId: (id) => { calls.push(['setEditingCharacterId', id]) },
-    openWorldBookEditor: (id) => { calls.push(['openWorldBookEditor', id]) },
+    openWorldBookEditor: (id, entryId) => { calls.push(['openWorldBookEditor', id, entryId]) },
     invokeInputBarAction: (id) => { calls.push(['invokeInputBarAction', id]) },
     invokeExtensionCommand: (id) => { calls.push(['invokeExtensionCommand', id]) },
   }
@@ -42,7 +42,7 @@ describe('H4 host action switch', () => {
     applyHostAction({ kind: 'settings_tab', id: 'voice' }, { anchorId: 'voice.stt' }, host)
     applyHostAction({ kind: 'command', id: 'action-new-chat' }, undefined, host)
     applyHostAction({ kind: 'modal', id: 'character_editor' }, { id: 'char-1' }, host)
-    applyHostAction({ kind: 'modal', id: 'world_book_editor' }, { id: 'book-1' }, host)
+    applyHostAction({ kind: 'modal', id: 'world_book_editor' }, { id: 'book-1', entryId: 'entry-1' }, host)
     await applyHostAction({ kind: 'input_bar_action', id: 'action-1' }, undefined, host)
     applyHostAction({ kind: 'ext_command', id: 'ext-cmd-other-command' }, undefined, host)
     expect(calls).toEqual([
@@ -50,7 +50,7 @@ describe('H4 host action switch', () => {
       ['openSettings', 'voice', 'voice.stt'],
       ['runCommand', 'action-new-chat'],
       ['setEditingCharacterId', 'char-1'],
-      ['openWorldBookEditor', 'book-1'],
+      ['openWorldBookEditor', 'book-1', 'entry-1'],
       ['invokeInputBarAction', 'action-1'],
       ['invokeExtensionCommand', 'ext-cmd-other-command'],
     ])
@@ -59,6 +59,8 @@ describe('H4 host action switch', () => {
   test('rejects arbitrary modal names and caller-supplied command params', () => {
     const { runtime: host } = runtime()
     expect(() => applyHostAction({ kind: 'modal', id: 'confirm' as never }, {}, host)).toThrow('HOST_ACTION_UNMAPPED')
+    expect(() => applyHostAction({ kind: 'modal', id: 'character_editor' }, { id: 'char-1', entryId: 'entry-1' }, host)).toThrow('HOST_ACTION_INVALID_PARAMS')
+    expect(() => applyHostAction({ kind: 'modal', id: 'world_book_editor' }, { id: 'book-1', entryId: '../entry' }, host)).toThrow('HOST_ACTION_INVALID_ID')
     expect(() => applyHostAction({ kind: 'command', id: 'action-new-chat' }, { params: 'unsafe' }, host)).toThrow('HOST_ACTION_INVALID_PARAMS')
   })
 })

--- a/frontend/src/lib/spindle/host-actions.ts
+++ b/frontend/src/lib/spindle/host-actions.ts
@@ -38,7 +38,7 @@ export interface HostActionRuntime {
   runCommand(id: string): void | Promise<void>
   navigate(path: string): void
   setEditingCharacterId(id: string): void
-  openWorldBookEditor(id: string): void
+  openWorldBookEditor(id: string, entryId?: string): void
   invokeInputBarAction(id: string): void | Promise<void>
   invokeExtensionCommand(id: string): void
 }
@@ -153,10 +153,14 @@ export function applyHostAction(
       if (ref.id !== 'character_editor' && ref.id !== 'world_book_editor') {
         throw new Error(`${HOST_ACTION_UNMAPPED}:modal:${ref.id}`)
       }
-      only(params, 'id')
+      if (ref.id === 'world_book_editor') only(params, 'id', 'entryId')
+      else only(params, 'id')
       assertHostId(params.id, 'id')
       if (ref.id === 'character_editor') runtime.setEditingCharacterId(params.id)
-      else if (ref.id === 'world_book_editor') runtime.openWorldBookEditor(params.id)
+      else if (ref.id === 'world_book_editor') {
+        if (params.entryId !== undefined) assertHostId(params.entryId, 'entryId')
+        runtime.openWorldBookEditor(params.id, params.entryId as string | undefined)
+      }
       return
     case 'input_bar_action':
       only(params)

--- a/frontend/src/lib/spindle/host-surfaces.test.ts
+++ b/frontend/src/lib/spindle/host-surfaces.test.ts
@@ -21,6 +21,16 @@ const testStore = {
   drawerTabs: [],
   extensionCommands: [],
   inputBarActions: [],
+  pendingWorldBookEditEntryId: null as string | null,
+  activeModal: null as string | null,
+  modalProps: {} as Record<string, unknown>,
+  setPendingWorldBookEditEntryId(id: string | null) {
+    testStore.pendingWorldBookEditEntryId = id
+  },
+  openModal(id: string, props: Record<string, unknown>) {
+    testStore.activeModal = id
+    testStore.modalProps = props
+  },
 }
 
 mock.module('@/lib/commands', () => ({ COMMANDS }))
@@ -86,6 +96,53 @@ describe('H4 host surface catalog and invocation', () => {
     expect(() => api.invoke({ kind: 'command', id: 'not-in-the-map' })).toThrow('HOST_ACTION_UNMAPPED')
     api.invoke({ kind: 'command', id: 'action-regenerate' })
     expect(calls).toEqual(['action-regenerate'])
+  })
+
+  test('world-book editor invocation requires permission and forwards the entry target', () => {
+    const calls: Array<[string, string | undefined]> = []
+    const denied = createHostSurfaceAPI({
+      extensionId: 'ext-a',
+      getGrantedPermissions: () => [],
+      getInputs: () => ({ userRole: 'user', inputBarActions: [], extensionCommands: [] }),
+    })
+    expect(() => denied.invoke(
+      { kind: 'modal', id: 'world_book_editor' },
+      { id: 'book-1', entryId: 'entry-1' },
+    )).toThrow('PERMISSION_DENIED:world_books')
+
+    const allowed = createHostSurfaceAPI({
+      extensionId: 'ext-a',
+      getGrantedPermissions: () => ['world_books'],
+      getInputs: () => ({ userRole: 'user', inputBarActions: [], extensionCommands: [] }),
+      runtime: {
+        openWorldBookEditor: (id, entryId) => { calls.push([id, entryId]) },
+      },
+    })
+    allowed.invoke(
+      { kind: 'modal', id: 'world_book_editor' },
+      { id: 'book-1', entryId: 'entry-1' },
+    )
+    expect(calls).toEqual([['book-1', 'entry-1']])
+  })
+
+  test('default world-book action opens the native editor at the requested book and entry', () => {
+    testStore.pendingWorldBookEditEntryId = 'stale-entry'
+    testStore.activeModal = null
+    testStore.modalProps = {}
+    const api = createHostSurfaceAPI({
+      extensionId: 'ext-a',
+      getGrantedPermissions: () => ['world_books'],
+      getInputs: () => ({ userRole: 'user', inputBarActions: [], extensionCommands: [] }),
+    })
+
+    api.invoke(
+      { kind: 'modal', id: 'world_book_editor' },
+      { id: 'book-1', entryId: 'entry-1' },
+    )
+
+    expect(testStore.activeModal).toBe('worldBookEditor')
+    expect(testStore.modalProps).toEqual({ bookId: 'book-1' })
+    expect(testStore.pendingWorldBookEditEntryId).toBe('entry-1')
   })
 
   test('self input actions are free, cross-extension actions require app_manipulation, and opt-out is honored', async () => {

--- a/frontend/src/lib/spindle/host-surfaces.ts
+++ b/frontend/src/lib/spindle/host-surfaces.ts
@@ -251,7 +251,11 @@ function defaultRuntime(
     },
     navigate: (path) => { void router.navigate(path) },
     setEditingCharacterId: (id) => useStore.getState().setEditingCharacterId(id),
-    openWorldBookEditor: (id) => useStore.getState().openModal('worldBookEditor', { bookId: id }),
+    openWorldBookEditor: (id, entryId) => {
+      const state = useStore.getState()
+      state.setPendingWorldBookEditEntryId(entryId ?? null)
+      state.openModal('worldBookEditor', { bookId: id })
+    },
     invokeInputBarAction: async (id) => {
       const action = getInputAction(id)
       if (!action) throw new Error(`HOST_ACTION_UNMAPPED:input_bar_action:${id}`)


### PR DESCRIPTION
## Summary

Adds Spindle support for opening the World Book Editor at a specific lorebook and entry.

## Validation

List the commands you ran and their results. Include any relevant test output.

```text
cd frontend && bun x tsc -b --pretty false
# Passed

bun test frontend/src/components/shared/WorldBookEntriesSection.token-count.test.tsx frontend/src/lib/spindle/frontend-authority-map.test.ts frontend/src/lib/spindle/host-actions.test.ts frontend/src/lib/spindle/host-surfaces.test.ts
# 25 passed, 0 failed

cd frontend && bun run build
# Production frontend build passed
```

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass.
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [x] Backend: `bun x tsc --noEmit`
  - [x] Frontend: `cd frontend && bun run typecheck`, `bun run lint`

## UI changes (if applicable)
N/A

## Performance changes (if applicable)
N/A

## Security-sensitive changes (if applicable)
N/A

## LLM-assisted work (if applicable)

- [x] I, as the human orchestrating this work, audited the submitted changes
      in a live environment.