### PR TITLE
Fix MESSAGE_EDITED wiping swipe-scoped extra on attachment append/remove

### DIFF
--- a/src/services/chats.service.ts
+++ b/src/services/chats.service.ts
@@ -2531,7 +2531,7 @@ export function appendMessageAttachment(
     .query("UPDATE messages SET extra = ? WHERE id = ? AND chat_id = ?")
     .run(JSON.stringify(normalizedExtra), messageId, existing.chat_id);
 
-  const updated: Message = { ...existing, extra: normalizedExtra };
+  const updated: Message = { ...existing, extra: projectActiveSwipeExtra(normalizedExtra, existing.swipe_id) };
   eventBus.emit(EventType.MESSAGE_EDITED, { chatId: updated.chat_id, message: updated }, userId);
   return updated;
 }
@@ -2609,7 +2609,7 @@ export function removeMessageAttachment(
   // message and the orphan can be GC'd manually.
   cleanupAudioAttachments(userId, removed);
 
-  const updated: Message = { ...existing, extra: normalizedExtra };
+  const updated: Message = { ...existing, extra: projectActiveSwipeExtra(normalizedExtra, existing.swipe_id) };
   eventBus.emit(EventType.MESSAGE_EDITED, { chatId: updated.chat_id, message: updated }, userId);
   return updated;
 }


### PR DESCRIPTION
Fixes #297

## What changed

Two lines in `src/services/chats.service.ts`: `appendMessageAttachment` and `removeMessageAttachment` now emit/return the message with `projectActiveSwipeExtra(normalizedExtra, existing.swipe_id)` instead of the raw stored `normalizedExtra`.

## Why

These two helpers are lightweight attachment paths that skip the read-back projection every other read path performs. `normalizeStoredMessageExtra` strips top-level swipe-scoped fields (`tokenCount`, `generationMetrics`, `reasoning`, …) into `*BySwipe` arrays, but WS/HTTP consumers read the top-level projection. The client's `MESSAGE_EDITED` handler replaces its message copy wholesale with the payload, so when an image attached to a freshly generated reply, the detail pill lost its token count and its generation-details hover tooltip until a full page reload. The projection is a superset of the stored form (the `*BySwipe` arrays are preserved), so consumers of the stored shape are unaffected.

## Validation

- Reproduced live before the fix: reply finishes → pill shows token count and tooltip → auto-generated image attaches → both vanish; refresh restores them (DB was always correct — the loss was client-side only).
- Audited in a live environment after the fix per CONTRIBUTING: same scenario, pill and tooltip now survive the image attachment.
- `bun test src/services/chats.service.test.ts` — 34 pass, 0 fail.
- Regression tests covering both helpers (asserting the `MESSAGE_EDITED` payload and return value keep projected `tokenCount`/`generationMetrics`/`reasoning`) were written and verified fail-before/pass-after; they're omitted here to keep the diff minimal, and can be added on request.

## Security

No security-sensitive areas touched: no Spindle involvement, no auth/permission paths — the change only affects the shape of an already-emitted WS payload and helper return value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)