### PR TITLE
Opt-in CommonMark paragraph semantics for Islands

### DIFF
--- a/frontend/src/components/chat/MessageContent.tsx
+++ b/frontend/src/components/chat/MessageContent.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { ChevronDown } from 'lucide-react'
 import { marked } from 'marked'
 import { highlightCode } from '@/lib/codeHighlight'
-import { processMarkdownInHtmlIsland } from './htmlIslandMarkdown'
+import { ISLAND_BLANK_LINE_RE, processMarkdownInHtmlIsland } from './htmlIslandMarkdown'
 import { resolveGalleryImageId } from '@/lib/galleryImageReference'
 import { parseOOC } from '@/lib/oocParser'
 import { createEmphasisAwareRenderer } from '@/lib/markedEmphasisRenderer'
@@ -880,7 +880,7 @@ function getIslandEndAt(raw: string, start: number, isStreaming: boolean): numbe
   return null
 }
 
-function renderIslandMarkdownText(markdown: string): string {
+function renderIslandMarkdownText(markdown: string, messageProse = false): string {
   const leadingWhitespace = markdown.match(/^\s*/)?.[0] ?? ''
   const trailingWhitespace = markdown.match(/\s*$/)?.[0] ?? ''
   const core = markdown.trim()
@@ -890,8 +890,15 @@ function renderIslandMarkdownText(markdown: string): string {
   let html = marked.parse(core, { async: false }) as string
   html = normalizeQuotesInHTML(html)
 
+  // In message-prose islands, text set apart by a blank line is a paragraph:
+  // keep its <p> so it gets paragraph spacing next to images and panels.
+  // Otherwise a lone <p> is marked wrapping a piece of a tag-split sentence,
+  // so unwrap it to keep the sentence inline.
+  const blockSeparated =
+    messageProse
+    && (ISLAND_BLANK_LINE_RE.test(leadingWhitespace) || ISLAND_BLANK_LINE_RE.test(trailingWhitespace))
   const singleParagraphMatch = html.match(/^<p>([\s\S]*)<\/p>\s*$/)
-  if (singleParagraphMatch && !/<\/p>\s*<p\b/i.test(html)) {
+  if (!blockSeparated && singleParagraphMatch && !/<\/p>\s*<p\b/i.test(html)) {
     html = singleParagraphMatch[1]
   }
 
@@ -973,9 +980,12 @@ function extractHtmlIslands(
   return { content, islands }
 }
 
+const MESSAGE_PROSE_WRAP_RE = /^\s*<div[^>]*\bdata-message-prose\b/i
+
 function processMarkdownInIsland(html: string): string {
+  const messageProse = MESSAGE_PROSE_WRAP_RE.test(html)
   return processMarkdownInHtmlIsland(html, {
-    renderBlockText: renderIslandMarkdownText,
+    renderBlockText: (markdown) => renderIslandMarkdownText(markdown, messageProse),
     renderInlineText: renderIslandInlineMarkdownText,
     normalizeHtml: normalizeLegacyFontTags,
   })

--- a/frontend/src/components/chat/htmlIslandMarkdown.test.ts
+++ b/frontend/src/components/chat/htmlIslandMarkdown.test.ts
@@ -58,4 +58,57 @@ describe('processMarkdownInHtmlIsland', () => {
   test('form is sanitizer-forbidden and does not become markdown context', () => {
     expect(render('<div><form>## heading</div>')).toContain('<block>## heading</block>')
   })
+
+  const WRAP = '<div data-message-prose class="not-island-prose">'
+
+  test('inline-led paragraph after a block element wraps in <p>', () => {
+    const html = `${WRAP}<table><tbody><tr><td>x</td></tr></tbody></table>\n\n<span>"Oho!"</span> she boomed.\n\nNext.</div>`
+    const outHtml = render(html)
+    expect(outHtml).toContain('<p><span><inline>"Oho!"</inline></span><inline>she boomed.</inline></p>')
+    expect(outHtml).toContain('<block>Next.</block>')
+  })
+
+  test('text-led paragraph joins its trailing inline tags in one <p>', () => {
+    const outHtml = render(`${WRAP}\n\nHe said <span>"hi"</span> and left.\n\n</div>`)
+    expect(outHtml).toContain('<p><inline>He said</inline><span><inline>"hi"</inline></span><inline>and left.</inline></p>')
+  })
+
+  test('standalone inline-only dialogue line wraps in <p>', () => {
+    const outHtml = render(`${WRAP}intro\n\n<span>"Quote"</span>\n\noutro</div>`)
+    expect(outHtml).toContain('<p><span><inline>"Quote"</inline></span></p>')
+    expect(outHtml).toContain('<block>intro</block>')
+    expect(outHtml).toContain('<block>outro</block>')
+  })
+
+  test('tag-only groups such as a lone image stay unwrapped', () => {
+    const outHtml = render(`${WRAP}a\n\n<img src="x">\n\nb</div>`)
+    expect(outHtml).toContain('<img src="x">')
+    expect(outHtml).not.toContain('<p><img')
+  })
+
+  test('blank line inside trailing text closes the paragraph', () => {
+    const outHtml = render(`${WRAP}<span>q</span> tail\n\n# heading</div>`)
+    expect(outHtml).toContain('<p><span><inline>q</inline></span><inline>tail</inline></p>')
+    expect(outHtml).toContain('<block># heading</block>')
+  })
+
+  test('raw HTML runs to the first blank line, CommonMark-style', () => {
+    const tight = render(`${WRAP}<div class="row">Name:\n<span>Haru</span></div></div>`)
+    expect(tight).not.toContain('<p>')
+    expect(tight).toContain('Name:\n<span>Haru</span>')
+    const blanked = render(`${WRAP}<div class="row">Name:\n\n<span>Haru</span></div></div>`)
+    expect(blanked).toContain('<p><span><inline>Haru</inline></span></p>')
+  })
+
+  test('plain islands without the prose root never group', () => {
+    const plainIsland = render('<div style="x">label\n\n<span>pill</span></div>')
+    expect(plainIsland).not.toContain('<p>')
+  })
+
+  test('unbalanced card HTML still yields paragraphs after a blank line', () => {
+    const html = `${WRAP}<div class="card"><h1>HP<br /><span>100</span></h15></div>\n\nThe dive begins.\n\n<span>"Ready?"</span> she asked.\n\n</div>`
+    const outHtml = render(html)
+    expect(outHtml).toContain('<block>The dive begins.</block>')
+    expect(outHtml).toContain('<p><span><inline>"Ready?"</inline></span><inline>she asked.</inline></p>')
+  })
 })

--- a/frontend/src/components/chat/htmlIslandMarkdown.ts
+++ b/frontend/src/components/chat/htmlIslandMarkdown.ts
@@ -26,6 +26,22 @@ const SANITIZER_KEPT_TAGS = new Set([
   'var', 'video', 'wbr',
 ])
 
+// Sanitizer-kept tags that flow inside a paragraph. At block level these open
+// a paragraph group (see processMarkdownInHtmlIsland) instead of standing
+// alone; every other kept tag is a block boundary that closes the group.
+const INLINE_FLOW_TAGS = new Set([
+  'a', 'abbr', 'acronym', 'audio', 'b', 'bdi', 'bdo', 'big', 'blink', 'br',
+  'button', 'cite', 'code', 'data', 'datalist', 'del', 'dfn', 'em', 'font',
+  'i', 'img', 'input', 'ins', 'kbd', 'label', 'mark', 'marquee', 'meter',
+  'nobr', 'optgroup', 'option', 'output', 'picture', 'progress', 'q', 'rp',
+  'rt', 'ruby', 's', 'samp', 'select', 'small', 'source', 'spacer', 'span',
+  'strike', 'strong', 'sub', 'sup', 'time', 'track', 'tt', 'u', 'var',
+  'video', 'wbr',
+])
+
+export const ISLAND_BLANK_LINE_RE = /\n[^\S\n]*\n/
+const BLANK_LINE_ALL_RE = /\n[^\S\n]*\n/g
+
 // Only these containers are allowed to promote child text into block markdown
 // like headings or lists. Everything else stays inline to avoid emitting
 // invalid HTML such as <span><h1>…</h1></span>.
@@ -88,6 +104,23 @@ function isMarkdownExcludedSubtree(tagStack: string[]): boolean {
   return tagStack.some((tag) => NO_MARKDOWN_SUBTREE_TAGS.has(tag))
 }
 
+function findLastBlankLine(text: string): { index: number } | null {
+  BLANK_LINE_ALL_RE.lastIndex = 0
+  let last: { index: number } | null = null
+  let m: RegExpExecArray | null
+  while ((m = BLANK_LINE_ALL_RE.exec(text)) !== null) {
+    last = { index: m.index }
+    BLANK_LINE_ALL_RE.lastIndex = m.index + 1
+  }
+  return last
+}
+
+function isInlineOpenTag(part: string | undefined): boolean {
+  if (!part) return false
+  const m = part.match(/^<([a-z][\w:-]*)\b/i)
+  return m != null && INLINE_FLOW_TAGS.has(m[1].toLowerCase())
+}
+
 export function processMarkdownInHtmlIsland(
   html: string,
   renderer: HtmlIslandMarkdownRenderer,
@@ -101,24 +134,172 @@ export function processMarkdownInHtmlIsland(
   const parts = shielded.split(/(<[^>]*>)/)
   const tagStack: string[] = []
   const rawTextState = { depth: 0 }
+  const out: string[] = []
+
+  // Paragraph grouping for islands whose root opts in via data-message-prose,
+  // following markdown's line-based HTML-block rule: a block tag enters raw
+  // HTML, the first blank line exits it, and only content outside raw HTML
+  // groups into <p> paragraphs. Tag balance is deliberately ignored, matching
+  // marked: card HTML with unclosed tags still gets its paragraphs.
+  let group: string[] | null = null
+  let groupHasText = false
+  let messageWrapRoot = false
+  let rawHtml = false
+
+  const closeGroup = (): void => {
+    if (!group) return
+    if (groupHasText) {
+      out.push('<p>', ...group, '</p>')
+    } else {
+      out.push(...group)
+    }
+    group = null
+    groupHasText = false
+  }
+
+  const emit = (piece: string): void => {
+    if (group) group.push(piece)
+    else out.push(piece)
+  }
+
+  const handleBlockTextWithoutGroup = (text: string, nextPart: string | undefined): void => {
+    if (!text.trim()) {
+      out.push(text)
+      return
+    }
+    if (isInlineOpenTag(nextPart) && messageWrapRoot) {
+      // Trailing segment joins the upcoming inline tag as one paragraph. Its
+      // leading blank line stays attached so pure-text fallback keeps its <p>.
+      const lastBlank = findLastBlankLine(text)
+      const head = lastBlank ? text.slice(0, lastBlank.index) : ''
+      const tail = lastBlank ? text.slice(lastBlank.index) : text
+      if (head.trim()) out.push(renderer.renderBlockText(head))
+      else if (head) out.push(head)
+      if (!tail.trim() && tail) out.push(tail)
+      group = []
+      groupHasText = false
+      if (tail.trim()) {
+        group.push(renderer.renderInlineText(tail))
+        groupHasText = true
+      }
+      return
+    }
+    out.push(renderer.renderBlockText(text))
+  }
+
+  const handleBlockText = (text: string, nextPart: string | undefined): void => {
+    if (!group) {
+      handleBlockTextWithoutGroup(text, nextPart)
+      return
+    }
+    const firstBlank = ISLAND_BLANK_LINE_RE.exec(text)
+    if (!firstBlank) {
+      if (text.trim()) {
+        group.push(renderer.renderInlineText(text))
+        groupHasText = true
+      } else {
+        group.push(text)
+      }
+      return
+    }
+    const head = text.slice(0, firstBlank.index)
+    if (head.trim()) {
+      group.push(renderer.renderInlineText(head))
+      groupHasText = true
+    } else if (head) {
+      group.push(head)
+    }
+    closeGroup()
+    const rest = text.slice(firstBlank.index)
+    if (rest) handleBlockTextWithoutGroup(rest, nextPart)
+  }
 
   for (let i = 0; i < parts.length; i++) {
     const part = parts[i]
+    if (!part) continue
 
     if (i % 2 === 1) {
+      if (part.startsWith('<!--')) {
+        if (STYLE_PLACEHOLDER_RE.test(part)) {
+          closeGroup()
+          out.push(part)
+        } else {
+          emit(part)
+        }
+        continue
+      }
+      const nameMatch = part.match(/^<\/?([a-z][\w:-]*)\b/i)
+      const name = nameMatch ? nameMatch[1].toLowerCase() : null
+      if (tagStack.length === 0 && !part.startsWith('</')) {
+        messageWrapRoot = part.includes('data-message-prose')
+      }
+      if (name && SANITIZER_KEPT_TAGS.has(name) && !INLINE_FLOW_TAGS.has(name)) {
+        closeGroup()
+        out.push(part)
+        if (messageWrapRoot && tagStack.length > 0) rawHtml = true
+      } else {
+        if (
+          name !== null
+          && INLINE_FLOW_TAGS.has(name)
+          && !group
+          && !part.startsWith('</')
+          && messageWrapRoot
+          && !rawHtml
+          && rawTextState.depth === 0
+          && !isMarkdownExcludedSubtree(tagStack)
+        ) {
+          group = []
+          groupHasText = false
+        }
+        emit(part)
+      }
       updateTagStack(part, tagStack, rawTextState)
       continue
     }
 
-    if (!part.trim() || rawTextState.depth > 0 || isMarkdownExcludedSubtree(tagStack)) continue
-    if (STYLE_PLACEHOLDER_RE.test(part.trim())) continue
-
-    parts[i] = shouldRenderInlineMarkdown(tagStack)
-      ? renderer.renderInlineText(part)
-      : renderer.renderBlockText(part)
+    if (rawTextState.depth > 0 || isMarkdownExcludedSubtree(tagStack)) {
+      emit(part)
+      continue
+    }
+    if (STYLE_PLACEHOLDER_RE.test(part.trim())) {
+      closeGroup()
+      out.push(part)
+      continue
+    }
+    if (messageWrapRoot) {
+      if (rawHtml) {
+        // Raw HTML runs to the first blank line, verbatim like CommonMark
+        // type-6 blocks. The remainder re-enters document flow.
+        const blank = ISLAND_BLANK_LINE_RE.exec(part)
+        if (!blank) {
+          out.push(part)
+        } else {
+          const head = part.slice(0, blank.index)
+          if (head) out.push(head)
+          rawHtml = false
+          const rest = part.slice(blank.index)
+          if (rest) handleBlockTextWithoutGroup(rest, parts[i + 1])
+        }
+      } else {
+        handleBlockText(part, parts[i + 1])
+      }
+      continue
+    }
+    if (shouldRenderInlineMarkdown(tagStack)) {
+      if (part.trim()) {
+        emit(renderer.renderInlineText(part))
+        if (group) groupHasText = true
+      } else {
+        emit(part)
+      }
+      continue
+    }
+    handleBlockText(part, parts[i + 1])
   }
 
-  let result = parts.join('')
+  closeGroup()
+
+  let result = out.join('')
   for (let i = 0; i < styleBlocks.length; i++) {
     result = result.replace(`<!--ISLAND_STYLE_${i}-->`, styleBlocks[i])
   }


### PR DESCRIPTION
## Summary

Islands whose root element declares `data-message-prose` now get CommonMark's paragraph semantics. This means that inline-led prose (e.g. dialogue starting with a colored quote span) is grouped into `<p>` blocks. Islands without the attribute render the same as before.


## Validation

```text
bun test src/components/chat/htmlIslandMarkdown.test.ts
cd frontend && bun run typecheck
cd frontend && bun run lint
cd frontend && bun run build:checked
```

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass.
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [ ] Backend: `bun x tsc --noEmit`
  - [x] Frontend: `cd frontend && bun run typecheck`, `bun run lint`

## UI changes (if applicable)

- [x] I validated this change in more than one browser.
- [x] I verified the integrated experience on a mobile interface or through
      the mobile PWA.
- Browsers, devices, and PWA coverage: Firefox, Chrome

## Performance changes (if applicable)
N/A

## Security-sensitive changes (if applicable)
N/A

## LLM-assisted work (if applicable)

- [x] I, as the human orchestrating this work, audited the submitted changes
      in a live environment.