### PR TITLE
Make mobile input actions horizontally scrollable

### DIFF
--- a/frontend/src/components/chat/InputArea.mobile-scroll.test.ts
+++ b/frontend/src/components/chat/InputArea.mobile-scroll.test.ts
@@ -1,0 +1,57 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const css = readFileSync(join(import.meta.dir, 'InputArea.module.css'), 'utf8')
+
+function readCssBlock(source: string, marker: string): string {
+  const markerIndex = source.indexOf(marker)
+  if (markerIndex < 0) throw new Error(`Missing CSS block: ${marker}`)
+
+  const openingBrace = source.indexOf('{', markerIndex)
+  if (openingBrace < 0) throw new Error(`Missing opening brace for: ${marker}`)
+
+  let depth = 0
+  for (let index = openingBrace; index < source.length; index += 1) {
+    if (source[index] === '{') depth += 1
+    if (source[index] === '}') depth -= 1
+    if (depth === 0) return source.slice(openingBrace + 1, index)
+  }
+
+  throw new Error(`Missing closing brace for: ${marker}`)
+}
+
+describe('mobile input action bar scrolling contract', () => {
+  const mobileCss = readCssBlock(css, '@media (max-width: 600px)')
+
+  test('uses native horizontal scrolling without wrapping', () => {
+    const actionBar = readCssBlock(mobileCss, '.actionBar {')
+
+    expect(actionBar).toMatch(/flex-wrap:\s*nowrap/)
+    expect(actionBar).toMatch(/overflow-x:\s*auto/)
+    expect(actionBar).toMatch(/overflow-y:\s*hidden/)
+    expect(actionBar).toMatch(/-webkit-overflow-scrolling:\s*touch/)
+  })
+
+  test('keeps native and extension actions from shrinking', () => {
+    const actionButton = readCssBlock(mobileCss, '.actionBtn {')
+    const extensionActions = readCssBlock(
+      mobileCss,
+      ".actionBar :global([data-spindle-mount='chat_actions'] > *) {",
+    )
+
+    expect(actionButton).toMatch(/width:\s*28px/)
+    expect(actionButton).toMatch(/flex:\s*0\s+0\s+28px/)
+    expect(extensionActions).toMatch(/flex-shrink:\s*0/)
+  })
+
+  test('hides the scrollbar while preserving the scroll container', () => {
+    const actionBar = readCssBlock(mobileCss, '.actionBar {')
+    const webkitScrollbar = readCssBlock(mobileCss, '.actionBar::-webkit-scrollbar {')
+
+    expect(actionBar).toMatch(/scrollbar-width:\s*none/)
+    expect(webkitScrollbar).toMatch(/display:\s*none/)
+  })
+})

--- a/frontend/src/components/chat/InputArea.module.css
+++ b/frontend/src/components/chat/InputArea.module.css
@@ -1120,10 +1120,26 @@
   .actionBar {
     gap: 1px;
     padding: 0;
+    max-width: 100%;
+    min-width: 0;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .actionBar::-webkit-scrollbar {
+    display: none;
   }
 
   .actionBtn {
     width: 28px;
+    flex: 0 0 28px;
+  }
+
+  .actionBar :global([data-spindle-mount='chat_actions'] > *) {
+    flex-shrink: 0;
   }
 
   :global(html[data-ios-pwa]) .container {


### PR DESCRIPTION
## Summary

Adds native horizontal scrolling to the mobile input action bar at widths up to 600px.

- Keeps built-in actions on one line at a fixed 28px width instead of shrinking.
- Keeps actions mounted by Spindle extensions from shrinking.
- Hides the visual scrollbar while preserving touch/swipe scrolling.
- Leaves desktop layout, action order, click behavior, and popovers unchanged.

This makes later actions reachable on narrow mobile screens when the row contains more buttons than can fit.

## Validation

```text
bun test frontend/src/components/chat/InputArea.mobile-scroll.test.ts
# 3 pass, 0 fail, 9 expect() calls

cd frontend && bun run build
# Passed: 9190 modules transformed; frontend and PWA service worker generated
```

Manual validation:

- Android PWA (Chrome 151): horizontal swipe works correctly and no regressions were observed.
- The compiled frontend was served successfully both locally and through Tailscale.

`cd frontend && bun run typecheck` was attempted, but the existing dependency tree does not contain `jsdom`, so it stops on missing-module errors from pre-existing test files. Dependencies were not reinstalled for this validation.

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable focused tests pass.
- [ ] I ran the relevant type check(s) with no type errors or warnings:
  - [ ] Backend: `bun x tsc --noEmit` (not applicable; no backend changes)
  - [ ] Frontend: `cd frontend && bun run typecheck`, `bun run lint` (see validation note above)

## UI changes (if applicable)

- [ ] I validated this change in more than one browser.
- [x] I verified the integrated experience on a mobile interface or through
      the mobile PWA.
- Browsers, devices, and PWA coverage: Android PWA, Chrome 151. iOS was not tested.

## Performance changes (if applicable)

Not applicable. This uses native CSS overflow with no JavaScript listeners or gesture handling.

- [ ] I added or updated tests.
- [ ] I included reproducible benchmarks and comparison results below.
- Benchmark commands and results: Not applicable.

## Security-sensitive changes (if applicable)

Not applicable. No backend, API, data, authentication, or Spindle security behavior changes.

## LLM-assisted work (if applicable)

- [x] I, as the human orchestrating this work, audited the submitted changes
      in a live environment.