### PR TITLE
Add a desktop build prerequisite check

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,9 @@ with Lumiverse's integrated browser as its primary interface and a macOS menu
 bar / Windows system tray / Linux StatusNotifier icon for controls. It starts
 and stops a local server, shows serving stats, opens the same address in your
 default browser on request, and applies updates through the runner. See
-[desktop/README.md](desktop/README.md) for build instructions.
+[desktop/README.md](desktop/README.md) for build instructions. There is no
+prebuilt download — run `bun run desktop:doctor` to check whether this machine
+can build it.
 
 ## Configuration
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -55,6 +55,9 @@ surface. Browser and PWA rendering ignore this desktop-only setting.
 
 ## Prerequisites
 
+Run `bun run desktop:doctor` from the repository root to check all of these at
+once. It reports what is missing and the exact command to install it.
+
 - [Bun](https://bun.sh) ≥ 1.4.0 (also required by the server itself)
 - [Rust](https://rustup.rs) stable (Tauri v2 builds the native shell)
 

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -1,3 +1,59 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn git_output(args: &[&str]) -> Option<String> {
+    Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|text| text.trim().to_owned())
+        .filter(|text| !text.is_empty())
+}
+
+/// Stamp the commit this shell was compiled from.
+///
+/// The tray is a compiled binary living outside the checkout, so the runner's
+/// git update flow cannot replace it the way it replaces server and frontend
+/// code. Without a build stamp there is nothing to compare a moved checkout
+/// against, and a shell that is several releases behind looks exactly like one
+/// that is current.
+fn stamp_build_revision() {
+    let sha = git_output(&["rev-parse", "HEAD"]);
+
+    // Builds from a source archive have no git metadata. Stamp an empty
+    // revision rather than failing the build — the tray reads that as "cannot
+    // tell" and stays silent instead of guessing.
+    println!(
+        "cargo:rustc-env=LUMIVERSE_DESKTOP_SHA={}",
+        sha.clone().unwrap_or_default()
+    );
+
+    // Once a build script emits any rerun-if-changed, Cargo reruns it *only*
+    // when those paths change. So the paths must be ones a fast-forward pull
+    // actually touches. `.git/HEAD` is not one of them — on a branch it holds
+    // `ref: refs/heads/<name>` and is untouched by a pull — and neither is the
+    // `refs/` directory, whose mtime does not change when a file nested below
+    // it is rewritten. Getting this wrong stamps the *previous* revision into
+    // a binary compiled from new sources, which then reports itself stale.
+    //
+    // `index` is rewritten by every checkout and reset, including the runner's
+    // `reset --hard` to upstream. Together with HEAD (branch switches) and
+    // packed-refs (post-gc ref storage) it covers how a checkout moves.
+    // Resolve the git dir rather than assuming `../../.git`, so a worktree —
+    // where `.git` is a file pointing elsewhere — still gets real paths.
+    if sha.is_some() {
+        if let Some(git_dir) = git_output(&["rev-parse", "--git-dir"]) {
+            let git_dir = PathBuf::from(git_dir);
+            for entry in ["HEAD", "index", "packed-refs"] {
+                println!("cargo:rerun-if-changed={}", git_dir.join(entry).display());
+            }
+        }
+    }
+}
+
 fn main() {
+    stamp_build_revision();
     tauri_build::build()
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -145,6 +145,7 @@ pub fn run() {
             runner::validate_repo,
             runner::discover_repo,
             runner::resolve_bun,
+            runner::desktop_shell_sha,
             runner::quit_app,
             runner::alert,
             runner::pick_folder,

--- a/desktop/src-tauri/src/runner.rs
+++ b/desktop/src-tauri/src/runner.rs
@@ -311,6 +311,21 @@ pub fn discover_repo() -> Option<String> {
     None
 }
 
+/// The commit this desktop shell was compiled from, or `None` when the build
+/// carried no git metadata to stamp (a source-archive build, for example).
+///
+/// The runner compares this against the checkout to decide whether a pulled
+/// update contains desktop changes the running binary predates.
+#[tauri::command]
+pub fn desktop_shell_sha() -> Option<String> {
+    let sha = env!("LUMIVERSE_DESKTOP_SHA");
+    if sha.is_empty() {
+        None
+    } else {
+        Some(sha.to_owned())
+    }
+}
+
 /// Locate a usable bun binary. GUI apps on macOS get a minimal PATH, so
 /// probe the common install locations before falling back to PATH lookup.
 #[tauri::command]

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -19,7 +19,13 @@ import { TrayIcon } from "@tauri-apps/api/tray";
 import { listen } from "@tauri-apps/api/event";
 import { disable as disableAutostart, enable as enableAutostart, isEnabled as autostartEnabled } from "@tauri-apps/plugin-autostart";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { RunnerClient, type FullStatus, type ServerState, type UpdateState } from "./runner-client";
+import {
+  RunnerClient,
+  type DesktopShellState,
+  type FullStatus,
+  type ServerState,
+  type UpdateState,
+} from "./runner-client";
 import { loadSettings, saveSetting, type TraySettings } from "./settings";
 import trayMacIcon from "./assets/tray-mac.png";
 import trayWinIcon from "./assets/tray-win.png";
@@ -47,6 +53,12 @@ let busyMessage: string | null = null;
 let port = 7860;
 let lastStatus: FullStatus | null = null;
 let updateState: UpdateState = { available: false, commitsBehind: 0, latestMessage: "" };
+// The tray is a compiled binary the git update flow cannot replace, so a pull
+// carrying desktop changes leaves this process running superseded code.
+let desktopShellStale = false;
+let desktopShellNoticeShown = false;
+let desktopShellChecked = false;
+let updateJustApplied = false;
 let customFrontendUrl: string | null = null;
 let openIntegratedBrowserWhenReady = false;
 
@@ -82,7 +94,19 @@ let desktopWidgetCatalog: DesktopWidgetCatalogEntry[] = [];
 
 function statusText(): string {
   if (busyMessage) return busyMessage;
-  if (externalRunning) return "Lumiverse running (external)";
+  // A dismissed dialog is easy to forget, and the symptom of a stale shell is
+  // simply that the old behaviour persists. Keep the state visible in the
+  // headline for as long as it is true.
+  const suffix = desktopShellStale ? " · desktop rebuild required" : "";
+  if (externalRunning) return `Lumiverse running (external)${suffix}`;
+  if (suffix) {
+    switch (serverState) {
+      case "running":
+        return `Lumiverse running${suffix}`;
+      case "stopped":
+        return `Lumiverse stopped${suffix}`;
+    }
+  }
   switch (serverState) {
     case "running":
       return "Lumiverse running";
@@ -259,6 +283,7 @@ async function checkForUpdates(interactive: boolean): Promise<void> {
   const result = await client.request<UpdateState>("check-updates", undefined, 90_000);
   updateState = result;
   await updateMenu();
+  await refreshDesktopShellState();
   if (interactive) {
     if (result.available) {
       await alert(
@@ -271,8 +296,47 @@ async function checkForUpdates(interactive: boolean): Promise<void> {
   }
 }
 
+/**
+ * Ask the checkout whether it has moved past the desktop sources this binary
+ * was compiled from. Only the checkout can answer — the shell knows just the
+ * revision stamped into it at build time.
+ */
+async function refreshDesktopShellState(): Promise<void> {
+  if (!repoDir || !(await client.alive())) return;
+  let state: DesktopShellState;
+  try {
+    const builtSha = await invoke<string | null>("desktop_shell_sha");
+    state = await client.request<DesktopShellState>("desktop-shell-status", { builtSha }, 15_000);
+  } catch {
+    // An unreachable or older runner cannot answer. Leave the previous
+    // verdict alone rather than clearing a warning we still believe.
+    return;
+  }
+
+  desktopShellChecked = true;
+  const becameStale = state.stale && !desktopShellStale;
+  desktopShellStale = state.stale;
+  // A rebuild clears the condition; let the notice fire again if it recurs.
+  if (!state.stale) desktopShellNoticeShown = false;
+  await updateMenu();
+
+  if (becameStale && !desktopShellNoticeShown) {
+    desktopShellNoticeShown = true;
+    await alert(
+      "Lumiverse Desktop rebuild required",
+      "This update changed Lumiverse Desktop itself. The app you are running " +
+        "was built before those changes and keeps its previous behaviour " +
+        "until it is rebuilt.\n\n" +
+        "To finish updating, quit Lumiverse Desktop and run:\n\n" +
+        `cd ${repoDir}/desktop && bun run tauri build\n\n` +
+        "Then replace the installed app with the new build.",
+    );
+  }
+}
+
 async function applyUpdate(): Promise<void> {
   await ensureRunner();
+  updateJustApplied = true;
   busyMessage = "Applying update…";
   await updateMenu();
   try {
@@ -563,6 +627,12 @@ async function boot(): Promise<void> {
     }
     if (state === "running" || state === "stopped" || state === "crashed") {
       busyMessage = null;
+    }
+    // The check needs a live runner, so the first chance to run it is the
+    // server coming up. Repeat it once an applied update has settled.
+    if (state === "running" && (!desktopShellChecked || updateJustApplied)) {
+      updateJustApplied = false;
+      void refreshDesktopShellState();
     }
     void refreshStatus().then(updateMenu);
   };

--- a/desktop/src/runner-client.ts
+++ b/desktop/src/runner-client.ts
@@ -31,6 +31,12 @@ export interface UpdateState {
   latestMessage: string;
 }
 
+export interface DesktopShellState {
+  stale: boolean;
+  builtSha: string | null;
+  requiredSha: string | null;
+}
+
 interface ResponsePayload {
   success: boolean;
   data?: unknown;

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "build:lancedb:android": "bash scripts/build-lancedb-android.sh",
     "setup": "bun run scripts/setup-wizard.ts",
     "install:smartctl": "bun run scripts/install-smartctl.ts",
+    "desktop:doctor": "bun run scripts/desktop-doctor.ts",
     "runner": "bun run scripts/runner.ts",
     "runner:dev": "bun run scripts/runner.ts -- --dev",
     "start:all": "bun run build:frontend && FRONTEND_DIR=$(cd frontend/dist && pwd) bun run start",

--- a/scripts/desktop-doctor.ts
+++ b/scripts/desktop-doctor.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env bun
+/**
+ * Lumiverse Desktop prerequisite check.
+ *
+ * Run with: bun run desktop:doctor
+ *
+ * Reports whether this machine can build the desktop app, and prints the exact
+ * remedy for anything missing. Exits non-zero when a required prerequisite is
+ * absent so it can gate a build in a script.
+ */
+
+import {
+  desktopBuildCommand,
+  inspectDesktopToolchain,
+  type ToolchainCheck,
+} from "./desktop-toolchain";
+import { printBanner, printDivider, theme } from "./ui";
+
+const SYMBOL: Record<ToolchainCheck["status"], string> = {
+  ok: `${theme.success}✓${theme.reset}`,
+  missing: `${theme.warning}✗${theme.reset}`,
+  unverified: `${theme.muted}?${theme.reset}`,
+};
+
+const PLATFORM_LABEL = {
+  macos: "macOS",
+  windows: "Windows",
+  linux: "Linux",
+  other: "this platform",
+} as const;
+
+async function main() {
+  printBanner("Desktop build prerequisites");
+
+  const report = await inspectDesktopToolchain();
+  console.log(`  ${theme.muted}Platform: ${PLATFORM_LABEL[report.platform]}${theme.reset}`);
+  console.log("");
+
+  const width = Math.max(...report.checks.map((check) => check.label.length));
+  for (const check of report.checks) {
+    console.log(`  ${SYMBOL[check.status]}  ${check.label.padEnd(width)}  ${theme.muted}${check.detail}${theme.reset}`);
+  }
+
+  const actionable = report.checks.filter((check) => check.status !== "ok" && check.remedy.length > 0);
+  if (actionable.length > 0) {
+    console.log("");
+    printDivider();
+    for (const check of actionable) {
+      console.log("");
+      console.log(`  ${theme.warning}${check.label}${theme.reset}`);
+      for (const line of check.remedy) {
+        console.log(`    ${theme.muted}${line}${theme.reset}`);
+      }
+    }
+  }
+
+  console.log("");
+  printDivider();
+  console.log("");
+  if (report.ready) {
+    console.log(`  ${theme.success}Ready to build.${theme.reset}`);
+    console.log(`  ${theme.muted}From the repository root:${theme.reset}`);
+    console.log(`    ${desktopBuildCommand()}`);
+    if (report.platform === "other") {
+      console.log("");
+      console.log(`  ${theme.muted}Lumiverse Desktop targets macOS, Windows and Linux; this platform is untested.${theme.reset}`);
+    }
+  } else {
+    console.log(`  ${theme.warning}Not ready to build.${theme.reset}`);
+    console.log(`  ${theme.muted}Resolve the items above, then run this check again.${theme.reset}`);
+  }
+  console.log("");
+
+  process.exit(report.ready ? 0 : 1);
+}
+
+main();

--- a/scripts/desktop-toolchain.test.ts
+++ b/scripts/desktop-toolchain.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import {
+  currentDesktopPlatform,
+  inspectDesktopToolchain,
+  meetsVersion,
+  MIN_BUN_VERSION,
+} from "./desktop-toolchain";
+
+describe("meetsVersion", () => {
+  test("accepts an exact match", () => {
+    expect(meetsVersion("1.4.0", "1.4.0")).toBe(true);
+  });
+
+  test("accepts newer versions at every position", () => {
+    expect(meetsVersion("2.0.0", "1.4.0")).toBe(true);
+    expect(meetsVersion("1.5.0", "1.4.0")).toBe(true);
+    expect(meetsVersion("1.4.1", "1.4.0")).toBe(true);
+  });
+
+  test("rejects older versions at every position", () => {
+    expect(meetsVersion("0.9.9", "1.4.0")).toBe(false);
+    expect(meetsVersion("1.3.9", "1.4.0")).toBe(false);
+    expect(meetsVersion("1.4.0", "1.4.1")).toBe(false);
+  });
+
+  test("does not compare version parts as strings", () => {
+    // A lexicographic comparison would call "1.10.0" older than "1.9.0".
+    expect(meetsVersion("1.10.0", "1.9.0")).toBe(true);
+  });
+
+  test("treats missing trailing parts as zero", () => {
+    expect(meetsVersion("1.4", "1.4.0")).toBe(true);
+    expect(meetsVersion("1.4", "1.4.1")).toBe(false);
+    expect(meetsVersion("1.4.0.1", "1.4.0")).toBe(true);
+  });
+
+  test("treats unparseable parts as zero rather than throwing", () => {
+    expect(meetsVersion("1.4.0-canary", "1.4.0")).toBe(true);
+    expect(() => meetsVersion("", "1.4.0")).not.toThrow();
+  });
+});
+
+describe("inspectDesktopToolchain", () => {
+  test("always reports on Bun and Rust", async () => {
+    const report = await inspectDesktopToolchain();
+    const ids = report.checks.map((check) => check.id);
+    expect(ids).toContain("bun");
+    expect(ids).toContain("cargo");
+  });
+
+  test("every check is fully populated", async () => {
+    const report = await inspectDesktopToolchain();
+    expect(report.checks.length).toBeGreaterThan(0);
+    for (const check of report.checks) {
+      expect(check.id).toBeTruthy();
+      expect(check.label).toBeTruthy();
+      expect(check.detail).toBeTruthy();
+      expect(["ok", "missing", "unverified"]).toContain(check.status);
+      expect(Array.isArray(check.remedy)).toBe(true);
+    }
+  });
+
+  test("anything reported missing tells the user how to fix it", async () => {
+    const report = await inspectDesktopToolchain();
+    for (const check of report.checks) {
+      if (check.status !== "missing") continue;
+      expect(check.remedy.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("readiness ignores unverified checks and fails only on missing ones", async () => {
+    const report = await inspectDesktopToolchain();
+    const hasMissing = report.checks.some((check) => check.status === "missing");
+    expect(report.ready).toBe(!hasMissing);
+  });
+
+  test("reports a platform the doctor knows how to label", async () => {
+    const report = await inspectDesktopToolchain();
+    expect(["macos", "windows", "linux", "other"]).toContain(report.platform);
+    expect(report.platform).toBe(currentDesktopPlatform());
+  });
+
+  test("the suite itself runs on a Bun new enough to build the desktop app", () => {
+    // Guards the floor the wizard and doctor both check against.
+    expect(meetsVersion(Bun.version, MIN_BUN_VERSION)).toBe(true);
+  });
+});

--- a/scripts/desktop-toolchain.ts
+++ b/scripts/desktop-toolchain.ts
@@ -1,0 +1,266 @@
+/**
+ * Prerequisite inspection for building Lumiverse Desktop.
+ *
+ * The desktop app ships no binaries — every install is compiled locally — so
+ * the build toolchain is the first thing standing between a new user and a
+ * working tray. Discovering a missing prerequisite as a linker error part-way
+ * through a Rust build is a poor introduction, and the requirements differ per
+ * platform.
+ *
+ * Shared by `bun run desktop:doctor` and the first-run setup wizard.
+ */
+
+import { existsSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+
+/** Minimum Bun the desktop build requires (see desktop/README.md). */
+export const MIN_BUN_VERSION = "1.4.0";
+
+export type CheckStatus = "ok" | "missing" | "unverified";
+
+export interface ToolchainCheck {
+  id: string;
+  label: string;
+  status: CheckStatus;
+  /** What was found, or why the check could not conclude. */
+  detail: string;
+  /** How to satisfy the requirement, one line per step. */
+  remedy: string[];
+}
+
+export type DesktopPlatform = "macos" | "windows" | "linux" | "other";
+
+export interface DesktopToolchainReport {
+  platform: DesktopPlatform;
+  /** No required check is missing. Unverified checks do not block. */
+  ready: boolean;
+  checks: ToolchainCheck[];
+}
+
+export function currentDesktopPlatform(): DesktopPlatform {
+  switch (platform()) {
+    case "darwin":
+      return "macos";
+    case "win32":
+      return "windows";
+    case "linux":
+      return "linux";
+    default:
+      return "other";
+  }
+}
+
+interface ProbeResult {
+  ok: boolean;
+  out: string;
+}
+
+async function probe(command: string[]): Promise<ProbeResult> {
+  try {
+    // stderr is deliberately dropped rather than piped: a pipe nobody reads
+    // fills its buffer and stalls the child. Only the exit code and stdout
+    // carry signal here.
+    const proc = Bun.spawn({ cmd: command, stdout: "pipe", stderr: "ignore" });
+    const [out, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      proc.exited,
+    ]);
+    return { ok: exitCode === 0, out: out.trim() };
+  } catch {
+    // A missing executable throws rather than exiting non-zero.
+    return { ok: false, out: "" };
+  }
+}
+
+/** Compare dotted numeric versions. Returns true when `value` >= `minimum`. */
+export function meetsVersion(value: string, minimum: string): boolean {
+  const parse = (text: string) =>
+    text
+      .split(".")
+      .map((part) => parseInt(part, 10))
+      .map((part) => (Number.isFinite(part) ? part : 0));
+  const actual = parse(value);
+  const required = parse(minimum);
+  const length = Math.max(actual.length, required.length);
+  for (let index = 0; index < length; index += 1) {
+    const left = actual[index] ?? 0;
+    const right = required[index] ?? 0;
+    if (left > right) return true;
+    if (left < right) return false;
+  }
+  return true;
+}
+
+function checkBun(): ToolchainCheck {
+  // This script is running under Bun, so the version is already known and
+  // needs no subprocess.
+  const version = Bun.version;
+  const ok = meetsVersion(version, MIN_BUN_VERSION);
+  return {
+    id: "bun",
+    label: "Bun",
+    status: ok ? "ok" : "missing",
+    detail: ok ? `v${version}` : `v${version}, below the required v${MIN_BUN_VERSION}`,
+    remedy: ok ? [] : ["Upgrade Bun:", "  bun upgrade"],
+  };
+}
+
+/**
+ * Locate cargo. A desktop-session shell and a GUI-launched process see very
+ * different PATHs, so fall back to the standard rustup location the same way
+ * the tray's own bun lookup does.
+ */
+async function checkCargo(): Promise<ToolchainCheck> {
+  const remedy = [
+    "Install the Rust toolchain:",
+    "  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh",
+    "  (Windows: download rustup-init.exe from https://rustup.rs)",
+  ];
+
+  const onPath = await probe(["cargo", "--version"]);
+  if (onPath.ok) {
+    return { id: "cargo", label: "Rust (cargo)", status: "ok", detail: onPath.out, remedy: [] };
+  }
+
+  const fallback = join(homedir(), ".cargo", "bin", platform() === "win32" ? "cargo.exe" : "cargo");
+  if (existsSync(fallback)) {
+    const direct = await probe([fallback, "--version"]);
+    if (direct.ok) {
+      return {
+        id: "cargo",
+        label: "Rust (cargo)",
+        status: "ok",
+        detail: `${direct.out} (at ${fallback}, not on PATH)`,
+        remedy: [
+          "cargo works but is not on your PATH. Add it so the build can find it:",
+          '  export PATH="$HOME/.cargo/bin:$PATH"',
+        ],
+      };
+    }
+  }
+
+  return { id: "cargo", label: "Rust (cargo)", status: "missing", detail: "not found", remedy };
+}
+
+async function checkMacosPrerequisites(): Promise<ToolchainCheck[]> {
+  const tools = await probe(["xcode-select", "-p"]);
+  return [
+    {
+      id: "xcode-clt",
+      label: "Xcode Command Line Tools",
+      status: tools.ok ? "ok" : "missing",
+      detail: tools.ok ? tools.out : "not installed",
+      remedy: tools.ok ? [] : ["Install them:", "  xcode-select --install"],
+    },
+  ];
+}
+
+async function checkLinuxPrerequisites(): Promise<ToolchainCheck[]> {
+  const remedy = [
+    "Install the GTK/WebKitGTK and AppIndicator development packages.",
+    "The exact package names for Debian, Fedora and Arch are listed in",
+    "desktop/README.md under Prerequisites.",
+  ];
+
+  const pkgConfig = await probe(["pkg-config", "--version"]);
+  if (!pkgConfig.ok) {
+    // Without pkg-config there is no reliable way to ask about the libraries,
+    // and guessing package state from the filesystem is worse than admitting
+    // the check could not run.
+    return [
+      {
+        id: "webkitgtk",
+        label: "WebKitGTK / AppIndicator",
+        status: "unverified",
+        detail: "pkg-config is not installed, so the libraries could not be checked",
+        remedy,
+      },
+    ];
+  }
+
+  const checks: ToolchainCheck[] = [];
+  for (const [id, label, packages] of [
+    ["webkitgtk", "WebKitGTK 4.1", ["webkit2gtk-4.1"]],
+    // Either implementation satisfies the build. desktop/README.md installs
+    // the Ayatana package on Debian and libappindicator-gtk3 on Fedora and
+    // Arch, and the two register different pkg-config names.
+    ["appindicator", "AppIndicator", ["ayatana-appindicator3-0.1", "appindicator3-0.1"]],
+  ] as const) {
+    let found: string | null = null;
+    for (const pkg of packages) {
+      if ((await probe(["pkg-config", "--exists", pkg])).ok) {
+        found = pkg;
+        break;
+      }
+    }
+    checks.push({
+      id,
+      label,
+      status: found ? "ok" : "missing",
+      detail: found ? `${found} found` : `${packages.join(" / ")} not found`,
+      remedy: found ? [] : remedy,
+    });
+  }
+  return checks;
+}
+
+function checkWindowsPrerequisites(): ToolchainCheck[] {
+  // Both of these can be present in forms this probe would not recognise: the
+  // MSVC linker only appears on PATH inside a Developer Command Prompt, and
+  // WebView2 ships preinstalled on Windows 11. Reporting them as missing would
+  // send people to reinstall software they already have, so surface them as
+  // requirements to confirm rather than as failures.
+  return [
+    {
+      id: "msvc",
+      label: "MSVC build tools",
+      status: "unverified",
+      detail: "cannot be detected reliably outside a Developer Command Prompt",
+      remedy: [
+        "If the build fails at the link step, install the Visual Studio",
+        "Build Tools with the C++ workload.",
+      ],
+    },
+    {
+      id: "webview2",
+      label: "WebView2 runtime",
+      status: "unverified",
+      detail: "preinstalled on Windows 11; not detected by this check",
+      remedy: [
+        "On Windows 10, install the WebView2 Evergreen runtime from Microsoft",
+        "if the app fails to open its window.",
+      ],
+    },
+  ];
+}
+
+export async function inspectDesktopToolchain(): Promise<DesktopToolchainReport> {
+  const target = currentDesktopPlatform();
+  const checks: ToolchainCheck[] = [checkBun(), await checkCargo()];
+
+  switch (target) {
+    case "macos":
+      checks.push(...(await checkMacosPrerequisites()));
+      break;
+    case "linux":
+      checks.push(...(await checkLinuxPrerequisites()));
+      break;
+    case "windows":
+      checks.push(...checkWindowsPrerequisites());
+      break;
+    default:
+      break;
+  }
+
+  return {
+    platform: target,
+    ready: checks.every((check) => check.status !== "missing"),
+    checks,
+  };
+}
+
+/** The command that builds the desktop app on the current platform. */
+export function desktopBuildCommand(): string {
+  return "cd desktop && bun install && bun run tauri build";
+}

--- a/scripts/runner/git-ops.ts
+++ b/scripts/runner/git-ops.ts
@@ -20,6 +20,15 @@ export interface UpdateState {
   latestMessage: string;
 }
 
+export interface DesktopShellState {
+  /** The checkout contains desktop changes the running binary predates. */
+  stale: boolean;
+  /** Commit the running desktop shell was compiled from, if it reported one. */
+  builtSha: string | null;
+  /** Newest commit touching `desktop/` in the checkout. */
+  requiredSha: string | null;
+}
+
 type ProgressReporter = (message: string) => void;
 
 const FRONTEND_BUILD_IGNORED_PATHS = [
@@ -69,6 +78,43 @@ function isFrontendBuildInput(filePath: string): boolean {
 
 function shouldRebuildFrontend(changedFiles: string[] | null): boolean {
   return changedFiles === null || changedFiles.some(isFrontendBuildInput);
+}
+
+/** Newest commit that touched the desktop shell's sources. */
+function getLastDesktopShellCommit(): string | null {
+  const log = runGit("log", "-1", "--format=%H", "--", "desktop");
+  if (!log.ok || !log.out) return null;
+  return log.out;
+}
+
+function commitExists(sha: string): boolean {
+  return runGit("cat-file", "-e", `${sha}^{commit}`).ok;
+}
+
+/**
+ * Decide whether the running desktop shell predates the checkout's desktop
+ * sources.
+ *
+ * The shell is a compiled binary that `applyUpdate` cannot replace, so a pull
+ * carrying `desktop/` changes leaves the user running code the checkout has
+ * already moved past — with no symptom other than the old behaviour
+ * persisting. Equality is the wrong test: the stamped revision is whatever
+ * HEAD was at build time, which normally sits *ahead* of the last commit that
+ * touched `desktop/`. What matters is whether that commit is already reachable
+ * from the build.
+ *
+ * Every branch that cannot answer confidently reports "not stale". A shell
+ * built from an archive, or from a history this checkout does not share, is
+ * unknowable rather than out of date, and a false warning telling someone to
+ * rebuild a current binary is worse than staying quiet.
+ */
+export function evaluateDesktopShell(builtSha: string | null): DesktopShellState {
+  const requiredSha = getLastDesktopShellCommit();
+  if (!builtSha || !requiredSha) return { stale: false, builtSha, requiredSha };
+  if (!commitExists(builtSha)) return { stale: false, builtSha, requiredSha };
+
+  const containsDesktopSources = runGit("merge-base", "--is-ancestor", requiredSha, builtSha).ok;
+  return { stale: !containsDesktopSources, builtSha, requiredSha };
 }
 
 // Termux/proot detection. start.sh exports LUMIVERSE_IS_TERMUX /

--- a/scripts/runner/ipc-handler.ts
+++ b/scripts/runner/ipc-handler.ts
@@ -18,6 +18,7 @@ import {
   runWithServerStopped,
   assertUpdateCanHardSync,
   assertBranchCanHardSync,
+  evaluateDesktopShell,
 } from "./git-ops.js";
 import { readEnvConfig, writeTrustAnyOrigin } from "./env-config.js";
 import { getCurrentBranch } from "./lib/git.js";
@@ -116,6 +117,13 @@ export async function handleIPCMessage(msg: any, sink?: ResponseSink): Promise<v
         commitsBehind: lastUpdateState.commitsBehind,
         latestUpdateMessage: lastUpdateState.latestMessage,
       });
+      break;
+    }
+
+    case "desktop-shell-status": {
+      // The tray reports the revision it was compiled from; only the checkout
+      // can say whether that predates its desktop sources.
+      respond(id, true, evaluateDesktopShell(payload?.builtSha ?? null));
       break;
     }
 

--- a/scripts/setup-wizard.ts
+++ b/scripts/setup-wizard.ts
@@ -28,6 +28,10 @@ import {
   theme,
 } from "./ui";
 import { askSecret, askText, closeInput } from "./input";
+import {
+  desktopBuildCommand,
+  inspectDesktopToolchain,
+} from "./desktop-toolchain";
 
 // All input goes through askText / askSecret (scripts/input.ts) so that a
 // single raw-mode consumer owns stdin.  Mixing Node's readline with a raw
@@ -96,7 +100,7 @@ async function main() {
 
   // ─── Step 1: Admin account ─────────────────────────────────────────────
 
-  printStepHeader(1, 5, "Admin Account", "Create the owner account for your Lumiverse instance.");
+  printStepHeader(1, 6, "Admin Account", "Create the owner account for your Lumiverse instance.");
 
   // BetterAuth rejects very short usernames and our macro/URL paths assume a
   // non-trivial identifier.  Validate up-front so a fat-finger doesn't seed
@@ -137,7 +141,7 @@ async function main() {
 
   // ─── Step 2: Server port ───────────────────────────────────────────────
 
-  printStepHeader(2, 5, "Server Port", "The port Lumiverse will listen on.");
+  printStepHeader(2, 6, "Server Port", "The port Lumiverse will listen on.");
 
   let port = 7860;
   const portInput = await askText("Port", { defaultValue: "7860" });
@@ -153,7 +157,7 @@ async function main() {
 
   // ─── Step 3: Extension storage ─────────────────────────────────────────
 
-  printStepHeader(3, 5, "Extension Storage", "Maximum disk budget for Spindle extension data pools.");
+  printStepHeader(3, 6, "Extension Storage", "Maximum disk budget for Spindle extension data pools.");
 
   const defaultStorage = 500 * 1024 * 1024; // 500MB
   const storageInput = await askText("Max extension storage", { defaultValue: "500MB" });
@@ -173,7 +177,7 @@ async function main() {
 
   // ─── Step 4: Optional SMART support ────────────────────────────────────
 
-  printStepHeader(4, 5, "Disk Health Monitoring", "Install smartmontools so Lumiverse can report physical-drive SMART health.");
+  printStepHeader(4, 6, "Disk Health Monitoring", "Install smartmontools so Lumiverse can report physical-drive SMART health.");
 
   let smartStatus = await getSmartctlStatus();
   if (smartStatus.binary) {
@@ -223,7 +227,35 @@ async function main() {
 
   // ─── Step 5: Generate identity + write config ─────────────────────────
 
-  printStepHeader(5, 5, "Generating Identity", "Creating your encryption identity and credentials.");
+  printStepHeader(5, 6, "Lumiverse Desktop (optional)", "The desktop tray app is built on this machine; no prebuilt download exists.");
+
+  // Advisory only. Probing the toolchain shells out to other programs, and a
+  // restricted environment can make that throw — which must not abort a setup
+  // run that has already collected the user's credentials.
+  const desktopReport = await inspectDesktopToolchain().catch(() => null);
+  if (!desktopReport) {
+    console.log(`    ${theme.muted}Could not check the desktop build prerequisites here.${theme.reset}`);
+    console.log(`    ${theme.muted}Run ${theme.reset}bun run desktop:doctor${theme.muted} later to check them.${theme.reset}`);
+  } else if (desktopReport.ready) {
+    console.log(`    ${theme.success}This machine has everything needed to build it.${theme.reset}`);
+    console.log(`    ${theme.muted}From the repository root:${theme.reset}`);
+    console.log(`    ${theme.muted}  ${desktopBuildCommand()}${theme.reset}`);
+  } else {
+    console.log(`    ${theme.muted}Some build prerequisites are missing:${theme.reset}`);
+    for (const check of desktopReport.checks) {
+      if (check.status !== "missing") continue;
+      console.log(`    ${theme.warning}${check.label}${theme.reset} ${theme.muted}— ${check.detail}${theme.reset}`);
+    }
+    console.log(`    ${theme.muted}Run ${theme.reset}bun run desktop:doctor${theme.muted} for the exact install steps.${theme.reset}`);
+  }
+  console.log(`    ${theme.muted}The desktop app is optional — Lumiverse runs in any browser without it.${theme.reset}`);
+
+  console.log("");
+  printDivider();
+
+  // ─── Step 6: Generate identity + write config ─────────────────────────
+
+  printStepHeader(6, 6, "Generating Identity", "Creating your encryption identity and credentials.");
 
   await printCompletionAnimation();
 
@@ -304,6 +336,7 @@ async function main() {
       "Keep the data/ directory safe — it contains your encryption key,",
       "credentials, and database. Back up the entire data/ folder.",
       "To reset your password: bun run reset-password",
+      "Desktop app prerequisites: bun run desktop:doctor",
     ]
   );
 }


### PR DESCRIPTION
> **Stacked on #337.** That PR's commit appears first in this branch so the three desktop PRs (#337 → #339 → #340) form one linear, conflict-free stack. Review only the second commit, `Add a desktop build prerequisite check`; once #337 merges this diff reduces to that commit alone.

## Summary

**In plain terms:** Lumiverse Desktop has no download — you compile it yourself, which means installing Rust and a few platform-specific build tools first. Right now nothing tells you that until a build fails partway through with a compiler error. This adds `bun run desktop:doctor`, a one-command check that says whether your machine can build the desktop app and, for anything missing, prints the exact command to install it. The first-run setup wizard now runs the same check and mentions the desktop app exists, so new users find out up front instead of never.

The detail:

The desktop app ships no prebuilt binaries — I checked every release, and the only binary assets ever published are the Android LanceDB builds. `user-docs/docs/getting-started/desktop-tray.md` tells people to open "the **generated** `.app`". So compiling locally is not one path to Lumiverse Desktop, it is the only one, and the build toolchain is the first thing standing between a new user and a working tray.

Nothing helps them across it. `scripts/setup-wizard.ts` has no awareness of the desktop app, Tauri, cargo or Rust. The root README mentions the desktop app once, at line 244, pointing off to another README. The prerequisites are listed there in prose, per platform, and the first feedback anyone gets on a missing one is a linker error several minutes into a Rust build.

This adds:

- **`scripts/desktop-toolchain.ts`** — a shared probe reporting Bun (against the ≥ 1.4.0 floor `desktop/README.md` specifies), cargo, and the platform prerequisites: Xcode Command Line Tools on macOS, WebKitGTK and AppIndicator via `pkg-config` on Linux, and MSVC and WebView2 on Windows.
- **`scripts/desktop-doctor.ts`** / `bun run desktop:doctor` — prints the report with a remedy for each failure, and exits non-zero when something required is absent so it can gate a build in a script.
- **A wizard step** that runs the same probe, so first-time users learn the desktop app exists and whether they can build it.
- **README pointers** in both places a builder actually looks.

Two deliberate choices about honesty:

The status is three-valued — `ok`, `missing`, `unverified` — and only `missing` blocks. MSVC only appears on `PATH` inside a Developer Command Prompt, and WebView2 ships preinstalled on Windows 11; reporting either as missing would send people to reinstall software they already have. Linux checks degrade to `unverified` when `pkg-config` is absent, rather than guessing library state from the filesystem. Saying "I could not check this" is more useful than a confident wrong answer.

The wizard step cannot fail the wizard. The probe shells out to other programs, and a restricted environment can make that throw. Aborting a setup run that has already collected the user's credentials, because an optional advisory step errored, would be a bad trade — so it catches and degrades to a pointer at the doctor.

Scope is detection and guidance only. Nothing installs a toolchain and nothing runs a build.

## Validation

```text
bun x tsc --noEmit
# clean, no output

cd frontend && bun run typecheck
# clean

cd frontend && bun run lint
# 1 error, pre-existing and unrelated:
#   src/components/modals/RegexPromptActivationEditor.test.tsx:58:5
#   react-compiler/react-compiler
# Identical on unmodified base 22104888. This PR touches no frontend files.

bun test --isolate
#  4254 pass, 3 skip, 2 fail, 1 error   (branch — includes 12 new tests)
#  4242 pass, 3 skip, 2 fail, 1 error   (unmodified base 22104888)
# Same 2 failures before and after; both are pre-existing and pass in
# isolation on branch and base alike.

bun test scripts/desktop-toolchain.test.ts
#  12 pass, 0 fail, 35 expect() calls
```

`scripts/desktop-toolchain.test.ts` covers version comparison (including that
`1.10.0` is correctly newer than `1.9.0`, which a string compare gets wrong),
that every emitted check is fully populated, that anything reported `missing`
carries a non-empty remedy, and that readiness ignores `unverified` and fails
only on `missing`.

Two corrections after a self-review:

- **AppIndicator detection accepts either implementation.** The first revision checked only `ayatana-appindicator3-0.1`. `desktop/README.md` installs the Ayatana package on Debian but `libappindicator-gtk3` on Fedora and Arch, which registers as `appindicator3-0.1` — so two of the three documented distros would have been told they were missing a library they had. Both names are now tried.
- **`probe()` drops stderr instead of piping it.** A pipe nobody reads fills its buffer and stalls the child. Harmless for `--version` output, but it is the wrong pattern to leave in a helper others will copy.

The doctor was exercised on macOS in all three states:

| scenario | result |
|---|---|
| full toolchain present | all checks ✓, "Ready to build", exit 0 |
| no Rust (`HOME` and `PATH` stripped) | cargo ✗ with rustup remedy, "Not ready", exit 1 |
| cargo installed but off `PATH` | ✓ with "at ~/.cargo/bin/cargo, not on PATH" and a PATH remedy |

The Windows and Linux branches were written from `desktop/README.md` and have
not been executed on those platforms — worth a look from anyone running them.

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass. *(Full-suite failures are identical to the
      unmodified base — see Validation. 12 new tests added, all passing.)*
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [x] Backend: `bun x tsc --noEmit`
  - [x] Frontend: `cd frontend && bun run typecheck`, `bun run lint`
        *(run for completeness; this PR touches no frontend files. The single
        lint error is pre-existing on base.)*

## UI changes (if applicable)

- [ ] I validated this change in more than one browser.
- [ ] I verified the integrated experience on a mobile interface or through
      the mobile PWA.
- Browsers, devices, and PWA coverage: **not applicable.** The only surfaces
  touched are two terminal scripts and two README files. No frontend file is
  modified and no browser code path is involved.

## Performance changes (if applicable)

Not applicable. The doctor is a manually-run command. The wizard step adds a
handful of short subprocess probes to a one-time interactive setup.

## Security-sensitive changes (if applicable)

No impact on Spindle or any other security system. The probe runs fixed,
non-configurable version commands (`cargo --version`, `xcode-select -p`,
`pkg-config --exists`) with no user input reaching a command line. Nothing is
installed, downloaded, elevated or written — remedies are printed for the user
to run themselves, following the existing smartctl step's precedent of never
executing an install without an explicit prompt.

## LLM-assisted work (if applicable)

- [ ] I, as the human orchestrating this work, audited the submitted changes
      in a live environment.

Not yet ticked — I will run `bun run desktop:doctor` and a fresh wizard pass on
my own machine and comment with the result before asking for merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

