### PR TITLE
fix(theme): preserve Vite component registry discovery

### DIFF
--- a/frontend/src/lib/cssModuleRegistry.ts
+++ b/frontend/src/lib/cssModuleRegistry.ts
@@ -13,14 +13,13 @@ import {
   type ComponentRegistryJoinEntry,
 } from './componentRegistryJoin'
 
-// Vite replaces these calls in production. The guard keeps non-Vite host
-// contract tests and SSR-like consumers from evaluating an unavailable API.
-const cssModulePaths = typeof import.meta.glob === 'function'
-  ? Object.keys(import.meta.glob('/src/**/*.module.css', { eager: false }))
-  : []
-const tsxPaths = typeof import.meta.glob === 'function'
-  ? Object.keys(import.meta.glob('/src/**/*.tsx', { eager: false }))
-  : []
+const cssModulePaths = Object.keys(
+  import.meta.glob('/src/**/*.module.css', { eager: false }),
+)
+
+const tsxPaths = Object.keys(
+  import.meta.glob('/src/**/*.tsx', { eager: false }),
+)
 
 export type CSSModuleEntry = Omit<ComponentRegistryJoinEntry, 'cssPath'> & { cssPath: string }
 

--- a/frontend/src/lib/cssModuleRegistry.vite-contract.test.ts
+++ b/frontend/src/lib/cssModuleRegistry.vite-contract.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test'
+
+const source = await Bun.file(new URL('./cssModuleRegistry.ts', import.meta.url)).text()
+
+describe('CSS module registry Vite contract', () => {
+  test('keeps component discovery as unconditional literal Vite macro calls', () => {
+    expect(source).toContain("import.meta.glob('/src/**/*.module.css', { eager: false })")
+    expect(source).toContain("import.meta.glob('/src/**/*.tsx', { eager: false })")
+    expect(source).not.toContain('typeof import.meta.glob')
+  })
+
+  test('Vite expands the globs into a populated native component registry', async () => {
+    const child = Bun.spawn([
+      process.execPath,
+      'test',
+      './src/lib/cssModuleRegistry.vite.isolated.ts',
+    ], {
+      cwd: `${import.meta.dir}/../..`,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const watchdog = setTimeout(() => child.kill(9), 14_000)
+    try {
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+        child.exited,
+      ])
+      const output = `${stdout}\n${stderr}`
+      try {
+        expect(exitCode).toBe(0)
+        expect(output).toMatch(/\b1 pass\b/)
+        expect(output).toMatch(/\b0 fail\b/)
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error)
+        throw new Error(`Isolated Vite registry test failed (${detail}):\n${output}`)
+      }
+    } finally {
+      clearTimeout(watchdog)
+    }
+  }, 15_000)
+})

--- a/frontend/src/lib/cssModuleRegistry.vite.isolated.ts
+++ b/frontend/src/lib/cssModuleRegistry.vite.isolated.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'bun:test'
+import { fileURLToPath } from 'node:url'
+import { createServer } from 'vite'
+
+test('Vite materializes the native component catalog', async () => {
+  const server = await createServer({
+    root: fileURLToPath(new URL('../..', import.meta.url)),
+    server: { middlewareMode: true },
+    appType: 'custom',
+    logLevel: 'silent',
+  })
+  try {
+    const registryModule = await server.ssrLoadModule('/src/lib/cssModuleRegistry.ts') as {
+      CSS_MODULE_REGISTRY: readonly unknown[]
+    }
+    expect(registryModule.CSS_MODULE_REGISTRY.length).toBeGreaterThan(100)
+  } finally {
+    await server.close()
+  }
+})

--- a/frontend/src/lib/spindle/loader.lifecycle.contract.isolated.ts
+++ b/frontend/src/lib/spindle/loader.lifecycle.contract.isolated.ts
@@ -269,6 +269,10 @@ mock.module('@/lib/drawer-tab-registry', () => ({
   sanitizeHiddenDrawerTabIds: (ids?: string[]) => ids ?? [],
 }))
 mock.module('./browser-scheduler', () => ({ yieldToBrowser: async () => {}, scheduleSpindleDomTask: () => () => {} }))
+// The native adapter intentionally imports the production Vite registry. This
+// lifecycle test exercises the loader boundary, so keep that compile-time-only
+// module graph behind its adapter rather than weakening the production macros.
+mock.module('./theme-authoring-native', () => ({ createNativeThemeAuthoringAPI: () => ({}) }))
 
 // These factories intentionally load after the narrow store and visual-component
 // mocks; the real production helpers retain the mocked boundary references.

--- a/frontend/src/lib/spindle/loader.lifecycle.isolated.ts
+++ b/frontend/src/lib/spindle/loader.lifecycle.isolated.ts
@@ -345,6 +345,10 @@ mock.module('./ui-events-helper', () => ({
   },
 }))
 mock.module('./browser-scheduler', () => ({ scheduleSpindleDomTask: () => () => {}, yieldToBrowser: async () => {} }))
+// The native adapter intentionally imports the production Vite registry. This
+// lifecycle test exercises the loader boundary, so keep that compile-time-only
+// module graph behind its adapter rather than weakening the production macros.
+mock.module('./theme-authoring-native', () => ({ createNativeThemeAuthoringAPI: () => ({}) }))
 
 const lifecycleModuleSource = `
   export function teardown() {


### PR DESCRIPTION
## Summary
Fixes the component/theme catalog regression introduced by #300.

`import.meta.glob` is a Vite compile-time macro, not a browser runtime API. Wrapping the literal calls in `typeof import.meta.glob === 'function'` left the transformed module behind a runtime-false condition, producing empty CSS and TSX path arrays in production.

- restores unconditional literal Vite glob calls in `cssModuleRegistry.ts`
- keeps Bun loader tests isolated from the Vite-only native theme adapter with narrow module mocks
- adds a source-level guard against reintroducing runtime feature detection
- adds an isolated Vite transform test that loads the real registry and verifies a populated native component catalog

## Impact
Restores the native Theme Editor component inventory and `ctx.theme.catalog.listComponents()` after #300. No catalog shape or authoring API changes.

## Verification
- Vite-transformed real registry: populated with more than 100 entries
- focused registry/loader/theme-authoring tests: 13 pass, 0 fail
- full isolated frontend suite: pass
- frontend typecheck: pass
- frontend lint: pass
- production Vite/PWA build: pass

## Regression source
Follow-up to #300. The test-only compatibility concern is now handled at the adapter boundary rather than by changing production macro semantics.