### PR TITLE
fix(spindle): validate CSS control characters correctly

### DIFF
--- a/src/spindle/css-value-validation.ts
+++ b/src/spindle/css-value-validation.ts
@@ -1,0 +1,27 @@
+/** The C0 controls disallowed in extension CSS values. HT, LF and CR remain valid CSS whitespace. */
+export function hasProhibitedCssControl(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 8 || code === 11 || code === 12 || (code >= 14 && code <= 31)) return true;
+  }
+  return false;
+}
+
+const MAX_CSS_VALUE_LENGTH = 1024;
+export function validateCssValue(value: unknown): string | null {
+  if (value === undefined || value === null || typeof value !== "string") return "value must be a string";
+  if (value.length > MAX_CSS_VALUE_LENGTH) return `value exceeds ${MAX_CSS_VALUE_LENGTH} characters`;
+  if (value.length === 0) return null;
+  const trimmed = value.trim(); const lowered = trimmed.toLowerCase().replace(/\\\\/g, "");
+  if (hasProhibitedCssControl(value)) return "control characters not allowed";
+  if (/[<>]/.test(value)) return "angle brackets not allowed";
+  if (value.includes("{") || value.includes("}") || value.includes(";")) return "must be a single property value (no { } ; )";
+  if (lowered.includes("javascript:")) return "javascript: URLs not allowed";
+  if (lowered.includes("vbscript:")) return "vbscript: URLs not allowed";
+  if (lowered.includes("data:text/html")) return "data:text/html URLs not allowed";
+  if (lowered.includes("expression(")) return "CSS expression() not allowed";
+  if (lowered.startsWith("@")) return "at-rules not allowed in variable values";
+  if (/^url\(\s*['"]?\s*(?!https?:|data:image\/)/i.test(trimmed)) return "url() must point to https: or a data:image/* payload";
+  if (/image-set\(/i.test(trimmed) && !/image-set\(\s*['"]?\s*(https?:|data:image\/)/i.test(trimmed)) return "image-set() must point to https: or a data:image/* payload";
+  return null;
+}

--- a/src/spindle/worker-host-presentation-api.ts
+++ b/src/spindle/worker-host-presentation-api.ts
@@ -13,30 +13,12 @@ import { generateThemeVariables as generateThemeVariablesFn } from "../utils/the
 import * as councilSettingsSvc from "../services/council/council-settings.service";
 import { buildCouncilMemberContext } from "../services/council/tool-runtime";
 import * as packsSvc from "../services/packs.service";
+import { validateCssValue } from "./css-value-validation";
 
 const FULL_THEME_SENTINEL_KEYS = ["--lumiverse-primary", "--lumiverse-bg", "--lumiverse-text", "--lumiverse-border", "--lumiverse-fill", "--lcs-glass-bg"] as const;
 const FULL_THEME_MIN_KEYS = 40;
 const USER_PREFERENCE_KEYS = new Set(["--lcs-glass-blur", "--lcs-glass-soft-blur", "--lcs-glass-strong-blur", "--lcs-radius", "--lcs-radius-sm", "--lcs-radius-xs", "--lcs-transition", "--lcs-transition-fast", "--lumiverse-radius", "--lumiverse-radius-sm", "--lumiverse-radius-md", "--lumiverse-radius-lg", "--lumiverse-radius-xl", "--lumiverse-font-family", "--lumiverse-font-mono", "--lumiverse-font-scale", "--lumiverse-ui-scale", "--lumiverse-transition", "--lumiverse-transition-fast"]);
-const MAX_CSS_VALUE_LENGTH = 1024;
 type SpindleUserRole = "operator" | "admin" | "user";
-
-function validateCssValue(value: unknown): string | null {
-  if (value === undefined || value === null || typeof value !== "string") return "value must be a string";
-  if (value.length > MAX_CSS_VALUE_LENGTH) return `value exceeds ${MAX_CSS_VALUE_LENGTH} characters`;
-  if (value.length === 0) return null;
-  const trimmed = value.trim(); const lowered = trimmed.toLowerCase().replace(/\\\\/g, "");
-  if (/[\\u0000-\\u0008\\u000B\\u000C\\u000E-\\u001F]/.test(value)) return "control characters not allowed";
-  if (/[<>]/.test(value)) return "angle brackets not allowed";
-  if (value.includes("{") || value.includes("}") || value.includes(";")) return "must be a single property value (no { } ; )";
-  if (lowered.includes("javascript:")) return "javascript: URLs not allowed";
-  if (lowered.includes("vbscript:")) return "vbscript: URLs not allowed";
-  if (lowered.includes("data:text/html")) return "data:text/html URLs not allowed";
-  if (lowered.includes("expression(")) return "CSS expression() not allowed";
-  if (lowered.startsWith("@")) return "at-rules not allowed in variable values";
-  if (/^url\(\s*['"]?\s*(?!https?:|data:image\/)/i.test(trimmed)) return "url() must point to https: or a data:image/* payload";
-  if (/image-set\(/i.test(trimmed) && !/image-set\(\s*['"]?\s*(https?:|data:image\/)/i.test(trimmed)) return "image-set() must point to https: or a data:image/* payload";
-  return null;
-}
 
 type PresentationPermission = "push_notification" | "web_search" | "app_manipulation";
 export type WorkerHostPresentationApiContext = {

--- a/tests/spindle-css-value-validation.test.ts
+++ b/tests/spindle-css-value-validation.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { validateCssValue } from "../src/spindle/css-value-validation";
+
+describe("Spindle CSS value validation", () => {
+  test("accepts ordinary numeric color values", () => {
+    for (const value of ["#ff0000", "#102030", "rgba(255, 0, 0, 0.5)", "oklch(62% 0.2 29)"]) expect(validateCssValue(value)).toBeNull();
+  });
+
+  test("rejects actual prohibited controls without rejecting surrounding CSS whitespace", () => {
+    for (const code of [0, 1, 8, 11, 12, 14, 31]) expect(validateCssValue(`red${String.fromCharCode(code)}`)).toBe("control characters not allowed");
+    expect(validateCssValue("\t#ff0000\r\n")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- extract Spindle CSS value validation into a focused module
- replace the escaped-regex control-character check with explicit C0 code-point validation
- preserve valid CSS whitespace while rejecting prohibited controls
- add regression coverage for ordinary numeric colors and actual control characters

## Why
The previous regex was double-escaped, so ordinary digits in values such as #ff0000 could be interpreted as prohibited controls and rejected by spindle.theme.apply().

## Testing
- bun test tests/spindle-css-value-validation.test.ts (2 passed, 0 failed)