### PR TITLE
fix(frontend): expose init_image and denoise roles in ComfyUI workflow editor

### DIFF
--- a/frontend/src/api/image-gen-connections.ts
+++ b/frontend/src/api/image-gen-connections.ts
@@ -17,9 +17,11 @@ import type {
 export type ComfyUIMappedFieldSemantic =
   | 'positive_prompt'
   | 'negative_prompt'
+  | 'init_image'
   | 'seed'
   | 'steps'
   | 'cfg'
+  | 'denoise'
   | 'sampler_name'
   | 'scheduler'
   | 'width'

--- a/frontend/src/components/panels/image-gen-connections/ComfyWorkflowEditor.tsx
+++ b/frontend/src/components/panels/image-gen-connections/ComfyWorkflowEditor.tsx
@@ -35,11 +35,13 @@ interface RoleDef {
 const ROLE_DEFS: readonly RoleDef[] = [
   { semantic: 'positive_prompt', group: 'core', required: true },
   { semantic: 'negative_prompt', group: 'core' },
+  { semantic: 'init_image', group: 'core' },
   { semantic: 'seed', group: 'core' },
   { semantic: 'width', group: 'core' },
   { semantic: 'height', group: 'core' },
   { semantic: 'steps', group: 'sampling' },
   { semantic: 'cfg', group: 'sampling' },
+  { semantic: 'denoise', group: 'sampling' },
   { semantic: 'sampler_name', group: 'sampling' },
   { semantic: 'scheduler', group: 'sampling' },
   { semantic: 'checkpoint', group: 'model' },

--- a/frontend/src/i18n/locales/en/panels.json
+++ b/frontend/src/i18n/locales/en/panels.json
@@ -47,11 +47,13 @@
     "role": {
       "positive_prompt": "Positive prompt",
       "negative_prompt": "Negative prompt",
+      "init_image": "Initial / Reference image",
       "seed": "Seed",
       "width": "Width",
       "height": "Height",
       "steps": "Steps",
       "cfg": "CFG",
+      "denoise": "Denoise",
       "sampler_name": "Sampler",
       "scheduler": "Scheduler",
       "checkpoint": "Checkpoint",

--- a/frontend/src/lib/comfyui-mapped-fields.ts
+++ b/frontend/src/lib/comfyui-mapped-fields.ts
@@ -20,9 +20,11 @@ const CUSTOM_CONTROL_PREFIX = 'custom:'
 const SEMANTIC_ORDER: ComfyUIMappedFieldSemantic[] = [
   'positive_prompt',
   'negative_prompt',
+  'init_image',
   'seed',
   'steps',
   'cfg',
+  'denoise',
   'width',
   'height',
   'checkpoint',
@@ -34,9 +36,11 @@ const SEMANTIC_ORDER: ComfyUIMappedFieldSemantic[] = [
 const SEMANTIC_LABELS: Record<Exclude<ComfyUIMappedFieldSemantic, 'custom'>, string> = {
   positive_prompt: 'Positive Prompt',
   negative_prompt: 'Negative Prompt',
+  init_image: 'Initial / Reference Image',
   seed: 'Seed',
   steps: 'Steps',
   cfg: 'CFG',
+  denoise: 'Denoise',
   sampler_name: 'Sampler',
   scheduler: 'Scheduler',
   width: 'Width',


### PR DESCRIPTION
### Summary

The backend ComfyUI workflow patcher (`comfyui-workflow-patch.ts`) and image generation pipeline (`image-gen.service.ts`) already have full support for `init_image` (used for img2img as well as reference images / IP-Adapter character portraits) and `denoise`.

However, the frontend `ComfyWorkflowEditor` omitted `init_image` and `denoise` from `ROLE_DEFS` and `ComfyUIMappedFieldSemantic`. Consequently:
1. Users importing workflows with a `LoadImage` node (for img2img or IP-Adapter character references) could only map the field as `'custom'`.
2. Because `image-gen.service.ts` specifically checks `mappings.some(m => m.mappedAs === 'init_image')`, mapping as `'custom'` completely bypassed the reference image resolution and `/upload/image` upload pipeline, leaving ComfyUI running with the template's embedded placeholder image.

### Changes

- **`frontend/src/api/image-gen-connections.ts`**: Added `'init_image'` and `'denoise'` to `ComfyUIMappedFieldSemantic`.
- **`frontend/src/components/panels/image-gen-connections/ComfyWorkflowEditor.tsx`**: Added `init_image` (under `'core'` / Roles) and `denoise` (under `'sampling'`) to `ROLE_DEFS`.
- **`frontend/src/lib/comfyui-mapped-fields.ts`**: Added `init_image` and `denoise` to `SEMANTIC_ORDER` and `SEMANTIC_LABELS`.
- **`frontend/src/i18n/locales/en/panels.json`**: Added role labels for `init_image` ("Initial / Reference image") and `denoise` ("Denoise").

### Verification

- Run `bun run typecheck` in `frontend` (clean 0 errors).
- Tested existing backend suite (`bun test src/image-gen/comfyui-workflow-patch.test.ts`).
