### PR TITLE
fix: return Google thought summaries with Auto reasoning

### DIFF
--- a/src/services/prompt-assembly-reasoning.test.ts
+++ b/src/services/prompt-assembly-reasoning.test.ts
@@ -304,3 +304,41 @@ describe("applyProviderReasoningOffSwitch (zai & moonshot)", () => {
     expect(params.reasoning_effort).toBeUndefined();
   });
 });
+
+describe("buildParameters (Google thought summaries)", () => {
+  for (const provider of ["google", "google_vertex"]) {
+    for (const effort of [undefined, "auto", "high"]) {
+      test(`${provider} requests summaries with effort ${effort ?? "unset"}`, () => {
+        const params = buildParameters(null, null, {
+          apiReasoning: true, reasoningEffort: effort,
+        }, provider, "gemini-3.8-flash");
+        expect(params.thinkingConfig).toEqual(effort === "high"
+          ? { includeThoughts: true, thinkingLevel: "high" }
+          : { includeThoughts: true });
+      });
+    }
+
+    test(`${provider} does not request summaries when reasoning is disabled`, () => {
+      const params = buildParameters(null, null, {
+        apiReasoning: false, reasoningEffort: "auto",
+      }, provider, "gemini-3.8-flash");
+      expect(params.thinkingConfig).toBeUndefined();
+    });
+
+    test(`${provider} preserves custom body precedence`, () => {
+      const params = buildParameters(null, null, {
+        apiReasoning: true, reasoningEffort: "auto",
+        customBody: { enabled: true, rawJson: JSON.stringify({
+          thinkingConfig: { thinkingBudget: 1024, includeThoughts: false },
+        }) },
+      }, provider, "gemini-3.8-flash");
+      expect(params.thinkingConfig).toEqual({ thinkingBudget: 1024, includeThoughts: false });
+    });
+
+    test(`${provider} auto injection preserves an explicit budget without adding a level`, () => {
+      const params: Record<string, any> = { thinkingConfig: { thinkingBudget: 1024 } };
+      injectReasoningParams(params, provider, "auto", "gemini-3.8-flash");
+      expect(params.thinkingConfig).toEqual({ thinkingBudget: 1024, includeThoughts: true });
+    });
+  }
+});

--- a/src/services/prompt-assembly.service.ts
+++ b/src/services/prompt-assembly.service.ts
@@ -7319,7 +7319,10 @@ export function buildParameters(
     const effort = reasoningSettings.reasoningEffort || "auto";
     const requiresExplicitOnSwitch =
       providerName === "moonshot" || providerName === "zai";
-    if (effort !== "auto" || requiresExplicitOnSwitch) {
+    // Google requires includeThoughts even when the model chooses its own effort.
+    const requiresThoughtSummaries =
+      providerName === "google" || providerName === "google_vertex";
+    if (effort !== "auto" || requiresExplicitOnSwitch || requiresThoughtSummaries) {
       injectReasoningParams(
         params,
         providerName,
@@ -7464,8 +7467,12 @@ export function injectReasoningParams(
     // emits zero `part.thought` parts and our parser sees nothing).
     params.thinkingConfig = {
       ...existing,
-      thinkingLevel:
-        existing.thinkingLevel ?? (validLevels.has(effort) ? effort : "medium"),
+      ...(effort !== "auto"
+        ? {
+            thinkingLevel:
+              existing.thinkingLevel ?? (validLevels.has(effort) ? effort : "medium"),
+          }
+        : {}),
       includeThoughts: true,
     };
   } else if (providerName === "openrouter") {


### PR DESCRIPTION
## Summary
- Request `thinkingConfig.includeThoughts: true` for Google AI Studio and Vertex AI when API reasoning is enabled with Auto (or unset) effort.
- Leave `thinkingLevel` and `thinkingBudget` unspecified in Auto mode unless explicitly supplied, so the model keeps its native default effort.
- Preserve custom-body precedence, explicit effort selection, and the reasoning off-switch.

## Cause
`buildParameters` skipped reasoning injection for Auto. Google can reason internally without returning readable thought summaries, so the UI had no reasoning text to display. The saved Vertex profile that exposed this used `gemini-3.8-flash`, API reasoning enabled, and Auto effort. Signature replay is separate and does not request summary text.

## Validation
- `bun test --isolate src/services/prompt-assembly-reasoning.test.ts src/llm/providers/google.test.ts src/llm/providers/google-vertex.test.ts tests/gemini-interleaved-thinking.test.ts` — 77 pass, 0 fail.
- `bun x tsc --noEmit` — pass, no diagnostics.
- `git diff --check` — pass.
- Regression check: restoring the old Auto injection gate makes all four Auto/unset summary-request cases fail; restoring the fix makes them pass.
- Added 12 regression cases covering both Google providers, Auto/unset/high effort, reasoning disabled, custom-body precedence, and explicit budget preservation.

Backend-only; no UI/browser/mobile changes and no security-sensitive or Spindle changes. No live Vertex generation or human live-environment audit was performed; the user requested submission after automated validation. AI-assisted change.
