### PR TITLE
Give extensions the chat signal on start

### DIFF
--- a/src/services/settings.service.ts
+++ b/src/services/settings.service.ts
@@ -78,6 +78,11 @@ export function getSetting(userId: string, key: string): Setting | null {
   return { ...row, value: JSON.parse(row.value) };
 }
 
+export function getSettingAcrossUsers(key: string): Array<{ user_id: string; value: any }> {
+  const rows = getDb().query("SELECT user_id, value FROM settings WHERE key = ?").all(key) as any[];
+  return rows.map((r) => ({ user_id: r.user_id, value: JSON.parse(r.value) }));
+}
+
 /**
  * The `editAndSendAlwaysUseActiveConnection` Productivity setting, read from the
  * persisted per-user `quickToolbarSettings` blob.

--- a/src/spindle/lifecycle.ts
+++ b/src/spindle/lifecycle.ts
@@ -1,5 +1,6 @@
 import { WorkerHost } from "./worker-host";
 import * as managerSvc from "./manager.service";
+import * as settingsSvc from "../services/settings.service";
 import { eventBus } from "../ws/bus";
 import { EventType } from "../ws/events";
 
@@ -81,6 +82,21 @@ export async function startExtension(id: string): Promise<void> {
     const host = new WorkerHost(freshExt.id, manifest, freshExt);
     await host.start();
     runningExtensions.set(id, host);
+
+    // CHAT_SWITCHED is one-shot, so an extension started while a chat is open
+    // (enable, restart) never learns about it until refresh. Replay each
+    // user's active chat to this worker once it subscribes.
+    try {
+      for (const row of settingsSvc.getSettingAcrossUsers("activeChatId")) {
+        const chatId = typeof row.value === "string" && row.value.length > 0 ? row.value : null;
+        if (chatId) host.queueEventReplay("CHAT_SWITCHED", { chatId }, row.user_id);
+      }
+    } catch (err: any) {
+      console.warn(
+        `[Spindle] Active-chat replay skipped for ${ext.identifier}:`,
+        err?.message ?? err
+      );
+    }
 
     eventBus.emit(EventType.SPINDLE_EXTENSION_LOADED, {
       extensionId: ext.id,

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -871,6 +871,11 @@ function concatChunks(chunks: Uint8Array[], total: number): Uint8Array {
 export class WorkerHost {
   private runtime: RuntimeTransport | null = null;
   private eventUnsubscribers = new Map<string, () => void>();
+  // Events queued before the worker subscribes (extension start replays);
+  // flushed by handleSubscribeEvent once the subscription lands. Entries
+  // expire so a late subscriber cannot receive boot-time state as fresh.
+  private pendingEventReplays = new Map<string, Array<{ payload: unknown; userId: string; queuedAt: number }>>();
+  private static readonly EVENT_REPLAY_TTL_MS = 30_000;
   private pendingRequests = new Map<
     string,
     { resolve: (value: unknown) => void; reject: (reason: unknown) => void }
@@ -2609,6 +2614,41 @@ export class WorkerHost {
       });
     });
     this.eventUnsubscribers.set(event, unsub);
+
+    const queued = this.pendingEventReplays.get(event);
+    if (queued) {
+      this.pendingEventReplays.delete(event);
+      const freshAfter = Date.now() - WorkerHost.EVENT_REPLAY_TTL_MS;
+      for (const replay of queued) {
+        if (replay.queuedAt < freshAfter) continue;
+        if (scopedUserId && replay.userId !== scopedUserId) continue;
+        this.postToWorker({
+          type: "event",
+          event,
+          payload: replay.payload,
+          userId: replay.userId,
+        });
+      }
+    }
+  }
+
+  /**
+   * Deliver an event to the worker even though it fired before the worker
+   * subscribed. Used on extension start to replay one-shot state such as the
+   * open chat, which otherwise leaves a restarted extension blind until the
+   * next real event. Posts immediately when already subscribed, else queues
+   * until handleSubscribeEvent lands.
+   */
+  queueEventReplay(event: string, payload: unknown, userId: string): void {
+    if (this.eventUnsubscribers.has(event)) {
+      const scopedUserId = this.getScopedUserId();
+      if (scopedUserId && userId !== scopedUserId) return;
+      this.postToWorker({ type: "event", event, payload, userId });
+      return;
+    }
+    const list = this.pendingEventReplays.get(event) ?? [];
+    list.push({ payload, userId, queuedAt: Date.now() });
+    this.pendingEventReplays.set(event, list);
   }
 
   private handleUnsubscribeEvent(event: string): void {


### PR DESCRIPTION
## Summary

When any extension starts (enable or restart), the host reads user's activeChatId setting and emits a CHAT_SWITCHED for that worker if the extension is subscribed to it. This allows an extension to properly initialize to the current chat, which is bound to be important if it's listening to that event. 

As an example, the LumiRealm extension will fail to render a chat on restart, until a page refresh, due to not initializing for the active chat on extension start. 

## Validation

```text
bun x tsc --noEmit
cd frontend && bun run typecheck
bun run lint
```

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass.
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [x] Backend: `bun x tsc --noEmit`
  - [ ] Frontend: `cd frontend && bun run typecheck`, `bun run lint`

## UI changes (if applicable)

N/A

## Performance changes (if applicable)

N/A

## Security-sensitive changes (if applicable)

N/A

## LLM-assisted work (if applicable)

- [x] I, as the human orchestrating this work, audited the submitted changes
      in a live environment.