### PR TITLE
Permit desktop_shell_sha so the rebuild check can run

### DIFF
--- a/desktop/src-tauri/permissions.test.ts
+++ b/desktop/src-tauri/permissions.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * A Tauri command is only callable when two separate things are true: it is
+ * registered in `generate_handler!`, and a capability that reaches the calling
+ * window grants it. Rust enforces the first at compile time and nothing
+ * enforces the second, so a command can be registered, invoked, and silently
+ * denied at runtime — the control simply does nothing.
+ *
+ * That has now happened twice: `hide_widget_poc` reached a window whose
+ * capability excluded its origin, and `desktop_shell_sha` was registered but
+ * never added to any permission. Both were invisible because the rejected
+ * promise was discarded. These tests close the gap the compiler leaves.
+ */
+
+const HERE = import.meta.dir;
+const PERMISSIONS_DIR = join(HERE, "permissions");
+const CAPABILITIES_DIR = join(HERE, "capabilities");
+
+function readSource(name: string): string {
+  return readFileSync(join(HERE, "src", name), "utf8");
+}
+
+/** Commands exposed to the webview via `generate_handler!`. */
+function registeredCommands(): string[] {
+  const lib = readSource("lib.rs");
+  const block = lib.match(/generate_handler!\[([\s\S]*?)\]/);
+  if (!block) throw new Error("generate_handler! block not found in lib.rs");
+  return [...block[1].matchAll(/(?:runner|frontend)::([a-z0-9_]+)/g)].map((m) => m[1]);
+}
+
+/** Every command name appearing in any `commands.allow` list. */
+function permittedCommands(): Set<string> {
+  const names = new Set<string>();
+  for (const file of readdirSync(PERMISSIONS_DIR).filter((f) => f.endsWith(".toml"))) {
+    const toml = readFileSync(join(PERMISSIONS_DIR, file), "utf8");
+    for (const list of toml.matchAll(/commands\.allow\s*=\s*\[([\s\S]*?)\]/g)) {
+      for (const entry of list[1].matchAll(/"([a-z0-9_]+)"/g)) names.add(entry[1]);
+    }
+  }
+  return names;
+}
+
+function capabilities(): Array<{ file: string; json: Record<string, unknown> }> {
+  return readdirSync(CAPABILITIES_DIR)
+    .filter((f) => f.endsWith(".json"))
+    .map((file) => ({
+      file,
+      json: JSON.parse(readFileSync(join(CAPABILITIES_DIR, file), "utf8")),
+    }));
+}
+
+describe("tauri command registration", () => {
+  test("every registered command is granted by some permission", () => {
+    const permitted = permittedCommands();
+    const orphaned = registeredCommands().filter((name) => !permitted.has(name));
+    // A registered-but-unpermitted command compiles, invokes, and is denied at
+    // runtime with no error surfaced to the user.
+    expect(orphaned).toEqual([]);
+  });
+
+  test("every permitted command is actually registered", () => {
+    const registered = new Set(registeredCommands());
+    const dangling = [...permittedCommands()].filter((name) => !registered.has(name));
+    // A permission naming a command that no longer exists is dead grant surface
+    // and hides a rename.
+    expect(dangling).toEqual([]);
+  });
+
+  test("the commands this bug was about are both covered", () => {
+    const permitted = permittedCommands();
+    // Regression pins: desktop_shell_sha was registered but unpermitted, which
+    // silently disabled the stale-shell check entirely.
+    expect(permitted.has("desktop_shell_sha")).toBe(true);
+    expect(permitted.has("hide_widget_poc")).toBe(true);
+  });
+});
+
+describe("capability origins", () => {
+  /**
+   * Labels of windows the Rust side builds from a bundled page. A capability
+   * covering one of these must apply to local origins, or it matches the
+   * window's label and grants it nothing.
+   */
+  function localWindowLabels(): string[] {
+    const frontend = readSource("frontend.rs");
+    const labels: string[] = [];
+    for (const m of frontend.matchAll(
+      /WebviewWindowBuilder::new\(\s*&app,\s*([^,]+?),\s*WebviewUrl::App/g,
+    )) {
+      const constName = m[1].trim().replace(/^&/, "");
+      // Resolve `const FOO: &str = "bar";` to its literal.
+      const decl = frontend.match(
+        new RegExp(`const\\s+${constName}\\s*:\\s*&str\\s*=\\s*"([^"]+)"`),
+      );
+      if (decl) labels.push(decl[1]);
+    }
+    return labels;
+  }
+
+  function matchesWindow(pattern: string, label: string): boolean {
+    if (pattern === label) return true;
+    if (!pattern.includes("*")) return false;
+    const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+    return new RegExp(`^${escaped}$`).test(label);
+  }
+
+  test("a local window is never left to a remote-only capability", () => {
+    const labels = localWindowLabels();
+    expect(labels.length).toBeGreaterThan(0);
+
+    const broken: string[] = [];
+    for (const label of labels) {
+      const matching = capabilities().filter((c) =>
+        ((c.json.windows as string[]) ?? []).some((w) => matchesWindow(w, label)),
+      );
+      if (matching.length === 0) continue;
+      // `local` defaults to true when the key is absent.
+      const reachable = matching.some((c) => c.json.local !== false);
+      if (!reachable) {
+        broken.push(`${label} → only ${matching.map((c) => c.file).join(", ")} (all local:false)`);
+      }
+    }
+    expect(broken).toEqual([]);
+  });
+});

--- a/desktop/src-tauri/permissions/tray-commands.toml
+++ b/desktop/src-tauri/permissions/tray-commands.toml
@@ -9,6 +9,7 @@ commands.allow = [
   "validate_repo",
   "discover_repo",
   "resolve_bun",
+  "desktop_shell_sha",
   "quit_app",
   "alert",
   "confirm",

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -60,8 +60,6 @@ let updateState: UpdateState = { available: false, commitsBehind: 0, latestMessa
 // carrying desktop changes leaves this process running superseded code.
 let desktopShellStale = false;
 let desktopShellNoticeShown = false;
-let desktopShellChecked = false;
-let updateJustApplied = false;
 let customFrontendUrl: string | null = null;
 let openIntegratedBrowserWhenReady = false;
 
@@ -311,17 +309,33 @@ async function checkForUpdates(interactive: boolean): Promise<void> {
  */
 async function refreshDesktopShellState(): Promise<void> {
   if (!repoDir || !(await client.alive())) return;
-  let state: DesktopShellState;
+
+  // Separate the two failure modes. A runner that predates this message is
+  // expected and transient — stay quiet and keep any verdict we already hold.
+  // The command failing is not: it means the shell is misconfigured, and
+  // swallowing that is what let this check silently never run at all.
+  let builtSha: string | null;
   try {
-    const builtSha = await invoke<string | null>("desktop_shell_sha");
-    state = await client.request<DesktopShellState>("desktop-shell-status", { builtSha }, 15_000);
-  } catch {
-    // An unreachable or older runner cannot answer. Leave the previous
-    // verdict alone rather than clearing a warning we still believe.
+    builtSha = await invoke<string | null>("desktop_shell_sha");
+  } catch (error) {
+    console.error(
+      "[desktop-shell] Could not read this build's revision, so the " +
+        "rebuild check cannot run. Is desktop_shell_sha missing from the " +
+        "tray-commands permission?",
+      error,
+    );
     return;
   }
 
-  desktopShellChecked = true;
+  let state: DesktopShellState;
+  try {
+    state = await client.request<DesktopShellState>("desktop-shell-status", { builtSha }, 15_000);
+  } catch {
+    // An older runner does not know this message. Leave the previous verdict
+    // alone rather than clearing a warning we still believe.
+    return;
+  }
+
   const becameStale = state.stale && !desktopShellStale;
   desktopShellStale = state.stale;
   // A rebuild clears the condition; let the notice fire again if it recurs.
@@ -348,7 +362,6 @@ async function refreshDesktopShellState(): Promise<void> {
 
 async function applyUpdate(): Promise<void> {
   await ensureRunner();
-  updateJustApplied = true;
   busyMessage = "Applying update…";
   await updateMenu();
   try {
@@ -688,10 +701,13 @@ async function boot(): Promise<void> {
     if (state === "running" || state === "stopped" || state === "crashed") {
       busyMessage = null;
     }
-    // The check needs a live runner, so the first chance to run it is the
-    // server coming up. Repeat it once an applied update has settled.
-    if (state === "running" && (!desktopShellChecked || updateJustApplied)) {
-      updateJustApplied = false;
+    // Re-check on every start, not just the first. The checkout can move
+    // underneath a long-running tray — a git pull outside the app is the most
+    // likely way a desktop change arrives, and it fires no event here. A
+    // latch would mean the notice waited for the next app launch. The cost is
+    // three git commands, and the dialog is gated on the stale transition
+    // rather than on this call, so restarting the server cannot nag.
+    if (state === "running") {
       void refreshDesktopShellState();
     }
     void refreshStatus().then(updateMenu);


### PR DESCRIPTION
## Summary

**In plain terms:** the "your desktop app is out of date, rebuild it" notice added in #337 has never actually worked, for two reasons that hid each other. The check asks the app which version it was built from, and that call was never granted permission — so it failed instantly and silently. Behind that sat a second problem: even once permitted, the check only ran once per app launch, so pulling an update while the app was open would never have triggered it. Both are fixed, plus a test so this class of mistake can't ship again — because it has now shipped twice.

The detail:

`desktop_shell_sha` is registered in `generate_handler!` but was never added to any `commands.allow` list. A Tauri command needs both: Rust enforces registration at compile time, and nothing enforces the permission. So the command compiled, invoked, and was denied at runtime.

`refreshDesktopShellState()` then swallowed the denial:

```ts
try {
  const builtSha = await invoke<string | null>("desktop_shell_sha");
  state = await client.request<DesktopShellState>("desktop-shell-status", { builtSha }, 15_000);
} catch {
  // An unreachable or older runner cannot answer. Leave the previous
  // verdict alone rather than clearing a warning we still believe.
  return;
}
```

That `catch` was written for one failure — an older runner that does not know the `desktop-shell-status` message, which is transient and worth staying quiet about. It also caught a denied `invoke`, which is a permanent misconfiguration and is not. The feature reported nothing, forever, in exactly the manner it exists to prevent.

**This was introduced by #337**, which is mine. The verification there confirmed the stamp reached the binary and that the comparison logic was correct — both true — but never that the tray could call the command at all. The one link that mattered end to end.

### The second bug, found while verifying the first

With the permission fixed, the notice still did not appear. The trigger was latched:

```ts
if (state === "running" && (!desktopShellChecked || updateJustApplied)) {
```

`desktopShellChecked` is set after the first successful check and never reset, so the check ran once per app launch. A `git pull` outside the app — the most likely way a `desktop/` change arrives — fires no event here, so the notice would have waited for the next launch. The permission bug was hiding a design bug behind it.

Both flags are now gone and the check runs whenever the server reaches `running`. That cannot nag: the dialog is gated on the stale false→true transition, not on the call, so restarting the server while already-stale shows nothing. `updateJustApplied` is redundant too, since the restart an applied update causes already re-checks.

### The changes

1. **`desktop_shell_sha` added to `tray-commands`.** The permission fix.
2. **Re-check on every server start**, with both latches removed.
3. **The two failure modes are separated.** A failed `invoke` now logs what happened and names the likely cause; a failed IPC request still stays quiet, since an older runner genuinely cannot answer.
4. **A test that checks the compiler's blind spot** — `desktop/src-tauri/permissions.test.ts`.

### Why the test earns its place

This is the second occurrence in a week. #341 was the same shape: `hide_widget_poc` reached a window whose capability excluded its origin, so the widget POC could not be dragged or closed. Registered, invoked, denied, silent.

The test covers both halves:

- **Every registered command is granted by some permission**, and every permitted command still exists (catching renames that leave dead grant surface).
- **No window built from a bundled page is left to a remote-only capability** — it parses `WebviewUrl::App` builders out of `frontend.rs`, resolves their label constants, and checks that at least one capability matching that label applies to local origins. That is precisely the #341 bug, expressed as an invariant.

Both were confirmed to fail on the bug and pass on the fix, rather than merely passing today:

```text
# reintroduce this bug (remove the permission)
(fail) every registered command is granted by some permission
(fail) the commands this bug was about are both covered
 2 pass, 2 fail

# reintroduce the #341 bug (capability back to local:false)
+   "widget-poc → only floating-widget-poc.json (all local:false)"
(fail) a local window is never left to a remote-only capability
 3 pass, 1 fail

# both fixes in place
 4 pass, 0 fail
```

## Validation

```text
bun x tsc --noEmit            # clean
cd desktop && bun run typecheck   # clean
cd frontend && bun run typecheck  # clean
cd frontend && bun run lint       # 1 pre-existing error, unrelated; no frontend files touched

cd desktop && bun run tauri build
# clean. Confirms the permission reaches the generated ACL:
#   desktop_shell_sha permitted: True

bun test desktop/src-tauri/permissions.test.ts
#  4 pass, 0 fail

bun test --isolate
#  branch: 4309 pass, 3 skip, 1 fail          (639 files, includes the new test file)
#          — unchanged after removing the latch
#  base:   4292 pass, 3 skip, 2 fail, 1 error (638 files, worktree, identical deps)
# The only named failure is the same known-flaky
# edit-send-streaming-native-placement.preservation case on both. Its neighbouring
# isolated-module-graph tests fluctuate between runs, which is why the totals and
# the error count differ; the branch run happened to be the cleaner of the two.
```

**Verified end to end against a real stale install.** The app currently in `/Applications` is stamped `9f00f4a0`; the checkout is at `664378ca`, whose newest `desktop/` commit is `33e9ee8a` (#341). Driving the real `desktop-shell-status` message through `handleIPCMessage` with that exact stamp:

```text
installed app's real stamp: 9f00f4a0
checkout HEAD:              664378ca
response: {"stale":true,
           "builtSha":"9f00f4a00b215dd10594c8b646fb8f4d0f706d6a",
           "requiredSha":"33e9ee8acc7ab21b479135696882690bbc0f2def"}
```

`stale: true` — the verdict that drives the notice, for a genuinely out-of-date install, which reported nothing before this change.

**The dialog itself was then confirmed on the running app.** A build carrying this
fix was launched, and its checkout advanced past it so a real `desktop/` commit
sat ahead of the build's stamp. On a fresh launch with the server started, the
"Lumiverse Desktop rebuild required" dialog appeared with its **Rebuild now** /
**Later** buttons. That same setup with only a *server* restart showed nothing,
which is what exposed the latch above.

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass. *(Full-suite results match the unmodified base
      apart from the new test file — see Validation. 4 new tests added, each
      confirmed to fail on the bug it guards.)*
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [x] Backend: `bun x tsc --noEmit`
  - [x] Frontend: `cd frontend && bun run typecheck`, `bun run lint`
        *(run for completeness; this PR touches no frontend files. The single
        lint error is pre-existing on base.)*

Also ran `cd desktop && bun run typecheck` and a full `tauri build`.

## UI changes (if applicable)

- [ ] I validated this change in more than one browser.
- [ ] I verified the integrated experience on a mobile interface or through
      the mobile PWA.
- Browsers, devices, and PWA coverage: **not applicable.** The affected surface
  is a native tray dialog in the desktop app. No frontend file is modified and
  no browser or PWA code path is involved.

## Performance changes (if applicable)

Not applicable. One entry in a build-time permission list, one `try` block split
into two, and a test that reads a handful of files.

## Security-sensitive changes (if applicable)

No impact on Spindle. The permission surface grows by exactly one command, and
it is a read: `desktop_shell_sha` takes no arguments and returns the git SHA
compiled into the binary, or `None` for a build with no git metadata. It exposes
no user data, touches no filesystem, and is granted only to the tray host —
the same scope as the `alert`, `confirm` and `resolve_bun` commands beside it.

The new test slightly *reduces* risk surface by flagging permitted commands that
no longer exist, which would otherwise linger as dead grants.

## LLM-assisted work (if applicable)

- [x] I, as the human orchestrating this work, audited the submitted changes
      in a live environment.

Ran a build of this branch against a checkout deliberately advanced past it, and
confirmed the "Lumiverse Desktop rebuild required" dialog appears with its
**Rebuild now** / **Later** buttons. The latch fix came directly out of that
session: the dialog did not appear on a server restart, only on a fresh launch,
which is the behaviour this PR now corrects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

