### PR TITLE
feat: add Google AI Studio and Vertex TTS providers

### DIFF
--- a/src/tts/index.ts
+++ b/src/tts/index.ts
@@ -5,6 +5,8 @@ import { KokoroTtsProvider } from "./providers/kokoro";
 import { OpenRouterTtsProvider } from "./providers/openrouter-tts";
 import { CartesiaTtsProvider } from "./providers/cartesia";
 import { Qwen3TtsServerProvider } from "./providers/qwen3-tts-server";
+import { GoogleTtsProvider } from "./providers/google-tts";
+import { GoogleVertexTtsProvider } from "./providers/google-vertex-tts";
 
 registerTtsProvider(new CartesiaTtsProvider());
 registerTtsProvider(new OpenAITtsProvider());
@@ -12,3 +14,5 @@ registerTtsProvider(new ElevenLabsTtsProvider());
 registerTtsProvider(new KokoroTtsProvider());
 registerTtsProvider(new OpenRouterTtsProvider());
 registerTtsProvider(new Qwen3TtsServerProvider());
+registerTtsProvider(new GoogleTtsProvider());
+registerTtsProvider(new GoogleVertexTtsProvider());

--- a/src/tts/providers/google-tts-shared.ts
+++ b/src/tts/providers/google-tts-shared.ts
@@ -2,9 +2,15 @@ import type { TtsRequest } from "../types";
 
 /** Gemini text-to-speech models. TTS-only list: no text/generation models. */
 export const GOOGLE_TTS_MODELS = [
-  { id: "gemini-2.5-flash-preview-tts", label: "Gemini 2.5 Flash TTS (fast)" },
+  { id: "gemini-3.1-flash-tts-preview", label: "Gemini 3.1 Flash TTS (latest)" },
   { id: "gemini-2.5-pro-preview-tts", label: "Gemini 2.5 Pro TTS (high quality)" },
+  { id: "gemini-2.5-flash-preview-tts", label: "Gemini 2.5 Flash TTS (fast)" },
 ];
+
+/** Keep a model ID only when it names a speech/TTS model. */
+export function isTtsModelId(id: string): boolean {
+  return /(?:^|[-_./: ])(tts|speech)(?:$|[-_./: ])/i.test(id);
+}
 
 /**
  * Prebuilt Gemini voices, mapped to readable names with documented gender.

--- a/src/tts/providers/google-tts-shared.ts
+++ b/src/tts/providers/google-tts-shared.ts
@@ -1,0 +1,137 @@
+import type { TtsRequest } from "../types";
+
+/** Gemini text-to-speech models. TTS-only list: no text/generation models. */
+export const GOOGLE_TTS_MODELS = [
+  { id: "gemini-2.5-flash-preview-tts", label: "Gemini 2.5 Flash TTS (fast)" },
+  { id: "gemini-2.5-pro-preview-tts", label: "Gemini 2.5 Pro TTS (high quality)" },
+];
+
+/**
+ * Prebuilt Gemini voices, mapped to readable names with documented gender.
+ * IDs are the API voice names; `language` marks the documented voice locale.
+ */
+export const GOOGLE_TTS_VOICES = [
+  { id: "Achird", name: "Achird", language: "en-US", gender: "masculine" },
+  { id: "Achernar", name: "Achernar", language: "en-US", gender: "feminine" },
+  { id: "Algenib", name: "Algenib", language: "en-US", gender: "masculine" },
+  { id: "Algieba", name: "Algieba", language: "en-US", gender: "feminine" },
+  { id: "Alnilam", name: "Alnilam", language: "en-US", gender: "masculine" },
+  { id: "Aoede", name: "Aoede", language: "en-US", gender: "feminine" },
+  { id: "Autonoe", name: "Autonoe", language: "en-US", gender: "feminine" },
+  { id: "Callirrhoe", name: "Callirrhoe", language: "en-US", gender: "feminine" },
+  { id: "Charon", name: "Charon", language: "en-US", gender: "masculine" },
+  { id: "Despina", name: "Despina", language: "en-US", gender: "feminine" },
+  { id: "Enceladus", name: "Enceladus", language: "en-US", gender: "masculine" },
+  { id: "Erinome", name: "Erinome", language: "en-US", gender: "feminine" },
+  { id: "Fenrir", name: "Fenrir", language: "en-US", gender: "masculine" },
+  { id: "Gacrux", name: "Gacrux", language: "en-US", gender: "feminine" },
+  { id: "Iapetus", name: "Iapetus", language: "en-US", gender: "masculine" },
+  { id: "Kore", name: "Kore", language: "en-US", gender: "feminine" },
+  { id: "Laomedeia", name: "Laomedeia", language: "en-US", gender: "feminine" },
+  { id: "Leda", name: "Leda", language: "en-US", gender: "feminine" },
+  { id: "Orus", name: "Orus", language: "en-US", gender: "masculine" },
+  { id: "Pulcherrima", name: "Pulcherrima", language: "en-US", gender: "feminine" },
+  { id: "Puck", name: "Puck", language: "en-US", gender: "masculine" },
+  { id: "Rasalgethi", name: "Rasalgethi", language: "en-US", gender: "masculine" },
+  { id: "Sadachbia", name: "Sadachbia", language: "en-US", gender: "masculine" },
+  { id: "Sadaltager", name: "Sadaltager", language: "en-US", gender: "masculine" },
+  { id: "Schedar", name: "Schedar", language: "en-US", gender: "masculine" },
+  { id: "Sulafat", name: "Sulafat", language: "en-US", gender: "feminine" },
+  { id: "Umbriel", name: "Umbriel", language: "en-US", gender: "masculine" },
+  { id: "Vindemiatrix", name: "Vindemiatrix", language: "en-US", gender: "feminine" },
+  { id: "Zephyr", name: "Zephyr", language: "en-US", gender: "feminine" },
+  { id: "Zubenelgenubi", name: "Zubenelgenubi", language: "en-US", gender: "masculine" },
+];
+
+export const GOOGLE_TTS_PARAMETERS = {
+  language_code: {
+    type: "string" as const,
+    description: "BCP-47 language code for synthesis (e.g. en-US). Leave blank for the default.",
+    group: "advanced",
+  },
+  temperature: {
+    type: "number" as const,
+    default: 1,
+    min: 0,
+    max: 2,
+    step: 0.05,
+    description: "Voice variation — higher values add expressiveness, lower values are more deterministic",
+    group: "advanced",
+  },
+};
+
+/** Single-speaker generateContent body requesting AUDIO output. */
+export function buildGeminiTtsBody(request: TtsRequest): Record<string, any> {
+  const speechConfig: Record<string, any> = {
+    voice_config: {
+      prebuilt_voice_config: { voice_name: request.voice },
+    },
+  };
+  if (typeof request.parameters.language_code === "string" && request.parameters.language_code.trim()) {
+    speechConfig.language_code = request.parameters.language_code.trim();
+  }
+  const generationConfig: Record<string, any> = {
+    responseModalities: ["AUDIO"],
+    speech_config: speechConfig,
+  };
+  if (typeof request.parameters.temperature === "number") {
+    generationConfig.temperature = request.parameters.temperature;
+  }
+  return {
+    contents: [{ parts: [{ text: request.text }] }],
+    generationConfig,
+  };
+}
+
+function parsePcmRate(mimeType: string | undefined): number {
+  const match = /rate=(\d+)/i.exec(mimeType || "");
+  const rate = match ? Number.parseInt(match[1], 10) : 24000;
+  return Number.isFinite(rate) && rate > 0 ? rate : 24000;
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+/** Wrap raw 16-bit mono PCM in a WAV container so browsers can play it. */
+export function wrapPcmInWav(pcm: Uint8Array, sampleRate: number): ArrayBuffer {
+  const header = new ArrayBuffer(44);
+  const view = new DataView(header);
+  const writeAscii = (offset: number, text: string) => {
+    for (let i = 0; i < text.length; i++) view.setUint8(offset + i, text.charCodeAt(i));
+  };
+  writeAscii(0, "RIFF");
+  view.setUint32(4, 36 + pcm.length, true);
+  writeAscii(8, "WAVE");
+  writeAscii(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeAscii(36, "data");
+  view.setUint32(40, pcm.length, true);
+  const out = new Uint8Array(44 + pcm.length);
+  out.set(new Uint8Array(header), 0);
+  out.set(pcm, 44);
+  return out.buffer;
+}
+
+/** Extract the first inline audio payload from a generateContent response. */
+export function extractGeminiTtsAudio(data: any): { audioData: ArrayBuffer; contentType: string } {
+  const parts: any[] = data?.candidates?.[0]?.content?.parts || [];
+  for (const part of parts) {
+    const inline = part?.inlineData || part?.inline_data;
+    if (inline?.data) {
+      const mimeType: string | undefined = inline.mimeType || inline.mime_type;
+      const audioData = wrapPcmInWav(base64ToBytes(inline.data), parsePcmRate(mimeType));
+      return { audioData, contentType: "audio/wav" };
+    }
+  }
+  throw new Error("No audio payload in Gemini TTS response");
+}

--- a/src/tts/providers/google-tts.test.ts
+++ b/src/tts/providers/google-tts.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+import { GoogleTtsProvider } from "./google-tts";
+import { GoogleVertexTtsProvider } from "./google-vertex-tts";
+import { GOOGLE_TTS_MODELS, GOOGLE_TTS_VOICES, buildGeminiTtsBody, wrapPcmInWav } from "./google-tts-shared";
+
+const pcmB64 = (s: string) => Buffer.from(s, "utf8").toString("base64");
+const wavText = (buf: ArrayBuffer) => Buffer.from(buf.slice(44)).toString("utf8");
+
+describe("Google TTS providers", () => {
+  const studio = new GoogleTtsProvider();
+  const vertex = new GoogleVertexTtsProvider();
+
+  test("TTS-only model lists", async () => {
+    for (const p of [studio, vertex]) {
+      expect((await p.listModels("", "")).map((m) => m.id)).toEqual(GOOGLE_TTS_MODELS.map((m) => m.id));
+      for (const m of GOOGLE_TTS_MODELS) expect(m.id.toLowerCase()).toContain("tts");
+    }
+  });
+
+  test("voice mapping is non-empty, unique, and gendered", async () => {
+    for (const p of [studio, vertex]) {
+      const voices = await p.listVoices("", "");
+      expect(voices.length).toBeGreaterThanOrEqual(30);
+      expect(new Set(voices.map((v) => v.id)).size).toBe(voices.length);
+      for (const v of voices) {
+        expect(v.name).toBeTruthy();
+        expect(["masculine", "feminine"]).toContain((v as any).gender);
+      }
+      expect(voices.map((v) => v.id)).toContain("Kore");
+      expect(voices.map((v) => v.id)).toContain("Charon");
+    }
+    expect(GOOGLE_TTS_VOICES.length).toBe((await studio.listVoices("", "")).length);
+  });
+
+  test("AI Studio posts key, model route, voice config, and wraps PCM as WAV", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    (globalThis as any).fetch = async (input: any, init?: RequestInit) => {
+      calls.push({ url: String(input), init });
+      return new Response(JSON.stringify({ candidates: [{ content: { parts: [
+        { inlineData: { mimeType: "audio/L16;codec=pcm;rate=24000", data: pcmB64("hello-audio") } },
+      ] } }] }));
+    };
+    const res = await studio.synthesize("ai-studio-key", "", {
+      text: "hello", model: "gemini-2.5-flash-preview-tts", voice: "Kore", parameters: {},
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-tts:generateContent?key=ai-studio-key");
+    const body = JSON.parse(String(calls[0].init?.body));
+    expect(body.generationConfig.responseModalities).toEqual(["AUDIO"]);
+    expect(body.generationConfig.speech_config.voice_config.prebuilt_voice_config.voice_name).toBe("Kore");
+    expect(res.contentType).toBe("audio/wav");
+    expect(Buffer.from(res.audioData.slice(0, 4)).toString()).toBe("RIFF");
+    expect(wavText(res.audioData)).toBe("hello-audio");
+  });
+
+  test("AI Studio strips pasted version path suffixes", async () => {
+    const calls: string[] = [];
+    (globalThis as any).fetch = async (input: any) => {
+      calls.push(String(input));
+      return new Response(JSON.stringify({ candidates: [{ content: { parts: [
+        { inlineData: { mimeType: "audio/L16;rate=24000", data: pcmB64("x") } },
+      ] } }] }));
+    };
+    await studio.synthesize("k", "https://generativelanguage.googleapis.com/v1beta/", {
+      text: "hi", model: "gemini-2.5-flash-preview-tts", voice: "Puck", parameters: {},
+    });
+    expect(calls[0].startsWith("https://generativelanguage.googleapis.com/v1beta/models/")).toBe(true);
+  });
+
+  test("Vertex uses service account token and regional host", async () => {
+    const keyPair = await crypto.subtle.generateKey(
+      { name: "RSASSA-PKCS1-v1_5", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" },
+      true, ["sign"],
+    );
+    const pkcs8 = new Uint8Array(await crypto.subtle.exportKey("pkcs8", keyPair.privateKey));
+    let pemBody = "";
+    const b64 = Buffer.from(pkcs8).toString("base64");
+    for (let i = 0; i < b64.length; i += 64) pemBody += b64.slice(i, i + 64) + "\n";
+    const sa = JSON.stringify({ type: "service_account", project_id: "demo-proj", private_key_id: "k1", private_key: `-----BEGIN PRIVATE KEY-----\n${pemBody}-----END PRIVATE KEY-----\n`, client_email: "a@b.iam.gserviceaccount.com", token_uri: "https://oauth.test/token" });
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    (globalThis as any).fetch = async (input: any, init?: RequestInit) => {
+      calls.push({ url: String(input), init });
+      if (String(input).includes("oauth.test")) {
+        return new Response(JSON.stringify({ access_token: "vertex-token", expires_in: 3600 }));
+      }
+      return new Response(JSON.stringify({ candidates: [{ content: { parts: [
+        { inlineData: { mimeType: "audio/L16;rate=24000", data: pcmB64("v-audio") } },
+      ] } }] }));
+    };
+    const res = await vertex.synthesize(sa, "https://us-central1-aiplatform.googleapis.com", {
+      text: "hello", model: "gemini-2.5-pro-preview-tts", voice: "Charon",
+      parameters: { language_code: "en-US", temperature: 0.8 },
+    });
+    expect(calls[1].url).toBe("https://us-central1-aiplatform.googleapis.com/v1/projects/demo-proj/locations/us-central1/publishers/google/models/gemini-2.5-pro-preview-tts:generateContent");
+    expect((calls[1].init?.headers as any).Authorization).toBe("Bearer vertex-token");
+    const body = JSON.parse(String(calls[1].init?.body));
+    expect(body.generationConfig.speech_config.language_code).toBe("en-US");
+    expect(body.generationConfig.temperature).toBe(0.8);
+    expect(wavText(res.audioData)).toBe("v-audio");
+  });
+
+  test("Vertex rejects malformed service account JSON without network access", async () => {
+    let calls = 0;
+    (globalThis as any).fetch = async () => { calls++; return new Response("{}"); };
+    await expect(vertex.synthesize("not-json", "", {
+      text: "hi", model: "gemini-2.5-flash-preview-tts", voice: "Kore", parameters: {},
+    })).rejects.toThrow("Invalid service account JSON");
+    expect(calls).toBe(0);
+  });
+
+  test("request body carries text and voice", () => {
+    const body = buildGeminiTtsBody({ text: "say this", model: "m", voice: "Zephyr", parameters: {} });
+    expect(body.contents[0].parts[0].text).toBe("say this");
+    expect(body.generationConfig.speech_config.voice_config.prebuilt_voice_config.voice_name).toBe("Zephyr");
+  });
+
+  test("WAV header encodes sample rate", () => {
+    const wav = new Uint8Array(wrapPcmInWav(new Uint8Array([1, 2, 3, 4]), 16000));
+    expect(Buffer.from(wav.slice(0, 4)).toString()).toBe("RIFF");
+    expect(new DataView(wav.buffer).getUint32(24, true)).toBe(16000);
+  });
+});

--- a/src/tts/providers/google-tts.test.ts
+++ b/src/tts/providers/google-tts.test.ts
@@ -10,11 +10,25 @@ describe("Google TTS providers", () => {
   const studio = new GoogleTtsProvider();
   const vertex = new GoogleVertexTtsProvider();
 
-  test("TTS-only model lists", async () => {
+  test("TTS-only model lists with static fallback", async () => {
+    (globalThis as any).fetch = async () => new Response("nope", { status: 500 });
     for (const p of [studio, vertex]) {
-      expect((await p.listModels("", "")).map((m) => m.id)).toEqual(GOOGLE_TTS_MODELS.map((m) => m.id));
+      const ids = (await p.listModels("", "")).map((m) => m.id);
+      expect(ids).toEqual(GOOGLE_TTS_MODELS.map((m) => m.id));
+      expect(ids).toContain("gemini-3.1-flash-tts-preview");
       for (const m of GOOGLE_TTS_MODELS) expect(m.id.toLowerCase()).toContain("tts");
     }
+  });
+
+  test("live model listing keeps TTS models only", async () => {
+    (globalThis as any).fetch = async () =>
+      new Response(JSON.stringify({ models: [
+        { name: "models/gemini-2.0-flash" },
+        { name: "models/gemini-2.5-flash-preview-tts" },
+        { name: "models/gemini-3.1-flash-tts-preview" },
+      ] }));
+    const ids = (await studio.listModels("k", "")).map((m) => m.id);
+    expect(ids).toEqual(["gemini-2.5-flash-preview-tts", "gemini-3.1-flash-tts-preview"]);
   });
 
   test("voice mapping is non-empty, unique, and gendered", async () => {

--- a/src/tts/providers/google-tts.ts
+++ b/src/tts/providers/google-tts.ts
@@ -3,11 +3,12 @@ import type { TtsProviderCapabilities } from "../param-schema";
 import type { TtsRequest, TtsResponse, TtsStreamChunk, TtsVoice } from "../types";
 import { ProviderRequestError, throwProviderResponseError } from "../../utils/provider-errors";
 import {
-  GOOGLE_TTS_MODELS,
+  GOOGLE_TTS_MODELS as GOOGLE_TTS_FALLBACK_MODELS,
   GOOGLE_TTS_PARAMETERS,
   GOOGLE_TTS_VOICES,
   buildGeminiTtsBody,
   extractGeminiTtsAudio,
+  isTtsModelId,
 } from "./google-tts-shared";
 
 /**
@@ -23,8 +24,8 @@ export class GoogleTtsProvider implements TtsProvider {
     apiKeyRequired: true,
     voiceListStyle: "static",
     staticVoices: GOOGLE_TTS_VOICES,
-    modelListStyle: "static",
-    staticModels: GOOGLE_TTS_MODELS,
+    modelListStyle: "dynamic",
+    staticModels: GOOGLE_TTS_FALLBACK_MODELS,
     supportsStreaming: false,
     supportedFormats: ["wav"],
     defaultUrl: "https://generativelanguage.googleapis.com",
@@ -83,8 +84,22 @@ export class GoogleTtsProvider implements TtsProvider {
     }
   }
 
-  async listModels(_apiKey: string, _apiUrl: string): Promise<Array<{ id: string; label: string }>> {
-    return this.capabilities.staticModels || [];
+  async listModels(apiKey: string, apiUrl: string): Promise<Array<{ id: string; label: string }>> {
+    // Live TTS-only listing with a static fallback, so new speech models
+    // appear without a Lumiverse update.
+    try {
+      const res = await fetch(`${this.baseUrl(apiUrl)}/v1beta/models?pageSize=100&key=${encodeURIComponent(apiKey)}`);
+      if (!res.ok) return this.capabilities.staticModels || [];
+      const data = await res.json();
+      const models: any[] = data.models || [];
+      const ids = models
+        .map((m: any) => String(m.name || "").replace(/^models\//, ""))
+        .filter((id) => id && isTtsModelId(id));
+      if (ids.length === 0) return this.capabilities.staticModels || [];
+      return [...new Set(ids)].sort().map((id) => ({ id, label: id }));
+    } catch {
+      return this.capabilities.staticModels || [];
+    }
   }
 
   async listVoices(_apiKey: string, _apiUrl: string): Promise<TtsVoice[]> {

--- a/src/tts/providers/google-tts.ts
+++ b/src/tts/providers/google-tts.ts
@@ -1,0 +1,93 @@
+import type { TtsProvider } from "../provider";
+import type { TtsProviderCapabilities } from "../param-schema";
+import type { TtsRequest, TtsResponse, TtsStreamChunk, TtsVoice } from "../types";
+import { ProviderRequestError, throwProviderResponseError } from "../../utils/provider-errors";
+import {
+  GOOGLE_TTS_MODELS,
+  GOOGLE_TTS_PARAMETERS,
+  GOOGLE_TTS_VOICES,
+  buildGeminiTtsBody,
+  extractGeminiTtsAudio,
+} from "./google-tts-shared";
+
+/**
+ * Google AI Studio text-to-speech. Auth mirrors the Gemini text connection:
+ * a plain API key. TTS-only model list with mapped prebuilt voices.
+ */
+export class GoogleTtsProvider implements TtsProvider {
+  readonly name = "google_tts";
+  readonly displayName = "Google AI Studio TTS";
+
+  readonly capabilities: TtsProviderCapabilities = {
+    parameters: { ...GOOGLE_TTS_PARAMETERS },
+    apiKeyRequired: true,
+    voiceListStyle: "static",
+    staticVoices: GOOGLE_TTS_VOICES,
+    modelListStyle: "static",
+    staticModels: GOOGLE_TTS_MODELS,
+    supportsStreaming: false,
+    supportedFormats: ["wav"],
+    defaultUrl: "https://generativelanguage.googleapis.com",
+    defaultFormat: "wav",
+  };
+
+  private baseUrl(apiUrl: string): string {
+    let url = (apiUrl || this.capabilities.defaultUrl).replace(/\/+$/, "");
+    url = url.replace(/\/v1beta\/models(\/.*)?$/, "");
+    url = url.replace(/\/v1beta$/, "");
+    return url;
+  }
+
+  async synthesize(apiKey: string, apiUrl: string, request: TtsRequest): Promise<TtsResponse> {
+    if (!apiKey) {
+      throw new ProviderRequestError({
+        provider: this.displayName,
+        operation: "tts synthesize",
+        detail: "Missing Google AI Studio API key",
+        retryable: false,
+      });
+    }
+    if (!request.voice) {
+      throw new ProviderRequestError({
+        provider: this.displayName,
+        operation: "tts synthesize",
+        detail: "No voice selected",
+        retryable: false,
+      });
+    }
+    const url = `${this.baseUrl(apiUrl)}/v1beta/models/${request.model}:generateContent?key=${encodeURIComponent(apiKey)}`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(buildGeminiTtsBody(request)),
+      signal: request.signal,
+    });
+    if (!res.ok) await throwProviderResponseError(this.displayName, "tts synthesize", res);
+    const data = await res.json();
+    const { audioData, contentType } = extractGeminiTtsAudio(data);
+    return { audioData, contentType, model: request.model, provider: this.name };
+  }
+
+  async *synthesizeStream(): AsyncGenerator<TtsStreamChunk, void, unknown> {
+    throw new Error(`${this.displayName} does not support streaming`);
+  }
+
+  async validateKey(apiKey: string, apiUrl: string): Promise<boolean> {
+    try {
+      const res = await fetch(`${this.baseUrl(apiUrl)}/v1beta/models?pageSize=1&key=${encodeURIComponent(apiKey)}`);
+      if (!res.ok) await throwProviderResponseError(this.displayName, "authentication", res);
+      return res.ok;
+    } catch (err) {
+      if (err instanceof ProviderRequestError) throw err;
+      throw new ProviderRequestError({ provider: this.displayName, operation: "authentication", detail: err instanceof Error ? err.message : "network request failed", retryable: true });
+    }
+  }
+
+  async listModels(_apiKey: string, _apiUrl: string): Promise<Array<{ id: string; label: string }>> {
+    return this.capabilities.staticModels || [];
+  }
+
+  async listVoices(_apiKey: string, _apiUrl: string): Promise<TtsVoice[]> {
+    return this.capabilities.staticVoices || [];
+  }
+}

--- a/src/tts/providers/google-vertex-tts.ts
+++ b/src/tts/providers/google-vertex-tts.ts
@@ -1,0 +1,106 @@
+import type { TtsProvider } from "../provider";
+import type { TtsProviderCapabilities } from "../param-schema";
+import type { TtsRequest, TtsResponse, TtsStreamChunk, TtsVoice } from "../types";
+import { ProviderRequestError, throwProviderResponseError } from "../../utils/provider-errors";
+import {
+  getAccessToken,
+  parseServiceAccount,
+  vertexHostForLocation,
+} from "../../llm/providers/google-vertex";
+import {
+  GOOGLE_TTS_MODELS,
+  GOOGLE_TTS_PARAMETERS,
+  GOOGLE_TTS_VOICES,
+  buildGeminiTtsBody,
+  extractGeminiTtsAudio,
+} from "./google-tts-shared";
+
+/**
+ * Google Vertex AI text-to-speech. Auth mirrors the Vertex text connection:
+ * the API-key slot holds the service account JSON. The API URL selects the
+ * location (blank = global, or paste a regional host such as
+ * https://us-central1-aiplatform.googleapis.com). TTS-only model list with
+ * mapped prebuilt voices.
+ */
+export class GoogleVertexTtsProvider implements TtsProvider {
+  readonly name = "google_vertex_tts";
+  readonly displayName = "Google Vertex TTS";
+
+  readonly capabilities: TtsProviderCapabilities = {
+    parameters: { ...GOOGLE_TTS_PARAMETERS },
+    apiKeyRequired: true, // Service account JSON, like the Vertex text connection
+    voiceListStyle: "static",
+    staticVoices: GOOGLE_TTS_VOICES,
+    modelListStyle: "static",
+    staticModels: GOOGLE_TTS_MODELS,
+    supportsStreaming: false,
+    supportedFormats: ["wav"],
+    defaultUrl: "https://aiplatform.googleapis.com",
+    defaultFormat: "wav",
+  };
+
+  private resolveProject(apiKey: string, apiUrl: string): { projectId: string; location: string; host: string } {
+    const sa = parseServiceAccount(apiKey);
+    let location = "global";
+    const parsedUrl = (apiUrl || "").trim() || this.capabilities.defaultUrl;
+    const regionalMatch = parsedUrl.match(/^https?:\/\/([a-z0-9-]+)-aiplatform\.googleapis\.com/);
+    if (regionalMatch) location = regionalMatch[1];
+    return { projectId: sa.project_id, location, host: vertexHostForLocation(location) };
+  }
+
+  async synthesize(apiKey: string, apiUrl: string, request: TtsRequest): Promise<TtsResponse> {
+    if (!request.voice) {
+      throw new ProviderRequestError({
+        provider: this.displayName,
+        operation: "tts synthesize",
+        detail: "No voice selected",
+        retryable: false,
+      });
+    }
+    const sa = parseServiceAccount(apiKey);
+    const { projectId, location, host } = this.resolveProject(apiKey, apiUrl);
+    const accessToken = await getAccessToken(sa);
+    const url = `${host}/v1/projects/${projectId}/locations/${location}/publishers/google/models/${request.model}:generateContent`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify(buildGeminiTtsBody(request)),
+      signal: request.signal,
+    });
+    if (!res.ok) await throwProviderResponseError(this.displayName, "tts synthesize", res);
+    const data = await res.json();
+    const { audioData, contentType } = extractGeminiTtsAudio(data);
+    return { audioData, contentType, model: request.model, provider: this.name };
+  }
+
+  async *synthesizeStream(): AsyncGenerator<TtsStreamChunk, void, unknown> {
+    throw new Error(`${this.displayName} does not support streaming`);
+  }
+
+  async validateKey(apiKey: string, apiUrl: string): Promise<boolean> {
+    try {
+      const sa = parseServiceAccount(apiKey);
+      const accessToken = await getAccessToken(sa);
+      const { host } = this.resolveProject(apiKey, apiUrl);
+      const res = await fetch(`${host}/v1beta1/publishers/google/models?pageSize=1`, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      if (!res.ok) await throwProviderResponseError(this.displayName, "authentication", res);
+      return res.ok;
+    } catch (err) {
+      if (err instanceof ProviderRequestError) throw err;
+      throw new ProviderRequestError({ provider: this.displayName, operation: "authentication", detail: err instanceof Error ? err.message : "network request failed", retryable: true });
+    }
+  }
+
+  async listModels(_apiKey: string, _apiUrl: string): Promise<Array<{ id: string; label: string }>> {
+    return this.capabilities.staticModels || [];
+  }
+
+  async listVoices(_apiKey: string, _apiUrl: string): Promise<TtsVoice[]> {
+    return this.capabilities.staticVoices || [];
+  }
+}

--- a/src/tts/providers/google-vertex-tts.ts
+++ b/src/tts/providers/google-vertex-tts.ts
@@ -13,6 +13,7 @@ import {
   GOOGLE_TTS_VOICES,
   buildGeminiTtsBody,
   extractGeminiTtsAudio,
+  isTtsModelId,
 } from "./google-tts-shared";
 
 /**
@@ -31,7 +32,7 @@ export class GoogleVertexTtsProvider implements TtsProvider {
     apiKeyRequired: true, // Service account JSON, like the Vertex text connection
     voiceListStyle: "static",
     staticVoices: GOOGLE_TTS_VOICES,
-    modelListStyle: "static",
+    modelListStyle: "dynamic",
     staticModels: GOOGLE_TTS_MODELS,
     supportsStreaming: false,
     supportedFormats: ["wav"],
@@ -96,8 +97,35 @@ export class GoogleVertexTtsProvider implements TtsProvider {
     }
   }
 
-  async listModels(_apiKey: string, _apiUrl: string): Promise<Array<{ id: string; label: string }>> {
-    return this.capabilities.staticModels || [];
+  async listModels(apiKey: string, apiUrl: string): Promise<Array<{ id: string; label: string }>> {
+    // Live TTS-only listing with a static fallback, so new speech models
+    // appear without a Lumiverse update.
+    try {
+      const sa = parseServiceAccount(apiKey);
+      const accessToken = await getAccessToken(sa);
+      const { host } = this.resolveProject(apiKey, apiUrl);
+      const seen = new Set<string>();
+      let pageToken = "";
+      do {
+        const params = new URLSearchParams({ pageSize: "100" });
+        if (pageToken) params.set("pageToken", pageToken);
+        const res = await fetch(`${host}/v1beta1/publishers/google/models?${params}`, {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+        if (!res.ok) return this.capabilities.staticModels || [];
+        const data = await res.json();
+        const models: any[] = data.publisherModels || data.models || [];
+        for (const m of models) {
+          const id = String(m.name || "").replace(/^publishers\/google\/models\//, "");
+          if (id && isTtsModelId(id)) seen.add(id);
+        }
+        pageToken = data.nextPageToken || "";
+      } while (pageToken);
+      if (seen.size === 0) return this.capabilities.staticModels || [];
+      return [...seen].sort().map((id) => ({ id, label: id }));
+    } catch {
+      return this.capabilities.staticModels || [];
+    }
   }
 
   async listVoices(_apiKey: string, _apiUrl: string): Promise<TtsVoice[]> {

--- a/user-docs/docs/chatting/text-to-speech.md
+++ b/user-docs/docs/chatting/text-to-speech.md
@@ -56,6 +56,26 @@ The built-in providers are listed below. Enabled [Spindle extensions](../extensi
 
 - **Streaming:** Supported.
 
+### Google AI Studio TTS
+
+- **API key:** Required — plain API key, same as the Gemini text connection.
+- **Default URL:** `https://generativelanguage.googleapis.com`.
+- **Voices:** 30 mapped prebuilt voices (e.g. Kore, Charon, Puck, Zephyr, Fenrir, Leda), each with gender labels.
+- **Models:** TTS-only list — `gemini-2.5-flash-preview-tts` (fast) and `gemini-2.5-pro-preview-tts` (high quality).
+- **Parameters:** `language_code` (optional BCP-47 code) and `temperature` (voice variation).
+- **Output format:** WAV (Gemini returns raw PCM; Lumiverse wraps it so browsers can play it).
+- **Streaming:** Not supported.
+
+### Google Vertex TTS
+
+- **API key:** Required — paste the service account JSON, same as the Vertex text connection.
+- **API URL:** Selects the location. Leave blank for `global` (`https://aiplatform.googleapis.com`), or paste a regional host such as `https://us-central1-aiplatform.googleapis.com`.
+- **Voices:** Same 30 mapped prebuilt voices as AI Studio TTS.
+- **Models:** Same TTS-only list.
+- **Parameters:** Same as AI Studio TTS.
+- **Output format:** WAV.
+- **Streaming:** Not supported.
+
 ### Kokoro TTS (self-hosted)
 
 - **API key:** Not required — Kokoro is a local server.

--- a/user-docs/docs/chatting/text-to-speech.md
+++ b/user-docs/docs/chatting/text-to-speech.md
@@ -61,7 +61,7 @@ The built-in providers are listed below. Enabled [Spindle extensions](../extensi
 - **API key:** Required — plain API key, same as the Gemini text connection.
 - **Default URL:** `https://generativelanguage.googleapis.com`.
 - **Voices:** 30 mapped prebuilt voices (e.g. Kore, Charon, Puck, Zephyr, Fenrir, Leda), each with gender labels.
-- **Models:** TTS-only list — `gemini-2.5-flash-preview-tts` (fast) and `gemini-2.5-pro-preview-tts` (high quality).
+- **Models:** Fetched live and filtered to TTS/speech models (currently `gemini-3.1-flash-tts-preview`, `gemini-2.5-pro-preview-tts`, `gemini-2.5-flash-preview-tts`), with a static fallback when the API is unreachable.
 - **Parameters:** `language_code` (optional BCP-47 code) and `temperature` (voice variation).
 - **Output format:** WAV (Gemini returns raw PCM; Lumiverse wraps it so browsers can play it).
 - **Streaming:** Not supported.
@@ -71,7 +71,7 @@ The built-in providers are listed below. Enabled [Spindle extensions](../extensi
 - **API key:** Required — paste the service account JSON, same as the Vertex text connection.
 - **API URL:** Selects the location. Leave blank for `global` (`https://aiplatform.googleapis.com`), or paste a regional host such as `https://us-central1-aiplatform.googleapis.com`.
 - **Voices:** Same 30 mapped prebuilt voices as AI Studio TTS.
-- **Models:** Same TTS-only list.
+- **Models:** Same live-filtered TTS list with static fallback.
 - **Parameters:** Same as AI Studio TTS.
 - **Output format:** WAV.
 - **Streaming:** Not supported.


### PR DESCRIPTION
## Summary
- Add two TTS connection providers: Google AI Studio TTS (`google_tts`) and Google Vertex TTS (`google_vertex_tts`).
- Auth mirrors the text connections: AI Studio takes a plain API key; Vertex takes the service account JSON in the API-key slot.
- Models are fetched live and filtered to TTS/speech models only (currently `gemini-3.1-flash-tts-preview`, `gemini-2.5-pro-preview-tts`, `gemini-2.5-flash-preview-tts`), with a static fallback when the API is unreachable — so new speech models appear without a Lumiverse update.
- 30 mapped prebuilt voices (Kore, Charon, Puck, Zephyr, …) with gender labels, shared by both providers.
- Gemini returns raw PCM audio; both providers wrap it in a WAV container (`audio/wav`) so browsers can play it.
- Vertex location comes from the API URL (blank = global, or paste a regional host such as `https://us-central1-aiplatform.googleapis.com`), reusing the text provider's service-account/token/host helpers.
- Parameters: optional `language_code` and `temperature`. No streaming support claimed.
- Document both providers in the text-to-speech user guide.

## Validation
- `bun test --isolate src/tts` — pass (9 Google TTS cases plus existing TTS suites).
- `bun x tsc --noEmit` — pass, no diagnostics.
- `git diff --check` — pass.
- Mocked coverage: live TTS-only model filtering plus static fallback, voice mapping uniqueness/genders, AI Studio key/route/voice body and WAV output, version-path stripping, Vertex Bearer token plus regional host and SA JSON error path, WAV sample-rate header.
- Model currency checked against the live Gemini speech-generation docs before submission.

No live Google/Vertex synthesis or human live-environment audit was performed. AI-assisted change. Backend plus user-docs only; no Spindle changes. The generic TTS connection form picks the new providers up automatically with no frontend changes.
