### PR TITLE
feat(spindle): expose native image generation

### DIFF
--- a/src/services/image-gen.service.ts
+++ b/src/services/image-gen.service.ts
@@ -236,6 +236,12 @@ export interface ImageGenPromptPreset {
   kind?: ImageGenPresetKind;
 }
 
+export type ImageGenCharacterLoraSelection =
+  | { source: "chat" }
+  | { source: "none" }
+  | { source: "character"; characterId: string }
+  | { source: "explicit"; lora: LoraEntry; baseTags?: string };
+
 export interface GenerateImageOptions {
   forceGeneration?: boolean;
   promptMode?: ImageGenPromptMode;
@@ -245,6 +251,19 @@ export interface GenerateImageOptions {
   bypassCharacterLora?: boolean;
   bypassActiveLoraPreset?: boolean;
   loraStrengthScale?: number;
+  /** Select the identity LoRA independently from the active chat owner. */
+  characterLora?: ImageGenCharacterLoraSelection;
+  /** Ordered LoRA layers appended after active preset + selected character. */
+  extraLoras?: LoraEntry[];
+  /** Additional positive anchor tags appended to preset/character base tags. */
+  extraBaseTags?: string;
+  /** Provider parameters merged over the active native connection defaults. */
+  parameters?: Record<string, unknown>;
+  /** Persistence owner supplied only by trusted host bridges. */
+  ownerExtensionIdentifier?: string;
+  ownerChatId?: string;
+  /** Override native gallery linkage; omitted preserves settings behavior. */
+  addToGallery?: boolean;
   outputTarget?: ImageGenOutputTarget;
   /** Existing message to attach the generated image to (output target = attach_to_message). */
   attachToMessageId?: string;
@@ -369,7 +388,7 @@ export async function generateSceneBackground(
       : opts?.promptMode || settings.promptMode || "scene";
     const outputTarget = opts?.outputTarget || settings.outputTarget || "background";
     const params = normalizeGenerationParameters(
-      { ...connection.default_parameters },
+      { ...connection.default_parameters, ...(opts?.parameters ?? {}) },
       provider.capabilities.parameters,
     );
     normalizeRandomSeed(params, !!provider.capabilities.parameters.seed);
@@ -419,19 +438,17 @@ export async function generateSceneBackground(
     // provider sees the same prompt tags; Comfy/Swarm/SD API consume params.
     const bypassChar = opts?.bypassCharacterLora ?? settings.bypassCharacterLora ?? false;
     const bypassPreset = opts?.bypassActiveLoraPreset ?? settings.bypassActiveLoraPreset ?? false;
-    const characterLora = bypassChar ? null : resolveCharacterLoraForChat(userId, chatId);
+    const characterLayer = bypassChar
+      ? null
+      : resolveImageCharacterLayer(userId, chatId, opts?.characterLora);
     const activePreset = bypassPreset ? null : resolveActiveLoraPreset(settings);
+    const extraLoras = (opts?.extraLoras ?? []).map((entry, index) =>
+      normalizeRequestedImageLora(entry, `Extra native image LoRA #${index + 1}`)
+    );
     let combinedLoras: LoraEntry[] = [
       ...(activePreset?.loras ?? []),
-      ...(characterLora
-        ? [
-            {
-              lora_name: characterLora.lora_name,
-              weight_model: characterLora.weight_model,
-              weight_clip: characterLora.weight_clip,
-            },
-          ]
-        : []),
+      ...(characterLayer ? [characterLayer.lora] : []),
+      ...extraLoras,
     ];
     const rawScale = opts?.loraStrengthScale ?? settings.loraStrengthScale ?? 1;
     const scale = Number.isFinite(rawScale) ? Math.min(2, Math.max(0, rawScale)) : 1;
@@ -442,8 +459,11 @@ export async function generateSceneBackground(
         weight_clip: Math.max(0, (entry.weight_clip ?? entry.weight_model) * scale),
       }));
     }
-
-    const tags = [activePreset?.base_tags, characterLora?.base_tags].filter(Boolean).join(", ");
+    const tags = [
+      activePreset?.base_tags,
+      characterLayer?.baseTags,
+      opts?.extraBaseTags,
+    ].filter(Boolean).join(", ");
     if (tags) promptResult.prompt = composeWithBaseTags(tags, promptResult.prompt);
 
     if (!promptResult.prompt.trim()) throw new Error("Image generation prompt is required");
@@ -498,7 +518,7 @@ export async function generateSceneBackground(
         promptResult.prompt,
         promptResult.negativePrompt,
         combinedLoras,
-        !activePreset,
+        !activePreset && combinedLoras.length <= 1,
         apiKey ?? undefined,
       );
     }
@@ -545,7 +565,10 @@ export async function generateSceneBackground(
         userId,
         response.imageDataUrl,
         `image-gen-${connection.provider}-${Date.now()}.png`,
-        { owner_chat_id: chatId },
+        {
+          owner_extension_identifier: opts?.ownerExtensionIdentifier,
+          owner_chat_id: opts?.ownerChatId ?? chatId,
+        },
       );
       imageId = image.id;
       imageUrl = `/api/v1/image-gen/results/${image.id}`;
@@ -612,7 +635,8 @@ export async function generateSceneBackground(
       // Gallery linkage is best-effort and not on the response's critical
       // path — defer to a microtask so the HTTP response (and the chat
       // re-render that follows from MESSAGE_EDITED) lands sooner.
-      if (settings.addToGallery !== false) {
+      const shouldAddToGallery = opts?.addToGallery ?? (settings.addToGallery !== false);
+      if (shouldAddToGallery) {
         const characterId = chatsSvc.getChat(userId, chatId)?.character_id;
         if (characterId) {
           scheduleLowPriorityTask(() => {
@@ -988,6 +1012,56 @@ function resolveCharacterLoraForChat(
   const chat = chatsSvc.getChat(userId, chatId);
   if (!chat?.character_id) return null;
   return characterLoraSvc.getCharacterLora(userId, chat.character_id);
+}
+
+type ResolvedImageCharacterLayer = { lora: LoraEntry; baseTags?: string };
+
+function normalizeRequestedImageLora(value: LoraEntry, label: string): LoraEntry {
+  const name = stringParam(value?.lora_name);
+  const model = numberParam(value?.weight_model);
+  const clip = numberParam(value?.weight_clip);
+  if (!name) throw new Error(`${label} requires lora_name`);
+  if (model === undefined) throw new Error(`${label} requires a finite weight_model`);
+  return {
+    lora_name: name,
+    weight_model: Math.max(0, model),
+    weight_clip: Math.max(0, clip ?? model),
+  };
+}
+
+function characterBindingToImageLayer(
+  binding: characterLoraSvc.CharacterLoraBinding | null,
+): ResolvedImageCharacterLayer | null {
+  if (!binding) return null;
+  return {
+    lora: {
+      lora_name: binding.lora_name,
+      weight_model: binding.weight_model,
+      weight_clip: binding.weight_clip,
+    },
+    baseTags: binding.base_tags,
+  };
+}
+
+function resolveImageCharacterLayer(
+  userId: string,
+  chatId: string,
+  selection?: ImageGenCharacterLoraSelection,
+): ResolvedImageCharacterLayer | null {
+  const resolved = selection ?? { source: "chat" as const };
+  if (resolved.source === "none") return null;
+  if (resolved.source === "chat") {
+    return characterBindingToImageLayer(resolveCharacterLoraForChat(userId, chatId));
+  }
+  if (resolved.source === "character") {
+    const characterId = resolved.characterId.trim();
+    if (!characterId) throw new Error("Native image character LoRA selection requires characterId");
+    return characterBindingToImageLayer(characterLoraSvc.getCharacterLora(userId, characterId));
+  }
+  return {
+    lora: normalizeRequestedImageLora(resolved.lora, "Explicit native image LoRA"),
+    baseTags: resolved.baseTags,
+  };
 }
 
 /**

--- a/src/spindle/worker-host-image-gen-api.ts
+++ b/src/spindle/worker-host-image-gen-api.ts
@@ -4,6 +4,7 @@ import type { ImageProvider } from "../image-gen/provider";
 import type { ImageGenRequest, ImageGenResponse } from "../image-gen/types";
 import * as imageGenConnSvc from "../services/image-gen-connections.service";
 import { applyActiveComfyUIWorkflowConfig } from "../services/image-gen.service";
+import * as nativeImageGenSvc from "../services/image-gen.service";
 import { PERMISSION_DENIED_PREFIX, type SpindlePermission } from "lumiverse-spindle-types";
 
 type ImageGenStreamEvent =
@@ -213,6 +214,116 @@ export class WorkerHostImageGenApi {
         generation.request,
       );
       this.postResponse(requestId, await this.persistResult(result, generation, input));
+    } catch (err: any) {
+      this.postResponse(requestId, undefined, err?.message ?? String(err));
+    }
+  }
+
+  async handleGenerateNative(requestId: string, input: any): Promise<void> {
+    try {
+      this.requirePermission();
+      const userId = this.context.resolveEffectiveUserId(input?.userId);
+      if (!userId) throw new Error("userId is required for operator-scoped extensions");
+      this.context.enforceScopedUser(userId);
+
+      const chatId = typeof input?.chat_id === "string" ? input.chat_id.trim() : "";
+      if (!chatId) throw new Error("chat_id is required for native image generation");
+
+      let characterLora: nativeImageGenSvc.ImageGenCharacterLoraSelection | undefined;
+      const requested = input?.characterLora;
+      if (requested && typeof requested === "object") {
+        if (requested.source === "chat" || requested.source === "none") {
+          characterLora = { source: requested.source };
+        } else if (requested.source === "character") {
+          if (!this.context.hasPermission("characters")) {
+            throw new Error(`${PERMISSION_DENIED_PREFIX} characters — Character access permission not granted`);
+          }
+          const characterId = typeof requested.characterId === "string"
+            ? requested.characterId.trim()
+            : "";
+          if (!characterId) throw new Error("characterLora.characterId is required");
+          characterLora = { source: "character", characterId };
+        } else if (requested.source === "explicit") {
+          const lora = requested.lora;
+          if (!lora || typeof lora !== "object") throw new Error("characterLora.lora is required");
+          characterLora = {
+            source: "explicit",
+            lora: {
+              lora_name: typeof lora.lora_name === "string" ? lora.lora_name : "",
+              weight_model: Number(lora.weight_model),
+              weight_clip: lora.weight_clip === undefined ? undefined : Number(lora.weight_clip),
+            },
+            baseTags: typeof requested.base_tags === "string" ? requested.base_tags : undefined,
+          };
+        } else {
+          throw new Error(`Unknown characterLora source: ${String(requested.source)}`);
+        }
+      }
+
+      const extraLoras = Array.isArray(input?.extraLoras)
+        ? input.extraLoras.map((entry: any) => ({
+            lora_name: typeof entry?.lora_name === "string" ? entry.lora_name : "",
+            weight_model: Number(entry?.weight_model),
+            weight_clip: entry?.weight_clip === undefined ? undefined : Number(entry.weight_clip),
+          }))
+        : undefined;
+
+      const promptMode = input?.promptMode === "scene"
+        || input?.promptMode === "custom"
+        || input?.promptMode === "parsed_custom"
+        ? input.promptMode
+        : undefined;
+
+      const result = await nativeImageGenSvc.generateSceneBackground(userId, chatId, {
+        forceGeneration: input?.forceGeneration !== false,
+        promptMode,
+        prompt: typeof input?.prompt === "string" ? input.prompt : undefined,
+        negativePrompt: typeof input?.negativePrompt === "string" ? input.negativePrompt : undefined,
+        promptPresetId: input?.promptPresetId === null || typeof input?.promptPresetId === "string"
+          ? input.promptPresetId
+          : undefined,
+        skipParse: input?.skipParse === true,
+        characterLora,
+        bypassCharacterLora: characterLora?.source === "none"
+          ? true
+          : characterLora
+            ? false
+            : undefined,
+        bypassActiveLoraPreset: typeof input?.bypassActiveLoraPreset === "boolean"
+          ? input.bypassActiveLoraPreset
+          : undefined,
+        extraLoras,
+        extraBaseTags: typeof input?.extraBaseTags === "string" ? input.extraBaseTags : undefined,
+        loraStrengthScale: typeof input?.loraStrengthScale === "number"
+          ? input.loraStrengthScale
+          : undefined,
+        parameters: input?.parameters && typeof input.parameters === "object" && !Array.isArray(input.parameters)
+          ? input.parameters
+          : undefined,
+        outputTarget: "preview",
+        clientJobId: typeof input?.clientJobId === "string" ? input.clientJobId : undefined,
+        promptGenerationTimeoutSeconds: input?.promptGenerationTimeoutSeconds,
+        generationTimeoutSeconds: input?.generationTimeoutSeconds,
+        ownerExtensionIdentifier: this.context.extensionIdentifier,
+        ownerChatId: chatId,
+        addToGallery: false,
+      });
+
+      const exposed: Record<string, unknown> = {
+        generated: result.generated,
+        reason: result.reason,
+        prompt: result.prompt,
+        negativePrompt: result.negativePrompt,
+        provider: result.provider,
+        imageDataUrl: result.imageDataUrl,
+        imageId: result.imageId,
+        imageUrl: result.imageUrl,
+        jobId: result.jobId,
+      };
+      this.postResponse(
+        requestId,
+        applyDataUrlInclusion(exposed, input?.includeDataUrl !== false),
+      );
     } catch (err: any) {
       this.postResponse(requestId, undefined, err?.message ?? String(err));
     }

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -316,6 +316,7 @@ type RuntimeWorkerToHost =
     }
   | { type: "toast_show"; toastType: "success" | "warning" | "error" | "info"; message: string; title?: string; duration?: number; userId?: string }
   | { type: "prompt_regex_set_owned"; chatIds: string[] }
+  | { type: "image_gen_generate_native"; requestId: string; input: any }
   | { type: "user_storage_read_binary"; requestId: string; path: string; userId?: string }
   | { type: "user_get_role"; requestId: string; userId?: string }
   | {
@@ -2462,6 +2463,9 @@ export class WorkerHost {
       // ─── Image Generation (gated: "image_gen") ─────────────────────────
       case "image_gen_generate":
         void this.imageGenApi.handleGenerate(msg.requestId, msg.input);
+        break;
+      case "image_gen_generate_native":
+        void this.imageGenApi.handleGenerateNative(msg.requestId, msg.input);
         break;
       case "image_gen_providers":
         this.imageGenApi.handleProviders(msg.requestId);

--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -333,6 +333,7 @@ type RuntimeWorkerToHost =
     }
   | { type: "toast_show"; toastType: "success" | "warning" | "error" | "info"; message: string; title?: string; duration?: number; userId?: string }
   | { type: "prompt_regex_set_owned"; chatIds: string[] }
+  | { type: "image_gen_generate_native"; requestId: string; input: any }
   | { type: "user_storage_read_binary"; requestId: string; path: string; userId?: string }
   | {
       type: "user_storage_write_binary";
@@ -726,6 +727,8 @@ type RuntimeSpindleAPI = Omit<SpindleAPI, "presets" | "imageGen" | "world_books"
   world_books: RuntimeWorldBooksAPI;
   entityExtensions: RuntimeEntityExtensionsAPI;
   imageGen: SpindleAPI["imageGen"] & {
+    /** Native Lumiverse image pipeline; public types are released separately. */
+    generateNative(input: any): Promise<any>;
     /**
      * Generate through a provider that explicitly supports WebSocket preview
      * images and status updates. The terminal `done` event contains the saved
@@ -2392,6 +2395,10 @@ const spindleApi: RuntimeSpindleAPI = {
     async generate(input: any): Promise<any> {
       const requestId = crypto.randomUUID();
       return request({ type: "image_gen_generate", requestId, input });
+    },
+    async generateNative(input: any): Promise<any> {
+      const requestId = crypto.randomUUID();
+      return request({ type: "image_gen_generate_native", requestId, input });
     },
     generateStream(input: ImageGenStreamInput): AsyncGenerator<ImageGenStreamEvent, void, void> {
       return requestImageGenStream(input);


### PR DESCRIPTION
## Summary

Implements the host/runtime side of the native image-generation Spindle contract.

This is an additive path. Existing `spindle.imageGen.generate()` behavior remains unchanged.

## What changed

- adds a native Spindle image-generation host route
- extends the integrated native image pipeline with request-scoped:
  - character-LoRA source selection (`chat`, `none`, another character, or explicit layer)
  - extra ordered LoRAs
  - extra base tags
  - active native LoRA-preset bypass
  - LoRA strength scaling
  - provider parameter overrides
- persists extension-triggered native results with extension ownership metadata
- suppresses automatic active-character gallery linkage for extension-native generations
- requires `characters` permission before an extension can select another character's native LoRA binding
- keeps the current raw image-generation route untouched

## Why

Spindle's current image generation bridge is intentionally connection-level. Calling the integrated Lumiverse image pipeline is useful for extensions that want to respect the user's native image configuration (prompt presets, LoRA presets, native workflow handling) without reproducing those rules themselves.

The current integrated pipeline also resolves the character LoRA from the active chat. An extension rendering a different actor therefore needs a supported way to select that actor—or intentionally use no character identity layer—without changing the chat.

## Security / Spindle audit notes

This PR affects the Spindle boundary and should receive the required Spindle/security review.

- continues to require the existing `image_gen` permission
- operator-scoped calls still resolve/enforce the effective user
- selecting an arbitrary character binding additionally requires `characters`
- the extension identifier used for persisted image ownership is host-owned; extensions cannot spoof it
- extension-native calls use the `preview` output target and do not mutate chat messages
- automatic gallery linkage is disabled for the extension-native route
- raw provider generation remains unchanged

## Validation

- `bun x tsc --noEmit`
- `bun test --isolate`
- `git diff --check`
- live Spindle smoke test covering raw generation and all native character-LoRA selector modes

No `lumiverse-spindle-types` dependency bump is included. The maintainer handles the package release/dependency bump after the related PRs merge.
t that actor—or intentionally use no character identity layer—without changing the chat.

## Security / Spindle audit notes

This PR affects the Spindle boundary and should receive the required Spindle/security review.

- continues to require the existing `image_gen` permission
- operator-scoped calls still resolve/enforce the effective user
- selecting an arbitrary character binding additionally requires `characters`
- the extension identifier used for persisted image ownership is host-owned; extensions cannot spoof it
- extension-native calls use the `preview` output target and do not mutate chat messages
- automatic gallery linkage is disabled for the extension-native route
- raw provider generation remains unchanged

## Validation

- `bun x tsc --noEmit`
- `bun test --isolate`
- `git diff --check`
- live Spindle smoke test covering raw generation and all native character-LoRA selector modes
PASS · raw generate() · swarmui 
PASS · native chat · swarmui 
PASS · native none · swarmui 
PASS · native character · swarmui 
PASS · native explicit · swarmui
When Characters permission is not granted: FAIL · Error: PERMISSION_DENIED: characters — Character access permission not granted
<img width="377" height="671" alt="image" src="https://github.com/user-attachments/assets/10cce507-1045-49e7-b1ed-7a851ab30e4c" />
