### PR TITLE
Warn when the desktop shell predates the checkout

### DIFF
--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -1,3 +1,59 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn git_output(args: &[&str]) -> Option<String> {
+    Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|text| text.trim().to_owned())
+        .filter(|text| !text.is_empty())
+}
+
+/// Stamp the commit this shell was compiled from.
+///
+/// The tray is a compiled binary living outside the checkout, so the runner's
+/// git update flow cannot replace it the way it replaces server and frontend
+/// code. Without a build stamp there is nothing to compare a moved checkout
+/// against, and a shell that is several releases behind looks exactly like one
+/// that is current.
+fn stamp_build_revision() {
+    let sha = git_output(&["rev-parse", "HEAD"]);
+
+    // Builds from a source archive have no git metadata. Stamp an empty
+    // revision rather than failing the build — the tray reads that as "cannot
+    // tell" and stays silent instead of guessing.
+    println!(
+        "cargo:rustc-env=LUMIVERSE_DESKTOP_SHA={}",
+        sha.clone().unwrap_or_default()
+    );
+
+    // Once a build script emits any rerun-if-changed, Cargo reruns it *only*
+    // when those paths change. So the paths must be ones a fast-forward pull
+    // actually touches. `.git/HEAD` is not one of them — on a branch it holds
+    // `ref: refs/heads/<name>` and is untouched by a pull — and neither is the
+    // `refs/` directory, whose mtime does not change when a file nested below
+    // it is rewritten. Getting this wrong stamps the *previous* revision into
+    // a binary compiled from new sources, which then reports itself stale.
+    //
+    // `index` is rewritten by every checkout and reset, including the runner's
+    // `reset --hard` to upstream. Together with HEAD (branch switches) and
+    // packed-refs (post-gc ref storage) it covers how a checkout moves.
+    // Resolve the git dir rather than assuming `../../.git`, so a worktree —
+    // where `.git` is a file pointing elsewhere — still gets real paths.
+    if sha.is_some() {
+        if let Some(git_dir) = git_output(&["rev-parse", "--git-dir"]) {
+            let git_dir = PathBuf::from(git_dir);
+            for entry in ["HEAD", "index", "packed-refs"] {
+                println!("cargo:rerun-if-changed={}", git_dir.join(entry).display());
+            }
+        }
+    }
+}
+
 fn main() {
+    stamp_build_revision();
     tauri_build::build()
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -145,6 +145,7 @@ pub fn run() {
             runner::validate_repo,
             runner::discover_repo,
             runner::resolve_bun,
+            runner::desktop_shell_sha,
             runner::quit_app,
             runner::alert,
             runner::pick_folder,

--- a/desktop/src-tauri/src/runner.rs
+++ b/desktop/src-tauri/src/runner.rs
@@ -311,6 +311,21 @@ pub fn discover_repo() -> Option<String> {
     None
 }
 
+/// The commit this desktop shell was compiled from, or `None` when the build
+/// carried no git metadata to stamp (a source-archive build, for example).
+///
+/// The runner compares this against the checkout to decide whether a pulled
+/// update contains desktop changes the running binary predates.
+#[tauri::command]
+pub fn desktop_shell_sha() -> Option<String> {
+    let sha = env!("LUMIVERSE_DESKTOP_SHA");
+    if sha.is_empty() {
+        None
+    } else {
+        Some(sha.to_owned())
+    }
+}
+
 /// Locate a usable bun binary. GUI apps on macOS get a minimal PATH, so
 /// probe the common install locations before falling back to PATH lookup.
 #[tauri::command]

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -19,7 +19,13 @@ import { TrayIcon } from "@tauri-apps/api/tray";
 import { listen } from "@tauri-apps/api/event";
 import { disable as disableAutostart, enable as enableAutostart, isEnabled as autostartEnabled } from "@tauri-apps/plugin-autostart";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { RunnerClient, type FullStatus, type ServerState, type UpdateState } from "./runner-client";
+import {
+  RunnerClient,
+  type DesktopShellState,
+  type FullStatus,
+  type ServerState,
+  type UpdateState,
+} from "./runner-client";
 import { loadSettings, saveSetting, type TraySettings } from "./settings";
 import trayMacIcon from "./assets/tray-mac.png";
 import trayWinIcon from "./assets/tray-win.png";
@@ -47,6 +53,12 @@ let busyMessage: string | null = null;
 let port = 7860;
 let lastStatus: FullStatus | null = null;
 let updateState: UpdateState = { available: false, commitsBehind: 0, latestMessage: "" };
+// The tray is a compiled binary the git update flow cannot replace, so a pull
+// carrying desktop changes leaves this process running superseded code.
+let desktopShellStale = false;
+let desktopShellNoticeShown = false;
+let desktopShellChecked = false;
+let updateJustApplied = false;
 let customFrontendUrl: string | null = null;
 let openIntegratedBrowserWhenReady = false;
 
@@ -82,7 +94,19 @@ let desktopWidgetCatalog: DesktopWidgetCatalogEntry[] = [];
 
 function statusText(): string {
   if (busyMessage) return busyMessage;
-  if (externalRunning) return "Lumiverse running (external)";
+  // A dismissed dialog is easy to forget, and the symptom of a stale shell is
+  // simply that the old behaviour persists. Keep the state visible in the
+  // headline for as long as it is true.
+  const suffix = desktopShellStale ? " · desktop rebuild required" : "";
+  if (externalRunning) return `Lumiverse running (external)${suffix}`;
+  if (suffix) {
+    switch (serverState) {
+      case "running":
+        return `Lumiverse running${suffix}`;
+      case "stopped":
+        return `Lumiverse stopped${suffix}`;
+    }
+  }
   switch (serverState) {
     case "running":
       return "Lumiverse running";
@@ -259,6 +283,7 @@ async function checkForUpdates(interactive: boolean): Promise<void> {
   const result = await client.request<UpdateState>("check-updates", undefined, 90_000);
   updateState = result;
   await updateMenu();
+  await refreshDesktopShellState();
   if (interactive) {
     if (result.available) {
       await alert(
@@ -271,8 +296,47 @@ async function checkForUpdates(interactive: boolean): Promise<void> {
   }
 }
 
+/**
+ * Ask the checkout whether it has moved past the desktop sources this binary
+ * was compiled from. Only the checkout can answer — the shell knows just the
+ * revision stamped into it at build time.
+ */
+async function refreshDesktopShellState(): Promise<void> {
+  if (!repoDir || !(await client.alive())) return;
+  let state: DesktopShellState;
+  try {
+    const builtSha = await invoke<string | null>("desktop_shell_sha");
+    state = await client.request<DesktopShellState>("desktop-shell-status", { builtSha }, 15_000);
+  } catch {
+    // An unreachable or older runner cannot answer. Leave the previous
+    // verdict alone rather than clearing a warning we still believe.
+    return;
+  }
+
+  desktopShellChecked = true;
+  const becameStale = state.stale && !desktopShellStale;
+  desktopShellStale = state.stale;
+  // A rebuild clears the condition; let the notice fire again if it recurs.
+  if (!state.stale) desktopShellNoticeShown = false;
+  await updateMenu();
+
+  if (becameStale && !desktopShellNoticeShown) {
+    desktopShellNoticeShown = true;
+    await alert(
+      "Lumiverse Desktop rebuild required",
+      "This update changed Lumiverse Desktop itself. The app you are running " +
+        "was built before those changes and keeps its previous behaviour " +
+        "until it is rebuilt.\n\n" +
+        "To finish updating, quit Lumiverse Desktop and run:\n\n" +
+        `cd ${repoDir}/desktop && bun run tauri build\n\n` +
+        "Then replace the installed app with the new build.",
+    );
+  }
+}
+
 async function applyUpdate(): Promise<void> {
   await ensureRunner();
+  updateJustApplied = true;
   busyMessage = "Applying update…";
   await updateMenu();
   try {
@@ -563,6 +627,12 @@ async function boot(): Promise<void> {
     }
     if (state === "running" || state === "stopped" || state === "crashed") {
       busyMessage = null;
+    }
+    // The check needs a live runner, so the first chance to run it is the
+    // server coming up. Repeat it once an applied update has settled.
+    if (state === "running" && (!desktopShellChecked || updateJustApplied)) {
+      updateJustApplied = false;
+      void refreshDesktopShellState();
     }
     void refreshStatus().then(updateMenu);
   };

--- a/desktop/src/runner-client.ts
+++ b/desktop/src/runner-client.ts
@@ -31,6 +31,12 @@ export interface UpdateState {
   latestMessage: string;
 }
 
+export interface DesktopShellState {
+  stale: boolean;
+  builtSha: string | null;
+  requiredSha: string | null;
+}
+
 interface ResponsePayload {
   success: boolean;
   data?: unknown;

--- a/scripts/runner/git-ops.ts
+++ b/scripts/runner/git-ops.ts
@@ -20,6 +20,15 @@ export interface UpdateState {
   latestMessage: string;
 }
 
+export interface DesktopShellState {
+  /** The checkout contains desktop changes the running binary predates. */
+  stale: boolean;
+  /** Commit the running desktop shell was compiled from, if it reported one. */
+  builtSha: string | null;
+  /** Newest commit touching `desktop/` in the checkout. */
+  requiredSha: string | null;
+}
+
 type ProgressReporter = (message: string) => void;
 
 const FRONTEND_BUILD_IGNORED_PATHS = [
@@ -69,6 +78,43 @@ function isFrontendBuildInput(filePath: string): boolean {
 
 function shouldRebuildFrontend(changedFiles: string[] | null): boolean {
   return changedFiles === null || changedFiles.some(isFrontendBuildInput);
+}
+
+/** Newest commit that touched the desktop shell's sources. */
+function getLastDesktopShellCommit(): string | null {
+  const log = runGit("log", "-1", "--format=%H", "--", "desktop");
+  if (!log.ok || !log.out) return null;
+  return log.out;
+}
+
+function commitExists(sha: string): boolean {
+  return runGit("cat-file", "-e", `${sha}^{commit}`).ok;
+}
+
+/**
+ * Decide whether the running desktop shell predates the checkout's desktop
+ * sources.
+ *
+ * The shell is a compiled binary that `applyUpdate` cannot replace, so a pull
+ * carrying `desktop/` changes leaves the user running code the checkout has
+ * already moved past — with no symptom other than the old behaviour
+ * persisting. Equality is the wrong test: the stamped revision is whatever
+ * HEAD was at build time, which normally sits *ahead* of the last commit that
+ * touched `desktop/`. What matters is whether that commit is already reachable
+ * from the build.
+ *
+ * Every branch that cannot answer confidently reports "not stale". A shell
+ * built from an archive, or from a history this checkout does not share, is
+ * unknowable rather than out of date, and a false warning telling someone to
+ * rebuild a current binary is worse than staying quiet.
+ */
+export function evaluateDesktopShell(builtSha: string | null): DesktopShellState {
+  const requiredSha = getLastDesktopShellCommit();
+  if (!builtSha || !requiredSha) return { stale: false, builtSha, requiredSha };
+  if (!commitExists(builtSha)) return { stale: false, builtSha, requiredSha };
+
+  const containsDesktopSources = runGit("merge-base", "--is-ancestor", requiredSha, builtSha).ok;
+  return { stale: !containsDesktopSources, builtSha, requiredSha };
 }
 
 // Termux/proot detection. start.sh exports LUMIVERSE_IS_TERMUX /

--- a/scripts/runner/ipc-handler.ts
+++ b/scripts/runner/ipc-handler.ts
@@ -18,6 +18,7 @@ import {
   runWithServerStopped,
   assertUpdateCanHardSync,
   assertBranchCanHardSync,
+  evaluateDesktopShell,
 } from "./git-ops.js";
 import { readEnvConfig, writeTrustAnyOrigin } from "./env-config.js";
 import { getCurrentBranch } from "./lib/git.js";
@@ -116,6 +117,13 @@ export async function handleIPCMessage(msg: any, sink?: ResponseSink): Promise<v
         commitsBehind: lastUpdateState.commitsBehind,
         latestUpdateMessage: lastUpdateState.latestMessage,
       });
+      break;
+    }
+
+    case "desktop-shell-status": {
+      // The tray reports the revision it was compiled from; only the checkout
+      // can say whether that predates its desktop sources.
+      respond(id, true, evaluateDesktopShell(payload?.builtSha ?? null));
       break;
     }
 


### PR DESCRIPTION
## Summary

`applyUpdate()` in `scripts/runner/git-ops.ts` installs changed dependencies and rebuilds the frontend when the pulled files touch frontend build inputs. There is no equivalent path for `desktop/`, and there cannot be — the tray is a compiled binary living outside the checkout, so a git update genuinely cannot replace it.

Nothing tells the user that. A pull carrying `desktop/` changes leaves them running a shell the checkout has already moved past, and the only symptom is that the old behaviour persists. It reads as "the fix didn't work" rather than "the fix isn't installed yet".

This is not hypothetical. #322 fixed a desktop-shell bug where the startup overlay never lifted on `/login`. Pulling that fix changed nothing for anyone whose installed binary predated it, because `git pull` cannot recompile the tray.

The shell also had no way to know it was stale: `build.rs` was a bare `tauri_build::build()`, nothing stamped the binary, and `CARGO_PKG_VERSION` has been `0.1.0` since the first commit. There was no fact to compare against.

This change adds that fact and reports it:

- **`build.rs`** stamps the commit the shell was compiled from into `LUMIVERSE_DESKTOP_SHA`, with `rerun-if-changed` on the repo's git refs so a rebuild after a pull restamps. A build with no git metadata (source archive) stamps empty.
- **`desktop_shell_sha`** exposes that revision, and a new `desktop-shell-status` IPC message hands it to the runner — the only side that can consult the checkout.
- **`evaluateDesktopShell()`** reports stale when the newest commit touching `desktop/` is not reachable from the build revision. Equality would be the wrong test: the stamp is HEAD at build time, which normally sits *ahead* of the last commit that touched `desktop/`.
- **The tray** evaluates this once the server is up and again after an applied update settles, then shows a dialog naming the exact rebuild command and keeps `· desktop rebuild required` in the status line. A dismissed dialog is easy to forget, and this failure mode is silent by nature.

Every branch that cannot answer confidently reports "not stale" — no stamped revision, no `desktop/` history, a revision this checkout does not contain, or an older runner that does not know the message. Falsely telling someone to rebuild a current binary is worse than staying quiet.

Scope is detection and notification only. Replacing a running bundle needs a detached helper process and a Rust/Xcode toolchain many installs do not have; the durable answer there is `tauri-plugin-updater` against signed releases, which is a much larger change and orthogonal to reporting the current state honestly.

## Validation

```text
bun x tsc --noEmit
# clean, no output

cd desktop && bun run typecheck
# clean (tsc --noEmit)

cd desktop && bun run tauri build
# Finished `release` profile [optimized] target(s) in 2m 19s
# Bundling Lumiverse Desktop.app — clean, no warnings

cd frontend && bun run typecheck
# clean

cd frontend && bun run lint
# 1 error, pre-existing and unrelated:
#   src/components/modals/RegexPromptActivationEditor.test.tsx:58:5
#   react-compiler/react-compiler
# Identical on unmodified base 22104888. This PR touches no frontend files.

bun test --isolate
#  4242 pass, 3 skip, 2 fail, 1 error   (branch)
#  4242 pass, 3 skip, 2 fail, 1 error   (unmodified base 22104888)
# Byte-identical totals. The failing test
# (frontend/.../edit-send-streaming-native-placement.preservation.vite.isolated)
# passes in isolation on both branch and base — flaky under the full run,
# not affected by this change.
```

Confirmed the stamp reaches the shipped binary: the SHA embedded in the built `lumiverse-tray` matches the checkout's HEAD.

**Confirmed the stamp follows the checkout across a rebuild** — the property this whole PR depends on. An earlier revision of `build.rs` watched `.git/HEAD` and `.git/refs`, and neither changes on a same-branch fast-forward (`HEAD` holds `ref: refs/heads/…`; the moved ref is nested below `refs/`, so the directory's mtime is untouched). Cargo would have reused the cached build script and stamped the *previous* revision into a binary compiled from new sources — which then reports itself stale. Measured on a scratch repository:

```text
.git/HEAD  mtime changed after new commit on same branch? NO
.git/refs  mtime changed after new commit on same branch? NO
```

`build.rs` now watches `HEAD`, `index` and `packed-refs`, resolved through `git rev-parse --git-dir` so worktrees get real paths. Verified end to end: build at `5475333f`, add a commit, `reset --hard` (the runner's own update path), rebuild.

```text
after commit:        index-mtime-changed=YES
build#2 stamp has NEW sha? 1   still has OLD sha? 0
build.rs + crate recompiled in #2: yes   (no source file changed — only .git/index)
```

Exercised `evaluateDesktopShell()` against this repository's real history, using the #322 desktop commit (`27a34973`) as the boundary:

| build revision | verdict |
|---|---|
| HEAD, built after the desktop change | current |
| `142a6fc3`, the commit before it | **stale** |
| exactly at the desktop change | current |
| none stamped (archive build) | current |
| revision absent from this history | current |

The second row is the #322 scenario reproduced: a shell built one commit too early, against a checkout that already has the fix.

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass. *(Full-suite results are identical to the
      unmodified base — see Validation. The one failure is pre-existing and
      passes in isolation.)*
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [x] Backend: `bun x tsc --noEmit`
  - [x] Frontend: `cd frontend && bun run typecheck`, `bun run lint`
        *(run for completeness; this PR touches no frontend files. The single
        lint error is pre-existing on base.)*

Also ran `cd desktop && bun run typecheck`, which is the type check that
actually covers the changed tray code.

## UI changes (if applicable)

- [ ] I validated this change in more than one browser.
- [ ] I verified the integrated experience on a mobile interface or through
      the mobile PWA.
- Browsers, devices, and PWA coverage: **not applicable.** The only UI surfaces
  touched are the native tray status line and a native dialog. No browser or
  PWA code path is involved, and no frontend file is modified.

## Performance changes (if applicable)

Not applicable. The check runs at most twice per session — once when the server
first comes up, and once after an applied update settles — and costs three
short git invocations.

## Security-sensitive changes (if applicable)

No impact on Spindle or any other security system. The new `desktop-shell-status`
IPC message is read-only: it accepts a commit SHA, runs `git log`, `git cat-file -e`
and `git merge-base --is-ancestor` inside the existing project root, and returns
two SHAs and a boolean. It grants no new authority, touches no auth or extension
surface, and writes nothing.

## LLM-assisted work (if applicable)

- [ ] I, as the human orchestrating this work, audited the submitted changes
      in a live environment.

Not yet ticked. This change is user-visible tray behaviour, so I am installing
the build and confirming the stale notice appears against a shell that predates
`27a34973` before claiming the audit. I will tick this and comment with the
result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

