### PR TITLE
Rebuild the desktop app from the tray

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,9 @@ with Lumiverse's integrated browser as its primary interface and a macOS menu
 bar / Windows system tray / Linux StatusNotifier icon for controls. It starts
 and stops a local server, shows serving stats, opens the same address in your
 default browser on request, and applies updates through the runner. See
-[desktop/README.md](desktop/README.md) for build instructions.
+[desktop/README.md](desktop/README.md) for build instructions. There is no
+prebuilt download — run `bun run desktop:doctor` to check whether this machine
+can build it.
 
 ## Configuration
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -55,6 +55,9 @@ surface. Browser and PWA rendering ignore this desktop-only setting.
 
 ## Prerequisites
 
+Run `bun run desktop:doctor` from the repository root to check all of these at
+once. It reports what is missing and the exact command to install it.
+
 - [Bun](https://bun.sh) ≥ 1.4.0 (also required by the server itself)
 - [Rust](https://rustup.rs) stable (Tauri v2 builds the native shell)
 

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -1,3 +1,59 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn git_output(args: &[&str]) -> Option<String> {
+    Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|text| text.trim().to_owned())
+        .filter(|text| !text.is_empty())
+}
+
+/// Stamp the commit this shell was compiled from.
+///
+/// The tray is a compiled binary living outside the checkout, so the runner's
+/// git update flow cannot replace it the way it replaces server and frontend
+/// code. Without a build stamp there is nothing to compare a moved checkout
+/// against, and a shell that is several releases behind looks exactly like one
+/// that is current.
+fn stamp_build_revision() {
+    let sha = git_output(&["rev-parse", "HEAD"]);
+
+    // Builds from a source archive have no git metadata. Stamp an empty
+    // revision rather than failing the build — the tray reads that as "cannot
+    // tell" and stays silent instead of guessing.
+    println!(
+        "cargo:rustc-env=LUMIVERSE_DESKTOP_SHA={}",
+        sha.clone().unwrap_or_default()
+    );
+
+    // Once a build script emits any rerun-if-changed, Cargo reruns it *only*
+    // when those paths change. So the paths must be ones a fast-forward pull
+    // actually touches. `.git/HEAD` is not one of them — on a branch it holds
+    // `ref: refs/heads/<name>` and is untouched by a pull — and neither is the
+    // `refs/` directory, whose mtime does not change when a file nested below
+    // it is rewritten. Getting this wrong stamps the *previous* revision into
+    // a binary compiled from new sources, which then reports itself stale.
+    //
+    // `index` is rewritten by every checkout and reset, including the runner's
+    // `reset --hard` to upstream. Together with HEAD (branch switches) and
+    // packed-refs (post-gc ref storage) it covers how a checkout moves.
+    // Resolve the git dir rather than assuming `../../.git`, so a worktree —
+    // where `.git` is a file pointing elsewhere — still gets real paths.
+    if sha.is_some() {
+        if let Some(git_dir) = git_output(&["rev-parse", "--git-dir"]) {
+            let git_dir = PathBuf::from(git_dir);
+            for entry in ["HEAD", "index", "packed-refs"] {
+                println!("cargo:rerun-if-changed={}", git_dir.join(entry).display());
+            }
+        }
+    }
+}
+
 fn main() {
+    stamp_build_revision();
     tauri_build::build()
 }

--- a/desktop/src-tauri/capabilities/desktop-rebuild.json
+++ b/desktop/src-tauri/capabilities/desktop-rebuild.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "desktop-rebuild",
+  "description": "Lets the hidden tray host reveal a freshly built desktop bundle in the file manager. Deliberately scoped to the tray window only — the frontend WebView loads the Lumiverse app and must not be able to reveal local paths.",
+  "windows": ["main"],
+  "permissions": ["opener:allow-reveal-item-in-dir"]
+}

--- a/desktop/src-tauri/capabilities/tray-dev.json
+++ b/desktop/src-tauri/capabilities/tray-dev.json
@@ -28,6 +28,7 @@
     "autostart:allow-enable",
     "autostart:allow-disable",
     "autostart:allow-is-enabled",
+    "opener:allow-reveal-item-in-dir",
     {
       "identifier": "opener:allow-open-url",
       "allow": [{ "url": "http://*" }, { "url": "https://*" }]

--- a/desktop/src-tauri/permissions/tray-commands.toml
+++ b/desktop/src-tauri/permissions/tray-commands.toml
@@ -11,6 +11,7 @@ commands.allow = [
   "resolve_bun",
   "quit_app",
   "alert",
+  "confirm",
   "pick_folder",
   "show_frontend",
   "hide_frontend",

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -145,6 +145,7 @@ pub fn run() {
             runner::validate_repo,
             runner::discover_repo,
             runner::resolve_bun,
+            runner::desktop_shell_sha,
             runner::quit_app,
             runner::alert,
             runner::pick_folder,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -148,6 +148,7 @@ pub fn run() {
             runner::desktop_shell_sha,
             runner::quit_app,
             runner::alert,
+            runner::confirm,
             runner::pick_folder,
             frontend::show_frontend,
             frontend::hide_frontend,

--- a/desktop/src-tauri/src/runner.rs
+++ b/desktop/src-tauri/src/runner.rs
@@ -311,6 +311,21 @@ pub fn discover_repo() -> Option<String> {
     None
 }
 
+/// The commit this desktop shell was compiled from, or `None` when the build
+/// carried no git metadata to stamp (a source-archive build, for example).
+///
+/// The runner compares this against the checkout to decide whether a pulled
+/// update contains desktop changes the running binary predates.
+#[tauri::command]
+pub fn desktop_shell_sha() -> Option<String> {
+    let sha = env!("LUMIVERSE_DESKTOP_SHA");
+    if sha.is_empty() {
+        None
+    } else {
+        Some(sha.to_owned())
+    }
+}
+
 /// Locate a usable bun binary. GUI apps on macOS get a minimal PATH, so
 /// probe the common install locations before falling back to PATH lookup.
 #[tauri::command]

--- a/desktop/src-tauri/src/runner.rs
+++ b/desktop/src-tauri/src/runner.rs
@@ -397,6 +397,33 @@ pub fn alert(app: AppHandle, title: String, message: String, error: bool) {
         .show(move |_| rehide_host_window(&app_for_rehide));
 }
 
+/// Two-button question with no parent window (see `alert`). Resolves to
+/// `true` when the user picks the affirmative button.
+///
+/// `async` so the blocking `recv` runs on Tauri's command pool rather than
+/// the main thread the dialog itself needs — the same shape as `pick_folder`.
+#[tauri::command]
+pub async fn confirm(
+    app: AppHandle,
+    title: String,
+    message: String,
+    ok_label: String,
+    cancel_label: String,
+) -> bool {
+    use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
+    let (tx, rx) = std::sync::mpsc::channel();
+    app.dialog()
+        .message(message)
+        .title(title)
+        .buttons(MessageDialogButtons::OkCancelCustom(ok_label, cancel_label))
+        .show(move |answer| {
+            let _ = tx.send(answer);
+        });
+    let answer = rx.recv().unwrap_or(false);
+    rehide_host_window(&app);
+    answer
+}
+
 /// Folder picker with no parent window (see `alert`).
 #[tauri::command]
 pub async fn pick_folder(app: AppHandle) -> Option<String> {

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -19,7 +19,13 @@ import { TrayIcon } from "@tauri-apps/api/tray";
 import { listen } from "@tauri-apps/api/event";
 import { disable as disableAutostart, enable as enableAutostart, isEnabled as autostartEnabled } from "@tauri-apps/plugin-autostart";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { RunnerClient, type FullStatus, type ServerState, type UpdateState } from "./runner-client";
+import {
+  RunnerClient,
+  type DesktopShellState,
+  type FullStatus,
+  type ServerState,
+  type UpdateState,
+} from "./runner-client";
 import { loadSettings, saveSetting, type TraySettings } from "./settings";
 import trayMacIcon from "./assets/tray-mac.png";
 import trayWinIcon from "./assets/tray-win.png";
@@ -47,6 +53,12 @@ let busyMessage: string | null = null;
 let port = 7860;
 let lastStatus: FullStatus | null = null;
 let updateState: UpdateState = { available: false, commitsBehind: 0, latestMessage: "" };
+// The tray is a compiled binary the git update flow cannot replace, so a pull
+// carrying desktop changes leaves this process running superseded code.
+let desktopShellStale = false;
+let desktopShellNoticeShown = false;
+let desktopShellChecked = false;
+let updateJustApplied = false;
 let customFrontendUrl: string | null = null;
 let openIntegratedBrowserWhenReady = false;
 
@@ -82,7 +94,19 @@ let desktopWidgetCatalog: DesktopWidgetCatalogEntry[] = [];
 
 function statusText(): string {
   if (busyMessage) return busyMessage;
-  if (externalRunning) return "Lumiverse running (external)";
+  // A dismissed dialog is easy to forget, and the symptom of a stale shell is
+  // simply that the old behaviour persists. Keep the state visible in the
+  // headline for as long as it is true.
+  const suffix = desktopShellStale ? " · desktop rebuild required" : "";
+  if (externalRunning) return `Lumiverse running (external)${suffix}`;
+  if (suffix) {
+    switch (serverState) {
+      case "running":
+        return `Lumiverse running${suffix}`;
+      case "stopped":
+        return `Lumiverse stopped${suffix}`;
+    }
+  }
   switch (serverState) {
     case "running":
       return "Lumiverse running";
@@ -259,6 +283,7 @@ async function checkForUpdates(interactive: boolean): Promise<void> {
   const result = await client.request<UpdateState>("check-updates", undefined, 90_000);
   updateState = result;
   await updateMenu();
+  await refreshDesktopShellState();
   if (interactive) {
     if (result.available) {
       await alert(
@@ -271,8 +296,47 @@ async function checkForUpdates(interactive: boolean): Promise<void> {
   }
 }
 
+/**
+ * Ask the checkout whether it has moved past the desktop sources this binary
+ * was compiled from. Only the checkout can answer — the shell knows just the
+ * revision stamped into it at build time.
+ */
+async function refreshDesktopShellState(): Promise<void> {
+  if (!repoDir || !(await client.alive())) return;
+  let state: DesktopShellState;
+  try {
+    const builtSha = await invoke<string | null>("desktop_shell_sha");
+    state = await client.request<DesktopShellState>("desktop-shell-status", { builtSha }, 15_000);
+  } catch {
+    // An unreachable or older runner cannot answer. Leave the previous
+    // verdict alone rather than clearing a warning we still believe.
+    return;
+  }
+
+  desktopShellChecked = true;
+  const becameStale = state.stale && !desktopShellStale;
+  desktopShellStale = state.stale;
+  // A rebuild clears the condition; let the notice fire again if it recurs.
+  if (!state.stale) desktopShellNoticeShown = false;
+  await updateMenu();
+
+  if (becameStale && !desktopShellNoticeShown) {
+    desktopShellNoticeShown = true;
+    await alert(
+      "Lumiverse Desktop rebuild required",
+      "This update changed Lumiverse Desktop itself. The app you are running " +
+        "was built before those changes and keeps its previous behaviour " +
+        "until it is rebuilt.\n\n" +
+        "To finish updating, quit Lumiverse Desktop and run:\n\n" +
+        `cd ${repoDir}/desktop && bun run tauri build\n\n` +
+        "Then replace the installed app with the new build.",
+    );
+  }
+}
+
 async function applyUpdate(): Promise<void> {
   await ensureRunner();
+  updateJustApplied = true;
   busyMessage = "Applying update…";
   await updateMenu();
   try {
@@ -563,6 +627,12 @@ async function boot(): Promise<void> {
     }
     if (state === "running" || state === "stopped" || state === "crashed") {
       busyMessage = null;
+    }
+    // The check needs a live runner, so the first chance to run it is the
+    // server coming up. Repeat it once an applied update has settled.
+    if (state === "running" && (!desktopShellChecked || updateJustApplied)) {
+      updateJustApplied = false;
+      void refreshDesktopShellState();
     }
     void refreshStatus().then(updateMenu);
   };

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -18,7 +18,7 @@ import {
 import { TrayIcon } from "@tauri-apps/api/tray";
 import { listen } from "@tauri-apps/api/event";
 import { disable as disableAutostart, enable as enableAutostart, isEnabled as autostartEnabled } from "@tauri-apps/plugin-autostart";
-import { openUrl } from "@tauri-apps/plugin-opener";
+import { openUrl, revealItemInDir } from "@tauri-apps/plugin-opener";
 import {
   RunnerClient,
   type DesktopShellState,
@@ -31,6 +31,9 @@ import trayMacIcon from "./assets/tray-mac.png";
 import trayWinIcon from "./assets/tray-win.png";
 
 const POLL_INTERVAL_MS = 15_000;
+// A cold Tauri build compiles the entire native dependency tree. This only
+// bounds the tray's wait; the runner enforces its own build deadline.
+const DESKTOP_REBUILD_TIMEOUT_MS = 35 * 60_000;
 const isMac = navigator.userAgent.includes("Mac");
 
 /**
@@ -74,6 +77,7 @@ let statsBranchItem: MenuItem;
 let statsVersionItem: MenuItem;
 let checkUpdatesItem: MenuItem;
 let applyUpdateItem: MenuItem;
+let rebuildDesktopItem: MenuItem;
 let autoStartItem: CheckMenuItem;
 let loginItem: CheckMenuItem;
 let openIntegratedBrowserItem: MenuItem;
@@ -169,6 +173,10 @@ async function updateMenu(): Promise<void> {
   await statsVersionItem.setText(`Version: ${lastStatus?.version ?? "—"}`);
 
   await checkUpdatesItem.setEnabled(!busyMessage && !externalRunning);
+  // The rebuild compiles from the configured checkout, so it needs one — but
+  // unlike the update items it stays available when a server is running
+  // externally, since it neither stops nor talks to that server.
+  await rebuildDesktopItem.setEnabled(!busyMessage && repoDir !== null);
   if (updateState.available) {
     await applyUpdateItem.setText(`Apply Update (${updateState.commitsBehind} behind)`);
     await applyUpdateItem.setEnabled(!busyMessage && !externalRunning);
@@ -322,15 +330,19 @@ async function refreshDesktopShellState(): Promise<void> {
 
   if (becameStale && !desktopShellNoticeShown) {
     desktopShellNoticeShown = true;
-    await alert(
-      "Lumiverse Desktop rebuild required",
-      "This update changed Lumiverse Desktop itself. The app you are running " +
+    const rebuildNow = await invoke<boolean>("confirm", {
+      title: "Lumiverse Desktop rebuild required",
+      message:
+        "This update changed Lumiverse Desktop itself. The app you are running " +
         "was built before those changes and keeps its previous behaviour " +
         "until it is rebuilt.\n\n" +
-        "To finish updating, quit Lumiverse Desktop and run:\n\n" +
-        `cd ${repoDir}/desktop && bun run tauri build\n\n` +
-        "Then replace the installed app with the new build.",
-    );
+        "Rebuild it now? You can keep using Lumiverse while it compiles. " +
+        "Or later, from the tray menu: Rebuild Desktop App…\n\n" +
+        `Manual equivalent: cd ${repoDir}/desktop && bun run tauri build`,
+      okLabel: "Rebuild now",
+      cancelLabel: "Later",
+    });
+    if (rebuildNow) action(rebuildDesktop)();
   }
 }
 
@@ -341,6 +353,48 @@ async function applyUpdate(): Promise<void> {
   await updateMenu();
   try {
     await client.request("apply-update", undefined, 60_000);
+  } catch (err) {
+    busyMessage = null;
+    await updateMenu();
+    throw err;
+  }
+}
+
+/**
+ * Compile the desktop shell from the configured checkout.
+ *
+ * This produces a bundle; it cannot replace the running app, because a process
+ * cannot overwrite its own bundle. The build therefore ends by pointing the
+ * user at what it made.
+ */
+async function rebuildDesktop(): Promise<void> {
+  await ensureRunner();
+  busyMessage = "Preparing desktop rebuild…";
+  await updateMenu();
+  try {
+    // The runner answers when the compile finishes rather than acking early,
+    // so this waits out the whole build. Progress arrives via onProgress.
+    const result = await client.request<{ bundlePath: string | null }>(
+      "rebuild-desktop",
+      undefined,
+      DESKTOP_REBUILD_TIMEOUT_MS,
+    );
+    busyMessage = null;
+    await updateMenu();
+
+    if (!result?.bundlePath) {
+      await alert("Lumiverse", "The desktop app was rebuilt.");
+      return;
+    }
+    await alert(
+      "Desktop app rebuilt",
+      "The new build is ready. Quit Lumiverse Desktop and replace the " +
+        "installed app with it to finish updating.\n\n" +
+        result.bundlePath,
+    );
+    // Best-effort: a file manager that refuses to open must not turn a
+    // successful build into a reported failure.
+    await revealItemInDir(result.bundlePath).catch(() => {});
   } catch (err) {
     busyMessage = null;
     await updateMenu();
@@ -485,6 +539,11 @@ async function buildTray(): Promise<void> {
     action: action(() => checkForUpdates(true)),
   });
   applyUpdateItem = await MenuItem.new({ text: "Apply Update", enabled: false, action: action(applyUpdate) });
+  rebuildDesktopItem = await MenuItem.new({
+    text: "Rebuild Desktop App…",
+    enabled: false,
+    action: action(rebuildDesktop),
+  });
 
   autoStartItem = await CheckMenuItem.new({
     text: "Start Server at Launch",
@@ -559,6 +618,7 @@ async function buildTray(): Promise<void> {
       await separator(),
       checkUpdatesItem,
       applyUpdateItem,
+      rebuildDesktopItem,
       await separator(),
       autoStartItem,
       loginItem,

--- a/desktop/src/runner-client.ts
+++ b/desktop/src/runner-client.ts
@@ -31,6 +31,12 @@ export interface UpdateState {
   latestMessage: string;
 }
 
+export interface DesktopShellState {
+  stale: boolean;
+  builtSha: string | null;
+  requiredSha: string | null;
+}
+
 interface ResponsePayload {
   success: boolean;
   data?: unknown;

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "build:lancedb:android": "bash scripts/build-lancedb-android.sh",
     "setup": "bun run scripts/setup-wizard.ts",
     "install:smartctl": "bun run scripts/install-smartctl.ts",
+    "desktop:doctor": "bun run scripts/desktop-doctor.ts",
     "runner": "bun run scripts/runner.ts",
     "runner:dev": "bun run scripts/runner.ts -- --dev",
     "start:all": "bun run build:frontend && FRONTEND_DIR=$(cd frontend/dist && pwd) bun run start",

--- a/scripts/desktop-doctor.ts
+++ b/scripts/desktop-doctor.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env bun
+/**
+ * Lumiverse Desktop prerequisite check.
+ *
+ * Run with: bun run desktop:doctor
+ *
+ * Reports whether this machine can build the desktop app, and prints the exact
+ * remedy for anything missing. Exits non-zero when a required prerequisite is
+ * absent so it can gate a build in a script.
+ */
+
+import {
+  desktopBuildCommand,
+  inspectDesktopToolchain,
+  type ToolchainCheck,
+} from "./desktop-toolchain";
+import { printBanner, printDivider, theme } from "./ui";
+
+const SYMBOL: Record<ToolchainCheck["status"], string> = {
+  ok: `${theme.success}✓${theme.reset}`,
+  missing: `${theme.warning}✗${theme.reset}`,
+  unverified: `${theme.muted}?${theme.reset}`,
+};
+
+const PLATFORM_LABEL = {
+  macos: "macOS",
+  windows: "Windows",
+  linux: "Linux",
+  other: "this platform",
+} as const;
+
+async function main() {
+  printBanner("Desktop build prerequisites");
+
+  const report = await inspectDesktopToolchain();
+  console.log(`  ${theme.muted}Platform: ${PLATFORM_LABEL[report.platform]}${theme.reset}`);
+  console.log("");
+
+  const width = Math.max(...report.checks.map((check) => check.label.length));
+  for (const check of report.checks) {
+    console.log(`  ${SYMBOL[check.status]}  ${check.label.padEnd(width)}  ${theme.muted}${check.detail}${theme.reset}`);
+  }
+
+  const actionable = report.checks.filter((check) => check.status !== "ok" && check.remedy.length > 0);
+  if (actionable.length > 0) {
+    console.log("");
+    printDivider();
+    for (const check of actionable) {
+      console.log("");
+      console.log(`  ${theme.warning}${check.label}${theme.reset}`);
+      for (const line of check.remedy) {
+        console.log(`    ${theme.muted}${line}${theme.reset}`);
+      }
+    }
+  }
+
+  console.log("");
+  printDivider();
+  console.log("");
+  if (report.ready) {
+    console.log(`  ${theme.success}Ready to build.${theme.reset}`);
+    console.log(`  ${theme.muted}From the repository root:${theme.reset}`);
+    console.log(`    ${desktopBuildCommand()}`);
+    if (report.platform === "other") {
+      console.log("");
+      console.log(`  ${theme.muted}Lumiverse Desktop targets macOS, Windows and Linux; this platform is untested.${theme.reset}`);
+    }
+  } else {
+    console.log(`  ${theme.warning}Not ready to build.${theme.reset}`);
+    console.log(`  ${theme.muted}Resolve the items above, then run this check again.${theme.reset}`);
+  }
+  console.log("");
+
+  process.exit(report.ready ? 0 : 1);
+}
+
+main();

--- a/scripts/desktop-toolchain.test.ts
+++ b/scripts/desktop-toolchain.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import {
+  currentDesktopPlatform,
+  inspectDesktopToolchain,
+  meetsVersion,
+  MIN_BUN_VERSION,
+} from "./desktop-toolchain";
+
+describe("meetsVersion", () => {
+  test("accepts an exact match", () => {
+    expect(meetsVersion("1.4.0", "1.4.0")).toBe(true);
+  });
+
+  test("accepts newer versions at every position", () => {
+    expect(meetsVersion("2.0.0", "1.4.0")).toBe(true);
+    expect(meetsVersion("1.5.0", "1.4.0")).toBe(true);
+    expect(meetsVersion("1.4.1", "1.4.0")).toBe(true);
+  });
+
+  test("rejects older versions at every position", () => {
+    expect(meetsVersion("0.9.9", "1.4.0")).toBe(false);
+    expect(meetsVersion("1.3.9", "1.4.0")).toBe(false);
+    expect(meetsVersion("1.4.0", "1.4.1")).toBe(false);
+  });
+
+  test("does not compare version parts as strings", () => {
+    // A lexicographic comparison would call "1.10.0" older than "1.9.0".
+    expect(meetsVersion("1.10.0", "1.9.0")).toBe(true);
+  });
+
+  test("treats missing trailing parts as zero", () => {
+    expect(meetsVersion("1.4", "1.4.0")).toBe(true);
+    expect(meetsVersion("1.4", "1.4.1")).toBe(false);
+    expect(meetsVersion("1.4.0.1", "1.4.0")).toBe(true);
+  });
+
+  test("treats unparseable parts as zero rather than throwing", () => {
+    expect(meetsVersion("1.4.0-canary", "1.4.0")).toBe(true);
+    expect(() => meetsVersion("", "1.4.0")).not.toThrow();
+  });
+});
+
+describe("inspectDesktopToolchain", () => {
+  test("always reports on Bun and Rust", async () => {
+    const report = await inspectDesktopToolchain();
+    const ids = report.checks.map((check) => check.id);
+    expect(ids).toContain("bun");
+    expect(ids).toContain("cargo");
+  });
+
+  test("every check is fully populated", async () => {
+    const report = await inspectDesktopToolchain();
+    expect(report.checks.length).toBeGreaterThan(0);
+    for (const check of report.checks) {
+      expect(check.id).toBeTruthy();
+      expect(check.label).toBeTruthy();
+      expect(check.detail).toBeTruthy();
+      expect(["ok", "missing", "unverified"]).toContain(check.status);
+      expect(Array.isArray(check.remedy)).toBe(true);
+    }
+  });
+
+  test("anything reported missing tells the user how to fix it", async () => {
+    const report = await inspectDesktopToolchain();
+    for (const check of report.checks) {
+      if (check.status !== "missing") continue;
+      expect(check.remedy.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("readiness ignores unverified checks and fails only on missing ones", async () => {
+    const report = await inspectDesktopToolchain();
+    const hasMissing = report.checks.some((check) => check.status === "missing");
+    expect(report.ready).toBe(!hasMissing);
+  });
+
+  test("reports a platform the doctor knows how to label", async () => {
+    const report = await inspectDesktopToolchain();
+    expect(["macos", "windows", "linux", "other"]).toContain(report.platform);
+    expect(report.platform).toBe(currentDesktopPlatform());
+  });
+
+  test("the suite itself runs on a Bun new enough to build the desktop app", () => {
+    // Guards the floor the wizard and doctor both check against.
+    expect(meetsVersion(Bun.version, MIN_BUN_VERSION)).toBe(true);
+  });
+});

--- a/scripts/desktop-toolchain.ts
+++ b/scripts/desktop-toolchain.ts
@@ -1,0 +1,266 @@
+/**
+ * Prerequisite inspection for building Lumiverse Desktop.
+ *
+ * The desktop app ships no binaries — every install is compiled locally — so
+ * the build toolchain is the first thing standing between a new user and a
+ * working tray. Discovering a missing prerequisite as a linker error part-way
+ * through a Rust build is a poor introduction, and the requirements differ per
+ * platform.
+ *
+ * Shared by `bun run desktop:doctor` and the first-run setup wizard.
+ */
+
+import { existsSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+
+/** Minimum Bun the desktop build requires (see desktop/README.md). */
+export const MIN_BUN_VERSION = "1.4.0";
+
+export type CheckStatus = "ok" | "missing" | "unverified";
+
+export interface ToolchainCheck {
+  id: string;
+  label: string;
+  status: CheckStatus;
+  /** What was found, or why the check could not conclude. */
+  detail: string;
+  /** How to satisfy the requirement, one line per step. */
+  remedy: string[];
+}
+
+export type DesktopPlatform = "macos" | "windows" | "linux" | "other";
+
+export interface DesktopToolchainReport {
+  platform: DesktopPlatform;
+  /** No required check is missing. Unverified checks do not block. */
+  ready: boolean;
+  checks: ToolchainCheck[];
+}
+
+export function currentDesktopPlatform(): DesktopPlatform {
+  switch (platform()) {
+    case "darwin":
+      return "macos";
+    case "win32":
+      return "windows";
+    case "linux":
+      return "linux";
+    default:
+      return "other";
+  }
+}
+
+interface ProbeResult {
+  ok: boolean;
+  out: string;
+}
+
+async function probe(command: string[]): Promise<ProbeResult> {
+  try {
+    // stderr is deliberately dropped rather than piped: a pipe nobody reads
+    // fills its buffer and stalls the child. Only the exit code and stdout
+    // carry signal here.
+    const proc = Bun.spawn({ cmd: command, stdout: "pipe", stderr: "ignore" });
+    const [out, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      proc.exited,
+    ]);
+    return { ok: exitCode === 0, out: out.trim() };
+  } catch {
+    // A missing executable throws rather than exiting non-zero.
+    return { ok: false, out: "" };
+  }
+}
+
+/** Compare dotted numeric versions. Returns true when `value` >= `minimum`. */
+export function meetsVersion(value: string, minimum: string): boolean {
+  const parse = (text: string) =>
+    text
+      .split(".")
+      .map((part) => parseInt(part, 10))
+      .map((part) => (Number.isFinite(part) ? part : 0));
+  const actual = parse(value);
+  const required = parse(minimum);
+  const length = Math.max(actual.length, required.length);
+  for (let index = 0; index < length; index += 1) {
+    const left = actual[index] ?? 0;
+    const right = required[index] ?? 0;
+    if (left > right) return true;
+    if (left < right) return false;
+  }
+  return true;
+}
+
+function checkBun(): ToolchainCheck {
+  // This script is running under Bun, so the version is already known and
+  // needs no subprocess.
+  const version = Bun.version;
+  const ok = meetsVersion(version, MIN_BUN_VERSION);
+  return {
+    id: "bun",
+    label: "Bun",
+    status: ok ? "ok" : "missing",
+    detail: ok ? `v${version}` : `v${version}, below the required v${MIN_BUN_VERSION}`,
+    remedy: ok ? [] : ["Upgrade Bun:", "  bun upgrade"],
+  };
+}
+
+/**
+ * Locate cargo. A desktop-session shell and a GUI-launched process see very
+ * different PATHs, so fall back to the standard rustup location the same way
+ * the tray's own bun lookup does.
+ */
+async function checkCargo(): Promise<ToolchainCheck> {
+  const remedy = [
+    "Install the Rust toolchain:",
+    "  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh",
+    "  (Windows: download rustup-init.exe from https://rustup.rs)",
+  ];
+
+  const onPath = await probe(["cargo", "--version"]);
+  if (onPath.ok) {
+    return { id: "cargo", label: "Rust (cargo)", status: "ok", detail: onPath.out, remedy: [] };
+  }
+
+  const fallback = join(homedir(), ".cargo", "bin", platform() === "win32" ? "cargo.exe" : "cargo");
+  if (existsSync(fallback)) {
+    const direct = await probe([fallback, "--version"]);
+    if (direct.ok) {
+      return {
+        id: "cargo",
+        label: "Rust (cargo)",
+        status: "ok",
+        detail: `${direct.out} (at ${fallback}, not on PATH)`,
+        remedy: [
+          "cargo works but is not on your PATH. Add it so the build can find it:",
+          '  export PATH="$HOME/.cargo/bin:$PATH"',
+        ],
+      };
+    }
+  }
+
+  return { id: "cargo", label: "Rust (cargo)", status: "missing", detail: "not found", remedy };
+}
+
+async function checkMacosPrerequisites(): Promise<ToolchainCheck[]> {
+  const tools = await probe(["xcode-select", "-p"]);
+  return [
+    {
+      id: "xcode-clt",
+      label: "Xcode Command Line Tools",
+      status: tools.ok ? "ok" : "missing",
+      detail: tools.ok ? tools.out : "not installed",
+      remedy: tools.ok ? [] : ["Install them:", "  xcode-select --install"],
+    },
+  ];
+}
+
+async function checkLinuxPrerequisites(): Promise<ToolchainCheck[]> {
+  const remedy = [
+    "Install the GTK/WebKitGTK and AppIndicator development packages.",
+    "The exact package names for Debian, Fedora and Arch are listed in",
+    "desktop/README.md under Prerequisites.",
+  ];
+
+  const pkgConfig = await probe(["pkg-config", "--version"]);
+  if (!pkgConfig.ok) {
+    // Without pkg-config there is no reliable way to ask about the libraries,
+    // and guessing package state from the filesystem is worse than admitting
+    // the check could not run.
+    return [
+      {
+        id: "webkitgtk",
+        label: "WebKitGTK / AppIndicator",
+        status: "unverified",
+        detail: "pkg-config is not installed, so the libraries could not be checked",
+        remedy,
+      },
+    ];
+  }
+
+  const checks: ToolchainCheck[] = [];
+  for (const [id, label, packages] of [
+    ["webkitgtk", "WebKitGTK 4.1", ["webkit2gtk-4.1"]],
+    // Either implementation satisfies the build. desktop/README.md installs
+    // the Ayatana package on Debian and libappindicator-gtk3 on Fedora and
+    // Arch, and the two register different pkg-config names.
+    ["appindicator", "AppIndicator", ["ayatana-appindicator3-0.1", "appindicator3-0.1"]],
+  ] as const) {
+    let found: string | null = null;
+    for (const pkg of packages) {
+      if ((await probe(["pkg-config", "--exists", pkg])).ok) {
+        found = pkg;
+        break;
+      }
+    }
+    checks.push({
+      id,
+      label,
+      status: found ? "ok" : "missing",
+      detail: found ? `${found} found` : `${packages.join(" / ")} not found`,
+      remedy: found ? [] : remedy,
+    });
+  }
+  return checks;
+}
+
+function checkWindowsPrerequisites(): ToolchainCheck[] {
+  // Both of these can be present in forms this probe would not recognise: the
+  // MSVC linker only appears on PATH inside a Developer Command Prompt, and
+  // WebView2 ships preinstalled on Windows 11. Reporting them as missing would
+  // send people to reinstall software they already have, so surface them as
+  // requirements to confirm rather than as failures.
+  return [
+    {
+      id: "msvc",
+      label: "MSVC build tools",
+      status: "unverified",
+      detail: "cannot be detected reliably outside a Developer Command Prompt",
+      remedy: [
+        "If the build fails at the link step, install the Visual Studio",
+        "Build Tools with the C++ workload.",
+      ],
+    },
+    {
+      id: "webview2",
+      label: "WebView2 runtime",
+      status: "unverified",
+      detail: "preinstalled on Windows 11; not detected by this check",
+      remedy: [
+        "On Windows 10, install the WebView2 Evergreen runtime from Microsoft",
+        "if the app fails to open its window.",
+      ],
+    },
+  ];
+}
+
+export async function inspectDesktopToolchain(): Promise<DesktopToolchainReport> {
+  const target = currentDesktopPlatform();
+  const checks: ToolchainCheck[] = [checkBun(), await checkCargo()];
+
+  switch (target) {
+    case "macos":
+      checks.push(...(await checkMacosPrerequisites()));
+      break;
+    case "linux":
+      checks.push(...(await checkLinuxPrerequisites()));
+      break;
+    case "windows":
+      checks.push(...checkWindowsPrerequisites());
+      break;
+    default:
+      break;
+  }
+
+  return {
+    platform: target,
+    ready: checks.every((check) => check.status !== "missing"),
+    checks,
+  };
+}
+
+/** The command that builds the desktop app on the current platform. */
+export function desktopBuildCommand(): string {
+  return "cd desktop && bun install && bun run tauri build";
+}

--- a/scripts/runner/desktop-bundle.test.ts
+++ b/scripts/runner/desktop-bundle.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { selectDesktopBundleArtifact } from "./git-ops.js";
+
+const created: string[] = [];
+
+function fixture(build: (root: string) => void): string {
+  const root = mkdtempSync(join(tmpdir(), "lumiverse-bundle-"));
+  created.push(root);
+  build(root);
+  return root;
+}
+
+function touch(root: string, dir: string, name: string): void {
+  mkdirSync(join(root, dir), { recursive: true });
+  writeFileSync(join(root, dir, name), "");
+}
+
+afterEach(() => {
+  for (const dir of created.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("selectDesktopBundleArtifact", () => {
+  test("returns null when the bundle root does not exist", () => {
+    expect(selectDesktopBundleArtifact(join(tmpdir(), "lumiverse-no-such-bundle-root"))).toBeNull();
+  });
+
+  test("finds the macOS app bundle by its exact name", () => {
+    const root = fixture((dir) => {
+      mkdirSync(join(dir, "macos", "Lumiverse Desktop.app"), { recursive: true });
+    });
+    expect(selectDesktopBundleArtifact(root)).toBe(join(root, "macos", "Lumiverse Desktop.app"));
+  });
+
+  test("prefers the app bundle over the dmg when both were produced", () => {
+    const root = fixture((dir) => {
+      mkdirSync(join(dir, "macos", "Lumiverse Desktop.app"), { recursive: true });
+      touch(dir, "dmg", "Lumiverse Desktop_0.1.0_aarch64.dmg");
+    });
+    expect(selectDesktopBundleArtifact(root)).toContain("Lumiverse Desktop.app");
+  });
+
+  test("finds version-stamped artifacts by extension", () => {
+    for (const [dir, name] of [
+      ["msi", "Lumiverse Desktop_0.1.0_x64_en-US.msi"],
+      ["appimage", "lumiverse-desktop_0.1.0_amd64.AppImage"],
+      ["deb", "lumiverse-desktop_0.1.0_amd64.deb"],
+    ] as const) {
+      const root = fixture((base) => touch(base, dir, name));
+      expect(selectDesktopBundleArtifact(root)).toBe(join(root, dir, name));
+    }
+  });
+
+  test("ignores files that are not installable artifacts", () => {
+    const root = fixture((dir) => {
+      touch(dir, "dmg", "bundle_dmg.sh");
+      touch(dir, "dmg", "Lumiverse Desktop_0.1.0_aarch64.dmg");
+    });
+    expect(selectDesktopBundleArtifact(root)).toBe(
+      join(root, "dmg", "Lumiverse Desktop_0.1.0_aarch64.dmg"),
+    );
+  });
+
+  test("prefers the most recently written artifact over a lexicographically later stale one", () => {
+    // bundle/ is never cleared between builds. A leftover 0.9.0 dmg sorts
+    // *after* a fresh 0.10.0 by name; only mtime tells them apart.
+    const root = fixture((dir) => {
+      touch(dir, "dmg", "Lumiverse Desktop_0.9.0_aarch64.dmg");
+      touch(dir, "dmg", "Lumiverse Desktop_0.10.0_aarch64.dmg");
+      const old = new Date(Date.now() - 60 * 60 * 1000);
+      utimesSync(join(dir, "dmg", "Lumiverse Desktop_0.9.0_aarch64.dmg"), old, old);
+    });
+    expect(selectDesktopBundleArtifact(root)).toBe(
+      join(root, "dmg", "Lumiverse Desktop_0.10.0_aarch64.dmg"),
+    );
+  });
+
+  test("falls back to the bundle root when it holds nothing recognisable", () => {
+    // A directory the user can open beats reporting nothing at all.
+    const root = fixture((dir) => touch(dir, "unknown-target", "artifact.bin"));
+    expect(selectDesktopBundleArtifact(root)).toBe(root);
+  });
+
+  test("skips an empty artifact directory rather than returning it", () => {
+    const root = fixture((dir) => {
+      mkdirSync(join(dir, "dmg"), { recursive: true });
+      touch(dir, "appimage", "lumiverse-desktop_0.1.0_amd64.AppImage");
+    });
+    expect(selectDesktopBundleArtifact(root)).toContain(".AppImage");
+  });
+});

--- a/scripts/runner/git-ops.ts
+++ b/scripts/runner/git-ops.ts
@@ -1,5 +1,6 @@
-import { join } from "path";
-import { existsSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "fs";
+import { delimiter, join } from "path";
+import { homedir } from "os";
+import { existsSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "fs";
 import { runGit, getUpstreamRef, getCurrentBranch } from "./lib/git.js";
 import {
   PROJECT_ROOT,
@@ -10,6 +11,7 @@ import {
   TIMEOUT_BUN_INSTALL_MS,
   TIMEOUT_BUN_INSTALL_TERMUX_MS,
   TIMEOUT_BUN_BUILD_MS,
+  TIMEOUT_DESKTOP_BUILD_MS,
 } from "./lib/constants.js";
 import { spawnAsync } from "./lib/spawn-async.js";
 import { npmCmd } from "./lib/termux-cli.js";
@@ -365,11 +367,12 @@ export async function runWithServerStopped(
 
 async function runCommandOrThrow(
   cmd: string[],
-  opts: { cwd: string; timeoutMs: number; label: string }
+  opts: { cwd: string; timeoutMs: number; label: string; env?: Record<string, string | undefined> }
 ): Promise<void> {
   const result = await spawnAsync(cmd, {
     cwd: opts.cwd,
     timeoutMs: opts.timeoutMs,
+    env: opts.env,
   });
 
   if (result.exitCode === 0) return;
@@ -875,6 +878,136 @@ export const FRONTEND_BUILD_STEPS = [
     command: ["bun", "run", "scripts/build-frontend.ts"],
   },
 ] as const;
+
+export const DESKTOP_BUILD_STEPS = [
+  {
+    label: "desktop dependency install",
+    progress: "Installing desktop app dependencies...",
+    // Resolved at run time: bunInstallCmd() carries the Windows copyfile
+    // backend and the Termux proot wrapping that a bare `bun install` lacks.
+    command: null,
+  },
+  {
+    label: "desktop Tauri build",
+    progress: "Compiling the desktop app — this can take several minutes...",
+    command: ["bun", "run", "tauri", "build"],
+  },
+] as const satisfies ReadonlyArray<{ label: string; progress: string; command: readonly string[] | null }>;
+
+/**
+ * PATH for the build steps. The tray is a GUI app and launches the runner with
+ * the minimal PATH GUI apps receive, plus bun's own directory — cargo is not on
+ * it. `tauri build` shells out to cargo, so without this the toolchain check
+ * passes (it finds `~/.cargo/bin` itself) and the build then fails to find the
+ * very tool it just confirmed. Mirrors the tray's `prepend_bun_dir_to_path`.
+ */
+function desktopBuildEnv(): Record<string, string | undefined> {
+  const cargoBin = join(homedir(), ".cargo", "bin");
+  const current = process.env.PATH ?? "";
+  const alreadyPresent = current.split(delimiter).includes(cargoBin);
+  return {
+    ...process.env,
+    PATH: alreadyPresent ? current : [cargoBin, current].filter(Boolean).join(delimiter),
+  };
+}
+
+/**
+ * Where `tauri build` leaves the installable artifact, per platform. Checked in
+ * order; the first hit wins. macOS names its bundle deterministically, so it is
+ * matched directly, while the Windows and Linux artifacts carry the version in
+ * their filenames and are found by extension.
+ */
+const DESKTOP_BUNDLE_CANDIDATES: Array<{ dir: string; exact?: string; extensions?: string[] }> = [
+  { dir: "macos", exact: "Lumiverse Desktop.app" },
+  { dir: "dmg", extensions: [".dmg"] },
+  { dir: "msi", extensions: [".msi"] },
+  { dir: "nsis", extensions: [".exe"] },
+  { dir: "appimage", extensions: [".AppImage"] },
+  { dir: "deb", extensions: [".deb"] },
+  { dir: "rpm", extensions: [".rpm"] },
+];
+
+/**
+ * Resolve the freshly built bundle so the tray can point the user straight at
+ * it. Returns the bundle root when no known artifact is present — a directory
+ * the user can open is more useful than reporting nothing.
+ */
+export function resolveDesktopBundlePath(): string | null {
+  return selectDesktopBundleArtifact(
+    join(PROJECT_ROOT, "desktop", "src-tauri", "target", "release", "bundle"),
+  );
+}
+
+/** The artifact-picking half of {@link resolveDesktopBundlePath}, taking an
+ * explicit root so it can be exercised against fixtures. */
+export function selectDesktopBundleArtifact(bundleRoot: string): string | null {
+  if (!existsSync(bundleRoot)) return null;
+
+  for (const candidate of DESKTOP_BUNDLE_CANDIDATES) {
+    const dir = join(bundleRoot, candidate.dir);
+    if (!existsSync(dir)) continue;
+
+    if (candidate.exact) {
+      const exact = join(dir, candidate.exact);
+      if (existsSync(exact)) return exact;
+      continue;
+    }
+
+    // Newest by mtime, not last by name: `bundle/` is never cleared, so a
+    // stale artifact from an earlier version can sit beside the fresh one,
+    // and "0.9.0" sorts after "0.10.0" lexicographically.
+    const match = readdirSync(dir)
+      .filter((entry) => candidate.extensions?.some((ext) => entry.endsWith(ext)))
+      .map((entry) => ({ entry, mtimeMs: statSync(join(dir, entry)).mtimeMs }))
+      .sort((a, b) => b.mtimeMs - a.mtimeMs)[0];
+    if (match) return join(dir, match.entry);
+  }
+
+  return bundleRoot;
+}
+
+/**
+ * Build the desktop shell in place.
+ *
+ * Deliberately not wrapped in `runWithServerStopped`. The frontend rebuild
+ * stops the server because it replaces the bundle the server is actively
+ * serving; a Tauri build only writes to `desktop/src-tauri/target`, which
+ * nothing serves. Users can keep chatting while it compiles.
+ *
+ * Note this cannot replace the running tray — it produces a bundle, and
+ * installing it is a separate step.
+ */
+export async function rebuildDesktopShell(reportProgress?: ProgressReporter): Promise<string | null> {
+  const desktopDir = join(PROJECT_ROOT, "desktop");
+  if (!existsSync(join(desktopDir, "src-tauri"))) {
+    throw new Error("This checkout has no desktop/src-tauri directory to build");
+  }
+
+  log("Rebuilding the desktop shell...");
+  const deadline = Date.now() + TIMEOUT_DESKTOP_BUILD_MS;
+  const env = desktopBuildEnv();
+
+  for (const step of DESKTOP_BUILD_STEPS) {
+    const timeoutMs = deadline - Date.now();
+    if (timeoutMs <= 0) {
+      throw new Error(
+        `${step.label} did not start because the desktop build exceeded its ${TIMEOUT_DESKTOP_BUILD_MS / 60_000}m timeout`,
+      );
+    }
+
+    reportProgress?.(step.progress);
+    log(step.progress);
+    await runCommandOrThrow(step.command ? [...step.command] : bunInstallCmd(), {
+      cwd: desktopDir,
+      timeoutMs,
+      label: step.label,
+      env,
+    });
+  }
+
+  log("Desktop shell rebuilt successfully.");
+  return resolveDesktopBundlePath();
+}
 
 export async function rebuildFrontend(
   frontendDir: string,

--- a/scripts/runner/git-ops.ts
+++ b/scripts/runner/git-ops.ts
@@ -20,6 +20,15 @@ export interface UpdateState {
   latestMessage: string;
 }
 
+export interface DesktopShellState {
+  /** The checkout contains desktop changes the running binary predates. */
+  stale: boolean;
+  /** Commit the running desktop shell was compiled from, if it reported one. */
+  builtSha: string | null;
+  /** Newest commit touching `desktop/` in the checkout. */
+  requiredSha: string | null;
+}
+
 type ProgressReporter = (message: string) => void;
 
 const FRONTEND_BUILD_IGNORED_PATHS = [
@@ -69,6 +78,43 @@ function isFrontendBuildInput(filePath: string): boolean {
 
 function shouldRebuildFrontend(changedFiles: string[] | null): boolean {
   return changedFiles === null || changedFiles.some(isFrontendBuildInput);
+}
+
+/** Newest commit that touched the desktop shell's sources. */
+function getLastDesktopShellCommit(): string | null {
+  const log = runGit("log", "-1", "--format=%H", "--", "desktop");
+  if (!log.ok || !log.out) return null;
+  return log.out;
+}
+
+function commitExists(sha: string): boolean {
+  return runGit("cat-file", "-e", `${sha}^{commit}`).ok;
+}
+
+/**
+ * Decide whether the running desktop shell predates the checkout's desktop
+ * sources.
+ *
+ * The shell is a compiled binary that `applyUpdate` cannot replace, so a pull
+ * carrying `desktop/` changes leaves the user running code the checkout has
+ * already moved past — with no symptom other than the old behaviour
+ * persisting. Equality is the wrong test: the stamped revision is whatever
+ * HEAD was at build time, which normally sits *ahead* of the last commit that
+ * touched `desktop/`. What matters is whether that commit is already reachable
+ * from the build.
+ *
+ * Every branch that cannot answer confidently reports "not stale". A shell
+ * built from an archive, or from a history this checkout does not share, is
+ * unknowable rather than out of date, and a false warning telling someone to
+ * rebuild a current binary is worse than staying quiet.
+ */
+export function evaluateDesktopShell(builtSha: string | null): DesktopShellState {
+  const requiredSha = getLastDesktopShellCommit();
+  if (!builtSha || !requiredSha) return { stale: false, builtSha, requiredSha };
+  if (!commitExists(builtSha)) return { stale: false, builtSha, requiredSha };
+
+  const containsDesktopSources = runGit("merge-base", "--is-ancestor", requiredSha, builtSha).ok;
+  return { stale: !containsDesktopSources, builtSha, requiredSha };
 }
 
 // Termux/proot detection. start.sh exports LUMIVERSE_IS_TERMUX /

--- a/scripts/runner/ipc-handler.ts
+++ b/scripts/runner/ipc-handler.ts
@@ -19,7 +19,9 @@ import {
   assertUpdateCanHardSync,
   assertBranchCanHardSync,
   evaluateDesktopShell,
+  rebuildDesktopShell,
 } from "./git-ops.js";
+import { inspectDesktopToolchain } from "../desktop-toolchain.js";
 import { readEnvConfig, writeTrustAnyOrigin } from "./env-config.js";
 import { getCurrentBranch } from "./lib/git.js";
 import {
@@ -124,6 +126,43 @@ export async function handleIPCMessage(msg: any, sink?: ResponseSink): Promise<v
       // The tray reports the revision it was compiled from; only the checkout
       // can say whether that predates its desktop sources.
       respond(id, true, evaluateDesktopShell(payload?.builtSha ?? null));
+      break;
+    }
+
+    case "rebuild-desktop": {
+      if (operationInProgress) {
+        respond(id, false, undefined, `Operation '${operationInProgress}' already in progress`);
+        break;
+      }
+
+      // Refuse before compiling rather than after. A missing linker surfaces
+      // as a Rust error several minutes in, which is a poor way to learn a
+      // prerequisite is absent.
+      const toolchain = await inspectDesktopToolchain();
+      if (!toolchain.ready) {
+        const missing = toolchain.checks
+          .filter((check) => check.status === "missing")
+          .map((check) => check.label)
+          .join(", ");
+        respond(id, false, undefined, `Missing desktop build prerequisites: ${missing}`);
+        break;
+      }
+
+      operationInProgress = "rebuild-desktop";
+      try {
+        // Unlike apply-update this answers on completion instead of acking
+        // early. Nothing here stops the server, so no in-flight request dies
+        // waiting, and the caller wants the bundle path the build produced.
+        const bundlePath = await rebuildDesktopShell((message) =>
+          progress(id, "rebuild-desktop", message),
+        );
+        respond(id, true, { bundlePath });
+      } catch (err) {
+        console.error("[runner] Desktop rebuild failed:", err);
+        respond(id, false, undefined, err instanceof Error ? err.message : "Desktop rebuild failed");
+      } finally {
+        operationInProgress = null;
+      }
       break;
     }
 

--- a/scripts/runner/ipc-handler.ts
+++ b/scripts/runner/ipc-handler.ts
@@ -18,6 +18,7 @@ import {
   runWithServerStopped,
   assertUpdateCanHardSync,
   assertBranchCanHardSync,
+  evaluateDesktopShell,
 } from "./git-ops.js";
 import { readEnvConfig, writeTrustAnyOrigin } from "./env-config.js";
 import { getCurrentBranch } from "./lib/git.js";
@@ -116,6 +117,13 @@ export async function handleIPCMessage(msg: any, sink?: ResponseSink): Promise<v
         commitsBehind: lastUpdateState.commitsBehind,
         latestUpdateMessage: lastUpdateState.latestMessage,
       });
+      break;
+    }
+
+    case "desktop-shell-status": {
+      // The tray reports the revision it was compiled from; only the checkout
+      // can say whether that predates its desktop sources.
+      respond(id, true, evaluateDesktopShell(payload?.builtSha ?? null));
       break;
     }
 

--- a/scripts/runner/lib/constants.ts
+++ b/scripts/runner/lib/constants.ts
@@ -35,3 +35,8 @@ export const TIMEOUT_BUN_INSTALL_TERMUX_MS = 30 * 60_000;
 // Windows Vite builds can legitimately take longer than five minutes on cold
 // disks or when an antivirus scanner inspects generated assets.
 export const TIMEOUT_BUN_BUILD_MS = 10 * 60_000;
+// A Tauri build compiles the whole native dependency tree — tauri, wry, and
+// the platform bindings — the first time it runs. That routinely outlasts the
+// frontend build budget on a laptop, and a timeout kill part-way through
+// leaves the user with nothing to show for the wait.
+export const TIMEOUT_DESKTOP_BUILD_MS = 30 * 60_000;

--- a/scripts/setup-wizard.ts
+++ b/scripts/setup-wizard.ts
@@ -28,6 +28,10 @@ import {
   theme,
 } from "./ui";
 import { askSecret, askText, closeInput } from "./input";
+import {
+  desktopBuildCommand,
+  inspectDesktopToolchain,
+} from "./desktop-toolchain";
 
 // All input goes through askText / askSecret (scripts/input.ts) so that a
 // single raw-mode consumer owns stdin.  Mixing Node's readline with a raw
@@ -96,7 +100,7 @@ async function main() {
 
   // ─── Step 1: Admin account ─────────────────────────────────────────────
 
-  printStepHeader(1, 5, "Admin Account", "Create the owner account for your Lumiverse instance.");
+  printStepHeader(1, 6, "Admin Account", "Create the owner account for your Lumiverse instance.");
 
   // BetterAuth rejects very short usernames and our macro/URL paths assume a
   // non-trivial identifier.  Validate up-front so a fat-finger doesn't seed
@@ -137,7 +141,7 @@ async function main() {
 
   // ─── Step 2: Server port ───────────────────────────────────────────────
 
-  printStepHeader(2, 5, "Server Port", "The port Lumiverse will listen on.");
+  printStepHeader(2, 6, "Server Port", "The port Lumiverse will listen on.");
 
   let port = 7860;
   const portInput = await askText("Port", { defaultValue: "7860" });
@@ -153,7 +157,7 @@ async function main() {
 
   // ─── Step 3: Extension storage ─────────────────────────────────────────
 
-  printStepHeader(3, 5, "Extension Storage", "Maximum disk budget for Spindle extension data pools.");
+  printStepHeader(3, 6, "Extension Storage", "Maximum disk budget for Spindle extension data pools.");
 
   const defaultStorage = 500 * 1024 * 1024; // 500MB
   const storageInput = await askText("Max extension storage", { defaultValue: "500MB" });
@@ -173,7 +177,7 @@ async function main() {
 
   // ─── Step 4: Optional SMART support ────────────────────────────────────
 
-  printStepHeader(4, 5, "Disk Health Monitoring", "Install smartmontools so Lumiverse can report physical-drive SMART health.");
+  printStepHeader(4, 6, "Disk Health Monitoring", "Install smartmontools so Lumiverse can report physical-drive SMART health.");
 
   let smartStatus = await getSmartctlStatus();
   if (smartStatus.binary) {
@@ -223,7 +227,35 @@ async function main() {
 
   // ─── Step 5: Generate identity + write config ─────────────────────────
 
-  printStepHeader(5, 5, "Generating Identity", "Creating your encryption identity and credentials.");
+  printStepHeader(5, 6, "Lumiverse Desktop (optional)", "The desktop tray app is built on this machine; no prebuilt download exists.");
+
+  // Advisory only. Probing the toolchain shells out to other programs, and a
+  // restricted environment can make that throw — which must not abort a setup
+  // run that has already collected the user's credentials.
+  const desktopReport = await inspectDesktopToolchain().catch(() => null);
+  if (!desktopReport) {
+    console.log(`    ${theme.muted}Could not check the desktop build prerequisites here.${theme.reset}`);
+    console.log(`    ${theme.muted}Run ${theme.reset}bun run desktop:doctor${theme.muted} later to check them.${theme.reset}`);
+  } else if (desktopReport.ready) {
+    console.log(`    ${theme.success}This machine has everything needed to build it.${theme.reset}`);
+    console.log(`    ${theme.muted}From the repository root:${theme.reset}`);
+    console.log(`    ${theme.muted}  ${desktopBuildCommand()}${theme.reset}`);
+  } else {
+    console.log(`    ${theme.muted}Some build prerequisites are missing:${theme.reset}`);
+    for (const check of desktopReport.checks) {
+      if (check.status !== "missing") continue;
+      console.log(`    ${theme.warning}${check.label}${theme.reset} ${theme.muted}— ${check.detail}${theme.reset}`);
+    }
+    console.log(`    ${theme.muted}Run ${theme.reset}bun run desktop:doctor${theme.muted} for the exact install steps.${theme.reset}`);
+  }
+  console.log(`    ${theme.muted}The desktop app is optional — Lumiverse runs in any browser without it.${theme.reset}`);
+
+  console.log("");
+  printDivider();
+
+  // ─── Step 6: Generate identity + write config ─────────────────────────
+
+  printStepHeader(6, 6, "Generating Identity", "Creating your encryption identity and credentials.");
 
   await printCompletionAnimation();
 
@@ -304,6 +336,7 @@ async function main() {
       "Keep the data/ directory safe — it contains your encryption key,",
       "credentials, and database. Back up the entire data/ folder.",
       "To reset your password: bun run reset-password",
+      "Desktop app prerequisites: bun run desktop:doctor",
     ]
   );
 }


### PR DESCRIPTION
> **Stacked on #337 → #339.** Those two commits appear first in this branch: #339 supplies the toolchain probe that gates the build, and #337 supplies the "your desktop app is stale" notice that this PR makes actionable. Review only the last commit, `Rebuild the desktop app from the tray`. As each predecessor merges, this diff shrinks to that commit alone.

## Summary

**In plain terms:** Lumiverse Desktop has no download — you compile it yourself — so every time the desktop app changes you have to open a terminal, find the repo, and run a build by hand. This adds a **Rebuild Desktop App…** item to the tray menu that does it for you, showing progress in the tray while it compiles and opening a file manager on the finished build. And when Lumiverse notices your desktop app is out of date (#337), the notice now has a **Rebuild now** button that does the same thing. You still drag the new app over the old one to install it; a running app can't replace itself.

The detail:

Every install of the desktop app is compiled locally, so keeping it current is a manual chore repeated after any `desktop/` change. The runner already knows how to do this kind of work — `applyUpdate()` runs `FRONTEND_BUILD_STEPS` and narrates each one to the tray through `progress()` → `onProgress` → the tray status line. This points that same machinery at `desktop/`.

- **`rebuildDesktopShell()`** in `git-ops.ts` mirrors `rebuildFrontend()`: a declarative `DESKTOP_BUILD_STEPS` list (dependency install, then `bun run tauri build`) walked against a deadline, reporting each step.
- **`rebuild-desktop`** IPC joins the existing `operationInProgress` lock, so it cannot race an update or a branch switch.
- **A tray menu item** runs it and reveals the finished bundle.
- **The #337 stale notice** gains *Rebuild now* / *Later* buttons via a new two-button `confirm` command, so detecting the problem and fixing it are one interaction.

Three things differ from the frontend rebuild, each for a reason:

**It does not stop the server.** `rebuildFrontend` is wrapped in `runWithServerStopped` because it replaces `frontend/dist`, which the live server is serving. A Tauri build only writes to `desktop/src-tauri/target`, which nothing serves — users can keep chatting while it compiles.

**It answers on completion instead of acking early.** `apply-update` acks first because it kills the server, which would destroy the in-flight request. Nothing here stops the server, so the request can simply wait — and the caller wants the bundle path. `handleIPCMessage` is dispatched fire-and-forget, so a long build does not block the tray's status polling.

**It gets its own timeout.** `TIMEOUT_BUN_BUILD_MS` is 10 minutes, which a cold Tauri build compiling `tauri`, `wry` and the platform bindings can exceed. `TIMEOUT_DESKTOP_BUILD_MS` is 30.

The toolchain is checked *before* compiling, using #339's probe. Discovering a missing linker as a Rust error several minutes in is exactly the failure this should prevent.

### Corrections after a self-review

The first revision of this PR had a bug that would have made the feature fail for every real user, and I had "verified" it because I tested from the wrong place.

- **cargo is not on a GUI app's PATH.** The tray launches the runner with the minimal PATH macOS gives GUI apps, plus bun's directory (`prepend_bun_dir_to_path`) — nothing else. `tauri build` shells out to cargo. So the toolchain gate would *pass* (it finds `~/.cargo/bin` itself and reports OK) and the build would then fail to find the tool it had just confirmed. My original end-to-end run was from a terminal where cargo was on PATH, which is why it succeeded. The build steps now receive cargo's directory on PATH, mirroring the tray's bun handling, and the e2e below runs under the real GUI PATH.
- **Dependency install bypassed `bunInstallCmd()`.** A bare `bun install` drops the `--backend=copyfile` the repo uses on Windows (filesystem filters leave hardlinked packages empty — a bug already fixed here once) and the Termux `proot` wrapping. It now goes through `bunInstallCmd()`.
- **Artifact selection was lexicographic.** `bundle/` is never cleared, so a stale `0.9.0` artifact sits beside a fresh `0.10.0` — and sorts after it by name. Selection is now by mtime, with a fixture test for exactly that case.

Scope stops at producing a bundle. A process cannot overwrite its own bundle, so the build ends by pointing the user at what it made. Automating that swap needs a detached helper and is a separate change.

## Validation

```text
bun x tsc --noEmit
# clean, no output

cd desktop && bun run typecheck
# clean

cargo check --release   (desktop/src-tauri)
# clean

cd frontend && bun run typecheck
# clean

cd frontend && bun run lint
# 1 error, pre-existing and unrelated (RegexPromptActivationEditor.test.tsx:58:5),
# identical on base. This PR touches no frontend files.

bun test --isolate
#  4262 pass, 3 skip, 2 fail, 1 error   (branch — includes 8 new tests)
#  4242 pass, 3 skip, 2 fail, 1 error   (unmodified base 22104888)
# Same 2 pre-existing failures before and after; both pass in isolation.

bun test scripts/runner/desktop-bundle.test.ts scripts/desktop-toolchain.test.ts
#  20 pass, 0 fail
```

`scripts/runner/desktop-bundle.test.ts` drives the artifact resolver against
temp-directory fixtures: the macOS `.app` matched by exact name, msi/AppImage/deb
matched by extension, `.app` preferred over `.dmg`, `bundle_dmg.sh` ignored next
to a real `.dmg`, an empty artifact directory skipped, the bundle root as a
fallback, and **the newest artifact preferred over a lexicographically later
stale one** (`0.10.0` fresh vs `0.9.0` an hour old).

**End to end under the real tray environment.** The `rebuild-desktop` message
driven through the real `handleIPCMessage` with a capturing sink, with `PATH`
set to exactly what the tray hands the runner — bun's directory plus the GUI
minimum, and nothing else:

```text
negative control — cargo resolvable on this PATH? NO (as in the real tray)
  [progress] Installing desktop app dependencies...
  [progress] Compiling the desktop app — this can take several minutes...
frames: progress, progress, response   elapsed: 159s
success: true
bundlePath: .../target/release/bundle/macos/Lumiverse Desktop.app
```

The new `confirm` command is registered in `generate_handler!`, which fails to
compile if the function does not exist; `cargo check` and the build above both
pass, and `tray-commands` in the generated ACL manifest lists it. (Tauri does
*not* cross-check a permission's command list against registered commands —
that is why the compile-time registration is the proof, not the toml.)

And the refusal path, with the Rust toolchain hidden entirely:

```text
elapsed: 0.0s    frames: response    success: false
error: Missing desktop build prerequisites: Rust (cargo)
```

It declines immediately, emitting no progress frames — it did not start a build
and then fail.

The Windows and Linux artifact paths are covered by fixtures but have not been
produced by a real build on those platforms.

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass. *(Full-suite failures are identical to the
      unmodified base — see Validation. 8 new tests added, all passing.)*
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [x] Backend: `bun x tsc --noEmit`
  - [x] Frontend: `cd frontend && bun run typecheck`, `bun run lint`
        *(run for completeness; this PR touches no frontend files. The single
        lint error is pre-existing on base.)*

Also ran `cd desktop && bun run typecheck` and `cargo check --release`, which
cover the changed tray code.

## UI changes (if applicable)

- [ ] I validated this change in more than one browser.
- [ ] I verified the integrated experience on a mobile interface or through
      the mobile PWA.
- Browsers, devices, and PWA coverage: **not applicable.** The only UI surfaces
  are a native tray menu item and two native dialogs. No frontend file is
  modified and no browser code path is involved.

## Performance changes (if applicable)

Not applicable as a change to existing behaviour. The build itself is
long-running by nature — 159s with a warm Cargo cache, substantially longer
cold — but it is explicitly user-initiated, reports progress throughout, and
does not stop the server or block the tray's status polling.

## Security-sensitive changes (if applicable)

No impact on Spindle. Three points deserve review:

**A new capability grants `opener:allow-reveal-item-in-dir`.** It is deliberately
*not* added to the `default` capability, which covers the `frontend` window —
that window loads the Lumiverse web app, and granting it the ability to reveal
local paths would put a filesystem affordance behind any frontend XSS. Instead
`capabilities/desktop-rebuild.json` scopes the permission to `windows: ["main"]`,
the hidden tray host running trusted local code. `tray-dev.json` gets the same
permission for development and is already `main`-only.

**A new `confirm` command joins `tray-commands`.** It shows a two-button native
dialog and returns which button was pressed. It takes only display strings,
exposes no data, and is granted only to the tray host — the same scope as the
existing `alert` and `pick_folder` it is modelled on.

**The IPC message takes no parameters.** `rebuild-desktop` accepts no payload:
the directory, the commands, the timeout and the PATH prefix are all fixed. No
caller input reaches a command line, and the path handed to `revealItemInDir`
is derived from `PROJECT_ROOT`, never from a request.

## LLM-assisted work (if applicable)

- [ ] I, as the human orchestrating this work, audited the submitted changes
      in a live environment.

Not yet ticked — I will run the tray menu item on my own machine and confirm
the progress line, the completion dialog and the revealed bundle before asking
for merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
