### PR TITLE
fix(spindle): retry one-shot extension list fetch at boot hydration

### DIFF
--- a/frontend/src/store/slices/spindle-list-retry.test.ts
+++ b/frontend/src/store/slices/spindle-list-retry.test.ts
@@ -1,0 +1,161 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test, beforeEach, mock } from 'bun:test'
+import type { SpindleSlice } from '@/types/store'
+
+/**
+ * Regression coverage for the one-shot boot hydration bug:
+ * "Canvas does not load until the Extensions tab is clicked".
+ *
+ * `loadExtensions` is triggered once by the WS CONNECTED event. A transient
+ * failure of `GET /api/v1/spindle` (`spindleApi.list()`) leaves the store
+ * empty, so the Canvas frontend never hydrates. The transient list fetch is
+ * now retried with a bounded backoff; these tests drive the real slice with
+ * mocked spindleApi/loader surfaces and assert the retry semantics.
+ */
+
+const canvasManifest = {
+  version: '1.0.0',
+  name: 'Canvas',
+  identifier: 'canvas',
+  author: 'test',
+  github: 'https://example.test/canvas',
+  homepage: 'https://example.test/canvas',
+}
+
+const canvasExt: import('lumiverse-spindle-types').ExtensionInfo = {
+  id: 'canvas',
+  identifier: 'canvas',
+  name: 'Canvas',
+  version: '1.0.0',
+  enabled: true,
+  has_frontend: true,
+  has_backend: false,
+  status: 'running',
+  author: 'test',
+  description: '',
+  github: 'https://example.test/canvas',
+  homepage: 'https://example.test/canvas',
+  permissions: [],
+  granted_permissions: [],
+  installed_at: 0,
+  updated_at: 0,
+  metadata: {},
+}
+
+let listCalls = 0
+let loadCalls = 0
+let listBehavior: 'succeed' | 'throw-once' | 'always-throw' = 'succeed'
+
+mock.module('@/api/spindle', () => ({
+  spindleApi: {
+    list: async () => {
+      listCalls += 1
+      if (listBehavior === 'always-throw' || (listBehavior === 'throw-once' && listCalls === 1)) {
+        throw new Error('transient cold-start list failure')
+      }
+      return { extensions: [canvasExt], isPrivileged: true }
+    },
+    getManifest: async () => canvasManifest,
+    install: async () => canvasExt,
+    update: async () => canvasExt,
+    switchBranch: async () => canvasExt,
+    remove: async () => {},
+    enable: async () => {},
+    disable: async () => {},
+    restart: async () => {},
+    setPermissions: async () => ({ granted: [] }),
+    clearManifestCache: () => {},
+    updateAll: async () => ({ total: 0, completed: 0, failed: 0 }),
+  },
+}))
+
+mock.module('@/lib/spindle/loader', () => ({
+  loadFrontendExtension: async () => {
+    loadCalls += 1
+  },
+  unloadFrontendExtension: async () => {},
+  getLoadedExtensions: () => new Set<string>(),
+}))
+
+mock.module('@/ws/client', () => ({
+  wsClient: { send: () => {} },
+}))
+
+mock.module('@/lib/spindle/browser-scheduler', () => ({
+  yieldToBrowser: async () => {},
+}))
+
+const { createSpindleSlice } = await import('./spindle')
+
+function makeSlice(): {
+  state: SpindleSlice
+  set: (partial: Partial<SpindleSlice> | ((s: SpindleSlice) => Partial<SpindleSlice>)) => void
+  get: () => SpindleSlice
+} {
+  let state = {} as SpindleSlice
+  const set = (partial: any) => {
+    const next = typeof partial === 'function' ? partial(state) : partial
+    state = { ...state, ...next }
+  }
+  const get = () => state
+  Object.assign(state, createSpindleSlice(set as any, get as any, {} as any))
+  return {
+    get state() {
+      return state
+    },
+    set,
+    get,
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+describe('spindle list retry', () => {
+  beforeEach(() => {
+    listCalls = 0
+    loadCalls = 0
+    listBehavior = 'succeed'
+  })
+
+  test('transient list failure is retried and extensions populate', async () => {
+    listBehavior = 'throw-once'
+    const slice = makeSlice()
+
+    await slice.state.loadExtensions()
+
+    // The second attempt (after ~1s backoff) should have succeeded
+    expect(listCalls).toBe(2)
+    expect(slice.get().extensions).toHaveLength(1)
+    expect(slice.get().extensions[0]?.id).toBe('canvas')
+    expect(slice.get().spindlePrivileged).toBe(true)
+    // Hydration should have proceeded after the recovered list
+    expect(loadCalls).toBe(1)
+  })
+
+  test('persisted list failure exhausts retries and leaves store empty', async () => {
+    listBehavior = 'always-throw'
+    const slice = makeSlice()
+
+    await slice.state.loadExtensions()
+
+    expect(listCalls).toBe(5)
+    expect(slice.get().extensions).toHaveLength(0)
+    expect(loadCalls).toBe(0)
+  }, 15000)
+
+  test('retry stops once list succeeds — no extra calls', async () => {
+    listBehavior = 'throw-once'
+    const slice = makeSlice()
+
+    await slice.state.loadExtensions()
+    expect(listCalls).toBe(2)
+
+    await sleep(1500)
+    // No further retries should fire after success
+    expect(listCalls).toBe(2)
+    expect(loadCalls).toBe(1)
+  }, 10000)
+})

--- a/frontend/src/store/slices/spindle.ts
+++ b/frontend/src/store/slices/spindle.ts
@@ -1,5 +1,6 @@
 import type { StateCreator } from 'zustand'
 import type { SpindleSlice, PendingPermissionRequest, PendingTextEditorRequest, PendingContextMenuRequest, ExtensionThemeOverride, BulkUpdateStatus } from '@/types/store'
+import type { ExtensionInfo } from 'lumiverse-spindle-types'
 import { wsClient } from '@/ws/client'
 import { spindleApi } from '@/api/spindle'
 import { loadFrontendExtension, unloadFrontendExtension } from '@/lib/spindle/loader'
@@ -10,6 +11,38 @@ import { shareExtensionLoad } from '@/lib/spindle/extension-load-flight'
 
 const MUTED_THEMES_KEY = 'lumiverse:mutedExtensionThemes'
 const FRONTEND_HYDRATION_CONCURRENCY = 4
+const SPINDLE_LIST_RETRY_ATTEMPTS = 5
+const SPINDLE_LIST_RETRY_BASE_DELAY_MS = 1_000
+const SPINDLE_LIST_RETRY_BACKOFF = 1.7
+const SPINDLE_LIST_RETRY_MAX_DELAY_MS = 8_000
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Boot hydration is one-shot (WS CONNECTED -> loadExtensions). A transient
+ * failure of the single `GET /api/v1/spindle` request at cold start left the
+ * store empty so Canvas never loaded until the user happened to open the
+ * Extensions panel (which only re-runs when empty). Retry the list fetch with
+ * a bounded backoff so a cold-start hiccup self-heals.
+ */
+async function retrySpindleList(): Promise<{ extensions: ExtensionInfo[]; isPrivileged: boolean }> {
+  let delay = SPINDLE_LIST_RETRY_BASE_DELAY_MS
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await spindleApi.list()
+    } catch (err) {
+      if (attempt >= SPINDLE_LIST_RETRY_ATTEMPTS) throw err
+      console.warn(
+        `[Spindle] Extension list fetch failed (attempt ${attempt}/${SPINDLE_LIST_RETRY_ATTEMPTS}), retrying:`,
+        err,
+      )
+      await sleep(delay)
+      delay = Math.min(delay * SPINDLE_LIST_RETRY_BACKOFF, SPINDLE_LIST_RETRY_MAX_DELAY_MS)
+    }
+  }
+}
 
 function loadMutedThemes(): Record<string, boolean> {
   try {
@@ -47,7 +80,10 @@ export const createSpindleSlice: StateCreator<SpindleSlice> = (set, get) => ({
 
   loadExtensions: () => shareExtensionLoad(async () => {
     try {
-      const { extensions, isPrivileged } = await spindleApi.list()
+      // Retry the one-shot list fetch so a transient cold-start failure does
+      // not leave the store empty (and the extension unloaded until the user
+      // happens to open the Extensions panel, which only re-runs when empty).
+      const { extensions, isPrivileged } = await retrySpindleList()
       set({ extensions, spindlePrivileged: isPrivileged })
 
       await new Promise<void>((resolveHydration) => {


### PR DESCRIPTION
### Summary

Boot hydration is one-shot (WS CONNECTED → loadExtensions()). A transient failure of the single GET /api/v1/spindle request at cold start left the store empty, so Canvas never loaded until the user opened the Extensions panel (which only re-runs when empty) or clicked the 'Restart' button. This is host-side.

### Changes
- `frontend/src/store/slices/spindle.ts`: retry `spindleApi.list()` with bounded backoff (5 attempts, 1s/1.7/2.9/4.9/8s, ~19.5s max) before giving up; success stays fast
- `frontend/src/store/slices/spindle-list-retry.test.ts`: 3 cases (transient recovery, bounded failure, no extra calls)

### Verification
- `bunx tsc -b --pretty false` — 0 errors
- `bun test src/store/slices/spindle-list-retry.test.ts` — 3 pass (bounded, with 15s timeout for exhaustive retry)
- `bun test src/lib/spindle/loader.test.ts loader.lifecycle.* connected-extension-sync extension-load-flight` — 11 pass

Fix is host-side; Canvas cannot self-heal the list class (host never calls Canvas setup() if list() fails).