### PR TITLE
Preserve chat scroll anchors after settled row resizes

### DIFF
--- a/frontend/src/components/chat/MessageList.tsx
+++ b/frontend/src/components/chat/MessageList.tsx
@@ -943,6 +943,7 @@ export default function MessageList({ messages, chatId, isStreaming, findTarget 
         itemEnd: item.end,
         scrollOffset: instance.scrollOffset ?? lastScrollTopRef.current,
         scrollDirection: instance.scrollDirection,
+        isScrolling: instance.isScrolling,
         hasMeasuredSize: instance.itemSizeCache.has(item.key),
         isPinned: isPinnedRef.current,
         isStreamingTail,

--- a/frontend/src/components/chat/messageListScrollAdjust.test.ts
+++ b/frontend/src/components/chat/messageListScrollAdjust.test.ts
@@ -84,17 +84,34 @@ describe('shouldAdjustMessageListScrollOnResize', () => {
     })).toBe(true)
   })
 
-  test('skips remeasurement compensation while scrolling backward', () => {
+  test('skips remeasurement compensation during active backward scrolling', () => {
     expect(shouldAdjustMessageListScrollOnResize({
       delta: 48,
       itemStart: 1200,
       itemEnd: 1300,
       scrollOffset: 1350,
       scrollDirection: 'backward',
+      isScrolling: true,
       hasMeasuredSize: true,
       isPinned: false,
       isStreamingTail: false,
     })).toBe(false)
+  })
+
+  test('preserves a settled viewport when the last direction was backward', () => {
+    const input = {
+      itemStart: 900,
+      itemEnd: 1200,
+      scrollOffset: 1350,
+      scrollDirection: 'backward' as const,
+      isScrolling: false,
+      hasMeasuredSize: true,
+      isPinned: false,
+      isStreamingTail: false,
+    }
+
+    expect(shouldAdjustMessageListScrollOnResize({ ...input, delta: 240 })).toBe(true)
+    expect(shouldAdjustMessageListScrollOnResize({ ...input, delta: -180 })).toBe(true)
   })
 
   test('preserves the viewport for programmatic content reflow while scrolling backward', () => {

--- a/frontend/src/components/chat/messageListScrollAdjust.ts
+++ b/frontend/src/components/chat/messageListScrollAdjust.ts
@@ -4,6 +4,7 @@ export interface MessageListScrollAdjustmentInput {
   itemEnd: number
   scrollOffset: number
   scrollDirection: 'forward' | 'backward' | null
+  isScrolling?: boolean
   hasMeasuredSize: boolean
   isPinned: boolean
   isStreamingTail: boolean
@@ -18,6 +19,7 @@ export function shouldAdjustMessageListScrollOnResize({
   itemEnd,
   scrollOffset,
   scrollDirection,
+  isScrolling = false,
   hasMeasuredSize,
   isPinned,
   isStreamingTail,
@@ -72,5 +74,11 @@ export function shouldAdjustMessageListScrollOnResize({
     return true
   }
 
-  return itemStart < scrollOffset && (!hasMeasuredSize || scrollDirection !== 'backward')
+  // scrollDirection records the last direction and can remain "backward"
+  // after the gesture has settled. Suppress measured-row correction only while
+  // upward scrolling is active; a later resize above the viewport must preserve
+  // the visible anchor.
+  return itemStart < scrollOffset && (
+    !hasMeasuredSize || scrollDirection !== 'backward' || !isScrolling
+  )
 }


### PR DESCRIPTION
## Summary

Preserve the visible chat position when an already measured virtual row changes size after upward scrolling has stopped.

TanStack retains the last scroll direction after a gesture settles. Lumiverse previously treated a stale `backward` direction as active scrolling and skipped resize compensation, which could move the visible anchor when content changed later.

This change passes the virtualizer's live `isScrolling` state into the existing resize policy. It keeps suppression during active upward scrolling, while allowing normal anchor correction once scrolling has settled. The behavior is based only on virtual-row geometry and scroll state.

## Validation

```text
cd frontend
bun test src/components/chat/messageListScrollAdjust.test.ts src/components/chat/messageListPinning.test.ts  # 17 pass
bun test src/components/chat/  # 63 pass
bun run typecheck              # pass
bun x eslint src/components/chat/MessageList.tsx src/components/chat/messageListScrollAdjust.ts src/components/chat/messageListScrollAdjust.test.ts  # pass
bun run build                  # pass
```

The broad Windows frontend test invocation is not clean in this checkout (`653 pass`, `72 fail`) because numerous unrelated jsdom/isolation suites fail together. The focused chat suite and all changed-file checks pass.

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets `staging`.
- [x] Applicable chat and scroll-policy tests pass.
- [x] Frontend typecheck and lint pass.

## UI changes

- [ ] Validated in more than one browser.
- [ ] Verified on a mobile interface or mobile PWA.
- Browsers, devices, and PWA coverage: Pending live validation; PR remains draft.

## Performance changes

Not applicable. The change adds one boolean check to an existing virtualizer resize callback.

## Security-sensitive changes

None. This does not change Spindle permissions, extension APIs, content rendering, or backend behavior.

## LLM-assisted work

- [ ] A human orchestrator audited the submitted change in a live environment.

Automated review and validation are complete. Live browser/mobile validation is intentionally left open while this PR is a draft.
