### PR TITLE
fix(spindle): propagate user context to inline extension tools

### DIFF
--- a/src/services/council/council-execution.service.ts
+++ b/src/services/council/council-execution.service.ts
@@ -344,12 +344,13 @@ async function executeMemberTools(
             bareToolName,
             {
               context: contextSummary,
-              // Deadline hint is opaque and useful for the extension; userId is
-              // intentionally NOT included here — the worker host strips any
-              // attempted __userId injection before posting to the worker.
+              // Deadline hint is opaque and useful for the extension. Authenticated
+              // userId is intentionally NOT included in model-controlled args; it
+              // travels separately below as trusted host-owned transport metadata.
               __deadlineMs: Date.now() + settings.toolsSettings.timeoutMs,
             },
             settings.toolsSettings.timeoutMs,
+            input.userId,
             memberContext,
             contextMessages
           );
@@ -601,15 +602,15 @@ export function appendCouncilDeliberationHistory(input: {
 }
 
 /**
- * Route a tool call to the extension worker that registered it. We never
- * forward the authenticated userId — extensions run in their own user-scoped
- * worker and reach back via the RPC bridge under that identity. Passing the
- * raw userId to the tool handler would let a malicious extension impersonate
- * the user via its own internal state, defeating the worker boundary.
+ * Extension tool invocations receive authenticated user context only as
+ * trusted host-owned transport metadata. It is never sourced from or merged
+ * into model-controlled tool args. The worker runtime exposes that context as
+ * the TOOL_INVOCATION handler's second argument so operator-scoped extensions
+ * can safely reach user-scoped Spindle APIs.
  *
- * `councilMember` is a trusted host-built snapshot of the assigned member's
- * identity/personality fields — delivered to the extension handler alongside
- * the invocation args so the tool can tailor its output to that member.
+ * `councilMember` remains a separate trusted host-built snapshot of the
+ * assigned member's identity/personality fields so the tool can tailor output
+ * without mixing either host-owned context object into user-space args.
  */
 /** Call the sidecar LLM for a single tool. */
 async function invokeSidecarTool(

--- a/src/services/council/tool-runtime.ts
+++ b/src/services/council/tool-runtime.ts
@@ -120,6 +120,7 @@ export async function invokeExtensionCouncilTool(
   toolName: string,
   args: Record<string, unknown>,
   timeoutMs: number,
+  userId: string,
   councilMember?: CouncilMemberContext,
   contextMessages?: LlmMessage[],
 ): Promise<string> {
@@ -127,5 +128,5 @@ export async function invokeExtensionCouncilTool(
   if (!host) {
     throw new Error(`Extension worker '${extensionId}' is not running`);
   }
-  return host.invokeExtensionTool(toolName, args, timeoutMs, councilMember, contextMessages);
+  return host.invokeExtensionTool(toolName, args, timeoutMs, userId, councilMember, contextMessages);
 }

--- a/src/services/generate.service.ts
+++ b/src/services/generate.service.ts
@@ -1073,6 +1073,7 @@ async function executeInlineCouncilToolCalls(
           __deadlineMs: Date.now() + timeoutMs,
         },
         timeoutMs,
+        userId,
         memberContext,
         contextMessages,
       );

--- a/src/spindle/tool-invocation-user-context.test.ts
+++ b/src/spindle/tool-invocation-user-context.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { ExtensionInfo, HostToWorker, SpindleManifest } from "lumiverse-spindle-types";
+import { WorkerHost } from "./worker-host";
+
+function manifest(identifier: string): SpindleManifest {
+  return {
+    identifier,
+    name: identifier,
+    version: "1.0.0",
+    author: "test",
+    description: "",
+  } as SpindleManifest;
+}
+
+function extensionInfo(id: string): ExtensionInfo {
+  return {
+    id,
+    identifier: id,
+    name: id,
+    version: "0.0.0",
+    author: "",
+    description: "",
+    github: "",
+    homepage: "",
+    permissions: [],
+    granted_permissions: [],
+    enabled: true,
+    installed_at: 0,
+    updated_at: 0,
+    has_frontend: false,
+    has_backend: false,
+    status: "stopped",
+    metadata: { install_scope: "operator", installed_by_user_id: "operator" },
+  };
+}
+
+function attachRuntime(host: WorkerHost): HostToWorker[] {
+  const posted: HostToWorker[] = [];
+  (host as unknown as { runtime: { mode: string; pid: null; postMessage(message: HostToWorker): void; terminate(): void } }).runtime = {
+    mode: "worker",
+    pid: null,
+    postMessage(message) { posted.push(message); },
+    terminate() {},
+  };
+  return posted;
+}
+
+function handle(host: WorkerHost, message: unknown): void {
+  (host as unknown as { handleMessage(msg: unknown): void }).handleMessage(message);
+}
+
+describe("tool invocation user context", () => {
+  test("fails closed before posting when authenticated user context is missing", async () => {
+    const host = new WorkerHost("inst-pocket", manifest("pocket"), extensionInfo("pocket"));
+    const posted = attachRuntime(host);
+
+    await expect(host.invokeExtensionTool("phone_action", { action: "send_message" }, 1_000, "")).rejects.toThrow(
+      /requires authenticated user context/,
+    );
+    expect(posted).toHaveLength(0);
+  });
+
+  test("forwards authenticated user context separately and strips model spoof fields", async () => {
+    const host = new WorkerHost("inst-pocket", manifest("pocket"), extensionInfo("pocket"));
+    const posted = attachRuntime(host);
+
+    const pending = host.invokeExtensionTool(
+      "phone_action",
+      {
+        userId: "model-spoof",
+        __userId: "model-spoof-2",
+        __user_id: "model-spoof-3",
+        action: "send_message",
+      },
+      1_000,
+      "authenticated-user",
+    );
+
+    const invocation = posted.find((message) => message.type === "tool_invocation");
+    expect(invocation).toBeDefined();
+    if (!invocation || invocation.type !== "tool_invocation") throw new Error("tool invocation was not posted");
+
+    expect(invocation.userId).toBe("authenticated-user");
+    expect(invocation.args.action).toBe("send_message");
+    expect("userId" in invocation.args).toBe(false);
+    expect("__userId" in invocation.args).toBe(false);
+    expect("__user_id" in invocation.args).toBe(false);
+
+    handle(host, {
+      type: "tool_invocation_result",
+      requestId: invocation.requestId,
+      result: "ok",
+    });
+    await expect(pending).resolves.toBe("ok");
+  });
+
+  test("keeps authenticated context wired across both callers, council runtime, host, and worker", async () => {
+    const generateSource = await readFile(join(import.meta.dir, "../services/generate.service.ts"), "utf8");
+    const councilExecutionSource = await readFile(join(import.meta.dir, "../services/council/council-execution.service.ts"), "utf8");
+    const toolRuntimeSource = await readFile(join(import.meta.dir, "../services/council/tool-runtime.ts"), "utf8");
+    const workerHostSource = await readFile(join(import.meta.dir, "./worker-host.ts"), "utf8");
+    const workerRuntimeSource = await readFile(join(import.meta.dir, "./worker-runtime.ts"), "utf8");
+
+    expect(generateSource).toMatch(/invokeExtensionCouncilTool\([\s\S]{0,900}?timeoutMs,\s*userId,\s*memberContext,/);
+    expect(councilExecutionSource).toMatch(/invokeExtensionCouncilTool\([\s\S]{0,900}?settings\.toolsSettings\.timeoutMs,\s*input\.userId,\s*memberContext,/);
+    expect(toolRuntimeSource).toContain("host.invokeExtensionTool(toolName, args, timeoutMs, userId, councilMember, contextMessages)");
+    expect(workerHostSource).toMatch(/type:\s*["']tool_invocation["'][\s\S]{0,300}?args:\s*sanitizedArgs,[\s\S]{0,100}?userId,/);
+    expect(workerRuntimeSource).toContain("handler(payload, msg.userId)");
+  });
+});

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -1470,20 +1470,26 @@ export class WorkerHost {
    * Forwarded on its own top-level field (same rationale as `councilMember`:
    * host-provided truth that must not collide with user-space `args`).
    * Multipart content is flattened to its text portion via `getTextContent`.
+   *
+   * `userId` is authenticated host context supplied by the generation path. It is
+   * transported separately from model-controlled `args` and must never be sourced
+   * from an invocation argument.
    */
   invokeExtensionTool(
     toolName: string,
     args: Record<string, unknown>,
     timeoutMs = 30_000,
+    userId: string,
     councilMember?: CouncilMemberContext,
     contextMessages?: LlmMessage[]
   ): Promise<string> {
+    if (!userId) return Promise.reject(new Error("Extension tool invocation requires authenticated user context"));
     const requestId = crypto.randomUUID();
 
-    // Defensive strip: never forward authentication-style metadata to the
-    // worker. Even if a caller leaks `__userId` or similar in args, the
-    // extension handler must not see it — extensions identify themselves via
-    // their worker context, not a string parameter they could exfiltrate.
+    // Defensive strip: never trust authentication-shaped metadata from tool
+    // args. Even if model-controlled input leaks `__userId` or similar, keep
+    // it out of the payload. The only user identity delivered to the worker is
+    // authenticated host context on the top-level invocation envelope.
     const sanitizedArgs: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(args)) {
       if (key === "__userId" || key === "__user_id" || key === "userId") continue;
@@ -1503,6 +1509,7 @@ export class WorkerHost {
       requestId,
       toolName,
       args: sanitizedArgs,
+      userId,
       ...(councilMember ? { councilMember } : {}),
       ...(contextMessagesDTO ? { contextMessages: contextMessagesDTO } : {}),
     });

--- a/src/spindle/worker-runtime.ts
+++ b/src/spindle/worker-runtime.ts
@@ -4545,7 +4545,7 @@ async function handleHostMessage(msg: RuntimeHostToWorker): Promise<void> {
         };
         let result: string | undefined;
         for (const handler of handlers) {
-          const val = await Promise.resolve(handler(payload));
+          const val = await Promise.resolve(handler(payload, msg.userId));
           if (val !== undefined && val !== null && result === undefined) {
             result = String(val);
           }


### PR DESCRIPTION
## Summary

## What changed

- Propagate authenticated `userId` through both extension-tool entry paths:
  - inline tool execution in `generate.service.ts`;
  - council/sidecar extension execution in `council-execution.service.ts`.
- Carry `userId` as trusted top-level host-to-worker `tool_invocation` metadata.
- Deliver it to `TOOL_INVOCATION` handlers through the Spindle callback's second argument.
- Require authenticated context on Lumiverse's internal invocation path and fail closed before posting if it is missing.
- Preserve stripping of `userId`, `__userId`, and `__user_id` from model/tool-controlled args.
- Update nearby comments so they distinguish untrusted auth-shaped args from trusted host-owned transport context.
- Add regression coverage for missing context, spoof stripping, trusted-envelope forwarding, and both call-site wiring paths.

## Why
Lumiverse already knows the authenticated user ID when extension tools execute, but the extension invocation transport previously dropped that context before `TOOL_INVOCATION` reached the worker. Operator-scoped extensions therefore could not reliably call user-scoped Spindle APIs from tool handlers.

There are two independent callers of `invokeExtensionCouncilTool()`: inline generation and council execution. Both must propagate the authenticated user ID before the common tool runtime forwards it to `WorkerHost`.

This is a contract-parity repair, not a model-facing feature. The model never receives or selects authenticated identity.

## Validation

List the commands you ran and their results. Include any relevant test output.

```text
- `bun x tsc --noEmit`
- `bun test --isolate src/spindle/tool-invocation-user-context.test.ts`
- `bun test --isolate tests/inline-tool-continuation.test.ts`
- `bun run typecheck`
- `bun run lint`
```

### src\spindle\tool-invocation-user-context.test.ts:
```
✓ tool invocation user context > fails closed before posting when authenticated user context is missing [1.02ms]
✓ tool invocation user context > forwards authenticated user context separately and strips model spoof fields [3.97ms]
✓ tool invocation user context > keeps authenticated context wired across both callers, council runtime, host, and worker [22.34ms]

 3 pass
 0 fail
 14 expect() calls
 ```
 
 ###  tests\inline-tool-continuation.test.ts:
 ```
✓ buildInlineToolContinuation — legacy text path > emits assistant text + a system results block [0.27ms]
✓ buildInlineToolContinuation — legacy text path > omits the assistant message when there is no output [0.07ms]
✓ buildInlineToolContinuation — structured interleaved path > emits tool_use + tool_result parts and echoes reasoning_content [0.18ms]
✓ buildInlineToolContinuation — structured interleaved path > only includes tool calls that actually produced a result (no orphans) [0.09ms]
✓ buildInlineToolContinuation — structured interleaved path > omits reasoning_content when the round produced no reasoning [0.03ms]
✓ buildInlineToolContinuation — structured interleaved path > falls back to legacy text when no tool resolved [0.03ms]
✓ DeepSeek provider round-trips the structured continuation > declares interleavedThinking capability [0.01ms]
✓ DeepSeek provider round-trips the structured continuation > echoes reasoning_content on the assistant tool-call message [0.23ms]
✓ DeepSeek provider round-trips the structured continuation > drops reasoning_content when the assistant turn has no tool call [0.04ms]

 9 pass
 0 fail
 33 expect() calls
 ```

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass.
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [x] Backend: `bun x tsc --noEmit`
  - [x] Frontend: `cd frontend && bun run typecheck`, `bun run lint`

## UI changes (if applicable)
N/A

## Performance changes (if applicable)

- [x] I added or updated tests.
- [ ] I included reproducible benchmarks and comparison results below.
- Benchmark commands and results: N/A

## Security-sensitive changes (if applicable)
This touches `src/spindle/` and authenticated user-context transport.

Security invariants preserved/added:
- model/tool args cannot supply or override authenticated identity;
- auth-shaped args remain stripped before worker delivery;
- trusted `userId` exists only as top-level host-owned transport metadata;
- missing internal user context rejects the invocation before any worker message is posted;
- `ToolInvocationPayloadDTO` remains identity-free in the public Spindle contract;
- both independent extension-tool callers are covered by regression assertions.


## LLM-assisted work (if applicable)
- [x] I, as the human orchestrating this work, audited the submitted changes
      in a live environment.