### PR TITLE
Spindle/chromeless dock

### DIFF
--- a/developer-docs/docs/frontend-api/ui-placement.md
+++ b/developer-docs/docs/frontend-api/ui-placement.md
@@ -436,6 +436,8 @@ const panel = ctx.ui.requestDockPanel({
   maxSize: 600,
   resizable: true,
   startCollapsed: false,
+  chromeless: false,     // opt in when the extension renders its own chrome
+  centerContent: false,  // center the extension root in the dock surface
 })
 
 // Render into the panel
@@ -455,6 +457,8 @@ panel.destroy()
 ```
 
 On mobile, left/right dock panels become full-width bottom sheets.
+
+`chromeless` removes the host header, background, border, shadow, and resize chrome. Use it only when the extension supplies its own close/navigation affordances. `centerContent` centers the extension root within the remaining panel area. Both options default to `false`, so existing dock panels are unaffected.
 
 ## App Mounts (requires `app_manipulation`)
 

--- a/frontend/src/components/spindle/SpindleDockPanel.module.css
+++ b/frontend/src/components/spindle/SpindleDockPanel.module.css
@@ -144,6 +144,18 @@
   min-height: 0;
 }
 
+/* Opt-in extension-owned presentation. Existing dock panels retain host chrome. */
+.panel.chromeless {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+
+.panel.centerContent > .content {
+  display: grid;
+  place-items: center;
+}
+
 /* ── Resize handles ── */
 
 .resizeHandle {
@@ -260,5 +272,13 @@
   .right,
   .top {
     top: var(--app-interactive-safe-top, env(safe-area-inset-top, 0px)) !important;
+  }
+}
+
+@media (max-width: 600px) {
+  .panel.chromeless {
+    background: transparent;
+    border: none;
+    border-radius: 0;
   }
 }

--- a/frontend/src/components/spindle/SpindleDockPanel.tsx
+++ b/frontend/src/components/spindle/SpindleDockPanel.tsx
@@ -192,27 +192,31 @@ export default function SpindleDockPanel({ panel }: Props) {
         styles.panel,
         styles[effectiveEdge],
         panel.collapsed && styles.collapsed,
+        panel.chromeless && styles.chromeless,
+        panel.centerContent && styles.centerContent,
         isResizing && styles.resizing,
       )}
       style={sizeStyle}
     >
-      <div className={styles.header}>
-        <button
-          className={styles.headerBtn}
-          onClick={handleToggle}
-          title={panel.collapsed ? 'Expand' : 'Collapse'}
-        >
-          <CollapseIcon size={14} />
-        </button>
-        {(!panel.collapsed || panel.showCollapsedTitle) && (
-          <span className={styles.title}>{panel.title}</span>
-        )}
-        {!panel.collapsed && (
-          <button className={styles.headerBtn} onClick={handleClose} title={tc('actions.close')}>
-            <X size={14} />
+      {!panel.chromeless && (
+        <div className={styles.header}>
+          <button
+            className={styles.headerBtn}
+            onClick={handleToggle}
+            title={panel.collapsed ? 'Expand' : 'Collapse'}
+          >
+            <CollapseIcon size={14} />
           </button>
-        )}
-      </div>
+          {(!panel.collapsed || panel.showCollapsedTitle) && (
+            <span className={styles.title}>{panel.title}</span>
+          )}
+          {!panel.collapsed && (
+            <button className={styles.headerBtn} onClick={handleClose} title={tc('actions.close')}>
+              <X size={14} />
+            </button>
+          )}
+        </div>
+      )}
 
       {!panel.collapsed && (
         <>

--- a/frontend/src/lib/spindle/frontend-context.ts
+++ b/frontend/src/lib/spindle/frontend-context.ts
@@ -67,6 +67,10 @@ export type FrontendDockPanelOptions = PublishedSpindleDockPanelOptions & {
   respectRequestedEdge?: boolean
   /** Show the panel title while the dock is collapsed. Defaults to false. */
   showCollapsedTitle?: boolean
+  /** Remove the host panel chrome so an extension can render its own surface. */
+  chromeless?: boolean
+  /** Center the extension root within the dock's content area. */
+  centerContent?: boolean
   onGeometryCommit?(rect: SpindleGeometryRect): void
 }
 

--- a/frontend/src/lib/spindle/placement-helper.ts
+++ b/frontend/src/lib/spindle/placement-helper.ts
@@ -240,6 +240,10 @@ type H6DockPanelOptions = SpindleDockPanelOptions & {
   respectRequestedEdge?: boolean
   /** Show the panel title while the dock is collapsed. Defaults to false. */
   showCollapsedTitle?: boolean
+  /** Remove the host panel chrome so an extension can render its own surface. */
+  chromeless?: boolean
+  /** Center the extension root within the dock's content area. */
+  centerContent?: boolean
   onGeometryCommit?: (rect: GeometryRect) => void
 }
 
@@ -1241,6 +1245,8 @@ export function createDockPanelHandle(
       iconUrl: dockOptions.iconUrl,
       respectRequestedEdge: dockOptions.respectRequestedEdge === true,
       showCollapsedTitle: dockOptions.showCollapsedTitle === true,
+      chromeless: dockOptions.chromeless === true,
+      centerContent: dockOptions.centerContent === true,
       persistGeometry: dockOptions.persistGeometry,
     } satisfies DockPanelState)
     registered = true

--- a/frontend/src/store/slices/spindle-placement.ts
+++ b/frontend/src/store/slices/spindle-placement.ts
@@ -160,6 +160,10 @@ export interface DockPanelState {
   respectRequestedEdge: boolean
   /** Show the panel title while collapsed. */
   showCollapsedTitle: boolean
+  /** Remove the host-provided border, background, shadow, header, and resize chrome. */
+  chromeless: boolean
+  /** Center the extension root within the available content area. */
+  centerContent: boolean
   /** Extension-local persistence segment, or false to disable persistence. */
   persistGeometry?: string | false
 }


### PR DESCRIPTION
## Summary

Adds an opt-in chromeless presentation mode for Spindle dock panels.

Existing dock panels retain their current appearance and behavior by default. Extensions can explicitly request the chromeless mode for embedded surfaces that provide their own visual chrome.

This removes the dock background/header/border/shadow for opted-in panels and supports centered content without requiring extensions to target host-private CSS.

Tested with the default dock behavior unchanged and an opted-in Pocket handset surface.

## Validation

List the commands you ran and their results. Include any relevant test output.

```text
bun x tsc --noEmit
cd frontend && bun run typecheck
bun run lint
```

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass.
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [x] Backend: `bun x tsc --noEmit`
  - [x] Frontend: `cd frontend && bun run typecheck`, `bun run lint`

## UI changes (if applicable)

- [x] I validated this change in more than one browser.
- [x] I verified the integrated experience on a mobile interface or through
      the mobile PWA.
- Browsers, devices, and PWA coverage:
  - chromium desktop and mobile
  - ff desktop and mobile

## Performance changes (if applicable)

- [ ] I added or updated tests.
- [ ] I included reproducible benchmarks and comparison results below.
- Benchmark commands and results:
N/A

## Security-sensitive changes (if applicable)
N/A, purely aesthetic.

## LLM-assisted work (if applicable)

- [x] I, as the human orchestrating this work, audited the submitted changes
      in a live environment.