### PR TITLE
Grant the widget POC window its own capability

### DIFF
--- a/desktop/src-tauri/capabilities/floating-widget-poc.json
+++ b/desktop/src-tauri/capabilities/floating-widget-poc.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "floating-widget-poc",
-  "description": "Minimal native-window controls for local and extension-backed floating widgets.",
-  "local": false,
+  "description": "Minimal native-window controls for local and extension-backed floating widgets. Both origins are required: the proof-of-concept window loads widget.html from the app bundle, while extension widgets load a remote URL. A remote-only capability matches the POC's label but not its origin, silently granting it nothing.",
+  "local": true,
   "windows": ["widget-*"],
   "remote": {
     "urls": ["http://127.0.0.1:*", "http://localhost:*", "http://*", "https://*"]

--- a/desktop/src/widget.ts
+++ b/desktop/src/widget.ts
@@ -16,9 +16,20 @@ const dragHandle = document.querySelector<HTMLElement>("#drag-handle")!;
 const closeButton = document.querySelector<HTMLButtonElement>("#close")!;
 const clickThroughButton = document.querySelector<HTMLButtonElement>("#click-through")!;
 
+/**
+ * Surface a rejected native call instead of dropping it.
+ *
+ * These all fail silently when the window's capability does not reach it —
+ * the button simply does nothing, with no clue why. Logging the rejection is
+ * what turns a dead control into a diagnosable one.
+ */
+function reportFailure(what: string) {
+  return (error: unknown) => console.error(`[widget] ${what} failed:`, error);
+}
+
 dragHandle.addEventListener("mousedown", (event) => {
   if (event.button === 0 && !(event.target instanceof Element && event.target.closest("button"))) {
-    void currentWindow.startDragging();
+    currentWindow.startDragging().catch(reportFailure("startDragging"));
   }
 });
 
@@ -26,16 +37,20 @@ for (const handle of document.querySelectorAll<HTMLButtonElement>("[data-directi
   handle.addEventListener("mousedown", (event) => {
     if (event.button !== 0) return;
     event.preventDefault();
-    void currentWindow.startResizeDragging(handle.dataset.direction as ResizeDirection);
+    currentWindow
+      .startResizeDragging(handle.dataset.direction as ResizeDirection)
+      .catch(reportFailure("startResizeDragging"));
   });
 }
 
 closeButton.addEventListener("click", () => {
-  void invoke("hide_widget_poc");
+  invoke("hide_widget_poc").catch(reportFailure("hide_widget_poc"));
 });
 
 clickThroughButton.addEventListener("click", () => {
   // A click-through native window cannot receive the next click to turn this
   // off, so the tray command deliberately owns restoration for this POC.
-  void invoke("set_widget_poc_click_through", { enabled: true });
+  invoke("set_widget_poc_click_through", { enabled: true }).catch(
+    reportFailure("set_widget_poc_click_through"),
+  );
 });


### PR DESCRIPTION
## Summary

**In plain terms:** the Native Widget POC window can't be moved or closed. Dragging its header does nothing and clicking its × does nothing, with no error anywhere. The window was being denied the permissions it needs because of a single flag in its capability file. One word fixes it.

The detail:

`capabilities/floating-widget-poc.json` was marked `"local": false`. In Tauri v2 that restricts a capability to the origins in its `remote` block — it never applies to a page loaded from the app bundle.

But the POC window *is* a local page:

```rust
// frontend.rs — show_widget_poc
WebviewWindowBuilder::new(&app, WIDGET_POC_LABEL, WebviewUrl::App("widget.html".into()))
```

So the window matched the capability's `widget-*` label pattern but not its origin, and received none of its permissions. Every native call from `widget.ts` was denied:

| Action | Permission needed | Result |
|---|---|---|
| Drag the header | `core:window:allow-start-dragging` | denied — nothing happens |
| Click the × | `widget-poc-commands` → `hide_widget_poc` | denied — nothing happens |
| Drag any edge to resize | `core:window:allow-start-resize-dragging` | denied — nothing happens |

Resizing was broken too; it just hadn't been reported.

Extension-backed widgets were unaffected, because they load a remote URL (`WebviewUrl::External`) and so *did* match the capability. That split is exactly what made this look like a mystery rather than a permissions problem.

The intent was never in doubt — `widget-poc-commands` is described in `permissions/tray-commands.toml` as *"Allows the **local** floating-widget proof of concept to hide itself and enter click-through mode."* The description says local; the flag said otherwise.

### Why the failure was invisible

Every call in `widget.ts` was fired as a floating promise — `void currentWindow.startDragging()`, `void invoke("hide_widget_poc")` — so the rejection was discarded. A denied permission produced a dead control and complete silence. Each now has a `.catch` that logs which call failed, so the next capability mistake is diagnosable instead of a mystery.

### Scope check on the other windows

I swept every window builder against every capability to confirm this was the only mismatch:

| Window | Origin | Covered by |
|---|---|---|
| `main` (tray host) | local — `App` | `default` (`local: true`) ✅ |
| `frontend-url-settings` | local — `App` | `default` (`local: true`) ✅ |
| `frontend` | remote — `External` | `frontend-titlebar` (`local: false` + remote) ✅ |
| extension widgets `widget-*` | remote — `External` | `floating-widget-poc` remote block ✅ |
| `widget-poc` | **local — `App`** | `floating-widget-poc` — **was `local: false`** ❌ |

`frontend-titlebar` and `tray-dev` are correctly `local: false`; both attach to remote windows. This was the only capability whose origin flag contradicted a real window.

Since `widget-*` covers both the local POC and remote extension widgets, the capability needs both origins — `local: true` alongside the existing `remote` block. The rationale now lives in the file's `description` so it does not get "tidied" back.

## Validation

```text
cd desktop && bun run tauri build
# clean

cd desktop && bun run typecheck
# clean

bun x tsc --noEmit
# clean, no output

cd frontend && bun run typecheck
# clean

cd frontend && bun run lint
# 1 error, pre-existing and unrelated (RegexPromptActivationEditor.test.tsx:58:5)
# This PR touches no frontend files.

bun test --isolate
#  4292 pass, 3 skip, 2 fail, 1 error   (branch)
#  4292 pass, 3 skip, 2 fail, 1 error   (unmodified base 9f00f4a0, run in a
#                                        separate worktree with identical deps)
# Byte-identical. The one failure is the known flaky
# edit-send-streaming-native-placement.preservation case, which passes in isolation.
```

**The fix verified at the ACL level**, which is where the bug lived. Tauri resolves capabilities into `gen/schemas/capabilities.json` at build time, so this is the grant the running window actually receives — not an inference from the source:

```text
BEFORE  floating-widget-poc: local=False  windows=['widget-*']
AFTER   floating-widget-poc: local=True   windows=['widget-*']
```

The rebuilt tray JS carries the new error handling (`[widget]` prefix present, `startDragging` and `hide_widget_poc` each with a `.catch`).

**Verified on the running window.** Built from this branch and launched on macOS
(Darwin 25.6.0) from outside `/Applications`, leaving the installed copy in place:
the POC header drags the window, the × hides it, and the edges resize. All three
were dead before the change.

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass. *(Full-suite results are byte-identical to the
      unmodified base — see Validation.)*
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [x] Backend: `bun x tsc --noEmit`
  - [x] Frontend: `cd frontend && bun run typecheck`, `bun run lint`
        *(run for completeness; this PR touches no frontend files. The single
        lint error is pre-existing on base.)*

Also ran `cd desktop && bun run typecheck` and a full `tauri build`, which cover
the changed tray code and validate the capability file.

## UI changes (if applicable)

- [ ] I validated this change in more than one browser.
- [ ] I verified the integrated experience on a mobile interface or through
      the mobile PWA.
- Browsers, devices, and PWA coverage: **not applicable.** The affected surface
  is a native Tauri window in the desktop app. No frontend file is modified and
  no browser or PWA code path is involved.

## Performance changes (if applicable)

Not applicable. One boolean in a build-time capability file, and four `.catch`
handlers that run only on failure.

## Security-sensitive changes (if applicable)

No impact on Spindle. This does widen a permission surface, so it is worth
stating precisely what by:

The capability now also applies to **local** pages in windows matching
`widget-*`. There is exactly one such page — `widget.html`, shipped inside the
app bundle as first-party code. Extension widgets are remote and were already
covered by the `remote` block, so their access is unchanged. No permission is
added to the capability; the same set now reaches the one trusted local window
that was always meant to have it.

Worth flagging separately, as pre-existing and untouched here: that `remote`
block admits `http://*` and `https://*`, so any extension widget origin gets
these window controls. That is presumably deliberate, given extension widgets
can be hosted anywhere — but it is a broad grant and I did not want to change
it silently inside a bug fix.

## LLM-assisted work (if applicable)

- [x] I, as the human orchestrating this work, audited the submitted changes
      in a live environment.

Opened the Native Widget POC from the tray on a build made from this branch and
confirmed all three previously dead controls now work: header drag, × to hide,
and edge resize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

