### PR TITLE
fix: honor the active ComfyUI workflow library selection in image gen

### DIFF
--- a/src/image-gen/comfyui-workflow-storage.ts
+++ b/src/image-gen/comfyui-workflow-storage.ts
@@ -66,6 +66,11 @@ function parseComfyUIConfigValue(value: unknown): ComfyUIWorkflowConfig | null {
 
 export function readComfyUIConfig(metadata: unknown): ComfyUIWorkflowConfig | null {
   if (!metadata || typeof metadata !== "object") return null;
+  const library = readComfyUIWorkflowLibrary(metadata);
+  if (library.activeId) {
+    const active = library.entries.find((e) => e.id === library.activeId);
+    if (active) return active.config;
+  }
   return parseComfyUIConfigValue((metadata as Record<string, unknown>).comfyui);
 }
 

--- a/src/services/image-gen.service.ts
+++ b/src/services/image-gen.service.ts
@@ -24,7 +24,7 @@ import { EventType } from "../ws/events";
 import { getImageProvider, getImageProviderList } from "../image-gen/registry";
 import { getComfyUIObjectInfo, resolveComfyTarget } from "../image-gen/comfyui-discovery";
 import { normalizeComfyUIWorkflow } from "../image-gen/comfyui-import";
-import { readComfyUIConfig } from "../image-gen/comfyui-workflow-storage";
+import { readComfyUIConfig, readComfyUIWorkflowLibrary } from "../image-gen/comfyui-workflow-storage";
 import { patchWorkflow, type ComfyUIPatchValues, type LoraEntry } from "../image-gen/comfyui-workflow-patch";
 import { uploadComfyImage } from "../image-gen/providers/comfy-runner";
 import type { ImageParameterSchemaMap } from "../image-gen/param-schema";
@@ -895,7 +895,12 @@ export async function applyActiveComfyUIWorkflowConfig(
   useLegacySingleLora: boolean,
   apiKey?: string,
 ): Promise<void> {
-  const config = readComfyUIConfig(connection.metadata);
+  const library = readComfyUIWorkflowLibrary(connection.metadata);
+  const targetId = (typeof params.workflow_id === "string" && params.workflow_id)
+    || (typeof params.workflowId === "string" && params.workflowId)
+    || library.activeId;
+  const explicitEntry = targetId ? library.entries.find((e) => e.id === targetId) : null;
+  const config = explicitEntry?.config ?? readComfyUIConfig(connection.metadata);
   if (!config) return;
 
   // `default_parameters` can retain a workflow from older connection

--- a/src/services/image-gen.workflow-selection.test.ts
+++ b/src/services/image-gen.workflow-selection.test.ts
@@ -112,4 +112,80 @@ describe("active ComfyUI workflow selection", () => {
       "active-node": { class_type: "CLIPTextEncode", inputs: { text: "new workflow prompt" } },
     });
   });
+
+  test("selects the active workflow from comfyui_workflows library over initial comfyui config", async () => {
+    const defaultWf = { "node-default": { class_type: "CLIPTextEncode", inputs: { text: "default wf" } } };
+    const activeWf = { "node-active": { class_type: "CLIPTextEncode", inputs: { text: "active wf" } } };
+    const connection = await imageGenConnSvc.createConnection(USER_ID, {
+      name: "ComfyUI Multi-Workflow",
+      provider: "comfyui",
+      model: "",
+      api_url: "http://127.0.0.1:1",
+      is_default: true,
+      metadata: {
+        comfyui: {
+          workflow_json: defaultWf,
+          workflow_api_json: defaultWf,
+          workflow_format: "api_prompt",
+          field_mappings: [{ nodeId: "node-default", fieldName: "text", mappedAs: "positive_prompt" }],
+          imported_at: 1000,
+        },
+        comfyui_active_workflow_id: "wf-active-id",
+        comfyui_workflows: [
+          {
+            id: "wf-default-id",
+            name: "Initial Workflow",
+            updated_at: 1000,
+            config: {
+              workflow_json: defaultWf,
+              workflow_api_json: defaultWf,
+              workflow_format: "api_prompt",
+              field_mappings: [{ nodeId: "node-default", fieldName: "text", mappedAs: "positive_prompt" }],
+              imported_at: 1000,
+            },
+          },
+          {
+            id: "wf-active-id",
+            name: "Active Workflow",
+            updated_at: 2000,
+            config: {
+              workflow_json: activeWf,
+              workflow_api_json: activeWf,
+              workflow_format: "api_prompt",
+              field_mappings: [{ nodeId: "node-active", fieldName: "text", mappedAs: "positive_prompt" }],
+              imported_at: 2000,
+            },
+          },
+        ],
+      },
+    });
+    settingsSvc.putSetting(USER_ID, "imageGeneration", {
+      enabled: true,
+      activeImageGenConnectionId: connection.id,
+      promptMode: "custom",
+      outputTarget: "preview",
+      forceGeneration: true,
+      addToGallery: false,
+    });
+
+    const character = charactersSvc.createCharacter(USER_ID, { name: "Character" });
+    const chatId = crypto.randomUUID();
+    const now = Math.floor(Date.now() / 1000);
+    getDb()
+      .query("INSERT INTO chats (id, user_id, character_id, name, metadata, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)")
+      .run(chatId, USER_ID, character.id, "workflow test", "{}", now, now);
+
+    await generateSceneBackground(USER_ID, chatId, {
+      promptMode: "custom",
+      prompt: "my prompt",
+      skipParse: true,
+      outputTarget: "preview",
+      forceGeneration: true,
+    });
+
+    expect(capturedRequest?.parameters?.workflow).toEqual({
+      "node-active": { class_type: "CLIPTextEncode", inputs: { text: "my prompt" } },
+    });
+  });
+
 });


### PR DESCRIPTION
## Problem

`readComfyUIConfig(connection.metadata)` only parsed the legacy `metadata.comfyui` blob. When a connection's workflow **library** (`metadata.comfyui_workflows` + `metadata.comfyui_active_workflow_id`) held a different active entry, generation kept using the first imported workflow, ignoring the user's selection in the Lumiverse UI.

## Fix

- `readComfyUIConfig` resolves the library's `activeId` first, falling back to the legacy `metadata.comfyui` value only when no library entry matches.
- `applyActiveComfyUIWorkflowConfig` accepts an explicit per-request override via `params.workflow_id` / `params.workflowId`, so callers (including Spindle extensions) can pin a specific saved workflow without mutating the connection's active selection.

## Tests

New `src/services/image-gen.workflow-selection.test.ts`:
- selects the active workflow from the `comfyui_workflows` library over the initial `comfyui` config
- replaces a stale `default_parameters` workflow with the active workflow

Both pass with `bun test src/services/image-gen.workflow-selection.test.ts`.
