### PR TITLE
Preserve Illarin delivery images and allow long polls to finish

### DIFF
--- a/src/illarin/api.test.ts
+++ b/src/illarin/api.test.ts
@@ -201,6 +201,15 @@ describe("illarin api client", () => {
     expect(JSON.parse(empty.requests[0].body!)).toEqual({ acknowledge: [] });
   });
 
+  test("allows Illarin's full delivery wait to finish", async () => {
+    const longPoll: IllarinFetch = async (_url, options) => {
+      expect(options?.timeoutMs).toBeGreaterThan(30_000);
+      return new Response(null, { status: 204 });
+    };
+
+    expect(await collectDeliveries("http://127.0.0.1", "ia1.live", [], { fetchImpl: longPoll })).toEqual([]);
+  });
+
   test("fetches signed delivery artifacts without forwarding a bearer token", async () => {
     const artifact = mock(() => new Response("card bytes", { status: 200 }));
     const response = await fetchDeliveryArtifact(`${artifact.baseUrl}/signed-card`, { fetchImpl: artifact.testFetch });

--- a/src/illarin/api.ts
+++ b/src/illarin/api.ts
@@ -31,6 +31,7 @@ import {
 } from "./types";
 
 export const DEFAULT_ILLARIN_BASE_URL = "https://illarin.xyz";
+const DELIVERY_COLLECT_TIMEOUT_MS = 40_000;
 
 export class IllarinApiError extends Error {
   readonly status: number;
@@ -75,6 +76,11 @@ export interface IllarinRequestOptions {
   fetchImpl?: IllarinFetch;
 }
 
+interface RequestJsonOptions extends IllarinRequestOptions {
+  accessToken?: string;
+  timeoutMs?: number;
+}
+
 function normalizeBaseUrl(url: string, allowTestHttp = false): string {
   const trimmed = url.trim().replace(/\/+$/, "");
   let parsed: URL;
@@ -101,7 +107,7 @@ async function requestJson<T>(
   method: "POST" | "PUT",
   path: string,
   body: unknown,
-  options?: IllarinRequestOptions & { accessToken?: string },
+  options?: RequestJsonOptions,
 ): Promise<JsonResponse<T>> {
   const doFetch = options?.fetchImpl ?? safeFetch;
   const headers: Record<string, string> = { "Content-Type": "application/json" };
@@ -116,6 +122,7 @@ async function requestJson<T>(
       method,
       headers,
       body: body === undefined ? undefined : JSON.stringify(body),
+      ...(options?.timeoutMs === undefined ? {} : { timeoutMs: options.timeoutMs }),
     });
   } catch {
     // Network failure. For state-changing calls the outcome is unknown;
@@ -320,7 +327,7 @@ export async function collectDeliveries(
     "POST",
     path,
     { acknowledge: [...acknowledge] },
-    { ...options, accessToken },
+    { ...options, accessToken, timeoutMs: DELIVERY_COLLECT_TIMEOUT_MS },
   );
   if (status === 204) return [];
   if (!data || !Array.isArray(data.deliveries) || !data.deliveries.every(isDelivery)) {

--- a/src/illarin/declaration.test.ts
+++ b/src/illarin/declaration.test.ts
@@ -31,8 +31,8 @@ describe("buildDeclaration", () => {
       "chat.lumiverse:theme-install",
     ]);
     expect(declaration.acceptedTargets).toEqual([
-      "chara_card_v3",
       "charx",
+      "chara_card_v3",
       "chara_card_v2",
       "lorebook",
       "lorebook_sillytavern",

--- a/src/illarin/declaration.ts
+++ b/src/illarin/declaration.ts
@@ -39,8 +39,8 @@ export const ILLARIN_CAPABILITIES = Object.freeze([
  * SillyTavern themes are deliberately absent — Lumiverse does not accept them.
  */
 export const ILLARIN_ACCEPTED_TARGETS = Object.freeze([
-  "chara_card_v3",
   "charx",
+  "chara_card_v3",
   "chara_card_v2",
   "lorebook",
   "lorebook_sillytavern",

--- a/src/illarin/delivery-installer.test.ts
+++ b/src/illarin/delivery-installer.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { persistIllarinPresetCover, type PresetCoverDependencies } from "./delivery-installer";
+import {
+  characterInstallPayload,
+  persistIllarinPresetCover,
+  type PresetCoverDependencies,
+} from "./delivery-installer";
 import type { IllarinDelivery } from "./types";
 
 function presetDelivery(artifacts: IllarinDelivery["artifacts"]): IllarinDelivery {
@@ -18,6 +22,27 @@ function presetDelivery(artifacts: IllarinDelivery["artifacts"]): IllarinDeliver
 }
 
 describe("Illarin delivery installer", () => {
+  test("does not import pictures twice when CharX already contains them", () => {
+    const delivery: IllarinDelivery = {
+      id: "delivery-1",
+      assetId: "asset-1",
+      contentGeneration: 2,
+      kind: "character",
+      name: "Aster",
+      format: "charx",
+      label: "Character Card Exchange",
+      queuedAt: "2026-08-24T20:00:00Z",
+      leaseExpiresAt: "2026-08-24T20:15:00Z",
+      artifacts: [
+        { kind: "export", url: "https://illarin.xyz/export" },
+        { kind: "picture", url: "https://illarin.xyz/avatar", role: "avatar", isCover: true },
+        { kind: "picture", url: "https://illarin.xyz/expression", role: "expression", isCover: false },
+      ],
+    };
+
+    expect(characterInstallPayload(delivery).galleryImageUrls).toBeUndefined();
+  });
+
   test("durably stores the designated preset cover and returns its local URL", async () => {
     const fetched: string[] = [];
     const uploaded: File[] = [];

--- a/src/illarin/delivery-installer.ts
+++ b/src/illarin/delivery-installer.ts
@@ -155,17 +155,23 @@ function requireSuccess(result: { success: boolean; error?: string }, delivery: 
   if (!result.success) throw new Error(result.error || `Illarin ${delivery.kind} installation failed`);
 }
 
+export function characterInstallPayload(delivery: IllarinDelivery) {
+  return {
+    source: "illarin" as const,
+    characterId: delivery.assetId,
+    characterName: delivery.name,
+    importUrl: exportUrl(delivery),
+    importEmbeddedWorldbook: true,
+    ...(delivery.format === "charx"
+      ? {}
+      : { galleryImageUrls: delivery.artifacts.filter((item) => item.kind === "picture").map((item) => item.url) }),
+  };
+}
+
 export async function installIllarinDelivery(userId: string, delivery: IllarinDelivery): Promise<void> {
   switch (delivery.kind) {
     case "character": {
-      const result = await installCharacter(delivery.id, userId, {
-        source: "illarin",
-        characterId: delivery.assetId,
-        characterName: delivery.name,
-        importUrl: exportUrl(delivery),
-        importEmbeddedWorldbook: true,
-        galleryImageUrls: delivery.artifacts.filter((item) => item.kind === "picture").map((item) => item.url),
-      });
+      const result = await installCharacter(delivery.id, userId, characterInstallPayload(delivery));
       requireSuccess(result, delivery);
       return;
     }


### PR DESCRIPTION
## Summary

- Prefer CharX for Illarin character deliveries so avatars, expressions, and gallery images are preserved.
- Avoid importing images twice when they are already contained in CharX.
- Give delivery collection 40 seconds to complete so Illarin's 30-second empty wait does not become a false network error.

## Validation

List the commands you ran and their results. Include any relevant test output.

```text
bunn test --isolate src/illarin 
72 pass, 0 fail

bun x tsc --noEmit
Completed with no errors or warnings.

git diff --check
Completed with no errors.
```

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass.
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [x] Backend: `bun x tsc --noEmit`
  - [ ] Frontend: `cd frontend && bun run typecheck`, `bun run lint`

## UI changes (if applicable)

N/A

## Performance changes (if applicable)

- [x] I added or updated tests.
- [x] I included reproducible benchmarks and comparison results below.
- Benchmark commands and results:

## Security-sensitive changes (if applicable)

N/A

## LLM-assisted work (if applicable)

N/A