### PR TITLE
Added user guide documentation to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,9 @@ COPY --from=frontend-build /app/frontend/package.json ./frontend/package.json
 COPY package.json ./
 COPY src/ ./src/
 
+# User guide docs for built-in help
+COPY user-docs/ ./user-docs/
+
 # Create data directory with correct ownership
 RUN mkdir -p /app/data && chown -R bun:bun /app/data
 


### PR DESCRIPTION
## Summary

The currently built docker images omit the user-docs directory, leading to all the guide/help buttons to show just a popup modal with an error 404. The solution is quite simply to include them in the Dockerfile.

## Validation

The change doesn't touch any code, so I manually verified simply that container builds, startup against `docker-compose.build.yml` starts and works as expected with the docs being available on the running container in the frontend.

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass.
```$ bun test --isolate --changed
bun test v1.4.1 (4661e494f)
--changed: 1 changed file, but no test files are affected

 0 pass
 0 fail
``` 

- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [x] Backend: `bun x tsc --noEmit`
  - [x] Frontend: `cd frontend && bun run typecheck`, `bun run lint`