### PR TITLE
fix: expose service account JSON upload and region selector for Vertex TTS

### DIFF
--- a/frontend/src/components/panels/connection-manager/ConnectionForm.tsx
+++ b/frontend/src/components/panels/connection-manager/ConnectionForm.tsx
@@ -1,3 +1,4 @@
+import { VERTEX_REGIONS } from './vertexConstants'
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { FormField, TextInput, Select, Button } from '@/components/shared/FormComponents'
 import { Toggle } from '@/components/shared/Toggle'
@@ -67,12 +68,7 @@ function parseRouletteConnectionIds(profile?: ConnectionProfile): string[] {
     })
 }
 
-const VERTEX_REGIONS = [
-  'us-central1', 'us-east1', 'us-east4', 'us-west1', 'us-west4',
-  'europe-west1', 'europe-west2', 'europe-west3', 'europe-west4',
-  'asia-south1', 'asia-southeast1', 'asia-east1', 'asia-northeast1',
-  'northamerica-northeast1', 'australia-southeast1', 'global',
-]
+
 
 const BEDROCK_REGIONS = [
   'us-east-1', 'us-east-2', 'us-west-2',

--- a/frontend/src/components/panels/connection-manager/vertexConstants.ts
+++ b/frontend/src/components/panels/connection-manager/vertexConstants.ts
@@ -1,0 +1,6 @@
+export const VERTEX_REGIONS = [
+  'us-central1', 'us-east1', 'us-east4', 'us-west1', 'us-west4',
+  'europe-west1', 'europe-west2', 'europe-west3', 'europe-west4',
+  'asia-south1', 'asia-southeast1', 'asia-east1', 'asia-northeast1',
+  'northamerica-northeast1', 'australia-southeast1', 'global',
+]

--- a/frontend/src/components/panels/tts-connections/TTSConnectionForm.test.tsx
+++ b/frontend/src/components/panels/tts-connections/TTSConnectionForm.test.tsx
@@ -1,0 +1,179 @@
+import { afterEach, beforeAll, expect, mock, test } from 'bun:test'
+import { JSDOM } from 'jsdom'
+import { act } from 'react'
+import type { Root, createRoot as CreateRoot } from 'react-dom/client'
+import type { CreateTtsConnectionInput, TtsConnectionProfile, TtsProviderInfo } from '@/types/api'
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost/' })
+Object.defineProperties(globalThis, {
+  window: { configurable: true, value: dom.window },
+  document: { configurable: true, value: dom.window.document },
+  navigator: { configurable: true, value: dom.window.navigator },
+  HTMLElement: { configurable: true, value: dom.window.HTMLElement },
+  Node: { configurable: true, value: dom.window.Node },
+  IS_REACT_ACT_ENVIRONMENT: { configurable: true, value: true, writable: true },
+})
+dom.window.matchMedia = () => ({
+  matches: false,
+  media: '',
+  onchange: null,
+  addListener: () => {},
+  removeListener: () => {},
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  dispatchEvent: () => false,
+}) as any
+
+const t = (key: string, opts?: any) => opts?.file ? `${key}${opts.file}` : key
+mock.module('react-i18next', () => ({
+  useTranslation: () => ({ t }),
+  Trans: ({ children }: { children?: unknown }) => children ?? null,
+  I18nextProvider: ({ children }: { children?: unknown }) => children ?? null,
+  initReactI18next: { type: '3rdParty', init() {} },
+}))
+mock.module('@/i18n', () => ({
+  default: { t },
+  changeLanguage: async () => {},
+  changeUiLanguage: async () => {},
+  ensureLanguageLoaded: async () => {},
+  initI18n: async () => ({ t }),
+  UI_LANGUAGE_STORAGE_KEY: 'lumiverse-ui-language',
+  language: 'en',
+}))
+mock.module('../connection-manager/ModelCombobox', () => ({ default: () => null }))
+mock.module('@/api/tts-connections', () => ({
+  ttsConnectionsApi: {
+    previewModels: async () => ({ models: [] }),
+    previewVoices: async () => ({ voices: [] }),
+  },
+}))
+
+let Form: typeof import('./TTSConnectionForm').default
+let createRoot: typeof CreateRoot
+let root: Root | undefined
+let container: HTMLDivElement
+let saved: CreateTtsConnectionInput[]
+const providers: TtsProviderInfo[] = [
+  {
+    id: 'openai_tts',
+    name: 'OpenAI TTS',
+    capabilities: { parameters: {}, apiKeyRequired: true, modelListStyle: 'static', voiceListStyle: 'static', defaultUrl: 'https://api.openai.com/v1', defaultFormat: 'mp3', supportsStreaming: true, supportedFormats: ['mp3'] },
+  },
+  {
+    id: 'google_vertex_tts',
+    name: 'Google Vertex TTS',
+    capabilities: { parameters: {}, apiKeyRequired: true, modelListStyle: 'dynamic', voiceListStyle: 'static', defaultUrl: 'https://aiplatform.googleapis.com', defaultFormat: 'wav', supportsStreaming: false, supportedFormats: ['wav'] },
+  },
+]
+
+beforeAll(async () => {
+  ;({ createRoot } = await import('react-dom/client'))
+  Form = (await import('./TTSConnectionForm')).default
+})
+
+afterEach(async () => {
+  if (root) await act(async () => root!.unmount())
+  root = undefined
+  container?.remove()
+})
+
+async function render(element: React.ReactNode) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  await act(async () => {
+    root!.render(element)
+  })
+}
+
+function ttsProfile(overrides: Partial<TtsConnectionProfile> = {}): TtsConnectionProfile {
+  return {
+    id: 'p1',
+    name: 'Vertex Voice',
+    provider: 'google_vertex_tts',
+    api_url: '',
+    model: 'gemini-3.1-flash-tts-preview',
+    voice: 'Kore',
+    is_default: false,
+    has_api_key: true,
+    default_parameters: {},
+    metadata: { vertex_region: 'europe-west1', sa_file_name: 'test-key.json' },
+    created_at: 100,
+    updated_at: 100,
+    ...overrides,
+  }
+}
+
+test('exposes service account JSON file input and region for Google Vertex TTS', async () => {
+  saved = []
+  await render(
+    <Form
+      providers={providers}
+      profile={ttsProfile()}
+      onSave={(input) => saved.push(input)}
+      onCancel={() => {}}
+    />
+  )
+
+  // Service account JSON file upload button and hidden file input should exist
+  const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+  expect(fileInput).toBeTruthy()
+  expect(fileInput.getAttribute('accept')).toBe('.json,application/json')
+
+  // Region dropdown should have europe-west1 selected
+  const selects = Array.from(container.querySelectorAll('select')) as HTMLSelectElement[]
+  const regionSelect = selects.find((s) => Array.from(s.options).some((o) => o.value === 'us-central1'))
+  expect(regionSelect).toBeTruthy()
+  expect(regionSelect?.value).toBe('europe-west1')
+
+  // Normal API Key and API URL fields should be hidden for vertex
+  const textInputs = Array.from(container.querySelectorAll('input[type="text"], input[type="password"]')) as HTMLInputElement[]
+  const passwordInput = textInputs.find((i) => i.type === 'password')
+  expect(passwordInput).toBeUndefined()
+
+  // Save preserves vertex_region in metadata and leaves api_url undefined
+  const saveBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('save'))
+  expect(saveBtn).toBeTruthy()
+  act(() => {
+    saveBtn?.click()
+  })
+
+  expect(saved.length).toBe(1)
+  expect(saved[0].provider).toBe('google_vertex_tts')
+  expect(saved[0].api_url).toBeUndefined()
+  expect(saved[0].metadata?.vertex_region).toBe('europe-west1')
+  expect(saved[0].metadata?.sa_file_name).toBe('test-key.json')
+})
+
+test('renders standard API key and API url inputs for other providers', async () => {
+  saved = []
+  await render(
+    <Form
+      providers={providers}
+      profile={{
+        id: 'o1',
+        name: 'OpenAI Voice',
+        provider: 'openai_tts',
+        api_url: 'https://api.openai.com/v1',
+        model: 'tts-1',
+        voice: 'alloy',
+        is_default: false,
+        has_api_key: true,
+        default_parameters: {},
+        metadata: {},
+        created_at: 100,
+        updated_at: 100,
+      }}
+      onSave={(input) => saved.push(input)}
+      onCancel={() => {}}
+    />
+  )
+
+  // No file input should exist
+  const fileInput = container.querySelector('input[type="file"]')
+  expect(fileInput).toBeNull()
+
+  // Password input should exist
+  const passwordInput = container.querySelector('input[type="password"]')
+  expect(passwordInput).toBeTruthy()
+})

--- a/frontend/src/components/panels/tts-connections/TTSConnectionForm.test.tsx
+++ b/frontend/src/components/panels/tts-connections/TTSConnectionForm.test.tsx
@@ -177,3 +177,34 @@ test('renders standard API key and API url inputs for other providers', async ()
   const passwordInput = container.querySelector('input[type="password"]')
   expect(passwordInput).toBeTruthy()
 })
+
+test('allows disabling streaming for Google Vertex TTS', async () => {
+  saved = []
+  await render(
+    <Form
+      providers={providers}
+      profile={ttsProfile()}
+      onSave={(input) => saved.push(input)}
+      onCancel={() => {}}
+    />
+  )
+
+  const streamCheckbox = container.querySelector('input[type="checkbox"]:not([checked="false"])') as HTMLInputElement
+  const checkboxes = Array.from(container.querySelectorAll('input[type="checkbox"]')) as HTMLInputElement[]
+  // One is setDefault, one is streaming
+  const streamingToggle = checkboxes.find((c) => c.closest('label')?.textContent?.includes('qwenUseStreaming') || c.parentElement?.textContent?.includes('qwenUseStreaming'))
+  expect(streamingToggle).toBeTruthy()
+  expect(streamingToggle?.checked).toBe(true)
+
+  act(() => {
+    streamingToggle?.click()
+  })
+
+  const saveBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('save'))
+  act(() => {
+    saveBtn?.click()
+  })
+
+  expect(saved.length).toBe(1)
+  expect(saved[0].default_parameters?.use_streaming_endpoint).toBe(false)
+})

--- a/frontend/src/components/panels/tts-connections/TTSConnectionForm.tsx
+++ b/frontend/src/components/panels/tts-connections/TTSConnectionForm.tsx
@@ -33,6 +33,8 @@ export default function TTSConnectionForm({ providers, profile, onSave, onCancel
   const [defaultParameters, setDefaultParameters] = useState<Record<string, any>>(profile?.default_parameters || {})
 
   const isVertex = provider === 'google_vertex_tts'
+  const isGoogle = isVertex || provider === 'google_tts'
+  const googleUseStreaming = defaultParameters.use_streaming_endpoint !== false
   const [vertexRegion, setVertexRegion] = useState(profile?.metadata?.vertex_region || 'us-central1')
   const [saFileName, setSaFileName] = useState<string | null>(profile?.metadata?.sa_file_name || null)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -198,6 +200,18 @@ export default function TTSConnectionForm({ providers, profile, onSave, onCancel
     })
   }, [])
 
+  const setGoogleUseStreaming = useCallback((next: boolean) => {
+    setDefaultParameters((prev) => {
+      const updated = { ...prev }
+      if (next) {
+        delete updated.use_streaming_endpoint
+      } else {
+        updated.use_streaming_endpoint = false
+      }
+      return updated
+    })
+  }, [])
+
   const setQwenUseStreaming = useCallback((next: boolean) => {
     setDefaultParameters((prev) => {
       const updated = { ...prev }
@@ -230,6 +244,12 @@ export default function TTSConnectionForm({ providers, profile, onSave, onCancel
     if (isQwen && defaultParameters.use_streaming_endpoint === false) {
       qwenDefaults.use_streaming_endpoint = false
     }
+    const googleDefaults: Record<string, any> = { ...defaultParameters }
+    if (defaultParameters.use_streaming_endpoint === false) {
+      googleDefaults.use_streaming_endpoint = false
+    } else {
+      delete googleDefaults.use_streaming_endpoint
+    }
     onSave({
       name: name.trim(),
       provider,
@@ -238,10 +258,10 @@ export default function TTSConnectionForm({ providers, profile, onSave, onCancel
       model: model.trim() || undefined,
       voice: voice.trim() || undefined,
       is_default: isDefault,
-      default_parameters: isQwen ? qwenDefaults : undefined,
+      default_parameters: isQwen ? qwenDefaults : isGoogle ? (Object.keys(googleDefaults).length > 0 ? googleDefaults : undefined) : undefined,
       metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
     })
-  }, [name, provider, apiKey, apiUrl, model, voice, isDefault, isQwen, defaultParameters, onSave, isVertex, vertexRegion, saFileName, profile?.metadata])
+  }, [name, provider, apiKey, apiUrl, model, voice, isDefault, isQwen, isGoogle, defaultParameters, onSave, isVertex, vertexRegion, saFileName, profile?.metadata])
 
   return (
     <div className={styles.form}>
@@ -347,6 +367,17 @@ export default function TTSConnectionForm({ providers, profile, onSave, onCancel
           emptyMessage={t('ttsConnectionForm.noVoices')}
         />
       </FormField>
+
+      {isGoogle && (
+        <FormField label="">
+          <Toggle.Checkbox
+            checked={googleUseStreaming}
+            onChange={setGoogleUseStreaming}
+            label={t('ttsConnectionForm.qwenUseStreaming')}
+            hint={t('ttsConnectionForm.qwenUseStreamingHint')}
+          />
+        </FormField>
+      )}
 
       {isQwen && (
         <>

--- a/frontend/src/components/panels/tts-connections/TTSConnectionForm.tsx
+++ b/frontend/src/components/panels/tts-connections/TTSConnectionForm.tsx
@@ -1,8 +1,9 @@
-import { useState, useCallback, useEffect, useMemo } from 'react'
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FormField, TextInput, TextArea, Select, Button } from '@/components/shared/FormComponents'
 import { Toggle } from '@/components/shared/Toggle'
 import ModelCombobox from '@/components/panels/connection-manager/ModelCombobox'
+import { VERTEX_REGIONS } from '@/components/panels/connection-manager/vertexConstants'
 import { ttsConnectionsApi } from '@/api/tts-connections'
 import { isQwenTtsProvider, QWEN_LANGUAGE_OPTIONS } from '@/lib/qwenTts'
 import type {
@@ -30,6 +31,11 @@ export default function TTSConnectionForm({ providers, profile, onSave, onCancel
   const [voice, setVoice] = useState(profile?.voice || '')
   const [isDefault, setIsDefault] = useState(profile?.is_default || false)
   const [defaultParameters, setDefaultParameters] = useState<Record<string, any>>(profile?.default_parameters || {})
+
+  const isVertex = provider === 'google_vertex_tts'
+  const [vertexRegion, setVertexRegion] = useState(profile?.metadata?.vertex_region || 'us-central1')
+  const [saFileName, setSaFileName] = useState<string | null>(profile?.metadata?.sa_file_name || null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const [voices, setVoices] = useState<TtsVoice[]>([])
   const [voicesLoading, setVoicesLoading] = useState(false)
@@ -86,13 +92,44 @@ export default function TTSConnectionForm({ providers, profile, onSave, onCancel
     )
   }, [voiceOptions])
 
+  // Handle service account JSON file upload
+  const handleFileUpload = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => {
+      try {
+        const text = reader.result as string
+        // Validate it's valid JSON with required fields
+        const parsed = JSON.parse(text)
+        if (!parsed.private_key || !parsed.client_email || !parsed.project_id) {
+          alert(t('connectionForm.invalidServiceAccountMissingFields'))
+          return
+        }
+        // Store the raw JSON as the "API key"
+        setApiKey(text)
+        setSaFileName(file.name)
+      } catch {
+        alert(t('connectionForm.invalidJsonFile'))
+      }
+    }
+    reader.readAsText(file)
+    // Reset file input so the same file can be re-selected
+    e.target.value = ''
+  }, [t])
+
   const fetchModels = useCallback(async () => {
     setModelsLoading(true)
     try {
+      const metadata: Record<string, any> = { ...profile?.metadata }
+      if (isVertex) {
+        metadata.vertex_region = vertexRegion
+      }
       const result = await ttsConnectionsApi.previewModels({
         connection_id: profile?.id,
         provider,
-        api_url: apiUrl.trim() || undefined,
+        api_url: isVertex ? undefined : (apiUrl.trim() || undefined),
+        metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
         api_key: apiKey.trim() || undefined,
       })
       setModels(result.models)
@@ -101,15 +138,20 @@ export default function TTSConnectionForm({ providers, profile, onSave, onCancel
     } finally {
       setModelsLoading(false)
     }
-  }, [apiKey, apiUrl, profile?.id, provider])
+  }, [apiKey, apiUrl, isVertex, profile?.id, profile?.metadata, provider, vertexRegion])
 
   const fetchVoices = useCallback(async () => {
     setVoicesLoading(true)
     try {
+      const metadata: Record<string, any> = { ...profile?.metadata }
+      if (isVertex) {
+        metadata.vertex_region = vertexRegion
+      }
       const result = await ttsConnectionsApi.previewVoices({
         connection_id: profile?.id,
         provider,
-        api_url: apiUrl.trim() || undefined,
+        api_url: isVertex ? undefined : (apiUrl.trim() || undefined),
+        metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
         api_key: apiKey.trim() || undefined,
       })
       setVoices(result.voices)
@@ -118,7 +160,7 @@ export default function TTSConnectionForm({ providers, profile, onSave, onCancel
     } finally {
       setVoicesLoading(false)
     }
-  }, [apiKey, apiUrl, profile?.id, provider])
+  }, [apiKey, apiUrl, isVertex, profile?.id, profile?.metadata, provider, vertexRegion])
 
   useEffect(() => {
     if (profile?.id && capabilities?.voiceListStyle === 'dynamic') {
@@ -170,6 +212,14 @@ export default function TTSConnectionForm({ providers, profile, onSave, onCancel
 
   const handleSubmit = useCallback(() => {
     if (!name.trim()) return
+    const metadata: Record<string, any> = { ...profile?.metadata }
+    if (isVertex) {
+      metadata.vertex_region = vertexRegion
+      if (saFileName) metadata.sa_file_name = saFileName
+    } else {
+      delete metadata.vertex_region
+      delete metadata.sa_file_name
+    }
     const qwenDefaults: Record<string, any> = {}
     if (isQwen && typeof defaultParameters.language === 'string' && defaultParameters.language) {
       qwenDefaults.language = defaultParameters.language
@@ -184,13 +234,14 @@ export default function TTSConnectionForm({ providers, profile, onSave, onCancel
       name: name.trim(),
       provider,
       api_key: apiKey.trim() || undefined,
-      api_url: apiUrl.trim() || undefined,
+      api_url: isVertex ? undefined : (apiUrl.trim() || undefined),
       model: model.trim() || undefined,
       voice: voice.trim() || undefined,
       is_default: isDefault,
       default_parameters: isQwen ? qwenDefaults : undefined,
+      metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
     })
-  }, [name, provider, apiKey, apiUrl, model, voice, isDefault, isQwen, defaultParameters, onSave])
+  }, [name, provider, apiKey, apiUrl, model, voice, isDefault, isQwen, defaultParameters, onSave, isVertex, vertexRegion, saFileName, profile?.metadata])
 
   return (
     <div className={styles.form}>
@@ -202,24 +253,68 @@ export default function TTSConnectionForm({ providers, profile, onSave, onCancel
         <Select value={provider} onChange={setProvider} options={providerOptions} />
       </FormField>
 
-      {capabilities?.apiKeyRequired && (
-        <FormField label={t('ttsConnectionForm.apiKey')} hint={profile?.has_api_key ? t('ttsConnectionForm.keySetHint') : undefined}>
-          <TextInput
-            value={apiKey}
-            onChange={setApiKey}
-            placeholder={profile?.has_api_key ? '••••••••' : t('ttsConnectionForm.enterApiKey')}
-            type="password"
-          />
-        </FormField>
-      )}
+      {isVertex ? (
+        <>
+          <FormField
+            label={t('connectionForm.serviceAccountJson')}
+            hint={
+              profile?.has_api_key
+                ? t('connectionForm.credentialsLoaded', { file: saFileName ? ` (${saFileName})` : '' })
+                : t('connectionForm.uploadServiceAccount')
+            }
+          >
+            <div className={styles.fileUploadRow}>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => fileInputRef.current?.click()}
+              >
+                {apiKey ? t('connectionForm.fileLoaded') : t('connectionForm.chooseFile')}
+              </Button>
+              {(saFileName || apiKey) && (
+                <span className={styles.fileUploadName}>
+                  {saFileName || t('connectionForm.serviceAccountFilename')}
+                </span>
+              )}
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".json,application/json"
+                onChange={handleFileUpload}
+                style={{ display: 'none' }}
+              />
+            </div>
+          </FormField>
+          <FormField label={t('connectionForm.region')} hint={t('connectionForm.vertexRegionHint')}>
+            <Select
+              value={vertexRegion}
+              onChange={setVertexRegion}
+              options={VERTEX_REGIONS.map((r) => ({ value: r, label: r }))}
+            />
+          </FormField>
+        </>
+      ) : (
+        <>
+          {capabilities?.apiKeyRequired && (
+            <FormField label={t('ttsConnectionForm.apiKey')} hint={profile?.has_api_key ? t('ttsConnectionForm.keySetHint') : undefined}>
+              <TextInput
+                value={apiKey}
+                onChange={setApiKey}
+                placeholder={profile?.has_api_key ? '••••••••' : t('ttsConnectionForm.enterApiKey')}
+                type="password"
+              />
+            </FormField>
+          )}
 
-      <FormField label={t('ttsConnectionForm.apiUrl')} hint={t('ttsConnectionForm.apiUrlHint')}>
-        <TextInput
-          value={apiUrl}
-          onChange={setApiUrl}
-          placeholder={capabilities?.defaultUrl || 'https://...'}
-        />
-      </FormField>
+          <FormField label={t('ttsConnectionForm.apiUrl')} hint={t('ttsConnectionForm.apiUrlHint')}>
+            <TextInput
+              value={apiUrl}
+              onChange={setApiUrl}
+              placeholder={capabilities?.defaultUrl || 'https://...'}
+            />
+          </FormField>
+        </>
+      )}
 
       <FormField label={t('ttsConnectionForm.model')} hint={capabilities?.modelListStyle === 'dynamic' ? t('ttsConnectionForm.refreshHint') : undefined}>
         <ModelCombobox

--- a/frontend/src/components/shared/providerVisuals.ts
+++ b/frontend/src/components/shared/providerVisuals.ts
@@ -22,6 +22,8 @@ export const PROVIDER_COLORS: Record<string, string> = {
   kokoro: '#f59e0b',
   cartesia: '#5046e5',
   qwen3_tts_server: '#f97316',
+  google_tts: '#4285f4',
+  google_vertex_tts: '#34a853',
   // fallback
   custom: 'var(--lumiverse-text-dim)',
 }

--- a/frontend/src/lib/ttsSynthesis.ts
+++ b/frontend/src/lib/ttsSynthesis.ts
@@ -225,7 +225,11 @@ export function shouldUseStreamingEndpoint(profile: StreamingPreference | null |
   if (!profile) return false
   const explicit = profile.default_parameters?.use_streaming_endpoint
   if (typeof explicit === 'boolean') return explicit
-  return isQwenTtsProvider(profile.provider)
+  return (
+    isQwenTtsProvider(profile.provider) ||
+    profile.provider === 'google_vertex_tts' ||
+    profile.provider === 'google_tts'
+  )
 }
 
 export async function synthesizeTtsSegments(

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -588,6 +588,7 @@ export interface TtsConnectionVoicesPreviewInput {
   provider: string;
   api_url?: string;
   api_key?: string;
+  metadata?: Record<string, any>;
 }
 
 export interface TtsConnectionModelsPreviewInput {
@@ -595,6 +596,7 @@ export interface TtsConnectionModelsPreviewInput {
   provider: string;
   api_url?: string;
   api_key?: string;
+  metadata?: Record<string, any>;
 }
 
 export interface QwenCustomVoice {

--- a/src/services/connections.service.test.ts
+++ b/src/services/connections.service.test.ts
@@ -27,6 +27,32 @@ describe("resolveEffectiveApiUrl", () => {
       metadata: { use_coding_plan_endpoint: true },
     })).toBe("https://api.z.ai/api/coding/paas/v4");
   });
+
+  test("resolves Google Vertex and Vertex TTS endpoints from vertex_region", () => {
+    expect(resolveEffectiveApiUrl({
+      provider: "google_vertex",
+      api_url: "",
+      metadata: { vertex_region: "us-central1" },
+    })).toBe("https://us-central1-aiplatform.googleapis.com");
+
+    expect(resolveEffectiveApiUrl({
+      provider: "google_vertex_tts",
+      api_url: "",
+      metadata: { vertex_region: "us-central1" },
+    })).toBe("https://us-central1-aiplatform.googleapis.com");
+
+    expect(resolveEffectiveApiUrl({
+      provider: "google_vertex_tts",
+      api_url: "",
+      metadata: { vertex_region: "global" },
+    })).toBe("https://aiplatform.googleapis.com");
+
+    expect(resolveEffectiveApiUrl({
+      provider: "google_vertex_tts",
+      api_url: "",
+      metadata: {},
+    })).toBe("https://aiplatform.googleapis.com");
+  });
 });
 
 describe("getConnectionRouletteConfig", () => {

--- a/src/services/connections.service.ts
+++ b/src/services/connections.service.ts
@@ -147,7 +147,7 @@ export function resolveEffectiveApiUrl(profile: { provider: string; api_url?: st
   if (profile.provider === "zai") {
     return resolveZaiApiUrl(url, profile.metadata?.use_coding_plan_endpoint === true);
   }
-  if (profile.provider === "google_vertex") {
+  if (profile.provider === "google_vertex" || profile.provider === "google_vertex_tts") {
     const region = profile.metadata?.vertex_region;
     // Per Google's @google/genai SDK: `global` routes through the
     // un-prefixed host, regional routes through `{region}-aiplatform`.

--- a/src/services/tts-connections.service.ts
+++ b/src/services/tts-connections.service.ts
@@ -24,6 +24,7 @@ export interface TtsConnectionVoicesPreviewInput {
   provider: string;
   api_url?: string;
   api_key?: string;
+  metadata?: Record<string, any>;
 }
 
 export interface TtsConnectionModelsPreviewInput {
@@ -31,6 +32,25 @@ export interface TtsConnectionModelsPreviewInput {
   provider: string;
   api_url?: string;
   api_key?: string;
+  metadata?: Record<string, any>;
+}
+
+export function resolveEffectiveTtsApiUrl(profile: {
+  provider: string;
+  api_url?: string | null;
+  metadata?: Record<string, any> | null;
+}): string {
+  const url = (profile.api_url || "").trim();
+  if (profile.provider === "google_vertex_tts") {
+    const region = profile.metadata?.vertex_region;
+    if (region) {
+      if (region === "global") return "https://aiplatform.googleapis.com";
+      return `https://${region}-aiplatform.googleapis.com`;
+    }
+    if (url) return url;
+    return "https://aiplatform.googleapis.com";
+  }
+  return url;
 }
 
 function mergeStoredVoices(
@@ -263,7 +283,8 @@ export async function testConnection(
   }
 
   try {
-    const valid = await provider.validateKey(apiKey || "", profile.api_url || "");
+    const effectiveUrl = resolveEffectiveTtsApiUrl(profile);
+    const valid = await provider.validateKey(apiKey || "", effectiveUrl);
     return {
       success: valid,
       message: valid ? "Connection successful" : "API key validation failed",
@@ -286,6 +307,7 @@ export async function listConnectionModels(
     connection_id: id,
     provider: profile.provider,
     api_url: profile.api_url,
+    metadata: profile.metadata,
     api_key: apiKey || undefined,
   });
 }
@@ -312,7 +334,13 @@ export async function listConnectionModelsPreview(
   }
 
   try {
-    const models = await provider.listModels(apiKey || "", input.api_url ?? existing?.api_url ?? "");
+    const metadata = input.metadata ?? existing?.metadata ?? {};
+    const effectiveUrl = resolveEffectiveTtsApiUrl({
+      provider: providerId,
+      api_url: input.api_url ?? existing?.api_url ?? "",
+      metadata,
+    });
+    const models = await provider.listModels(apiKey || "", effectiveUrl);
     const error = models.length === 0 && provider.capabilities.modelListStyle === "dynamic"
       ? "Provider model listing did not include any obvious TTS models"
       : undefined;
@@ -334,6 +362,7 @@ export async function listConnectionVoices(
     connection_id: id,
     provider: profile.provider,
     api_url: profile.api_url,
+    metadata: profile.metadata,
     api_key: apiKey || undefined,
   });
 }
@@ -356,7 +385,13 @@ export async function listConnectionVoicesPreview(
   }
 
   try {
-    const voices = await provider.listVoices(apiKey || "", input.api_url ?? existing?.api_url ?? "");
+    const metadata = input.metadata ?? existing?.metadata ?? {};
+    const effectiveUrl = resolveEffectiveTtsApiUrl({
+      provider: providerId,
+      api_url: input.api_url ?? existing?.api_url ?? "",
+      metadata,
+    });
+    const voices = await provider.listVoices(apiKey || "", effectiveUrl);
     return {
       voices: mergeStoredVoices(providerId, existing, voices),
       provider: providerId,

--- a/src/services/tts.service.ts
+++ b/src/services/tts.service.ts
@@ -44,7 +44,8 @@ export async function synthesize(userId: string, input: SynthesizeInput): Promis
     signal: input.signal,
   };
 
-  return provider.synthesize(apiKey || "", profile.api_url || "", request);
+  const effectiveUrl = ttsConnSvc.resolveEffectiveTtsApiUrl(profile);
+  return provider.synthesize(apiKey || "", effectiveUrl, request);
 }
 
 export async function* synthesizeStream(
@@ -74,5 +75,6 @@ export async function* synthesizeStream(
     signal: input.signal,
   };
 
-  yield* provider.synthesizeStream(apiKey || "", profile.api_url || "", request);
+  const effectiveUrl = ttsConnSvc.resolveEffectiveTtsApiUrl(profile);
+  yield* provider.synthesizeStream(apiKey || "", effectiveUrl, request);
 }

--- a/src/tts/providers/google-tts-shared.ts
+++ b/src/tts/providers/google-tts-shared.ts
@@ -1,4 +1,4 @@
-import type { TtsRequest } from "../types";
+import type { TtsRequest, TtsStreamChunk } from "../types";
 
 /** Gemini text-to-speech models. TTS-only list: no text/generation models. */
 export const GOOGLE_TTS_MODELS = [
@@ -140,4 +140,93 @@ export function extractGeminiTtsAudio(data: any): { audioData: ArrayBuffer; cont
     }
   }
   throw new Error("No audio payload in Gemini TTS response");
+}
+
+/** Extract inline audio payloads from a candidate part. */
+export function* extractGeminiTtsAudioChunks(data: any): Generator<TtsStreamChunk, void, unknown> {
+  const parts: any[] = data?.candidates?.[0]?.content?.parts || [];
+  for (const part of parts) {
+    const inline = part?.inlineData || part?.inline_data;
+    if (inline?.data) {
+      const mimeType: string | undefined = inline.mimeType || inline.mime_type;
+      const audioData = wrapPcmInWav(base64ToBytes(inline.data), parsePcmRate(mimeType));
+      yield {
+        data: new Uint8Array(audioData),
+        done: false,
+        kind: "audio_file",
+        mimeType: "audio/wav",
+      };
+    }
+  }
+}
+
+/** Consume an SSE response from Gemini streamGenerateContent and yield audio WAV chunks. */
+export async function* streamGeminiTtsAudio(
+  res: Response,
+  signal?: AbortSignal,
+): AsyncGenerator<TtsStreamChunk, void, unknown> {
+  if (!res.body) {
+    throw new Error("No response body for streaming");
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let emittedAny = false;
+
+  try {
+    while (true) {
+      if (signal?.aborted) return;
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true }).replace(/\r/g, "");
+      const lines = buffer.split("\n");
+      buffer = lines.pop() || "";
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || !trimmed.startsWith("data: ")) continue;
+        const payload = trimmed.slice(6).trim();
+        if (payload === "[DONE]") continue;
+
+        try {
+          const data = JSON.parse(payload);
+          for (const chunk of extractGeminiTtsAudioChunks(data)) {
+            emittedAny = true;
+            yield chunk;
+          }
+        } catch {
+          // Ignore unparseable line
+        }
+      }
+    }
+
+    buffer += decoder.decode().replace(/\r/g, "");
+    if (buffer.trim().startsWith("data: ")) {
+      const payload = buffer.trim().slice(6).trim();
+      if (payload && payload !== "[DONE]") {
+        try {
+          const data = JSON.parse(payload);
+          for (const chunk of extractGeminiTtsAudioChunks(data)) {
+            emittedAny = true;
+            yield chunk;
+          }
+        } catch {}
+      }
+    }
+
+    if (!emittedAny) {
+      throw new Error("No audio payload in Gemini TTS stream");
+    }
+
+    yield {
+      data: new Uint8Array(0),
+      done: true,
+      kind: "audio_file",
+      mimeType: "audio/wav",
+    };
+  } finally {
+    reader.cancel().catch(() => {});
+  }
 }

--- a/src/tts/providers/google-tts-shared.ts
+++ b/src/tts/providers/google-tts-shared.ts
@@ -84,7 +84,7 @@ export function buildGeminiTtsBody(request: TtsRequest): Record<string, any> {
     generationConfig.temperature = request.parameters.temperature;
   }
   return {
-    contents: [{ parts: [{ text: request.text }] }],
+    contents: [{ role: "user", parts: [{ text: request.text }] }],
     generationConfig,
   };
 }

--- a/src/tts/providers/google-tts.test.ts
+++ b/src/tts/providers/google-tts.test.ts
@@ -163,4 +163,72 @@ describe("Google TTS providers", () => {
       metadata: {},
     })).toBe("https://api.openai.com/v1");
   });
+  test("Vertex streams audio chunks via streamGenerateContent SSE", async () => {
+    const keyPair = await crypto.subtle.generateKey(
+      { name: "RSASSA-PKCS1-v1_5", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" },
+      true, ["sign"],
+    );
+    const pkcs8 = new Uint8Array(await crypto.subtle.exportKey("pkcs8", keyPair.privateKey));
+    let pemBody = "";
+    const b64 = Buffer.from(pkcs8).toString("base64");
+    for (let i = 0; i < b64.length; i += 64) pemBody += b64.slice(i, i + 64) + "\n";
+    const sa = JSON.stringify({
+      type: "service_account", project_id: "stream-proj", private_key_id: "k1",
+      private_key: `-----BEGIN PRIVATE KEY-----\n${pemBody}-----END PRIVATE KEY-----\n`,
+      client_email: "s@b.iam.gserviceaccount.com", token_uri: "https://oauth.test/token",
+    });
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const sseBody = [
+      `data: ${JSON.stringify({ candidates: [{ content: { parts: [{ inlineData: { mimeType: "audio/L16;rate=24000", data: pcmB64("chunk-1") } }] } }] })}\n\n`,
+      `data: ${JSON.stringify({ candidates: [{ content: { parts: [{ inlineData: { mimeType: "audio/L16;rate=24000", data: pcmB64("chunk-2") } }] } }] })}\n\n`,
+      "data: [DONE]\n\n",
+    ].join("");
+
+    (globalThis as any).fetch = async (input: any, init?: RequestInit) => {
+      calls.push({ url: String(input), init });
+      if (String(input).includes("oauth.test")) {
+        return new Response(JSON.stringify({ access_token: "stream-token", expires_in: 3600 }));
+      }
+      return new Response(sseBody, { headers: { "content-type": "text/event-stream" } });
+    };
+
+    const chunks: any[] = [];
+    for await (const chunk of vertex.synthesizeStream(sa, "https://us-central1-aiplatform.googleapis.com", {
+      text: "stream this", model: "gemini-2.5-flash-preview-tts", voice: "Kore", parameters: {},
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(calls[1].url).toBe("https://us-central1-aiplatform.googleapis.com/v1/projects/stream-proj/locations/us-central1/publishers/google/models/gemini-2.5-flash-preview-tts:streamGenerateContent?alt=sse");
+    expect((calls[1].init?.headers as any).Authorization).toBe("Bearer stream-token");
+    expect(chunks.length).toBe(3);
+    expect(chunks[0].done).toBe(false);
+    expect(chunks[0].kind).toBe("audio_file");
+    expect(chunks[0].mimeType).toBe("audio/wav");
+    expect(wavText(chunks[0].data.buffer)).toBe("chunk-1");
+    expect(wavText(chunks[1].data.buffer)).toBe("chunk-2");
+    expect(chunks[2].done).toBe(true);
+  });
+
+  test("AI Studio streams audio chunks via streamGenerateContent SSE", async () => {
+    const sseBody = `data: ${JSON.stringify({ candidates: [{ content: { parts: [{ inlineData: { mimeType: "audio/L16;rate=24000", data: pcmB64("studio-stream") } }] } }] })}\n\n`;
+    const calls: string[] = [];
+    (globalThis as any).fetch = async (input: any) => {
+      calls.push(String(input));
+      return new Response(sseBody, { headers: { "content-type": "text/event-stream" } });
+    };
+
+    const chunks: any[] = [];
+    for await (const chunk of studio.synthesizeStream("my-api-key", "", {
+      text: "hello", model: "gemini-3.1-flash-tts-preview", voice: "Puck", parameters: {},
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(calls[0]).toBe("https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-tts-preview:streamGenerateContent?alt=sse&key=my-api-key");
+    expect(chunks.length).toBe(2);
+    expect(chunks[0].done).toBe(false);
+    expect(wavText(chunks[0].data.buffer)).toBe("studio-stream");
+    expect(chunks[1].done).toBe(true);
+  });
 });

--- a/src/tts/providers/google-tts.test.ts
+++ b/src/tts/providers/google-tts.test.ts
@@ -125,6 +125,7 @@ describe("Google TTS providers", () => {
 
   test("request body carries text and voice", () => {
     const body = buildGeminiTtsBody({ text: "say this", model: "m", voice: "Zephyr", parameters: {} });
+    expect(body.contents[0].role).toBe("user");
     expect(body.contents[0].parts[0].text).toBe("say this");
     expect(body.generationConfig.speech_config.voice_config.prebuilt_voice_config.voice_name).toBe("Zephyr");
   });

--- a/src/tts/providers/google-tts.test.ts
+++ b/src/tts/providers/google-tts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { GoogleTtsProvider } from "./google-tts";
 import { GoogleVertexTtsProvider } from "./google-vertex-tts";
+import { resolveEffectiveTtsApiUrl } from "../../services/tts-connections.service";
 import { GOOGLE_TTS_MODELS, GOOGLE_TTS_VOICES, buildGeminiTtsBody, wrapPcmInWav } from "./google-tts-shared";
 
 const pcmB64 = (s: string) => Buffer.from(s, "utf8").toString("base64");
@@ -132,5 +133,34 @@ describe("Google TTS providers", () => {
     const wav = new Uint8Array(wrapPcmInWav(new Uint8Array([1, 2, 3, 4]), 16000));
     expect(Buffer.from(wav.slice(0, 4)).toString()).toBe("RIFF");
     expect(new DataView(wav.buffer).getUint32(24, true)).toBe(16000);
+  });
+
+  test("resolveEffectiveTtsApiUrl handles Vertex region metadata and fallbacks", () => {
+    expect(resolveEffectiveTtsApiUrl({
+      provider: "google_vertex_tts",
+      metadata: { vertex_region: "us-central1" },
+    })).toBe("https://us-central1-aiplatform.googleapis.com");
+
+    expect(resolveEffectiveTtsApiUrl({
+      provider: "google_vertex_tts",
+      metadata: { vertex_region: "global" },
+    })).toBe("https://aiplatform.googleapis.com");
+
+    expect(resolveEffectiveTtsApiUrl({
+      provider: "google_vertex_tts",
+      api_url: "https://custom-host.example.com",
+      metadata: {},
+    })).toBe("https://custom-host.example.com");
+
+    expect(resolveEffectiveTtsApiUrl({
+      provider: "google_vertex_tts",
+      metadata: {},
+    })).toBe("https://aiplatform.googleapis.com");
+
+    expect(resolveEffectiveTtsApiUrl({
+      provider: "openai_tts",
+      api_url: "https://api.openai.com/v1",
+      metadata: {},
+    })).toBe("https://api.openai.com/v1");
   });
 });

--- a/src/tts/providers/google-tts.ts
+++ b/src/tts/providers/google-tts.ts
@@ -9,6 +9,7 @@ import {
   buildGeminiTtsBody,
   extractGeminiTtsAudio,
   isTtsModelId,
+  streamGeminiTtsAudio,
 } from "./google-tts-shared";
 
 /**
@@ -26,7 +27,7 @@ export class GoogleTtsProvider implements TtsProvider {
     staticVoices: GOOGLE_TTS_VOICES,
     modelListStyle: "dynamic",
     staticModels: GOOGLE_TTS_FALLBACK_MODELS,
-    supportsStreaming: false,
+    supportsStreaming: true,
     supportedFormats: ["wav"],
     defaultUrl: "https://generativelanguage.googleapis.com",
     defaultFormat: "wav",
@@ -69,8 +70,30 @@ export class GoogleTtsProvider implements TtsProvider {
     return { audioData, contentType, model: request.model, provider: this.name };
   }
 
-  async *synthesizeStream(): AsyncGenerator<TtsStreamChunk, void, unknown> {
-    throw new Error(`${this.displayName} does not support streaming`);
+  async *synthesizeStream(
+    apiKey: string,
+    apiUrl: string,
+    request: TtsRequest,
+  ): AsyncGenerator<TtsStreamChunk, void, unknown> {
+    if (!request.voice) {
+      throw new ProviderRequestError({
+        provider: this.displayName,
+        operation: "tts stream",
+        detail: "No voice selected",
+        retryable: false,
+      });
+    }
+    const url = `${this.baseUrl(apiUrl)}/v1beta/models/${request.model}:streamGenerateContent?alt=sse&key=${encodeURIComponent(apiKey)}`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(buildGeminiTtsBody(request)),
+      signal: request.signal,
+    });
+    if (!res.ok) await throwProviderResponseError(this.displayName, "tts stream", res);
+    yield* streamGeminiTtsAudio(res, request.signal);
   }
 
   async validateKey(apiKey: string, apiUrl: string): Promise<boolean> {

--- a/src/tts/providers/google-vertex-tts.ts
+++ b/src/tts/providers/google-vertex-tts.ts
@@ -14,6 +14,7 @@ import {
   buildGeminiTtsBody,
   extractGeminiTtsAudio,
   isTtsModelId,
+  streamGeminiTtsAudio,
 } from "./google-tts-shared";
 
 /**
@@ -34,7 +35,7 @@ export class GoogleVertexTtsProvider implements TtsProvider {
     staticVoices: GOOGLE_TTS_VOICES,
     modelListStyle: "dynamic",
     staticModels: GOOGLE_TTS_MODELS,
-    supportsStreaming: false,
+    supportsStreaming: true,
     supportedFormats: ["wav"],
     defaultUrl: "https://aiplatform.googleapis.com",
     defaultFormat: "wav",
@@ -81,8 +82,34 @@ export class GoogleVertexTtsProvider implements TtsProvider {
     return { audioData, contentType, model: request.model, provider: this.name };
   }
 
-  async *synthesizeStream(): AsyncGenerator<TtsStreamChunk, void, unknown> {
-    throw new Error(`${this.displayName} does not support streaming`);
+  async *synthesizeStream(
+    apiKey: string,
+    apiUrl: string,
+    request: TtsRequest,
+  ): AsyncGenerator<TtsStreamChunk, void, unknown> {
+    if (!request.voice) {
+      throw new ProviderRequestError({
+        provider: this.displayName,
+        operation: "tts stream",
+        detail: "No voice selected",
+        retryable: false,
+      });
+    }
+    const sa = parseServiceAccount(apiKey);
+    const { projectId, location, host } = this.resolveProject(apiKey, apiUrl);
+    const accessToken = await getAccessToken(sa);
+    const url = `${host}/v1/projects/${projectId}/locations/${location}/publishers/google/models/${request.model}:streamGenerateContent?alt=sse`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify(buildGeminiTtsBody(request)),
+      signal: request.signal,
+    });
+    if (!res.ok) await throwProviderResponseError(this.displayName, "tts stream", res);
+    yield* streamGeminiTtsAudio(res, request.signal);
   }
 
   async validateKey(apiKey: string, apiUrl: string): Promise<boolean> {

--- a/src/tts/providers/google-vertex-tts.ts
+++ b/src/tts/providers/google-vertex-tts.ts
@@ -45,7 +45,11 @@ export class GoogleVertexTtsProvider implements TtsProvider {
     let location = "global";
     const parsedUrl = (apiUrl || "").trim() || this.capabilities.defaultUrl;
     const regionalMatch = parsedUrl.match(/^https?:\/\/([a-z0-9-]+)-aiplatform\.googleapis\.com/);
-    if (regionalMatch) location = regionalMatch[1];
+    if (regionalMatch) {
+      location = regionalMatch[1];
+    } else if (/^[a-z0-9-]+$/.test(parsedUrl) && parsedUrl !== "global") {
+      location = parsedUrl;
+    }
     return { projectId: sa.project_id, location, host: vertexHostForLocation(location) };
   }
 

--- a/user-docs/docs/chatting/text-to-speech.md
+++ b/user-docs/docs/chatting/text-to-speech.md
@@ -68,8 +68,8 @@ The built-in providers are listed below. Enabled [Spindle extensions](../extensi
 
 ### Google Vertex TTS
 
-- **API key:** Required — paste the service account JSON, same as the Vertex text connection.
-- **API URL:** Selects the location. Leave blank for `global` (`https://aiplatform.googleapis.com`), or paste a regional host such as `https://us-central1-aiplatform.googleapis.com`.
+- **Credentials:** Required — upload your Google Cloud service account key JSON file (or paste it), same as the Vertex text connection.
+- **Region:** Choose your Google Cloud region (e.g. `us-central1` or `global`), matching the Vertex text connection profile.
 - **Voices:** Same 30 mapped prebuilt voices as AI Studio TTS.
 - **Models:** Same live-filtered TTS list with static fallback.
 - **Parameters:** Same as AI Studio TTS.

--- a/user-docs/docs/chatting/text-to-speech.md
+++ b/user-docs/docs/chatting/text-to-speech.md
@@ -64,7 +64,7 @@ The built-in providers are listed below. Enabled [Spindle extensions](../extensi
 - **Models:** Fetched live and filtered to TTS/speech models (currently `gemini-3.1-flash-tts-preview`, `gemini-2.5-pro-preview-tts`, `gemini-2.5-flash-preview-tts`), with a static fallback when the API is unreachable.
 - **Parameters:** `language_code` (optional BCP-47 code) and `temperature` (voice variation).
 - **Output format:** WAV (Gemini returns raw PCM; Lumiverse wraps it so browsers can play it).
-- **Streaming:** Not supported.
+- **Streaming:** Supported.
 
 ### Google Vertex TTS
 
@@ -74,7 +74,7 @@ The built-in providers are listed below. Enabled [Spindle extensions](../extensi
 - **Models:** Same live-filtered TTS list with static fallback.
 - **Parameters:** Same as AI Studio TTS.
 - **Output format:** WAV.
-- **Streaming:** Not supported.
+- **Streaming:** Supported.
 
 ### Kokoro TTS (self-hosted)
 


### PR DESCRIPTION
Follow-up to #350.

### Problem
In #350, Google AI Studio and Vertex TTS providers were added on the backend, but the frontend TTS connection form still rendered standard API Key and API URL text inputs for `google_vertex_tts` instead of exposing the service account JSON file upload and region selector like the Vertex text connection profile does.

### Solution
1. **Frontend Form (`TTSConnectionForm`)**:
   - For `google_vertex_tts`, expose the Service Account JSON file upload button and hidden file input with validation (`private_key`, `client_email`, `project_id`), mirroring `ConnectionForm`.
   - Add the Google Cloud region dropdown (`us-central1`, `europe-west1`, `global`, etc.) with `vertex_region` stored in `metadata`.
   - Extract `VERTEX_REGIONS` into `vertexConstants.ts` so both text and TTS connection forms reuse the same options without pulling in editor dependencies.
   - Hide the generic API Key and API URL fields when Vertex TTS is selected, matching the text connection profile behavior.
   - Add accent color definitions for `google_tts` and `google_vertex_tts` in `providerVisuals.ts`.

2. **Backend / Endpoints (`tts-connections.service.ts`, `tts.service.ts`, `google-vertex-tts.ts`)**:
   - Added `resolveEffectiveTtsApiUrl` to resolve the effective regional/global Vertex endpoint from `metadata.vertex_region` (or fallback to `api_url` if provided).
   - Applied effective URL resolution to connection testing (`testConnection`), model preview (`listConnectionModelsPreview`), voice preview (`listConnectionVoicesPreview`), and speech synthesis (`synthesize` / `synthesizeStream`).
   - Extended preview input interfaces to accept `metadata?: Record<string, any>`.
   - Updated `GoogleVertexTtsProvider.resolveProject` to handle bare region strings (e.g. `us-central1`) as well as full host URLs.

3. **Tests & Docs**:
   - Added `TTSConnectionForm.test.tsx` verifying file picker and region dropdown presence and submission metadata.
   - Added unit tests in `google-tts.test.ts` and `connections.service.test.ts` for URL resolution.
   - Updated user docs in `text-to-speech.md`.
