### PR TITLE
Lift desktop startup shell on routes outside the app shell

### DIFF
--- a/desktop/src-tauri/src/frontend.rs
+++ b/desktop/src-tauri/src/frontend.rs
@@ -280,13 +280,28 @@ fn frontend_startup_shell_script(appearance: &FrontendStartupAppearance) -> Stri
     style.textContent = '#lumiverse-startup-shell{{position:fixed;inset:0;z-index:2147483647;pointer-events:none;background:var(--lumiverse-startup-background,#0a0812);color:var(--lumiverse-startup-text-muted,rgba(255,255,255,.64));font:600 12px -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;letter-spacing:.02em}}.lumiverse-startup-titlebar{{height:36px;box-sizing:border-box;display:flex;align-items:center;justify-content:center;gap:8px;border-bottom:1px solid var(--lumiverse-startup-border,rgba(255,255,255,.08));background:color-mix(in srgb,var(--lumiverse-startup-background,#0a0812) 86%,transparent)}}.lumiverse-startup-dot{{width:8px;height:8px;border-radius:999px;background:var(--lumiverse-startup-primary,#9370db);box-shadow:0 0 0 3px color-mix(in srgb,var(--lumiverse-startup-primary,#9370db) 12%,transparent)}}.lumiverse-startup-controls{{position:absolute;right:12px;display:flex;gap:7px}}.lumiverse-startup-controls i{{display:block;width:11px;height:11px;border-radius:999px;border:1px solid var(--lumiverse-startup-border,rgba(255,255,255,.12))}}.lumiverse-startup-pulse{{position:absolute;top:50%;left:50%;width:42px;height:42px;margin:-21px;border-radius:50%;border:2px solid var(--lumiverse-startup-primary,#9370db);border-left-color:transparent;opacity:.55;animation:lumiverse-startup-spin .9s linear infinite}}@keyframes lumiverse-startup-spin{{to{{transform:rotate(360deg)}}}}';
     document.head.appendChild(style);
     document.body.appendChild(shell);
+    // The shell must lift on every route the frontend can land on, not just
+    // the authenticated one. /login, /sso-complete and the Stream Deck
+    // handoff render as siblings of <App> in the router, so they never
+    // produce [data-app-root] — waiting on it alone leaves an opaque overlay
+    // over a working login form forever. Any mounted React root means the
+    // page is up: the app commits its first render in one pass, so this
+    // cannot uncover a half-drawn tree. Keep a wall-clock failsafe as well,
+    // so no future route can trap the window again.
+    const mounted = () =>
+      !!document.querySelector('[data-app-root]') ||
+      (document.getElementById('root')?.childElementCount ?? 0) > 0;
+    const dismiss = () => {{
+      shell.remove(); style.remove(); root.removeAttribute('data-lumiverse-startup-shell'); observer.disconnect();
+    }};
     const remove = () => {{
-      if (!document.querySelector('[data-app-root]')) return false;
-      shell.remove(); style.remove(); root.removeAttribute('data-lumiverse-startup-shell'); observer.disconnect(); return true;
+      if (!mounted()) return false;
+      dismiss(); return true;
     }};
     const observer = new MutationObserver(remove);
     observer.observe(document.documentElement, {{ childList: true, subtree: true }});
     requestAnimationFrame(remove);
+    setTimeout(dismiss, 15000);
   }};
   if (document.body) mount(); else document.addEventListener('DOMContentLoaded', mount, {{ once: true }});
 }})();"#


### PR DESCRIPTION
> *Description rewritten after merge to match `.github/PULL_REQUEST_TEMPLATE.md`. The code is unchanged.*

## Summary

**In plain terms:** if the Lumiverse Desktop window just spun forever, it wasn't hung — you were looking at the login page with an opaque loading overlay stuck on top of it. This makes the overlay go away as soon as the page has drawn anything, and adds a 15-second failsafe so it can never get stuck again.

The detail:

The desktop startup shell (`frontend_startup_shell_script` in `desktop/src-tauri/src/frontend.rs`) removed itself only when `[data-app-root]` appeared in the DOM. That attribute is rendered exclusively by the authenticated `<App>` shell (`frontend/src/App.tsx`).

In `frontend/src/router.tsx`, `/login`, `/sso-complete` and `/stream-deck/open/chat/:chatId` are siblings of `<App>` under `WindowShell`, not children of it. They never render `data-app-root`.

The overlay is opaque (`background: var(--lumiverse-startup-background)`, alpha 1) at `z-index: 2147483647`. So whenever the desktop window landed on any of those routes, the spinner never lifted. Because the overlay is `pointer-events: none`, the page underneath was still interactive — the login form could be filled in blind — which made the failure look like a hang rather than a paint bug.

This is easy to hit: first launch before signing in, after a session expires, and any time the window opens while the server is stopped (a registered service worker serves the cached shell, the auth check fails, and the app routes to `/login`).

This change:

- widens the dismissal predicate to "a React root is mounted" — `[data-app-root]` **or** `#root` having child elements. The frontend commits its first render in a single pass (`createRoot(...).render(...)` runs once, after `initI18n()` and `initializeSafeThemeMode()` resolve in `frontend/src/main.tsx`), so this cannot uncover a half-drawn tree. On the authenticated path both conditions become true in the same commit, so behaviour there is unchanged.
- adds a 15s wall-clock failsafe, so a future route added outside `<App>` cannot reintroduce an unrecoverable overlay.

Adding `data-app-root` to the auth routes instead would have worked, but it overloads an attribute that `useThemeApplicator.ts` and `SpindleAppMount.tsx` both query against, and would need re-adding for every future route outside `<App>`.

## Validation

```text
cargo check --release
# clean

cd desktop && bun run tauri build --bundles app
# builds and bundles clean; patched predicate confirmed present in the binary
```

Reproduced the original trap against a live server: on `/login`, `document.querySelector('[data-app-root]')` is null and stays null under a `MutationObserver` for 5s, while `input[type=password]` is present — a rendered login form under an overlay that will never lift. With the same page state `#root.childElementCount` is 2, so the new predicate dismisses the shell on the first `requestAnimationFrame` / mutation callback.

Audited live on macOS (Darwin 25.6.0) by the author: with the patched build installed, the desktop window renders the login page instead of the endless startup spinner.

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass. *(No TypeScript or test files are touched;
      the change is one Rust string. `cargo check` and a full `tauri build`
      are the applicable checks.)*
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [ ] Backend: `bun x tsc --noEmit` — *not applicable, no backend files touched*
  - [ ] Frontend: `cd frontend && bun run typecheck`, `bun run lint` — *not applicable, no frontend files touched*

## UI changes (if applicable)

- [ ] I validated this change in more than one browser.
- [ ] I verified the integrated experience on a mobile interface or through
      the mobile PWA.
- Browsers, devices, and PWA coverage: **not applicable.** The overlay is
  injected only into the Tauri desktop WebView by the native shell. Browser and
  PWA sessions never receive this script.

## Performance changes (if applicable)

Not applicable. One additional `childElementCount` read per mutation callback
during startup, plus a single 15s timer.

## Security-sensitive changes (if applicable)

No impact on Spindle or any other security system. The change alters only the
condition under which a purely cosmetic overlay removes itself.

## LLM-assisted work (if applicable)

- [x] I, as the human orchestrating this work, audited the submitted changes
      in a live environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
