### PR TITLE
Move prompt variables to the input action bar

### DIFF
--- a/frontend/src/components/chat/InputArea.prompt-variables-action.test.ts
+++ b/frontend/src/components/chat/InputArea.prompt-variables-action.test.ts
@@ -1,0 +1,37 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const source = readFileSync(join(import.meta.dir, 'InputArea.tsx'), 'utf8').replace(/\r\n/g, '\n')
+
+describe('prompt variables input action contract', () => {
+  const actionBarStart = source.indexOf('<div className={styles.actionBar}>')
+  const actionBarEnd = source.indexOf('\n        </div>\n      </div>', actionBarStart)
+  const actionBar = source.slice(actionBarStart, actionBarEnd)
+
+  test('renders only when prompt variables are available', () => {
+    expect(actionBarStart).toBeGreaterThan(-1)
+    expect(actionBarEnd).toBeGreaterThan(actionBarStart)
+    expect(actionBar).toMatch(/\{promptVariablesAvailable && \(\s*<button/)
+  })
+
+  test('places prompt variables immediately before tools', () => {
+    const quickRepliesButton = actionBar.indexOf('<MessageSquareQuote size={14} />')
+    const promptVariablesButton = actionBar.indexOf('{promptVariablesAvailable && (')
+    const promptVariablesButtonEnd = actionBar.indexOf('\n          )}', promptVariablesButton) + '\n          )}'.length
+    const toolsMarker = actionBar.indexOf("openPopover === 'tools'")
+    const toolsButton = actionBar.lastIndexOf('<button', toolsMarker)
+
+    expect(promptVariablesButton).toBeGreaterThan(quickRepliesButton)
+    expect(promptVariablesButtonEnd).toBeGreaterThan(promptVariablesButton)
+    expect(toolsButton).toBeGreaterThan(promptVariablesButton)
+    expect(actionBar.slice(promptVariablesButton, promptVariablesButtonEnd)).toContain('<Sliders size={14} />')
+    expect(actionBar.slice(promptVariablesButtonEnd, toolsButton).trim()).toBe('')
+  })
+
+  test('keeps a single prompt variables entry point', () => {
+    expect(source.match(/onClick=\{\(\) => void openPromptVariablesModal\(\)\}/g)).toHaveLength(1)
+  })
+})

--- a/frontend/src/components/chat/InputArea.tsx
+++ b/frontend/src/components/chat/InputArea.tsx
@@ -20,6 +20,10 @@ import { uuidv7 } from '@/lib/uuid'
 import { toast } from '@/lib/toast'
 import { shouldForceLoomRuntimePreset } from '@/lib/loom/runtimeProfile'
 import { unmarshalPreset } from '@/lib/loom/service'
+import {
+  inspectPromptVariablesAvailability,
+  type PromptVariablesAvailability,
+} from '@/lib/loom/prompt-variable-availability'
 import { presetSaveCoordinator, StalePresetHydrationError } from '@/lib/loom/preset-save-coordinator'
 import { resolveAutoPersonaBinding } from '@/store/slices/personas'
 import {
@@ -283,6 +287,7 @@ export default function InputArea({ chatId, onNavigateHome, onOpenChatFind }: In
   const promptVariablesBindingRef = useRef<PromptVariableProfileTarget | null>(null)
   promptVariablesBindingRef.current = promptVariablesBinding
   const [promptVariablesLoading, setPromptVariablesLoading] = useState(false)
+  const [promptVariablesAvailability, setPromptVariablesAvailability] = useState<PromptVariablesAvailability | null>(null)
   const [pendingAttachments, setPendingAttachments] = useState<(MessageAttachment & { previewUrl?: string })[]>([])
   const [uploading, setUploading] = useState(false)
   const [dragActive, setDragActive] = useState(false)
@@ -1066,7 +1071,48 @@ export default function InputArea({ chatId, onNavigateHome, onOpenChatFind }: In
   const activeGuides = guidedGenerations.filter((g) => g.enabled)
   const activeGuideCount = activeGuides.length
   const activeQuickReplySets = quickReplySets.filter((s) => s.enabled)
-  const activeLoomPresetName = activeLoomPresetId ? loomRegistry[activeLoomPresetId]?.name ?? null : null
+  const activeLoomPresetRegistryUpdatedAt = activeLoomPresetId
+    ? loomRegistry[activeLoomPresetId]?.updatedAt ?? null
+    : null
+  const promptVariablesAvailable = !!activeLoomPresetId
+    && promptVariablesAvailability?.presetId === activeLoomPresetId
+    && promptVariablesAvailability.registryUpdatedAt === activeLoomPresetRegistryUpdatedAt
+    && promptVariablesAvailability.hasDefinitions
+
+  useEffect(() => {
+    setPromptVariablesAvailability(null)
+    if (!activeLoomPresetId) return
+
+    let cancelled = false
+    const presetId = activeLoomPresetId
+    const registryUpdatedAt = activeLoomPresetRegistryUpdatedAt
+    const isCurrent = () => {
+      const state = useStore.getState()
+      return !cancelled
+        && state.activeLoomPresetId === presetId
+        && (state.loomRegistry[presetId]?.updatedAt ?? null) === registryUpdatedAt
+    }
+
+    void inspectPromptVariablesAvailability({
+      presetId,
+      registryUpdatedAt,
+      loadBlocks: async () => {
+        const preset = await presetsApi.get(presetId)
+        return unmarshalPreset(preset).blocks
+      },
+      isCurrent,
+    }).then((availability) => {
+      if (!availability) return
+      setPromptVariablesAvailability(availability)
+    }).catch((err) => {
+      if (!isCurrent()) return
+      console.warn('[InputArea] Failed to inspect prompt variable availability:', err)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [activeLoomPresetId, activeLoomPresetRegistryUpdatedAt])
 
   const openPromptVariablesModal = useCallback(async () => {
     if (!activeLoomPresetId) {
@@ -3154,6 +3200,18 @@ export default function InputArea({ chatId, onNavigateHome, onOpenChatFind }: In
           >
             <MessageSquareQuote size={14} />
           </button>
+          {promptVariablesAvailable && (
+            <button
+              type="button"
+              className={styles.actionBtn}
+              onClick={() => void openPromptVariablesModal()}
+              disabled={promptVariablesLoading}
+              title={t('quickMenu.promptVariables')}
+              aria-label={t('quickMenu.promptVariables')}
+            >
+              <Sliders size={14} />
+            </button>
+          )}
           <button
             type="button"
             className={clsx(styles.actionBtn, openPopover === 'tools' && styles.actionBtnActive)}
@@ -3410,28 +3468,6 @@ export default function InputArea({ chatId, onNavigateHome, onOpenChatFind }: In
                 <span className={styles.personaMain}>
                   <Settings2 size={14} />
                   <span>{isGroupChat ? t('quickMenu.groupSettings') : t('quickMenu.chatSettings')}</span>
-                </span>
-              </button>
-              <button
-                type="button"
-                className={styles.popRowBtn}
-                onClick={() => void openPromptVariablesModal()}
-                disabled={!activeLoomPresetId || promptVariablesLoading}
-                style={!activeLoomPresetId || promptVariablesLoading ? { opacity: 0.5 } : undefined}
-                title={!activeLoomPresetId ? t('quickMenu.promptVariablesSelectPreset') : undefined}
-              >
-                <span className={styles.personaMain}>
-                  <Sliders size={14} />
-                  <span className={styles.personaNameGroup}>
-                    <span>{t('quickMenu.promptVariables')}</span>
-                    <span className={styles.personaTitle}>
-                      {promptVariablesLoading
-                        ? t('quickMenu.loadingPromptVariables')
-                        : activeLoomPresetName
-                          ? t('quickMenu.promptVariablesFor', { name: activeLoomPresetName })
-                          : t('quickMenu.promptVariablesActivePreset')}
-                    </span>
-                  </span>
                 </span>
               </button>
               {!isGroupChat && activeCharacterId && (

--- a/frontend/src/lib/loom/prompt-variable-availability.test.ts
+++ b/frontend/src/lib/loom/prompt-variable-availability.test.ts
@@ -1,0 +1,48 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import type { PromptVariableDef } from './types'
+import {
+  hasPromptVariableDefinitions,
+  inspectPromptVariablesAvailability,
+} from './prompt-variable-availability'
+
+const promptVariable: PromptVariableDef = {
+  id: 'tone',
+  name: 'tone',
+  label: 'Tone',
+  type: 'text',
+  defaultValue: 'warm',
+}
+
+describe('prompt variable availability', () => {
+  test('requires at least one prompt variable definition', () => {
+    expect(hasPromptVariableDefinitions(undefined)).toBe(false)
+    expect(hasPromptVariableDefinitions([])).toBe(false)
+    expect(hasPromptVariableDefinitions([{}])).toBe(false)
+    expect(hasPromptVariableDefinitions([{ variables: [] }])).toBe(false)
+    expect(hasPromptVariableDefinitions([{ variables: [promptVariable] }])).toBe(true)
+  })
+
+  test('returns availability for the current preset revision', async () => {
+    await expect(inspectPromptVariablesAvailability({
+      presetId: 'preset-a',
+      registryUpdatedAt: 42,
+      loadBlocks: async () => [{ variables: [promptVariable] }],
+      isCurrent: () => true,
+    })).resolves.toEqual({
+      presetId: 'preset-a',
+      registryUpdatedAt: 42,
+      hasDefinitions: true,
+    })
+  })
+
+  test('discards a result after the selected preset changes', async () => {
+    await expect(inspectPromptVariablesAvailability({
+      presetId: 'preset-a',
+      registryUpdatedAt: 42,
+      loadBlocks: async () => [{ variables: [promptVariable] }],
+      isCurrent: () => false,
+    })).resolves.toBeNull()
+  })
+})

--- a/frontend/src/lib/loom/prompt-variable-availability.ts
+++ b/frontend/src/lib/loom/prompt-variable-availability.ts
@@ -1,0 +1,36 @@
+import type { PromptBlock } from './types'
+
+type PromptVariableBlock = Pick<PromptBlock, 'variables'>
+
+export type PromptVariablesAvailability = {
+  presetId: string
+  registryUpdatedAt: number | null
+  hasDefinitions: boolean
+}
+
+export function hasPromptVariableDefinitions(
+  blocks: readonly PromptVariableBlock[] | null | undefined,
+): boolean {
+  return blocks?.some((block) => Array.isArray(block.variables) && block.variables.length > 0) ?? false
+}
+
+export async function inspectPromptVariablesAvailability({
+  presetId,
+  registryUpdatedAt,
+  loadBlocks,
+  isCurrent,
+}: {
+  presetId: string
+  registryUpdatedAt: number | null
+  loadBlocks: () => Promise<readonly PromptVariableBlock[] | null | undefined>
+  isCurrent: () => boolean
+}): Promise<PromptVariablesAvailability | null> {
+  const blocks = await loadBlocks()
+  if (!isCurrent()) return null
+
+  return {
+    presetId,
+    registryUpdatedAt,
+    hasDefinitions: hasPromptVariableDefinitions(blocks),
+  }
+}


### PR DESCRIPTION
## Summary

Moves the existing Prompt Variables action from the Extras menu to the chat input action bar, immediately before Tools.

- Shows the action only when the active preset contains at least one Prompt Variable definition.
- Keeps the action hidden when no preset is selected or the selected preset has no variable definitions.
- Uses the existing preset API as a read-only availability check; no backend or data format changes are required.
- Discards stale availability results when the active preset or its registry revision changes.
- Reuses the existing modal, profile binding, and save flow without changing their behavior.

This makes Prompt Variables directly accessible during chats while keeping the mobile action bar contextual. The previous entry inside Extras is removed rather than duplicated.

## Validation

```text
bun test frontend/src/lib/loom/prompt-variable-availability.test.ts frontend/src/components/chat/InputArea.prompt-variables-action.test.ts frontend/src/components/chat/InputArea.mobile-scroll.test.ts
# 9 pass, 0 fail, 25 expect() calls

cd frontend && bun run build
# Passed: 9191 modules transformed; frontend bundle and PWA service worker generated
```

`cd frontend && bun run typecheck` was attempted with the existing dependency tree. It reached `tsc -b` and stopped on missing `jsdom` module/type declarations in pre-existing test files. No type error was reported in the files changed by this PR, and dependencies were not reinstalled.

Manual validation confirmed the contextual visibility, icon order, modal workflow, and absence of regressions in:

- Android Chrome PWA
- Android regular browser
- Windows 10 desktop browser

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass.
- [ ] I ran the relevant type check(s) with no type errors or warnings:
  - [ ] Backend: `bun x tsc --noEmit` (not applicable; no backend changes)
  - [ ] Frontend: `cd frontend && bun run typecheck`, `bun run lint` (blocked by the existing missing `jsdom` dependency; see Validation)

## UI changes (if applicable)

- [x] I validated this change in more than one browser.
- [x] I verified the integrated experience on a mobile interface or through
      the mobile PWA.
- Browsers, devices, and PWA coverage: Android Chrome PWA, Android regular browser, and Windows 10 desktop browser. iOS was not tested.

## Performance changes (if applicable)

Not applicable. The availability check runs only when the active preset or its registry revision changes.

- [x] I added or updated tests.
- [ ] I included reproducible benchmarks and comparison results below.
- Benchmark commands and results: Not applicable.

## Security-sensitive changes (if applicable)

Not applicable. No backend, API, database, authentication, or Spindle security behavior changes.

## LLM-assisted work (if applicable)

- [x] I, as the human orchestrating this work, audited the submitted changes
      in a live environment.