### PR TITLE
feat(spindle): expose native theme authoring to frontend extensions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
         "hono": "^4.7.0",
         "js-tiktoken": "^1.0.16",
         "jsdom": "^29.0.1",
-        "lumiverse-spindle-types": "0.6.18",
+        "lumiverse-spindle-types": "0.6.19",
         "mute-stream": "^3.0.0",
         "sharp": "^0.34.5",
         "ssh2-sftp-client": "^12.1.1",
@@ -643,7 +643,7 @@
 
     "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
-    "lumiverse-spindle-types": ["lumiverse-spindle-types@0.6.18", "", {}, "sha512-Cn/LTKIMwD3XelayXFuZnh0B5raBiOusP7VxbN6Y037UGANO0YmFztr1W7fnncwJ9tIbkHHsCaKDUDNoH+3s6Q=="],
+    "lumiverse-spindle-types": ["lumiverse-spindle-types@0.6.19", "", {}, "sha512-jg3hUTzaes85bFdai1achd7guoTh6CdvWmSIvBwmPSOsY8q8/3fY2ee4mPu3ZTDIlt3qK0xpJisF6B2Vd6OLkw=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 

--- a/developer-docs/docs/frontend-api/index.md
+++ b/developer-docs/docs/frontend-api/index.md
@@ -47,3 +47,4 @@ Frontend UI can follow two supported rendering paths:
 | [Message Tags](message-tags.md) | Free | Intercept custom XML tags in chat messages |
 | [Display Resolver](display-resolver.md) | Free | Resolve message display (macros, format, regex) in the browser for chats your extension owns |
 | [File Uploads](file-uploads.md) | Free | Open file picker and read selected files |
+| [Theme Authoring](theme-authoring.md) | Varies | Work with native theme assets, safe `.lumitheme` drafts, the component/variable catalog, and native Theme Editor navigation |

--- a/developer-docs/docs/frontend-api/theme-authoring.md
+++ b/developer-docs/docs/frontend-api/theme-authoring.md
@@ -1,0 +1,60 @@
+# Theme Authoring
+
+`ctx.theme` is the persistent/native theme-authoring counterpart to the backend `spindle.theme` presentation API. Use `spindle.theme` for extension-scoped live variable overrides; use `ctx.theme` for native assets, `.lumitheme` packs, catalog inspection, and navigation into Lumiverse's Theme Editor.
+
+Each subtree is independently versioned. Feature-detect the host capability before using it:
+
+| API | Host capability | Permission |
+|---|---|---|
+| `ctx.theme.assets` | `theme-assets-v1` | Reads are free; upload, update, optimize, and delete require `app_manipulation` |
+| `ctx.theme.packs` | `theme-packs-v1` | Export is free; import and install require `app_manipulation` |
+| `ctx.theme.catalog` | `theme-catalog-v1` | Free, read-only |
+| `ctx.theme.openEditor` | `theme-editor-navigation-v1` | Free |
+
+```ts
+const capabilities = ctx.host.capabilities
+if ((capabilities['theme-assets-v1'] ?? 0) >= 1) {
+  const assets = await ctx.theme.assets.list(bundleId)
+  for (const asset of assets) {
+    preview.src = asset.contentUrl       // authenticated live preview
+    css += `url("${asset.cssPath}")`    // canonical ./assets/<slug> pack path
+  }
+}
+```
+
+The asset DTO deliberately provides both paths. Do not reconstruct either value from an asset id or slug.
+
+## Safe theme-pack drafts
+
+Extensions author a stable draft rather than Lumiverse's internal archive manifest:
+
+```ts
+const draft = {
+  name: 'My Theme',
+  globalCSS: ':root { --my-accent: #a855f7; }',
+  components: {
+    BubbleMessage: { css: '[data-component="BubbleMessage"] { border-radius: 12px; }' },
+  },
+  assetBundleId: bundleId,
+}
+
+const archiveBytes = await ctx.theme.packs.exportDraft(draft)
+const result = await ctx.theme.packs.installDraft(draft, {
+  apply: true,
+  saveToLibrary: true,
+})
+```
+
+Drafts cannot supply TSX. Native owns the canonical `.lumitheme` codec, asset localization, CSS sanitization, application revisions, and saved-theme workflow. `importArchive()` creates a fresh asset bundle and returns a safe draft without applying it; executable TSX from imported archives is omitted and reported in `warnings`.
+
+## Catalog and editor navigation
+
+`listComponents()` returns stable labels, categories, public selectors, and CSS/TSX availability without source paths. `listVariables()` returns the native reference defaults plus current computed values when available.
+
+```ts
+if ((ctx.host.capabilities['theme-editor-navigation-v1'] ?? 0) >= 1) {
+  ctx.theme.openEditor({ target: 'component', componentId: 'BubbleMessage' })
+}
+```
+
+The bridge intentionally does not expose settings mutation, Zustand stores, arbitrary TSX installation, or component source files.

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -30,7 +30,7 @@
         "i18next": "^26.2.0",
         "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "^0.468.0",
-        "lumiverse-spindle-types": "0.6.18",
+        "lumiverse-spindle-types": "0.6.19",
         "marked": "^15.0.4",
         "motion": "^12.0.0",
         "react": "^19.2.6",
@@ -919,7 +919,7 @@
 
     "lucide-react": ["lucide-react@0.468.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA=="],
 
-    "lumiverse-spindle-types": ["lumiverse-spindle-types@0.6.18", "", {}, "sha512-Cn/LTKIMwD3XelayXFuZnh0B5raBiOusP7VxbN6Y037UGANO0YmFztr1W7fnncwJ9tIbkHHsCaKDUDNoH+3s6Q=="],
+    "lumiverse-spindle-types": ["lumiverse-spindle-types@0.6.19", "", {}, "sha512-jg3hUTzaes85bFdai1achd7guoTh6CdvWmSIvBwmPSOsY8q8/3fY2ee4mPu3ZTDIlt3qK0xpJisF6B2Vd6OLkw=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
     "i18next": "^26.2.0",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^0.468.0",
-    "lumiverse-spindle-types": "0.6.18",
+    "lumiverse-spindle-types": "0.6.19",
     "marked": "^15.0.4",
     "motion": "^12.0.0",
     "react": "^19.2.6",

--- a/frontend/src/lib/cssModuleRegistry.ts
+++ b/frontend/src/lib/cssModuleRegistry.ts
@@ -13,12 +13,14 @@ import {
   type ComponentRegistryJoinEntry,
 } from './componentRegistryJoin'
 
-const cssModulePaths = Object.keys(
-  import.meta.glob('/src/**/*.module.css', { eager: false }),
-)
-const tsxPaths = Object.keys(
-  import.meta.glob('/src/**/*.tsx', { eager: false }),
-)
+// Vite replaces these calls in production. The guard keeps non-Vite host
+// contract tests and SSR-like consumers from evaluating an unavailable API.
+const cssModulePaths = typeof import.meta.glob === 'function'
+  ? Object.keys(import.meta.glob('/src/**/*.module.css', { eager: false }))
+  : []
+const tsxPaths = typeof import.meta.glob === 'function'
+  ? Object.keys(import.meta.glob('/src/**/*.tsx', { eager: false }))
+  : []
 
 export type CSSModuleEntry = Omit<ComponentRegistryJoinEntry, 'cssPath'> & { cssPath: string }
 

--- a/frontend/src/lib/spindle/frontend-authority-map.ts
+++ b/frontend/src/lib/spindle/frontend-authority-map.ts
@@ -188,6 +188,23 @@ const LEGACY_ROWS: readonly AuthorityRow[] = [
   gated('app_manipulation|ui_panels', { surface: 'legacy_ctx_member', id: 'ctx.ui.requestTabLocation', source: 'ui.requestTabLocation', ctxLeaf: 'ctx.ui.requestTabLocation', gatedBecause: 'Rule-B clause (c): changes placement in a host-managed tab surface' }),
 ]
 
+const THEME_AUTHORING_ROWS: readonly AuthorityRow[] = [
+  free({ surface: 'ctx_member', id: 'ctx.theme.assets.getActiveBundleId', source: 'theme.assets.activeBundleId', ctxLeaf: 'ctx.theme.assets.getActiveBundleId', freeBecause: 'rest: exposes only the active user-scoped theme asset bundle identifier' }),
+  free({ surface: 'ctx_member', id: 'ctx.theme.assets.createBundle', source: 'theme.assets.bundleId', ctxLeaf: 'ctx.theme.assets.createBundle', freeBecause: 'pure-host-action: generates an inert bundle UUID without persisting host state' }),
+  free({ surface: 'ctx_member', id: 'ctx.theme.assets.list', source: 'theme.assets.read', ctxLeaf: 'ctx.theme.assets.list', freeBecause: 'rest: returns the authenticated user-scoped theme asset projection' }),
+  free({ surface: 'ctx_member', id: 'ctx.theme.assets.getBytes', source: 'theme.assets.read', ctxLeaf: 'ctx.theme.assets.getBytes', freeBecause: 'rest: returns authenticated bytes for an existing user-scoped theme asset' }),
+  gated('app_manipulation', { surface: 'ctx_member', id: 'ctx.theme.assets.upload', source: 'theme.assets.upload', ctxLeaf: 'ctx.theme.assets.upload', gatedBecause: 'Rule-B clause (b): persists a new native theme asset' }),
+  gated('app_manipulation', { surface: 'ctx_member', id: 'ctx.theme.assets.update', source: 'theme.assets.update', ctxLeaf: 'ctx.theme.assets.update', gatedBecause: 'Rule-B clause (b): mutates durable native theme asset metadata' }),
+  gated('app_manipulation', { surface: 'ctx_member', id: 'ctx.theme.assets.delete', source: 'theme.assets.delete', ctxLeaf: 'ctx.theme.assets.delete', gatedBecause: 'Rule-B clause (b): destructively removes a durable native theme asset' }),
+  gated('app_manipulation', { surface: 'ctx_member', id: 'ctx.theme.assets.optimizeWebp', source: 'theme.assets.optimizeWebp', ctxLeaf: 'ctx.theme.assets.optimizeWebp', gatedBecause: 'Rule-B clause (b): replaces durable native theme asset content' }),
+  free({ surface: 'ctx_member', id: 'ctx.theme.packs.exportDraft', source: 'theme.packs.export', ctxLeaf: 'ctx.theme.packs.exportDraft', freeBecause: 'pure-host-action: snapshots user-scoped assets and encodes bytes without mutating host state' }),
+  gated('app_manipulation', { surface: 'ctx_member', id: 'ctx.theme.packs.importArchive', source: 'theme.packs.import', ctxLeaf: 'ctx.theme.packs.importArchive', gatedBecause: 'Rule-B clause (b): imports archive assets into a durable native bundle' }),
+  gated('app_manipulation', { surface: 'ctx_member', id: 'ctx.theme.packs.installDraft', source: 'theme.packs.install', ctxLeaf: 'ctx.theme.packs.installDraft', gatedBecause: 'Rule-B clause (b): installs and optionally saves durable native theme state' }),
+  free({ surface: 'ctx_member', id: 'ctx.theme.catalog.listComponents', source: 'theme.catalog.components', ctxLeaf: 'ctx.theme.catalog.listComponents', freeBecause: 'shipped-twin: returns the sanitized component inventory already exposed by the native Theme Editor' }),
+  free({ surface: 'ctx_member', id: 'ctx.theme.catalog.listVariables', source: 'theme.catalog.variables', ctxLeaf: 'ctx.theme.catalog.listVariables', freeBecause: 'shipped-twin: returns the CSS variable reference already exposed by the native Theme Editor' }),
+  free({ surface: 'ctx_member', id: 'ctx.theme.openEditor', source: 'theme.editor.navigation', ctxLeaf: 'ctx.theme.openEditor', freeBecause: 'pure-host-action: opens and focuses an allowlisted native Theme Editor location' }),
+]
+
 export const FRONTEND_AUTHORITY_MAP: readonly AuthorityRow[] = createAuthorityMap([
   ...SELECTOR_ROWS,
   ...settingsAuthorityRows(),
@@ -195,6 +212,7 @@ export const FRONTEND_AUTHORITY_MAP: readonly AuthorityRow[] = createAuthorityMa
   ...GEOMETRY_ROWS,
   ...HOST_ACTION_ROWS,
   ...HOST_SURFACE_ROWS,
+  ...THEME_AUTHORING_ROWS,
   ...LEGACY_ROWS,
 ])
 

--- a/frontend/src/lib/spindle/loader.ts
+++ b/frontend/src/lib/spindle/loader.ts
@@ -118,6 +118,11 @@ import {
   type FrontendDockPanelOptions,
   type FrontendFloatWidgetOptions,
 } from './frontend-context'
+import {
+  THEME_AUTHORING_HOST_CAPABILITIES,
+  type SpindleThemeAuthoringAPI,
+} from './theme-authoring'
+import { createNativeThemeAuthoringAPI } from './theme-authoring-native'
 import { legacyCtxPermission } from './legacy-ctx-members'
 import type { SpindleSettingsTabHandle, SpindleSettingsTabOptions } from './settings-tab-bridge'
 
@@ -294,6 +299,7 @@ type FrontendExtensionHost = {
 
 type FrontendExtensionContextBase = Omit<SpindleFrontendContext, 'ui' | 'messages' | 'dom'> & {
   host: FrontendExtensionHost
+  theme: SpindleThemeAuthoringAPI
   dom: FrontendExtensionDOM
   ready(): void
   deferReady(): void
@@ -1306,7 +1312,7 @@ async function doLoadFrontendExtension(
     const host = Object.freeze({
       descriptorVersion: 1 as const,
       lumiverseVersion: LUMIVERSE_VERSION,
-      capabilities: SPINDLE_HOST_CAPABILITIES,
+      capabilities: Object.freeze({ ...SPINDLE_HOST_CAPABILITIES, ...THEME_AUTHORING_HOST_CAPABILITIES }),
       extensionInstallationId: extensionId,
       surfaces: createHostSurfaceAPI({
         extensionId,
@@ -1346,6 +1352,10 @@ async function doLoadFrontendExtension(
 
     const baseContext: FrontendExtensionContextBase = {
       host,
+      theme: createNativeThemeAuthoringAPI(
+        assertFrontendActive,
+        (member) => assertCanonicalPermission('app_manipulation', member),
+      ),
       locale,
       dom,
       ready() {

--- a/frontend/src/lib/spindle/theme-authoring-native.ts
+++ b/frontend/src/lib/spindle/theme-authoring-native.ts
@@ -1,0 +1,29 @@
+import { themeAssetsApi } from '@/api/theme-assets'
+import { useStore } from '@/store'
+import { CSS_MODULE_REGISTRY } from '@/lib/cssModuleRegistry'
+import GENERATED_VARS from '@/lib/generatedCssVariables'
+import { generateUUID } from '@/lib/uuid'
+import {
+  createThemeAuthoringAPI,
+  type SpindleThemeAuthoringAPI,
+} from './theme-authoring'
+
+/** Bind the public authoring façade to Lumiverse's existing native services. */
+export function createNativeThemeAuthoringAPI(
+  assertActive: () => void,
+  requireAppManipulation: (member: string) => void,
+): SpindleThemeAuthoringAPI {
+  return createThemeAuthoringAPI({
+    assertActive,
+    requireAppManipulation,
+    assetClient: themeAssetsApi,
+    getStore: () => useStore.getState(),
+    createBundleId: generateUUID,
+    componentCatalog: CSS_MODULE_REGISTRY,
+    variableCatalog: GENERATED_VARS,
+    computedValue: (name) => {
+      if (typeof document === 'undefined') return undefined
+      return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || undefined
+    },
+  })
+}

--- a/frontend/src/lib/spindle/theme-authoring.test.ts
+++ b/frontend/src/lib/spindle/theme-authoring.test.ts
@@ -1,0 +1,179 @@
+import { beforeAll, describe, expect, test } from 'bun:test'
+import type { ThemeAsset } from '@/types/api'
+import { createThemePack, decodeThemePackArchive, encodeThemePackArchive } from '@/lib/themePack'
+import {
+  createThemeAuthoringAPI,
+  THEME_AUTHORING_HOST_CAPABILITIES,
+  type ThemeAuthoringDependencies,
+} from './theme-authoring'
+
+beforeAll(() => {
+  if (typeof CSSStyleSheet === 'undefined') {
+    ;(globalThis as any).CSSStyleSheet = class { replaceSync(_css: string) {} }
+  }
+})
+
+function nativeAsset(id: string, bundleId: string, slug = 'portrait.png', sizeBytes = 3): ThemeAsset {
+  return {
+    id,
+    bundle_id: bundleId,
+    slug,
+    storage_type: 'file',
+    image_id: null,
+    file_name: slug,
+    original_filename: slug,
+    mime_type: 'image/png',
+    byte_size: sizeBytes,
+    tags: ['theme'],
+    metadata: { role: 'portrait' },
+    created_at: 1,
+    updated_at: 1,
+  }
+}
+
+function fixture() {
+  let nextId = 0
+  const assets = new Map<string, ThemeAsset>()
+  const blobs = new Map<string, Blob>()
+  const applied: any[] = []
+  const saved: any[] = []
+  const sessions: any[] = []
+  const modals: string[] = []
+  const permissionChecks: string[] = []
+  const initial = nativeAsset('asset-source', 'source-bundle')
+  assets.set(initial.id, initial)
+  blobs.set(initial.id, new Blob([Uint8Array.from([1, 2, 3])], { type: initial.mime_type }))
+
+  const assetClient = {
+    async list(bundleId: string) { return [...assets.values()].filter((asset) => asset.bundle_id === bundleId) },
+    async upload(file: File, input: { bundleId: string; slug?: string; tags?: string[]; metadata?: Record<string, unknown> }) {
+      const id = `uploaded-${++nextId}`
+      const asset = nativeAsset(id, input.bundleId, input.slug ?? file.name, file.size)
+      asset.original_filename = file.name
+      asset.mime_type = file.type
+      asset.tags = [...(input.tags ?? [])]
+      asset.metadata = { ...(input.metadata ?? {}) }
+      assets.set(id, asset)
+      blobs.set(id, file)
+      return asset
+    },
+    async update(id: string, patch: { slug?: string; tags?: string[]; metadata?: Record<string, unknown> }) {
+      const current = assets.get(id)!
+      const next = { ...current, slug: patch.slug ?? current.slug, tags: patch.tags ?? current.tags, metadata: patch.metadata ?? current.metadata }
+      assets.set(id, next)
+      return next
+    },
+    async optimizeWebp(id: string) { return assets.get(id)! },
+    async delete(id: string) { assets.delete(id); blobs.delete(id) },
+    async getBlob(id: string) { return blobs.get(id)! },
+    contentUrl(id: string) { return `/api/v1/theme-assets/${id}/content` },
+  }
+  const store = {
+    customCSS: { bundleId: 'active-bundle' as string | null },
+    applyThemePack(pack: any) { applied.push(pack) },
+    addSavedTheme(input: any) { saved.push(input); return { id: `saved-${saved.length}` } },
+    setCustomCSSEditorSession(patch: any) { sessions.push(patch) },
+    openModal(name: string) { modals.push(name) },
+  }
+  const dependencies: ThemeAuthoringDependencies = {
+    assertActive() {},
+    requireAppManipulation(member) { permissionChecks.push(member) },
+    assetClient,
+    getStore: () => store,
+    createBundleId: () => `bundle-${++nextId}`,
+    componentCatalog: [{ component: 'BubbleMessage', category: 'Chat', cssPath: '/private/BubbleMessage.module.css', tsxPath: '/private/BubbleMessage.tsx' }],
+    variableCatalog: { '--lumiverse-primary': '#9370db' },
+    computedValue: (name) => name === '--lumiverse-primary' ? 'rgb(147, 112, 219)' : undefined,
+  }
+  return { api: createThemeAuthoringAPI(dependencies), dependencies, assets, applied, saved, sessions, modals, permissionChecks }
+}
+
+describe('Spindle native theme authoring bridge', () => {
+  test('advertises each independently feature-detectable capability', () => {
+    expect(THEME_AUTHORING_HOST_CAPABILITIES).toEqual({
+      'theme-assets-v1': 1,
+      'theme-packs-v1': 1,
+      'theme-catalog-v1': 1,
+      'theme-editor-navigation-v1': 1,
+    })
+  })
+
+  test('returns both canonical CSS paths and authenticated preview URLs', async () => {
+    const { api } = fixture()
+    const [asset] = await api.assets.list('source-bundle')
+    expect(asset.cssPath).toBe('./assets/portrait.png')
+    expect(asset.contentUrl).toBe('/api/v1/theme-assets/asset-source/content')
+  })
+
+  test('uploads SpindleUploadFile bytes through the native File client', async () => {
+    const { api, permissionChecks } = fixture()
+    const uploaded = await api.assets.upload({ name: 'font.woff2', mimeType: 'font/woff2', sizeBytes: 4, bytes: Uint8Array.from([1, 2, 3, 4]) }, { bundleId: 'fonts', slug: 'font.woff2' })
+    expect(uploaded.sizeBytes).toBe(4)
+    expect(uploaded.cssPath).toBe('./assets/font.woff2')
+    expect(permissionChecks).toContain('ctx.theme.assets.upload')
+  })
+
+  test('exports drafts through the canonical archive codec', async () => {
+    const { api } = fixture()
+    const bytes = await api.packs.exportDraft({ name: 'Studio Theme', globalCSS: ':root { --demo: 1; }', assetBundleId: 'source-bundle' })
+    const decoded = decodeThemePackArchive(bytes)
+    expect(decoded.error).toBeUndefined()
+    if (decoded.error) return
+    expect(decoded.pack.name).toBe('Studio Theme')
+    expect(decoded.pack.theme).toBeNull()
+    expect(decoded.pack.assets).toHaveLength(1)
+  })
+
+  test('imports into a fresh bundle without applying or exposing executable TSX', async () => {
+    const { api, applied, permissionChecks } = fixture()
+    const pack = createThemePack(null, { css: '.global {}', enabled: true, revision: 1, bundleId: 'archive' }, {
+      BubbleMessage: { css: '.bubble {}', tsx: 'return <script />', enabled: true },
+    }, [], { name: 'Imported' })
+    const result = await api.packs.importArchive(encodeThemePackArchive(pack))
+    expect(result.draft.assetBundleId).toStartWith('bundle-')
+    expect(result.draft.components?.BubbleMessage).toEqual({ css: '.bubble {}', enabled: false })
+    expect(result.warnings.join(' ')).toContain('TSX')
+    expect(applied).toHaveLength(0)
+    expect(permissionChecks).toContain('ctx.theme.packs.importArchive')
+  })
+
+  test('installs a safe pack with a fresh bundle and optional library save', async () => {
+    const { api, applied, saved } = fixture()
+    const result = await api.packs.installDraft({
+      name: 'Installed',
+      globalCSS: '.global {}',
+      components: { BubbleMessage: { css: '.bubble {}' } },
+      assetBundleId: 'source-bundle',
+    }, { apply: true, saveToLibrary: true })
+    expect(result.bundleId).toStartWith('bundle-')
+    expect(result.bundleId).not.toBe('source-bundle')
+    expect(result).toMatchObject({ applied: true, savedToLibrary: true, assetCount: 1, componentCount: 1, savedThemeId: 'saved-1' })
+    expect(applied[0].components.BubbleMessage).toEqual({ css: '.bubble {}', tsx: '', enabled: true })
+    expect(saved).toHaveLength(1)
+  })
+
+  test('catalog projections contain selectors but never source paths', () => {
+    const { api } = fixture()
+    const [component] = api.catalog.listComponents()
+    expect(component).toEqual({ id: 'BubbleMessage', label: 'BubbleMessage', category: 'Chat', selector: '[data-component="BubbleMessage"]', hasCss: true, hasTsx: true })
+    expect(component).not.toHaveProperty('cssPath')
+    expect(component).not.toHaveProperty('tsxPath')
+    expect(api.catalog.listVariables()[0]).toMatchObject({ name: '--lumiverse-primary', defaultValue: '#9370db', value: 'rgb(147, 112, 219)' })
+  })
+
+  test('opens supported native editor locations and rejects unknown components', () => {
+    const { api, sessions, modals } = fixture()
+    expect(api.openEditor({ target: 'assets' })).toBeTrue()
+    expect(sessions[0]).toMatchObject({ selected: '__global__', activeTab: 'css', showAssets: true })
+    expect(modals).toEqual(['customCSS'])
+    expect(api.openEditor({ target: 'component', componentId: 'Missing' })).toBeFalse()
+  })
+
+  test('mutating methods fail cleanly when app manipulation is absent', async () => {
+    const setup = fixture()
+    setup.dependencies.requireAppManipulation = () => { throw new Error('PERMISSION_DENIED:app_manipulation') }
+    const api = createThemeAuthoringAPI(setup.dependencies)
+    await expect(api.assets.delete('asset-source')).rejects.toThrow('PERMISSION_DENIED:app_manipulation')
+    await expect(api.packs.installDraft({ name: 'Nope', globalCSS: '' })).rejects.toThrow('PERMISSION_DENIED:app_manipulation')
+  })
+})

--- a/frontend/src/lib/spindle/theme-authoring.test.ts
+++ b/frontend/src/lib/spindle/theme-authoring.test.ts
@@ -13,7 +13,7 @@ beforeAll(() => {
   }
 })
 
-function nativeAsset(id: string, bundleId: string, slug = 'portrait.png', sizeBytes = 3): ThemeAsset {
+function nativeAsset(id: string, bundleId: string, slug = 'assets/portrait.png', sizeBytes = 3): ThemeAsset {
   return {
     id,
     bundle_id: bundleId,
@@ -48,7 +48,8 @@ function fixture() {
     async list(bundleId: string) { return [...assets.values()].filter((asset) => asset.bundle_id === bundleId) },
     async upload(file: File, input: { bundleId: string; slug?: string; tags?: string[]; metadata?: Record<string, unknown> }) {
       const id = `uploaded-${++nextId}`
-      const asset = nativeAsset(id, input.bundleId, input.slug ?? file.name, file.size)
+      const requestedSlug = input.slug ?? file.name
+      const asset = nativeAsset(id, input.bundleId, requestedSlug.startsWith('assets/') ? requestedSlug : `assets/${requestedSlug}`, file.size)
       asset.original_filename = file.name
       asset.mime_type = file.type
       asset.tags = [...(input.tags ?? [])]

--- a/frontend/src/lib/spindle/theme-authoring.ts
+++ b/frontend/src/lib/spindle/theme-authoring.ts
@@ -3,6 +3,7 @@ import type { ThemeAsset } from '@/types/api'
 import { sanitizeCSS, validateCSS } from '@/lib/cssValidator'
 import { disableImportedThemePackTsx } from '@/lib/componentOverrideSecurity'
 import { componentSelector } from '@/lib/componentRegistryJoin'
+import { toThemeAssetRelativePath } from '@/lib/themeAssetCss'
 import {
   createThemePack,
   decodeThemePackArchive,
@@ -167,7 +168,7 @@ function toPublicAsset(asset: ThemeAsset, client: ThemeAssetClient): SpindleThem
     sizeBytes: asset.byte_size,
     tags: [...(asset.tags ?? [])],
     metadata: { ...(asset.metadata ?? {}) },
-    cssPath: `./assets/${asset.slug}`,
+    cssPath: toThemeAssetRelativePath(asset.slug),
     contentUrl: client.contentUrl(asset.id),
   }
 }

--- a/frontend/src/lib/spindle/theme-authoring.ts
+++ b/frontend/src/lib/spindle/theme-authoring.ts
@@ -1,0 +1,371 @@
+import type { SpindleUploadFile } from 'lumiverse-spindle-types'
+import type { ThemeAsset } from '@/types/api'
+import { sanitizeCSS, validateCSS } from '@/lib/cssValidator'
+import { disableImportedThemePackTsx } from '@/lib/componentOverrideSecurity'
+import { componentSelector } from '@/lib/componentRegistryJoin'
+import {
+  createThemePack,
+  decodeThemePackArchive,
+  encodeThemePackArchive,
+  type ThemePack,
+  type ThemePackAsset,
+} from '@/lib/themePack'
+
+export const THEME_AUTHORING_HOST_CAPABILITIES = Object.freeze({
+  'theme-assets-v1': 1,
+  'theme-packs-v1': 1,
+  'theme-catalog-v1': 1,
+  'theme-editor-navigation-v1': 1,
+} as const)
+
+export interface SpindleThemeAsset {
+  id: string
+  bundleId: string
+  slug: string
+  originalFilename: string
+  mimeType: string
+  sizeBytes: number
+  tags?: string[]
+  metadata?: Record<string, unknown>
+  cssPath: string
+  contentUrl: string
+}
+
+export interface SpindleThemeAssetUploadOptions {
+  bundleId: string
+  slug?: string
+  tags?: string[]
+  metadata?: Record<string, unknown>
+}
+
+export interface SpindleThemeAssetUpdate {
+  slug?: string
+  tags?: string[]
+  metadata?: Record<string, unknown>
+}
+
+export interface SpindleThemePackComponentDraft { css: string; enabled?: boolean }
+export interface SpindleThemePackDraft {
+  name: string
+  author?: string
+  description?: string
+  globalCSS: string
+  components?: Record<string, SpindleThemePackComponentDraft>
+  assetBundleId?: string | null
+}
+export interface SpindleThemePackImportResult {
+  draft: SpindleThemePackDraft
+  assets: SpindleThemeAsset[]
+  warnings: string[]
+}
+export interface SpindleThemePackInstallOptions { apply?: boolean; saveToLibrary?: boolean }
+export interface SpindleThemePackInstallResult {
+  bundleId: string
+  applied: boolean
+  savedToLibrary: boolean
+  savedThemeId?: string
+  assetCount: number
+  componentCount: number
+}
+export interface SpindleThemeComponentCatalogEntry {
+  id: string
+  label: string
+  category: string
+  selector: string
+  hasCss: boolean
+  hasTsx: boolean
+}
+export interface SpindleThemeVariableCatalogEntry {
+  name: string
+  defaultValue?: string
+  value?: string
+  category?: string
+}
+export type SpindleThemeEditorTarget = 'global' | 'assets' | 'component'
+export interface SpindleThemeEditorOptions { target?: SpindleThemeEditorTarget; componentId?: string }
+
+export interface SpindleThemeAuthoringAPI {
+  readonly assets: {
+    getActiveBundleId(): string | null
+    createBundle(): string
+    list(bundleId: string): Promise<SpindleThemeAsset[]>
+    upload(file: SpindleUploadFile, options: SpindleThemeAssetUploadOptions): Promise<SpindleThemeAsset>
+    update(assetId: string, patch: SpindleThemeAssetUpdate): Promise<SpindleThemeAsset>
+    delete(assetId: string): Promise<void>
+    optimizeWebp(assetId: string): Promise<SpindleThemeAsset>
+    getBytes(assetId: string): Promise<Uint8Array>
+  }
+  readonly packs: {
+    exportDraft(draft: SpindleThemePackDraft): Promise<Uint8Array>
+    importArchive(bytes: Uint8Array): Promise<SpindleThemePackImportResult>
+    installDraft(draft: SpindleThemePackDraft, options?: SpindleThemePackInstallOptions): Promise<SpindleThemePackInstallResult>
+  }
+  readonly catalog: {
+    listComponents(): readonly SpindleThemeComponentCatalogEntry[]
+    listVariables(): readonly SpindleThemeVariableCatalogEntry[]
+  }
+  openEditor(options?: SpindleThemeEditorOptions): boolean
+}
+
+interface ThemeAssetClient {
+  list(bundleId: string): Promise<ThemeAsset[]>
+  upload(file: File, input: SpindleThemeAssetUploadOptions): Promise<ThemeAsset>
+  update(id: string, input: SpindleThemeAssetUpdate): Promise<ThemeAsset>
+  optimizeWebp(id: string): Promise<ThemeAsset>
+  delete(id: string): Promise<void>
+  getBlob(id: string): Promise<Blob>
+  contentUrl(id: string): string
+}
+
+interface ThemeAuthoringStore {
+  customCSS: { bundleId: string | null }
+  applyThemePack(pack: ThemePack): void
+  addSavedTheme(input: { kind: 'pack'; name: string; pack: ThemePack }): { id: string }
+  setCustomCSSEditorSession(patch: {
+    selected?: string
+    activeTab?: 'css' | 'tsx'
+    showAssets?: boolean
+    showReference?: boolean
+  }): void
+  openModal(name: string): void
+}
+
+export interface ThemeComponentRegistryEntry {
+  component: string
+  category: string
+  cssPath: string | null
+  tsxPath: string | null
+}
+
+export interface ThemeAuthoringDependencies {
+  assertActive(): void
+  requireAppManipulation(member: string): void
+  assetClient: ThemeAssetClient
+  getStore(): ThemeAuthoringStore
+  createBundleId(): string
+  componentCatalog: readonly ThemeComponentRegistryEntry[]
+  variableCatalog: Readonly<Record<string, string>>
+  computedValue(name: string): string | undefined
+}
+
+const MUTATING_MEMBERS = {
+  upload: 'ctx.theme.assets.upload',
+  update: 'ctx.theme.assets.update',
+  delete: 'ctx.theme.assets.delete',
+  optimizeWebp: 'ctx.theme.assets.optimizeWebp',
+  importArchive: 'ctx.theme.packs.importArchive',
+  installDraft: 'ctx.theme.packs.installDraft',
+} as const
+
+function toPublicAsset(asset: ThemeAsset, client: ThemeAssetClient): SpindleThemeAsset {
+  return {
+    id: asset.id,
+    bundleId: asset.bundle_id,
+    slug: asset.slug,
+    originalFilename: asset.original_filename,
+    mimeType: asset.mime_type,
+    sizeBytes: asset.byte_size,
+    tags: [...(asset.tags ?? [])],
+    metadata: { ...(asset.metadata ?? {}) },
+    cssPath: `./assets/${asset.slug}`,
+    contentUrl: client.contentUrl(asset.id),
+  }
+}
+
+async function blobToBase64(blob: Blob): Promise<string> {
+  const bytes = new Uint8Array(await blob.arrayBuffer())
+  let binary = ''
+  for (let index = 0; index < bytes.length; index += 1) binary += String.fromCharCode(bytes[index])
+  return btoa(binary)
+}
+
+function base64ToFile(asset: ThemePackAsset): File {
+  const binary = atob(asset.dataBase64)
+  const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0))
+  return new File([bytes], asset.originalFilename, { type: asset.mimeType })
+}
+
+function prepareStylesheet(label: string, css: string, warnings?: string[]): string {
+  const sanitized = sanitizeCSS(css)
+  if (sanitized !== css) warnings?.push(`${label} contained unsafe external CSS constructs that were removed.`)
+  const result = validateCSS(sanitized)
+  if (!result.valid) throw new Error(`INVALID_THEME_CSS:${label}: ${result.error ?? 'CSS could not be parsed'}`)
+  return sanitized
+}
+
+function prepareDraft(draft: SpindleThemePackDraft, warnings?: string[]): SpindleThemePackDraft {
+  const components = Object.fromEntries(Object.entries(draft.components ?? {}).map(([id, component]) => [id, {
+    css: prepareStylesheet(`component ${id}`, component.css, warnings),
+    enabled: component.enabled ?? true,
+  }]))
+  return {
+    name: draft.name.trim().slice(0, 200) || 'Untitled Theme',
+    author: draft.author?.slice(0, 200),
+    description: draft.description?.slice(0, 5000),
+    globalCSS: prepareStylesheet('global CSS', draft.globalCSS, warnings),
+    components,
+    assetBundleId: draft.assetBundleId ?? null,
+  }
+}
+
+async function readPackAssets(bundleId: string | null | undefined, client: ThemeAssetClient): Promise<ThemePackAsset[]> {
+  if (!bundleId) return []
+  const assets = await client.list(bundleId)
+  return Promise.all(assets.map(async (asset) => ({
+    slug: asset.slug,
+    originalFilename: asset.original_filename,
+    mimeType: asset.mime_type,
+    tags: [...(asset.tags ?? [])],
+    metadata: { ...(asset.metadata ?? {}) },
+    dataBase64: await blobToBase64(await client.getBlob(asset.id)),
+  })))
+}
+
+function draftToPack(draft: SpindleThemePackDraft, bundleId: string, assets: ThemePackAsset[]): ThemePack {
+  return createThemePack(
+    null,
+    { css: draft.globalCSS, enabled: !!draft.globalCSS.trim(), revision: Date.now(), bundleId },
+    Object.fromEntries(Object.entries(draft.components ?? {}).map(([id, component]) => [id, {
+      css: component.css,
+      tsx: '',
+      enabled: component.enabled ?? true,
+    }])),
+    assets,
+    { name: draft.name, author: draft.author, description: draft.description },
+  )
+}
+
+async function uploadPackAssets(
+  packAssets: readonly ThemePackAsset[],
+  bundleId: string,
+  client: ThemeAssetClient,
+): Promise<SpindleThemeAsset[]> {
+  const uploaded: ThemeAsset[] = []
+  try {
+    for (const asset of packAssets) {
+      uploaded.push(await client.upload(base64ToFile(asset), {
+        bundleId,
+        slug: asset.slug,
+        tags: asset.tags,
+        metadata: asset.metadata,
+      }))
+    }
+  } catch (error) {
+    await Promise.all(uploaded.map((asset) => client.delete(asset.id).catch(() => {})))
+    throw error
+  }
+  return uploaded.map((asset) => toPublicAsset(asset, client))
+}
+
+function variableCategory(name: string): string | undefined {
+  const match = name.match(/^--(?:lumiverse|lcs)-([a-z]+)/i)
+  return match?.[1]
+}
+
+export function createThemeAuthoringAPI(dependencies: ThemeAuthoringDependencies): SpindleThemeAuthoringAPI {
+  const { assetClient } = dependencies
+  const active = () => dependencies.assertActive()
+  const mutate = (member: string) => { active(); dependencies.requireAppManipulation(member) }
+
+  return Object.freeze({
+    assets: Object.freeze({
+      getActiveBundleId() { active(); return dependencies.getStore().customCSS.bundleId },
+      createBundle() { active(); return dependencies.createBundleId() },
+      async list(bundleId) { active(); return (await assetClient.list(bundleId)).map((asset) => toPublicAsset(asset, assetClient)) },
+      async upload(file, options) {
+        mutate(MUTATING_MEMBERS.upload)
+        if (file.bytes.byteLength !== file.sizeBytes) throw new Error('INVALID_UPLOAD_FILE:sizeBytes does not match bytes')
+        const browserFile = new File([Uint8Array.from(file.bytes)], file.name, { type: file.mimeType })
+        return toPublicAsset(await assetClient.upload(browserFile, options), assetClient)
+      },
+      async update(assetId, patch) { mutate(MUTATING_MEMBERS.update); return toPublicAsset(await assetClient.update(assetId, patch), assetClient) },
+      async delete(assetId) { mutate(MUTATING_MEMBERS.delete); await assetClient.delete(assetId) },
+      async optimizeWebp(assetId) { mutate(MUTATING_MEMBERS.optimizeWebp); return toPublicAsset(await assetClient.optimizeWebp(assetId), assetClient) },
+      async getBytes(assetId) { active(); return new Uint8Array(await (await assetClient.getBlob(assetId)).arrayBuffer()) },
+    }),
+    packs: Object.freeze({
+      async exportDraft(input) {
+        active()
+        const draft = prepareDraft(input)
+        const assets = await readPackAssets(draft.assetBundleId, assetClient)
+        return encodeThemePackArchive(draftToPack(draft, draft.assetBundleId ?? dependencies.createBundleId(), assets))
+      },
+      async importArchive(bytes) {
+        mutate(MUTATING_MEMBERS.importArchive)
+        const decoded = decodeThemePackArchive(Uint8Array.from(bytes))
+        if (decoded.error) throw new Error(`INVALID_THEME_ARCHIVE:${decoded.error.code}: ${decoded.error.message}`)
+        const warnings: string[] = []
+        const unsafeTsxCount = Object.values(decoded.pack.components).filter((component) => component.tsx.trim()).length
+        const secured = disableImportedThemePackTsx(decoded.pack).pack
+        if (unsafeTsxCount) warnings.push(`${unsafeTsxCount} component TSX override${unsafeTsxCount === 1 ? ' was' : 's were'} omitted and left disabled.`)
+        const draft = prepareDraft({
+          name: secured.name,
+          author: secured.author,
+          description: secured.description,
+          globalCSS: secured.globalCSS,
+          components: Object.fromEntries(Object.entries(secured.components).map(([id, component]) => [id, {
+            css: component.css,
+            enabled: component.enabled,
+          }])),
+          assetBundleId: dependencies.createBundleId(),
+        }, warnings)
+        const assets = await uploadPackAssets(secured.assets, draft.assetBundleId!, assetClient)
+        return { draft, assets, warnings }
+      },
+      async installDraft(input, options: SpindleThemePackInstallOptions = {}) {
+        mutate(MUTATING_MEMBERS.installDraft)
+        const draft = prepareDraft(input)
+        const bundleId = dependencies.createBundleId()
+        const sourceAssets = await readPackAssets(draft.assetBundleId, assetClient)
+        const installedAssets = await uploadPackAssets(sourceAssets, bundleId, assetClient)
+        const pack = draftToPack(draft, bundleId, sourceAssets)
+        const store = dependencies.getStore()
+        const applied = options.apply ?? true
+        if (applied) store.applyThemePack(pack)
+        let savedThemeId: string | undefined
+        if (options.saveToLibrary) savedThemeId = store.addSavedTheme({ kind: 'pack', name: pack.name, pack }).id
+        return {
+          bundleId,
+          applied,
+          savedToLibrary: !!options.saveToLibrary,
+          savedThemeId,
+          assetCount: installedAssets.length,
+          componentCount: Object.keys(pack.components).length,
+        }
+      },
+    }),
+    catalog: Object.freeze({
+      listComponents() {
+        active()
+        return Object.freeze(dependencies.componentCatalog.map((entry) => Object.freeze({
+          id: entry.component,
+          label: entry.component,
+          category: entry.category,
+          selector: componentSelector(entry.component),
+          hasCss: !!entry.cssPath,
+          hasTsx: !!entry.tsxPath,
+        })))
+      },
+      listVariables() {
+        active()
+        return Object.freeze(Object.entries(dependencies.variableCatalog).map(([name, defaultValue]) => Object.freeze({
+          name,
+          defaultValue,
+          value: dependencies.computedValue(name),
+          category: variableCategory(name),
+        })))
+      },
+    }),
+    openEditor(options: SpindleThemeEditorOptions = {}) {
+      active()
+      const target = options.target ?? 'global'
+      if (target === 'component' && !dependencies.componentCatalog.some((entry) => entry.component === options.componentId)) return false
+      const store = dependencies.getStore()
+      store.setCustomCSSEditorSession(target === 'component'
+        ? { selected: options.componentId!, activeTab: 'css', showAssets: false }
+        : { selected: '__global__', activeTab: 'css', showAssets: target === 'assets' })
+      store.openModal('customCSS')
+      return true
+    },
+  })
+}

--- a/frontend/src/lib/themePack.ts
+++ b/frontend/src/lib/themePack.ts
@@ -388,12 +388,23 @@ export function validateThemePack(data: any): data is ThemePack {
   return normalizeThemePack(data) !== null
 }
 
+/** Encode a theme pack with Lumiverse's canonical .lumitheme archive codec. */
+export function encodeThemePackArchive(pack: ThemePack): Uint8Array {
+  const { files } = toArchiveManifest(pack)
+  return Uint8Array.from(zipSync(files, { level: 6 }))
+}
+
+/** Decode .lumitheme bytes (or the supported legacy JSON form) without UI. */
+export function decodeThemePackArchive(bytes: Uint8Array): ThemePackImportResult {
+  return isZipBytes(bytes) ? fromArchiveBytes(bytes) : importLegacyThemePack(bytes)
+}
+
 /** Download a theme pack as a .lumitheme zip bundle. */
 export function exportThemePack(pack: ThemePack): void {
-  const { files } = toArchiveManifest(pack)
-  const archive = zipSync(files, { level: 6 })
-  const archiveCopy = Uint8Array.from(archive)
-  const blob = new Blob([archiveCopy], { type: MIME })
+  const archiveCopy = encodeThemePackArchive(pack)
+  const blobBytes = new Uint8Array(archiveCopy.byteLength)
+  blobBytes.set(archiveCopy)
+  const blob = new Blob([blobBytes.buffer], { type: MIME })
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = url
@@ -426,11 +437,7 @@ export function importThemePack(): Promise<ThemePackImportResult | null> {
       if (!file) return resolve(null)
       try {
         const bytes = new Uint8Array(await file.arrayBuffer())
-        if (isZipBytes(bytes) || file.name.toLowerCase().endsWith(EXTENSION) || file.type === 'application/zip') {
-          resolve(fromArchiveBytes(bytes))
-          return
-        }
-        resolve(importLegacyThemePack(bytes))
+        resolve(decodeThemePackArchive(bytes))
       } catch {
         resolve(importError('unsupported-legacy-file', 'Selected file is not a supported Lumiverse theme bundle.'))
       }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "hono": "^4.7.0",
     "js-tiktoken": "^1.0.16",
     "jsdom": "^29.0.1",
-    "lumiverse-spindle-types": "0.6.18",
+    "lumiverse-spindle-types": "0.6.19",
     "mute-stream": "^3.0.0",
     "sharp": "^0.34.5",
     "ssh2-sftp-client": "^12.1.1"


### PR DESCRIPTION
## Summary
Adds a supported native theme-authoring facade to frontend extensions at `ctx.theme`, while leaving worker-side `spindle.theme` unchanged as the extension-scoped live presentation API.

### Assets and packs
- exposes native asset CRUD with distinct `contentUrl` (live browser retrieval) and `cssPath` (pack-safe CSS reference)
- accepts the existing `SpindleUploadFile` byte model and gates mutating leaves with canonical `app_manipulation` authority
- exports/imports canonical `.lumitheme` bytes through Lumiverse's own pack codec
- accepts a CSS-only draft rather than exposing archive internals or component TSX
- installs through the native store and asset bundle lifecycle; imported executable TSX is disabled and omitted

### Catalog and navigation
- projects a sanitized read-only native component/variable catalog with no source paths
- opens the native Theme Editor at Global CSS, Assets, or a validated component
- advertises four independently feature-detectable frontend host capabilities

This deliberately does not expose settings mutation, Zustand, arbitrary TSX replacement, or stylesheet injection.

## Public contract dependency
Depends on prolix-oc/lumiverse-spindle-types#43. The implementation currently carries a narrow local compatibility declaration so it can build against the presently published package; after the types release, that can be replaced by the published exports in the normal dependency bump.

## Verification
After rebasing onto current `staging`:
- focused bridge/loader/authority tests: 26 pass, 0 fail
- frontend typecheck: pass
- frontend lint: pass
- clean worktree

Before the final rebase (the intervening staging commit is unrelated lorebook navigation):
- full isolated frontend suite: 942 pass, 0 fail
- backend/root TypeScript: pass
- frontend production build: pass