### PR TITLE
Restore world info capture contract

### DIFF
--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -47,6 +47,7 @@ import {
   type WorldInfoInterceptorCtxDTO,
   type WorldInfoInterceptorResultDTO,
 } from "./world-info-interceptor";
+import { projectWorldInfoCaptureContext } from "./world-info-capture";
 import { toolRegistry } from "./tool-registry";
 import {
   setPromptRegexOwnedChats,
@@ -2741,7 +2742,11 @@ export class WorkerHost {
           };
         });
 
-        const interceptorContext = context as Omit<InterceptorContextDTO, "signal">;
+        const interceptorContext =
+          projectWorldInfoCaptureContext(
+            context,
+            this.extensionId,
+          ) as unknown as Omit<InterceptorContextDTO, "signal">;
         this.activeInterceptorContexts.set(registrationId, interceptorContext);
         this.postToWorker({
           type: "intercept_request",

--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -3708,7 +3708,11 @@ const spindleApi: RuntimeSpindleAPI = {
     });
   },
 
-  contracts: Object.freeze({ preAssemblyGenerationContext: 1 }),
+  contracts: Object.freeze({
+    preAssemblyGenerationContext: 1,
+    worldInfoActivationCapture: 1,
+    worldInfoRuntimePlacement: 1,
+  }),
 
   registerContextHandler(
     handler: (context: unknown) => Promise<unknown>,

--- a/src/spindle/world-info-capture.wiring.test.ts
+++ b/src/spindle/world-info-capture.wiring.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+// projectWorldInfoCaptureContext is unit-tested in isolation, so it stays green
+// even when nothing calls it. These assert the wiring a branch merge can drop.
+const read = (file: string): Promise<string> => readFile(join(import.meta.dir, file), 'utf8')
+
+describe('world-info capture wiring', () => {
+  test('worker-host projects captures into the interceptor context', async () => {
+    const source = await read('./worker-host.ts')
+    expect(source).toContain('from "./world-info-capture"')
+    expect(source).toMatch(/const interceptorContext\s*=\s*projectWorldInfoCaptureContext\(/)
+  })
+
+  test('worker-runtime advertises the contracts extensions gate on', async () => {
+    const source = await read('./worker-runtime.ts')
+    const block = source.match(/contracts:\s*Object\.freeze\(\{([\s\S]*?)\}\)/)
+    expect(block).not.toBeNull()
+    expect(block![1]).toContain('worldInfoActivationCapture: 1')
+    expect(block![1]).toContain('worldInfoRuntimePlacement: 1')
+  })
+})


### PR DESCRIPTION
## Summary

Restores functionality that commit `a9bb9bf7` deleted by accident, which broke world info capture for all extensions.

## Validation

List the commands you ran and their results. Include any relevant test output.

```text
$ bun x tsc --noEmit

$ cd frontend && bun run typecheck
[10.53s] Total Extraction Time
Wrote 95 CSS variables to .../generatedCssVariables.ts

$ cd frontend && bun run lint
```

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass.
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [x] Backend: `bun x tsc --noEmit`
  - [x] Frontend: `cd frontend && bun run typecheck`, `bun run lint`

## UI changes (if applicable)
N/A

## Performance changes (if applicable)
N/A

## Security-sensitive changes (if applicable)
N/A

## LLM-assisted work (if applicable)
N/A