### PR TITLE
feat: reorganize extensions panel UX

### DIFF
--- a/frontend/src/components/panels/SpindlePanel.module.css
+++ b/frontend/src/components/panels/SpindlePanel.module.css
@@ -725,3 +725,408 @@
   color: var(--lumiverse-danger);
   background: var(--lumiverse-danger-015);
 }
+
+/* ─── Extension manager organization / density pass ─── */
+.managementToolbar {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+}
+
+.toolbarPrimaryRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: stretch;
+  gap: 8px;
+}
+
+.toolbarPrimaryRow .addMenuWrap {
+  display: flex;
+  align-items: stretch;
+}
+
+.toolbarPrimaryRow .installBtn {
+  min-height: 34px;
+}
+
+.searchField {
+  width: 100%;
+  min-width: 0;
+  min-height: 34px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 9px;
+  border-radius: var(--lumiverse-radius);
+  background: var(--lumiverse-fill-subtle);
+  border: 1px solid var(--lumiverse-border);
+  color: var(--lumiverse-text-dim);
+  transition: border-color var(--lumiverse-transition-fast), background var(--lumiverse-transition-fast);
+}
+
+.searchField:focus-within {
+  border-color: var(--lumiverse-primary);
+  background: var(--lumiverse-fill);
+}
+
+.searchField input {
+  flex: 1;
+  min-width: 0;
+  padding: 7px 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--lumiverse-text);
+  font: inherit;
+  font-size: calc(12px * var(--lumiverse-font-scale, 1));
+}
+
+.searchField input::placeholder {
+  color: var(--lumiverse-text-dim);
+}
+
+.searchField input::-webkit-search-cancel-button {
+  display: none;
+}
+
+.searchClearBtn {
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--lumiverse-text-dim);
+  cursor: pointer;
+}
+
+.searchClearBtn:hover {
+  background: var(--lumiverse-fill-hover);
+  color: var(--lumiverse-text);
+}
+
+.toolbarActions {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: stretch;
+  gap: 7px;
+}
+
+.viewToggle {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  padding: 2px;
+  border: 1px solid var(--lumiverse-border);
+  border-radius: var(--lumiverse-radius);
+  background: var(--lumiverse-fill-subtle);
+}
+
+.viewToggleBtn {
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  padding: 4px 8px;
+  border: 0;
+  border-radius: calc(var(--lumiverse-radius) - 2px);
+  background: transparent;
+  color: var(--lumiverse-text-dim);
+  font-family: inherit;
+  font-size: calc(11px * var(--lumiverse-font-scale, 1));
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--lumiverse-transition-fast), color var(--lumiverse-transition-fast);
+}
+
+.viewToggleBtn:hover {
+  color: var(--lumiverse-text);
+}
+
+.viewToggleBtnActive {
+  background: var(--lumiverse-fill-hover);
+  color: var(--lumiverse-primary);
+}
+
+.sortField {
+  width: 100%;
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 34px;
+  padding: 0 7px 0 9px;
+  border: 1px solid var(--lumiverse-border);
+  border-radius: var(--lumiverse-radius);
+  background: var(--lumiverse-fill-subtle);
+  color: var(--lumiverse-text-dim);
+  font-size: calc(10px * var(--lumiverse-font-scale, 1));
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.sortField select {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: none;
+  padding: 4px 22px 4px 5px;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--lumiverse-text);
+  font-family: inherit;
+  font-size: calc(11px * var(--lumiverse-font-scale, 1));
+  font-weight: 500;
+  text-transform: none;
+  letter-spacing: normal;
+  cursor: pointer;
+}
+
+.sortField select option {
+  background: var(--lumiverse-bg);
+  color: var(--lumiverse-text);
+}
+
+.listHeaderMeta {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: auto;
+  color: var(--lumiverse-text-dim);
+  font-size: calc(10px * var(--lumiverse-font-scale, 1));
+}
+
+.extensionCard {
+  position: relative;
+}
+
+.extensionCardManual {
+  padding-left: 40px;
+}
+
+.dragHandle {
+  position: absolute;
+  left: 8px;
+  top: 9px;
+  width: 24px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--lumiverse-text-dim);
+  cursor: grab;
+  touch-action: none;
+  transition: background var(--lumiverse-transition-fast), color var(--lumiverse-transition-fast);
+}
+
+.dragHandle:hover {
+  background: var(--lumiverse-fill-hover);
+  color: var(--lumiverse-text);
+}
+
+.dragHandle:active {
+  cursor: grabbing;
+}
+
+.extensionCardDragging {
+  z-index: 5;
+  box-shadow: var(--lumiverse-shadow-lg);
+  border-color: var(--lumiverse-primary-020);
+}
+
+.extensionCardList {
+  gap: 6px;
+  padding: 8px 10px;
+}
+
+.extensionCardList.extensionCardManual {
+  padding-left: 40px;
+}
+
+.extensionCardListExpanded {
+  background: var(--lumiverse-fill-subtle);
+}
+
+.extensionCardList .extensionHeader {
+  min-height: 28px;
+  align-items: center;
+}
+
+.extensionCardList .extensionInfo {
+  flex: 1 1 auto;
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+  overflow: hidden;
+}
+
+.extensionCardList .extensionName {
+  flex: 0 1 220px;
+  min-width: 120px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.extensionCardList .extensionMeta {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.expandRowBtn {
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--lumiverse-text-dim);
+  cursor: pointer;
+  transition: background var(--lumiverse-transition-fast), color var(--lumiverse-transition-fast);
+}
+
+.expandRowBtn:hover {
+  background: var(--lumiverse-fill-hover);
+  color: var(--lumiverse-text);
+}
+
+.permissionsSummary {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
+.permissionsCount {
+  color: var(--lumiverse-text-dim);
+  font-size: calc(10px * var(--lumiverse-font-scale, 1));
+  font-variant-numeric: tabular-nums;
+}
+
+.permissionsCountIncomplete {
+  color: var(--lumiverse-warning);
+}
+
+.permissionHeaderActions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.enableAllBtnProminent {
+  background: var(--lumiverse-primary-015);
+  color: var(--lumiverse-primary);
+  border-color: var(--lumiverse-primary-020);
+}
+
+.enableAllBtnProminent:hover:not(:disabled) {
+  background: var(--lumiverse-primary-020);
+  color: var(--lumiverse-primary);
+  border-color: var(--lumiverse-primary);
+}
+
+.permissionReviewBtn {
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 4px 9px;
+  border-radius: 999px;
+  background: transparent;
+  border: 1px solid var(--lumiverse-border);
+  color: var(--lumiverse-text-dim);
+  font-family: inherit;
+  font-size: calc(11px * var(--lumiverse-font-scale, 1));
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--lumiverse-transition-fast), color var(--lumiverse-transition-fast), border-color var(--lumiverse-transition-fast);
+}
+
+.permissionReviewBtn:hover {
+  background: var(--lumiverse-fill-hover);
+  color: var(--lumiverse-text);
+  border-color: var(--lumiverse-border-hover);
+}
+
+@container extCard (max-width: 620px) {
+  .extensionCardList .extensionInfo {
+    flex-wrap: wrap;
+    column-gap: 8px;
+    row-gap: 1px;
+  }
+
+  .extensionCardList .extensionName {
+    flex-basis: calc(100% - 4px);
+  }
+}
+
+@media (max-width: 760px) {
+  .toolbarPrimaryRow {
+    gap: 7px;
+  }
+}
+
+@media (max-width: 520px) {
+  .viewToggleBtn span {
+    display: none;
+  }
+
+  .sortField select {
+    flex: 1;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .updateAllBtn {
+    padding-inline: 8px;
+  }
+
+  .installBtn {
+    padding-inline: 10px;
+  }
+
+  .listHeaderActions {
+    width: 100%;
+  }
+
+  .listHeaderMeta {
+    flex: 1 1 auto;
+    min-width: 0;
+    margin-left: 0;
+  }
+
+  .extensionCardList .extensionMeta {
+    max-width: 100%;
+  }
+
+  .permissionsHeader {
+    align-items: flex-start;
+  }
+
+  .permissionHeaderActions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}

--- a/frontend/src/components/panels/SpindlePanel.tsx
+++ b/frontend/src/components/panels/SpindlePanel.tsx
@@ -1,8 +1,43 @@
-import { useState, useEffect, useCallback, useMemo, useRef, useSyncExternalStore } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef, useSyncExternalStore, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { createPortal } from 'react-dom'
-import { RefreshCw, RotateCw, Trash2, Github, Plus, ChevronDown, Download, FolderOpen, SlidersHorizontal, Bell, BellOff } from 'lucide-react'
+import {
+  Bell,
+  BellOff,
+  ChevronDown,
+  ChevronRight,
+  Download,
+  FolderOpen,
+  Github,
+  GripVertical,
+  LayoutGrid,
+  List,
+  Plus,
+  RefreshCw,
+  RotateCw,
+  Search,
+  SlidersHorizontal,
+  Trash2,
+  X,
+} from 'lucide-react'
 import { IconVersions } from '@tabler/icons-react'
+import {
+  DndContext,
+  KeyboardSensor,
+  MouseSensor,
+  TouchSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
 import { useStore } from '@/store'
 import { spindleApi } from '@/api/spindle'
 import type { ExtensionInfo, SpindlePermission } from 'lumiverse-spindle-types'
@@ -11,17 +46,19 @@ import SpindleSettings from './SpindleSettings'
 import { Spinner } from '@/components/shared/Spinner'
 import ConfirmationModal from '@/components/shared/ConfirmationModal'
 import { getSafeHttpsUrl } from '@/lib/navigationSafety'
+import { useScaledSortableStyle } from '@/lib/dndUiScale'
 import {
   getExtensionMountPointsVersion,
   hasExtensionMountPoint,
   subscribeExtensionMountPoints,
 } from '@/lib/spindle/loader'
 import { toast } from '@/lib/toast'
-import { SortControl } from '@/components/shared/SortControl'
 import styles from './SpindlePanel.module.css'
 import clsx from 'clsx'
 import {
   EXTENSION_SORT_OPTIONS,
+  filterExtensions,
+  reconcileExtensionOrder,
   sortExtensions,
   type ExtensionSortMode,
 } from './spindle-extension-sort'
@@ -30,6 +67,98 @@ interface EnableAllPermissionsTarget {
   extensionId: string
   extensionName: string
   permissions: string[]
+}
+
+type ExtensionViewMode = 'cards' | 'list'
+
+interface ExtensionPanelPreferences {
+  sortMode: ExtensionSortMode
+  viewMode: ExtensionViewMode
+  manualOrder: string[]
+}
+
+const EXTENSION_PANEL_PREFS_KEY = 'lumiverse:spindle:extension-panel-preferences'
+
+const DEFAULT_PANEL_PREFERENCES: ExtensionPanelPreferences = {
+  sortMode: 'installed',
+  viewMode: 'cards',
+  manualOrder: [],
+}
+
+const SORT_LABEL_FALLBACKS: Record<ExtensionSortMode, string> = {
+  manual: 'Manual',
+  installed: 'Recently installed',
+  updated: 'Recently updated',
+  'name-asc': 'Name A–Z',
+  'name-desc': 'Name Z–A',
+}
+
+function readPanelPreferences(): ExtensionPanelPreferences {
+  if (typeof window === 'undefined') return DEFAULT_PANEL_PREFERENCES
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(EXTENSION_PANEL_PREFS_KEY) || '{}') as Partial<ExtensionPanelPreferences>
+    const sortMode = EXTENSION_SORT_OPTIONS.some((option) => option.value === parsed.sortMode)
+      ? parsed.sortMode as ExtensionSortMode
+      : DEFAULT_PANEL_PREFERENCES.sortMode
+    const viewMode = parsed.viewMode === 'list' ? 'list' : 'cards'
+    const manualOrder = Array.isArray(parsed.manualOrder)
+      ? parsed.manualOrder.filter((id): id is string => typeof id === 'string')
+      : []
+    return { sortMode, viewMode, manualOrder }
+  } catch {
+    return DEFAULT_PANEL_PREFERENCES
+  }
+}
+
+function sameStringArray(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index])
+}
+
+function SortableExtensionCard({
+  id,
+  dragEnabled,
+  className,
+  children,
+  dragLabel,
+}: {
+  id: string
+  dragEnabled: boolean
+  className: string
+  children: ReactNode
+  dragLabel: string
+}) {
+  const { attributes, listeners, setNodeRef: setSortableRef, transform, transition, isDragging } = useSortable({
+    id,
+    disabled: !dragEnabled,
+  })
+  const { setNodeRef, style } = useScaledSortableStyle({
+    setNodeRef: setSortableRef,
+    transform,
+    transition,
+    isDragging,
+  })
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={clsx(className, dragEnabled && styles.extensionCardManual, isDragging && styles.extensionCardDragging)}
+    >
+      {dragEnabled && (
+        <button
+          type="button"
+          className={styles.dragHandle}
+          aria-label={dragLabel}
+          title={dragLabel}
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical size={15} />
+        </button>
+      )}
+      {children}
+    </div>
+  )
 }
 
 export default function SpindlePanel() {
@@ -87,7 +216,18 @@ export default function SpindlePanel() {
   const [confirmUpdateAllOpen, setConfirmUpdateAllOpen] = useState(false)
   const [enableAllPermissionsTarget, setEnableAllPermissionsTarget] = useState<EnableAllPermissionsTarget | null>(null)
   const [bulkPermissionExtensionId, setBulkPermissionExtensionId] = useState<string | null>(null)
-  const [extensionSortMode, setExtensionSortMode] = useState<ExtensionSortMode>('installed')
+  const [extensionSearch, setExtensionSearch] = useState('')
+  const [extensionSortMode, setExtensionSortMode] = useState<ExtensionSortMode>(() => readPanelPreferences().sortMode)
+  const [extensionViewMode, setExtensionViewMode] = useState<ExtensionViewMode>(() => readPanelPreferences().viewMode)
+  const [manualExtensionOrder, setManualExtensionOrder] = useState<string[]>(() => readPanelPreferences().manualOrder)
+  const [expandedListRows, setExpandedListRows] = useState<Set<string>>(() => new Set())
+  const [expandedPermissionRows, setExpandedPermissionRows] = useState<Set<string>>(() => new Set())
+
+  const extensionDragSensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 180, tolerance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  )
 
   // Branch selection for install
   const [installBranches, setInstallBranches] = useState<string[]>([])
@@ -121,6 +261,24 @@ export default function SpindlePanel() {
     if (useStore.getState().extensions.length > 0) return
     loadExtensions()
   }, [loadExtensions])
+
+  useEffect(() => {
+    if (extensions.length === 0) return
+    setManualExtensionOrder((current) => {
+      const reconciled = reconcileExtensionOrder(extensions, current)
+      return sameStringArray(current, reconciled) ? current : reconciled
+    })
+  }, [extensions])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const preferences: ExtensionPanelPreferences = {
+      sortMode: extensionSortMode,
+      viewMode: extensionViewMode,
+      manualOrder: manualExtensionOrder,
+    }
+    window.localStorage.setItem(EXTENSION_PANEL_PREFS_KEY, JSON.stringify(preferences))
+  }, [extensionSortMode, extensionViewMode, manualExtensionOrder])
 
   useEffect(() => {
     if (!addMenuOpen) return
@@ -342,16 +500,18 @@ export default function SpindlePanel() {
     return isPrivileged || (scope === 'user' && !!user?.id && installedBy === user.id)
   })
   const manageableCount = manageableExtensions.length
+  const filteredExtensions = useMemo(
+    () => filterExtensions(extensions, extensionSearch),
+    [extensions, extensionSearch],
+  )
   const sortedExtensions = useMemo(
-    () => sortExtensions(extensions, extensionSortMode),
-    [extensions, extensionSortMode],
+    () => sortExtensions(filteredExtensions, extensionSortMode, manualExtensionOrder),
+    [filteredExtensions, extensionSortMode, manualExtensionOrder],
   )
   const extensionSortOptions = EXTENSION_SORT_OPTIONS.map((option) => ({
     value: option.value,
-    label: t(`spindlePanel.sort.${option.labelKey}`),
+    label: t(`spindlePanel.sort.${option.labelKey}`, { defaultValue: SORT_LABEL_FALLBACKS[option.value] }),
   }))
-  const extensionSortLabel = extensionSortOptions.find((option) => option.value === extensionSortMode)?.label
-    ?? t('spindlePanel.sort.dateInstalled')
   const extensionUpdatesById = useMemo(
     () => new Map(extensionUpdates.map((update) => [update.extensionId, update])),
     [extensionUpdates],
@@ -429,25 +589,123 @@ export default function SpindlePanel() {
     setAddMenuOpen(true)
   }, [addMenuOpen, computeAddMenuPosition])
 
+  const toggleListRow = useCallback((extensionId: string) => {
+    setExpandedListRows((current) => {
+      const next = new Set(current)
+      if (next.has(extensionId)) next.delete(extensionId)
+      else next.add(extensionId)
+      return next
+    })
+  }, [])
+
+  const togglePermissionDetails = useCallback((extensionId: string) => {
+    setExpandedPermissionRows((current) => {
+      const next = new Set(current)
+      if (next.has(extensionId)) next.delete(extensionId)
+      else next.add(extensionId)
+      return next
+    })
+  }, [])
+
+  const handleExtensionDragEnd = useCallback((event: DragEndEvent) => {
+    if (extensionSortMode !== 'manual' || extensionSearch.trim()) return
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+
+    const reconciled = reconcileExtensionOrder(extensions, manualExtensionOrder)
+    const oldIndex = reconciled.indexOf(String(active.id))
+    const newIndex = reconciled.indexOf(String(over.id))
+    if (oldIndex < 0 || newIndex < 0) return
+    setManualExtensionOrder(arrayMove(reconciled, oldIndex, newIndex))
+  }, [extensionSortMode, extensionSearch, extensions, manualExtensionOrder])
+
+  const canDragExtensions = extensionSortMode === 'manual' && !extensionSearch.trim()
+
   return (
     <>
     <div className={styles.panel}>
-      {/* Add extension menu — only visible to admin/owner */}
-      {isPrivileged && (
-        <div className={styles.installRow}>
-          <div className={styles.addMenuWrap}>
+      <div className={styles.managementToolbar}>
+        <div className={styles.toolbarPrimaryRow}>
+          <div className={styles.searchField}>
+            <Search size={14} aria-hidden="true" />
+            <input
+              type="search"
+              value={extensionSearch}
+              onChange={(event) => setExtensionSearch(event.target.value)}
+              placeholder={t('spindlePanel.searchPlaceholder', { defaultValue: 'Search extensions…' })}
+              aria-label={t('spindlePanel.searchAria', { defaultValue: 'Search installed extensions' })}
+            />
+            {extensionSearch && (
+              <button
+                type="button"
+                className={styles.searchClearBtn}
+                onClick={() => setExtensionSearch('')}
+                aria-label={t('spindlePanel.clearSearch', { defaultValue: 'Clear extension search' })}
+                title={t('spindlePanel.clearSearch', { defaultValue: 'Clear extension search' })}
+              >
+                <X size={13} />
+              </button>
+            )}
+          </div>
+
+          {isPrivileged && (
+            <div className={styles.addMenuWrap}>
+              <button
+                ref={addMenuButtonRef}
+                className={styles.installBtn}
+                onClick={toggleAddMenu}
+                aria-expanded={addMenuOpen}
+                aria-haspopup="menu"
+              >
+                <Plus size={13} /> {t('spindlePanel.addExtension')} <ChevronDown size={13} />
+              </button>
+            </div>
+          )}
+        </div>
+
+        <div className={styles.toolbarActions}>
+          <div
+            className={styles.viewToggle}
+            role="group"
+            aria-label={t('spindlePanel.viewMode', { defaultValue: 'Extension view' })}
+          >
             <button
-              ref={addMenuButtonRef}
-              className={styles.installBtn}
-              onClick={toggleAddMenu}
-              aria-expanded={addMenuOpen}
-              aria-haspopup="menu"
+              type="button"
+              className={clsx(styles.viewToggleBtn, extensionViewMode === 'cards' && styles.viewToggleBtnActive)}
+              onClick={() => setExtensionViewMode('cards')}
+              aria-pressed={extensionViewMode === 'cards'}
+              title={t('spindlePanel.cardView', { defaultValue: 'Card view' })}
             >
-              <Plus size={13} /> {t('spindlePanel.addExtension')} <ChevronDown size={13} />
+              <LayoutGrid size={13} />
+              <span>{t('spindlePanel.cards', { defaultValue: 'Cards' })}</span>
+            </button>
+            <button
+              type="button"
+              className={clsx(styles.viewToggleBtn, extensionViewMode === 'list' && styles.viewToggleBtnActive)}
+              onClick={() => setExtensionViewMode('list')}
+              aria-pressed={extensionViewMode === 'list'}
+              title={t('spindlePanel.listView', { defaultValue: 'List view' })}
+            >
+              <List size={13} />
+              <span>{t('spindlePanel.list', { defaultValue: 'List' })}</span>
             </button>
           </div>
+
+          <label className={styles.sortField}>
+            <span>{t('spindlePanel.sortLabel', { defaultValue: 'Sort' })}</span>
+            <select
+              value={extensionSortMode}
+              onChange={(event) => setExtensionSortMode(event.target.value as ExtensionSortMode)}
+              aria-label={t('spindlePanel.sortLabel', { defaultValue: 'Sort extensions' })}
+            >
+              {extensionSortOptions.map((option) => (
+                <option key={option.value} value={option.value}>{option.label}</option>
+              ))}
+            </select>
+          </label>
+
         </div>
-      )}
+      </div>
 
       {importSummary && <div className={styles.importSummary}>{importSummary}</div>}
 
@@ -455,20 +713,28 @@ export default function SpindlePanel() {
 
       <SpindleUIControlPanel />
 
-      {/* Extensions list */}
       <div className={styles.listHeaderRow}>
         <span className={styles.sectionLabel}>
           {t('spindlePanel.installed', { count: extensions.length })}
         </span>
         <div className={styles.listHeaderActions}>
-          <SortControl<ExtensionSortMode>
-            options={extensionSortOptions}
-            value={extensionSortMode}
-            onChange={setExtensionSortMode}
-            title={t('spindlePanel.sortBy', { field: extensionSortLabel })}
-            dropdownWidth={150}
-            dropdownAlign="end"
-          />
+          <div className={styles.listHeaderMeta}>
+            {extensionSearch.trim() && (
+              <span>
+                {t('spindlePanel.searchResults', {
+                  count: sortedExtensions.length,
+                  defaultValue: `${sortedExtensions.length} matching`,
+                })}
+              </span>
+            )}
+            {extensionSortMode === 'manual' && (
+              <span>
+                {extensionSearch.trim()
+                  ? t('spindlePanel.clearSearchToReorder', { defaultValue: 'Clear search to reorder' })
+                  : t('spindlePanel.dragToReorderHint', { defaultValue: 'Drag to reorder' })}
+              </span>
+            )}
+          </div>
           {manageableCount > 0 && (
             <button
               type="button"
@@ -507,11 +773,22 @@ export default function SpindlePanel() {
             </>
           )}
         </div>
+      ) : sortedExtensions.length === 0 ? (
+        <div className={styles.emptyState}>
+          {t('spindlePanel.noSearchResults', { defaultValue: 'No installed extensions match this search.' })}
+        </div>
       ) : (
-        <div className={styles.extensionList}>
-          {sortedExtensions.map((ext) => (
-            <div key={ext.id} className={styles.extensionCard}>
-              {(() => {
+        <DndContext
+          sensors={extensionDragSensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleExtensionDragEnd}
+        >
+          <SortableContext
+            items={sortedExtensions.map((extension) => extension.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className={styles.extensionList}>
+              {sortedExtensions.map((ext) => {
                 const installScope = ((ext.metadata as any)?.install_scope || 'operator') as 'operator' | 'user'
                 const installedBy = ((ext.metadata as any)?.installed_by_user_id || null) as string | null
                 const extBranch = ((ext.metadata as any)?.branch || null) as string | null
@@ -523,257 +800,322 @@ export default function SpindlePanel() {
                 const updateAlertLabel = updateToastsEnabled
                   ? t('spindlePanel.updateAlertsToastAndBadge')
                   : t('spindlePanel.updateAlertsBadgeOnly')
-
-                return (
-                  <>
-              <div className={styles.extensionHeader}>
-                <div className={styles.extensionInfo}>
-                  <div className={styles.extensionName}>
-                    <span
-                      className={clsx(
-                        styles.statusDot,
-                        ext.status === 'running' && styles.statusRunning,
-                        ext.status === 'error' && styles.statusError,
-                        ext.status === 'stopped' && styles.statusStopped
-                      )}
-                    />{' '}
-                    {ext.name}
-                  </div>
-                  <span className={styles.extensionMeta}>
-                    {t('spindlePanel.extensionVersionBy', { version: ext.version, author: ext.author })}
-                  </span>
-                  <span className={styles.extensionMeta}>
-                    {scopeLabel}
-                    {isNonDefaultBranch && (
-                      <span className={styles.branchBadge}>
-                        <IconVersions size={10} /> {extBranch}
-                      </span>
-                    )}
-                  </span>
-                </div>
-
-                <div className={styles.extensionActions}>
-                  {canManage && (
-                    <button
-                      type="button"
-                      className={clsx(
-                        styles.updateNotificationBtn,
-                        updateToastsEnabled && styles.updateNotificationBtnActive,
-                      )}
-                      onClick={() => handleUpdateToastToggle(ext.identifier)}
-                      aria-pressed={updateToastsEnabled}
-                      aria-label={updateAlertLabel}
-                      title={updateAlertLabel}
-                    >
-                      {updateToastsEnabled ? <Bell size={13} /> : <BellOff size={13} />}
-                    </button>
-                  )}
-                  <button
-                    className={clsx(
-                      styles.toggleBtn,
-                      ext.enabled ? styles.toggleOn : styles.toggleOff
-                    )}
-                    onClick={() => handleToggle(ext)}
-                    disabled={isExtBusy(ext.id) || !canManage}
-                    title={canManage ? (ext.enabled ? t('spindlePanel.disable') : t('spindlePanel.enable')) : t('spindlePanel.managedByOperator')}
-                  />
-                </div>
-              </div>
-
-              {/* Operation status indicator */}
-              {extensionOperationStatus?.extensionId === ext.id && extensionOperationStatus.operation.endsWith('ing') && (
-                <div className={styles.operationStatus}>
-                  <Spinner size={12} fast />
-                  {t(`spindlePanel.operations.${extensionOperationStatus.operation}`, { defaultValue: extensionOperationStatus.operation })}
-                </div>
-              )}
-
-              {ext.description && (
-                <div className={styles.extensionDesc}>{ext.description}</div>
-              )}
-
-              {/* Permissions — union of declared + granted so runtime-requested perms are visible */}
-              {(() => {
+                const isExpanded = extensionViewMode === 'cards' || expandedListRows.has(ext.id)
                 const allPerms = [...new Set([...ext.permissions, ...ext.granted_permissions])]
                 const disabledPerms = allPerms.filter((perm) => !ext.granted_permissions.includes(perm))
+                const grantedPermissionCount = allPerms.length - disabledPerms.length
                 const isBulkPermissionBusy = bulkPermissionExtensionId === ext.id
                 const isPermissionBusy = isBulkPermissionBusy || togglingPerm?.startsWith(`${ext.id}:`) === true
-                return allPerms.length > 0 ? (
-                  <div className={styles.permissionsBlock}>
-                    <div className={styles.permissionsHeader}>
-                      <span className={styles.permissionsLabel}>{t('spindlePanel.permissionsLabel')}</span>
-                      <button
-                        type="button"
-                        className={styles.enableAllBtn}
-                        onClick={() => handleEnableAllPermissions(ext, disabledPerms)}
-                        disabled={!canManage || disabledPerms.length === 0 || isPermissionBusy}
-                        title={
-                          !canManage
-                            ? t('spindlePanel.managedByOperator')
-                            : disabledPerms.length === 0
-                              ? t('spindlePanel.allPermissionsEnabled')
-                              : t('spindlePanel.enableAllPermissionsHint')
-                        }
-                      >
-                        {isBulkPermissionBusy && <Spinner size={12} fast />}
-                        {isBulkPermissionBusy ? t('spindlePanel.enablingAllPermissions') : t('spindlePanel.enableAllPermissions')}
-                      </button>
-                    </div>
-                    <div className={styles.permissions}>
-                      {allPerms.map((perm) => {
-                        const granted = ext.granted_permissions.includes(perm)
-                        const isToggling = togglingPerm === `${ext.id}:${perm}`
-                        const pretty = perm
-                          .replaceAll('_', ' ')
-                          .replace(/\b\w/g, (ch) => ch.toUpperCase())
-                        return (
-                          <button
-                            key={perm}
-                            className={clsx(
-                              styles.permPill,
-                              granted ? styles.permPillActive : styles.permPillInactive,
-                              (isToggling || isBulkPermissionBusy) && styles.permPillToggling
-                            )}
-                            onClick={() => handlePermissionToggle(ext, perm)}
-                            title={
-                              canManage
-                                ? t('spindlePanel.permissionStatus', { name: pretty, status: granted ? t('spindlePanel.enabled') : t('spindlePanel.disabled') })
-                                : t('spindlePanel.managedByOperator')
-                            }
-                            disabled={!canManage || isToggling || isBulkPermissionBusy}
-                          >
-                            {isToggling && <Spinner size={10} fast />}
-                            {pretty}
-                          </button>
-                        )
-                      })}
-                    </div>
-                  </div>
-                ) : null
-              })()}
+                const permissionsExpanded = expandedPermissionRows.has(ext.id)
 
-              {/* Actions row — labeled primaries + small secondary icons */}
-              <div className={styles.actionRow}>
-                <div className={styles.primaryActions}>
-                  <button
-                    type="button"
+                return (
+                  <SortableExtensionCard
+                    key={ext.id}
+                    id={ext.id}
+                    dragEnabled={canDragExtensions}
                     className={clsx(
-                      styles.labeledBtn,
-                      hasUpdate && styles.updateAvailableBtn,
+                      styles.extensionCard,
+                      extensionViewMode === 'list' && styles.extensionCardList,
+                      extensionViewMode === 'list' && isExpanded && styles.extensionCardListExpanded,
                     )}
-                    onClick={() => handleUpdate(ext)}
-                    disabled={isExtBusy(ext.id) || !canManage}
-                    title={canManage
-                      ? (hasUpdate ? t('spindlePanel.updateAvailableHint') : t('spindlePanel.updateHint'))
-                      : t('spindlePanel.managedByOperator')}
+                    dragLabel={t('spindlePanel.dragToReorder', { name: ext.name, defaultValue: `Drag ${ext.name} to reorder` })}
                   >
-                    {extensionOperationStatus?.extensionId === ext.id && extensionOperationStatus.operation === 'updating'
-                      ? <Spinner size={14} fast />
-                      : (
-                        <span className={styles.updateIconWrap}>
-                          <RefreshCw size={14} />
-                          {hasUpdate && <span className={styles.updateDot} aria-hidden="true" />}
-                        </span>
+                    <div className={styles.extensionHeader}>
+                      {extensionViewMode === 'list' && (
+                        <button
+                          type="button"
+                          className={styles.expandRowBtn}
+                          onClick={() => toggleListRow(ext.id)}
+                          aria-expanded={isExpanded}
+                          aria-label={isExpanded
+                            ? t('spindlePanel.collapseExtension', { name: ext.name, defaultValue: `Collapse ${ext.name}` })
+                            : t('spindlePanel.expandExtension', { name: ext.name, defaultValue: `Expand ${ext.name}` })}
+                          title={isExpanded
+                            ? t('spindlePanel.collapse', { defaultValue: 'Collapse' })
+                            : t('spindlePanel.expand', { defaultValue: 'Expand' })}
+                        >
+                          {isExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                        </button>
                       )}
-                    <span>{t('spindlePanel.update')}</span>
-                  </button>
-                  <button
-                    type="button"
-                    className={styles.labeledBtn}
-                    onClick={() => handleRestart(ext)}
-                    disabled={isExtBusy(ext.id) || !ext.enabled}
-                    title={ext.enabled ? t('spindlePanel.restartHint') : t('spindlePanel.notEnabled')}
-                  >
-                    {extensionOperationStatus?.extensionId === ext.id && extensionOperationStatus.operation === 'restarting'
-                      ? <Spinner size={14} fast />
-                      : <RotateCw size={14} />}
-                    <span>{t('spindlePanel.restart')}</span>
-                  </button>
-                  {canManage && (
-                    <button
-                      type="button"
-                      className={clsx(
-                        styles.labeledBtn,
-                        branchMenuExtId === ext.id && styles.labeledBtnActive,
-                      )}
-                      onClick={() => handleOpenBranchMenu(ext)}
-                      disabled={isExtBusy(ext.id)}
-                      title={t('spindlePanel.switchBranch')}
-                    >
-                      <IconVersions size={14} />
-                      <span>{t('spindlePanel.branch')}</span>
-                    </button>
-                  )}
-                  {extensionsWithRegisteredSettings.has(ext.id) && (
-                    <button
-                      type="button"
-                      className={styles.labeledBtn}
-                      onClick={() => openSettings('extensions', { extensionId: ext.id })}
-                      title={t('spindlePanel.openSettings')}
-                    >
-                      <SlidersHorizontal size={14} />
-                      <span>{t('spindlePanel.settingsLabel')}</span>
-                    </button>
-                  )}
-                </div>
-                <div className={styles.secondaryActions}>
-                  {getSafeHttpsUrl(ext.github) && (
-                    <a
-                      className={styles.iconBtnSmall}
-                      href={getSafeHttpsUrl(ext.github)!}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      title={t('spindlePanel.viewOnGitHub')}
-                      aria-label={t('spindlePanel.viewOnGitHub')}
-                    >
-                      <Github size={13} />
-                    </a>
-                  )}
-                  <button
-                    type="button"
-                    className={clsx(styles.iconBtnSmall, styles.iconBtnDanger)}
-                    onClick={() => handleRemove(ext)}
-                    disabled={isExtBusy(ext.id) || !canManage}
-                    title={canManage ? t('spindlePanel.removeExtension') : t('spindlePanel.managedByOperator')}
-                    aria-label={t('spindlePanel.removeExtension')}
-                  >
-                    <Trash2 size={13} />
-                  </button>
-                </div>
-              </div>
 
-              {/* Branch switch dropdown */}
-              {branchMenuExtId === ext.id && (
-                <div className={styles.branchMenu}>
-                  {fetchingExtBranches ? (
-                    <span className={styles.branchMenuLoading}>{t('spindlePanel.loadingBranches')}</span>
-                  ) : branchMenuBranches.length === 0 ? (
-                    <span className={styles.branchMenuLoading}>{t('spindlePanel.noBranches')}</span>
-                  ) : (
-                    branchMenuBranches.map((b) => (
-                      <button
-                        key={b}
-                        className={clsx(
-                          styles.branchMenuItem,
-                          b === branchMenuCurrent && styles.branchMenuItemCurrent
+                      <div className={styles.extensionInfo}>
+                        <div className={styles.extensionName}>
+                          <span
+                            className={clsx(
+                              styles.statusDot,
+                              ext.status === 'running' && styles.statusRunning,
+                              ext.status === 'error' && styles.statusError,
+                              ext.status === 'stopped' && styles.statusStopped
+                            )}
+                          />{' '}
+                          {ext.name}
+                        </div>
+                        <span className={styles.extensionMeta}>
+                          {t('spindlePanel.extensionVersionBy', { version: ext.version, author: ext.author })}
+                        </span>
+                        <span className={styles.extensionMeta}>
+                          {scopeLabel}
+                          {isNonDefaultBranch && (
+                            <span className={styles.branchBadge}>
+                              <IconVersions size={10} /> {extBranch}
+                            </span>
+                          )}
+                        </span>
+                        {extensionViewMode === 'list' && allPerms.length > 0 && (
+                          <span className={styles.extensionMeta}>
+                            {t('spindlePanel.permissionsCompact', {
+                              granted: grantedPermissionCount,
+                              total: allPerms.length,
+                              defaultValue: `${grantedPermissionCount}/${allPerms.length} permissions`,
+                            })}
+                          </span>
                         )}
-                        onClick={() => b !== branchMenuCurrent && handleSwitchBranch(ext, b)}
-                        disabled={b === branchMenuCurrent || isExtBusy(ext.id)}
-                      >
-                        <IconVersions size={12} />
-                        {b}
-                        {b === branchMenuCurrent && <span className={styles.branchCurrentLabel}>{t('spindlePanel.current')}</span>}
-                      </button>
-                    ))
-                  )}
-                </div>
-              )}
-                  </>
+                      </div>
+
+                      <div className={styles.extensionActions}>
+                        {canManage && (
+                          <button
+                            type="button"
+                            className={clsx(
+                              styles.updateNotificationBtn,
+                              updateToastsEnabled && styles.updateNotificationBtnActive,
+                            )}
+                            onClick={() => handleUpdateToastToggle(ext.identifier)}
+                            aria-pressed={updateToastsEnabled}
+                            aria-label={updateAlertLabel}
+                            title={updateAlertLabel}
+                          >
+                            {updateToastsEnabled ? <Bell size={13} /> : <BellOff size={13} />}
+                          </button>
+                        )}
+                        <button
+                          className={clsx(
+                            styles.toggleBtn,
+                            ext.enabled ? styles.toggleOn : styles.toggleOff
+                          )}
+                          onClick={() => handleToggle(ext)}
+                          disabled={isExtBusy(ext.id) || !canManage}
+                          title={canManage ? (ext.enabled ? t('spindlePanel.disable') : t('spindlePanel.enable')) : t('spindlePanel.managedByOperator')}
+                        />
+                      </div>
+                    </div>
+
+                    {isExpanded && (
+                      <>
+                        {extensionOperationStatus?.extensionId === ext.id && extensionOperationStatus.operation.endsWith('ing') && (
+                          <div className={styles.operationStatus}>
+                            <Spinner size={12} fast />
+                            {t(`spindlePanel.operations.${extensionOperationStatus.operation}`, { defaultValue: extensionOperationStatus.operation })}
+                          </div>
+                        )}
+
+                        {ext.description && (
+                          <div className={styles.extensionDesc}>{ext.description}</div>
+                        )}
+
+                        {allPerms.length > 0 && (
+                          <div className={styles.permissionsBlock}>
+                            <div className={styles.permissionsHeader}>
+                              <div className={styles.permissionsSummary}>
+                                <span className={styles.permissionsLabel}>{t('spindlePanel.permissionsLabel')}</span>
+                                <span className={clsx(
+                                  styles.permissionsCount,
+                                  disabledPerms.length > 0 && styles.permissionsCountIncomplete,
+                                )}>
+                                  {t('spindlePanel.permissionsGrantedSummary', {
+                                    granted: grantedPermissionCount,
+                                    total: allPerms.length,
+                                    defaultValue: `${grantedPermissionCount} / ${allPerms.length} enabled`,
+                                  })}
+                                </span>
+                              </div>
+                              <div className={styles.permissionHeaderActions}>
+                                {disabledPerms.length > 0 && (
+                                  <button
+                                    type="button"
+                                    className={clsx(
+                                      styles.enableAllBtn,
+                                      grantedPermissionCount === 0 && styles.enableAllBtnProminent,
+                                    )}
+                                    onClick={() => handleEnableAllPermissions(ext, disabledPerms)}
+                                    disabled={!canManage || isPermissionBusy}
+                                    title={!canManage
+                                      ? t('spindlePanel.managedByOperator')
+                                      : t('spindlePanel.enableAllPermissionsHint')}
+                                  >
+                                    {isBulkPermissionBusy && <Spinner size={12} fast />}
+                                    {isBulkPermissionBusy ? t('spindlePanel.enablingAllPermissions') : t('spindlePanel.enableAllPermissions')}
+                                  </button>
+                                )}
+                                <button
+                                  type="button"
+                                  className={styles.permissionReviewBtn}
+                                  onClick={() => togglePermissionDetails(ext.id)}
+                                  aria-expanded={permissionsExpanded}
+                                >
+                                  {permissionsExpanded
+                                    ? t('spindlePanel.hidePermissions', { defaultValue: 'Hide' })
+                                    : t('spindlePanel.reviewPermissions', { defaultValue: 'Review' })}
+                                  {permissionsExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                                </button>
+                              </div>
+                            </div>
+                            {permissionsExpanded && (
+                              <div className={styles.permissions}>
+                                {allPerms.map((perm) => {
+                                  const granted = ext.granted_permissions.includes(perm)
+                                  const isToggling = togglingPerm === `${ext.id}:${perm}`
+                                  const pretty = perm
+                                    .replaceAll('_', ' ')
+                                    .replace(/\b\w/g, (ch) => ch.toUpperCase())
+                                  return (
+                                    <button
+                                      key={perm}
+                                      className={clsx(
+                                        styles.permPill,
+                                        granted ? styles.permPillActive : styles.permPillInactive,
+                                        (isToggling || isBulkPermissionBusy) && styles.permPillToggling
+                                      )}
+                                      onClick={() => handlePermissionToggle(ext, perm)}
+                                      title={canManage
+                                        ? t('spindlePanel.permissionStatus', { name: pretty, status: granted ? t('spindlePanel.enabled') : t('spindlePanel.disabled') })
+                                        : t('spindlePanel.managedByOperator')}
+                                      disabled={!canManage || isToggling || isBulkPermissionBusy}
+                                    >
+                                      {isToggling && <Spinner size={10} fast />}
+                                      {pretty}
+                                    </button>
+                                  )
+                                })}
+                              </div>
+                            )}
+                          </div>
+                        )}
+
+                        <div className={styles.actionRow}>
+                          <div className={styles.primaryActions}>
+                            <button
+                              type="button"
+                              className={clsx(
+                                styles.labeledBtn,
+                                hasUpdate && styles.updateAvailableBtn,
+                              )}
+                              onClick={() => handleUpdate(ext)}
+                              disabled={isExtBusy(ext.id) || !canManage}
+                              title={canManage
+                                ? (hasUpdate ? t('spindlePanel.updateAvailableHint') : t('spindlePanel.updateHint'))
+                                : t('spindlePanel.managedByOperator')}
+                            >
+                              {extensionOperationStatus?.extensionId === ext.id && extensionOperationStatus.operation === 'updating'
+                                ? <Spinner size={14} fast />
+                                : (
+                                  <span className={styles.updateIconWrap}>
+                                    <RefreshCw size={14} />
+                                    {hasUpdate && <span className={styles.updateDot} aria-hidden="true" />}
+                                  </span>
+                                )}
+                              <span>{t('spindlePanel.update')}</span>
+                            </button>
+                            <button
+                              type="button"
+                              className={styles.labeledBtn}
+                              onClick={() => handleRestart(ext)}
+                              disabled={isExtBusy(ext.id) || !ext.enabled}
+                              title={ext.enabled ? t('spindlePanel.restartHint') : t('spindlePanel.notEnabled')}
+                            >
+                              {extensionOperationStatus?.extensionId === ext.id && extensionOperationStatus.operation === 'restarting'
+                                ? <Spinner size={14} fast />
+                                : <RotateCw size={14} />}
+                              <span>{t('spindlePanel.restart')}</span>
+                            </button>
+                            {canManage && (
+                              <button
+                                type="button"
+                                className={clsx(
+                                  styles.labeledBtn,
+                                  branchMenuExtId === ext.id && styles.labeledBtnActive,
+                                )}
+                                onClick={() => handleOpenBranchMenu(ext)}
+                                disabled={isExtBusy(ext.id)}
+                                title={t('spindlePanel.switchBranch')}
+                              >
+                                <IconVersions size={14} />
+                                <span>{t('spindlePanel.branch')}</span>
+                              </button>
+                            )}
+                            {extensionsWithRegisteredSettings.has(ext.id) && (
+                              <button
+                                type="button"
+                                className={styles.labeledBtn}
+                                onClick={() => openSettings('extensions', { extensionId: ext.id })}
+                                title={t('spindlePanel.openSettings')}
+                              >
+                                <SlidersHorizontal size={14} />
+                                <span>{t('spindlePanel.settingsLabel')}</span>
+                              </button>
+                            )}
+                          </div>
+                          <div className={styles.secondaryActions}>
+                            {getSafeHttpsUrl(ext.github) && (
+                              <a
+                                className={styles.iconBtnSmall}
+                                href={getSafeHttpsUrl(ext.github)!}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                title={t('spindlePanel.viewOnGitHub')}
+                                aria-label={t('spindlePanel.viewOnGitHub')}
+                              >
+                                <Github size={13} />
+                              </a>
+                            )}
+                            <button
+                              type="button"
+                              className={clsx(styles.iconBtnSmall, styles.iconBtnDanger)}
+                              onClick={() => handleRemove(ext)}
+                              disabled={isExtBusy(ext.id) || !canManage}
+                              title={canManage ? t('spindlePanel.removeExtension') : t('spindlePanel.managedByOperator')}
+                              aria-label={t('spindlePanel.removeExtension')}
+                            >
+                              <Trash2 size={13} />
+                            </button>
+                          </div>
+                        </div>
+
+                        {branchMenuExtId === ext.id && (
+                          <div className={styles.branchMenu}>
+                            {fetchingExtBranches ? (
+                              <span className={styles.branchMenuLoading}>{t('spindlePanel.loadingBranches')}</span>
+                            ) : branchMenuBranches.length === 0 ? (
+                              <span className={styles.branchMenuLoading}>{t('spindlePanel.noBranches')}</span>
+                            ) : (
+                              branchMenuBranches.map((branch) => (
+                                <button
+                                  key={branch}
+                                  className={clsx(
+                                    styles.branchMenuItem,
+                                    branch === branchMenuCurrent && styles.branchMenuItemCurrent
+                                  )}
+                                  onClick={() => branch !== branchMenuCurrent && handleSwitchBranch(ext, branch)}
+                                  disabled={branch === branchMenuCurrent || isExtBusy(ext.id)}
+                                >
+                                  <IconVersions size={12} />
+                                  {branch}
+                                  {branch === branchMenuCurrent && (
+                                    <span className={styles.branchCurrentLabel}>{t('spindlePanel.current')}</span>
+                                  )}
+                                </button>
+                              ))
+                            )}
+                          </div>
+                        )}
+                      </>
+                    )}
+                  </SortableExtensionCard>
                 )
-              })()}
+              })}
             </div>
-          ))}
-        </div>
+          </SortableContext>
+        </DndContext>
       )}
     </div>
     {addMenuOpen && isPrivileged && createPortal(

--- a/frontend/src/components/panels/SpindleSettings.module.css
+++ b/frontend/src/components/panels/SpindleSettings.module.css
@@ -1,11 +1,71 @@
 .card {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  padding: 10px 12px;
   border-radius: var(--lumiverse-radius);
   background: var(--lumiverse-fill-subtle);
   border: 1px solid var(--lumiverse-border);
+  overflow: hidden;
+}
+
+.collapseHeader {
+  width: 100%;
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 12px;
+  border: 0;
+  background: transparent;
+  color: var(--lumiverse-text-muted);
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  transition: background var(--lumiverse-transition-fast), color var(--lumiverse-transition-fast);
+}
+
+.collapseHeader:hover {
+  background: var(--lumiverse-fill-hover);
+  color: var(--lumiverse-text);
+}
+
+.collapseTitle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  font-size: calc(11px * var(--lumiverse-font-scale, 1));
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--lumiverse-text-dim);
+}
+
+.summary {
+  flex-shrink: 0;
+  font-size: calc(11px * var(--lumiverse-font-scale, 1));
+  color: var(--lumiverse-text-dim);
+  text-transform: none;
+  letter-spacing: normal;
+  font-variant-numeric: tabular-nums;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border-top: 1px solid var(--lumiverse-border);
+}
+
+.setting {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+}
+
+.setting + .setting {
+  border-top: 1px solid var(--lumiverse-border);
 }
 
 .headerRow {
@@ -63,7 +123,7 @@
 }
 
 .input {
-  width: 72px;
+  width: 64px;
   padding: 4px 8px;
   border-radius: var(--lumiverse-radius);
   background: var(--lumiverse-bg);
@@ -91,7 +151,18 @@
 
 .hint {
   margin: 0;
+  max-width: 78ch;
   font-size: calc(11px * var(--lumiverse-font-scale, 1));
   line-height: 1.45;
   color: var(--lumiverse-text-muted);
+}
+
+@media (max-width: 520px) {
+  .summary {
+    display: none;
+  }
+
+  .headerRow {
+    align-items: flex-start;
+  }
 }

--- a/frontend/src/components/panels/SpindleSettings.tsx
+++ b/frontend/src/components/panels/SpindleSettings.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { PanelsLeftRight, Timer } from 'lucide-react'
+import { ChevronDown, ChevronRight, PanelsLeftRight, SlidersHorizontal, Timer } from 'lucide-react'
 import { useStore } from '@/store'
 import { toast } from '@/lib/toast'
 import styles from './SpindleSettings.module.css'
@@ -8,10 +8,17 @@ import styles from './SpindleSettings.module.css'
 const DEFAULT_SECONDS = 10
 const MIN_SECONDS = 1
 const MAX_SECONDS = 300
+const COLLAPSE_STORAGE_KEY = 'lumiverse:spindle:extension-settings-collapsed'
 
 function clamp(n: number): number {
   if (!Number.isFinite(n)) return DEFAULT_SECONDS
   return Math.min(MAX_SECONDS, Math.max(MIN_SECONDS, Math.round(n)))
+}
+
+function readCollapsedPreference(): boolean {
+  if (typeof window === 'undefined') return true
+  const value = window.localStorage.getItem(COLLAPSE_STORAGE_KEY)
+  return value === null ? true : value === 'true'
 }
 
 export default function SpindleSettings() {
@@ -19,12 +26,18 @@ export default function SpindleSettings() {
   const spindleSettings = useStore((s) => s.spindleSettings)
   const setSetting = useStore((s) => s.setSetting)
   const [draft, setDraft] = useState<string>(String(DEFAULT_SECONDS))
+  const [collapsed, setCollapsed] = useState(readCollapsedPreference)
 
   useEffect(() => {
     const ms = Number(spindleSettings.interceptorTimeoutMs)
     const value = Number.isFinite(ms) && ms > 0 ? clamp(ms / 1000) : DEFAULT_SECONDS
     setDraft(String(value))
   }, [spindleSettings.interceptorTimeoutMs])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    window.localStorage.setItem(COLLAPSE_STORAGE_KEY, String(collapsed))
+  }, [collapsed])
 
   const commit = useCallback(async () => {
     const parsed = clamp(parseInt(draft, 10))
@@ -48,62 +61,86 @@ export default function SpindleSettings() {
 
   return (
     <div className={styles.card}>
-      <div className={styles.headerRow}>
-        <span className={styles.label}>
-          <Timer size={12} /> {t('interceptorTimeout')}
+      <button
+        type="button"
+        className={styles.collapseHeader}
+        onClick={() => setCollapsed((value) => !value)}
+        aria-expanded={!collapsed}
+      >
+        <span className={styles.collapseTitle}>
+          {collapsed ? <ChevronRight size={13} /> : <ChevronDown size={13} />}
+          <SlidersHorizontal size={13} />
+          {t('sectionTitle', { defaultValue: 'Extension settings' })}
         </span>
-        <div className={styles.inputGroup}>
-          <input
-            type="number"
-            name="spindle-interceptor-timeout"
-            aria-label={t('interceptorTimeoutAria')}
-            min={MIN_SECONDS}
-            max={MAX_SECONDS}
-            step={1}
-            value={draft}
-            className={styles.input}
-            onChange={(e) => setDraft(e.target.value)}
-            onBlur={commit}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault()
-                ;(e.target as HTMLInputElement).blur()
-              }
-            }}
-          />
-          <span className={styles.suffix}>{t('seconds')}</span>
-        </div>
-      </div>
-      <p className={styles.hint}>
-        {t('interceptorHint', { min: MIN_SECONDS, max: MAX_SECONDS, default: DEFAULT_SECONDS })}
-      </p>
+        <span className={styles.summary}>
+          {draft}{t('secondsShort', { defaultValue: 's' })} · {t(spindleSettings.dockPanelDesktopSide)}
+        </span>
+      </button>
 
-      <div className={styles.headerRow}>
-        <span className={styles.label}>
-          <PanelsLeftRight size={12} /> {t('dockPanelSide')}
-        </span>
-        <div className={styles.segmented}>
-          <button
-            type="button"
-            className={styles.segmentedBtn}
-            data-active={spindleSettings.dockPanelDesktopSide === 'left'}
-            onClick={() => updateDockSide('left')}
-          >
-            {t('left')}
-          </button>
-          <button
-            type="button"
-            className={styles.segmentedBtn}
-            data-active={spindleSettings.dockPanelDesktopSide === 'right'}
-            onClick={() => updateDockSide('right')}
-          >
-            {t('right')}
-          </button>
+      {!collapsed && (
+        <div className={styles.content}>
+          <div className={styles.setting}>
+            <div className={styles.headerRow}>
+              <span className={styles.label}>
+                <Timer size={12} /> {t('interceptorTimeout')}
+              </span>
+              <div className={styles.inputGroup}>
+                <input
+                  type="number"
+                  name="spindle-interceptor-timeout"
+                  aria-label={t('interceptorTimeoutAria')}
+                  min={MIN_SECONDS}
+                  max={MAX_SECONDS}
+                  step={1}
+                  value={draft}
+                  className={styles.input}
+                  onChange={(e) => setDraft(e.target.value)}
+                  onBlur={commit}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault()
+                      ;(e.target as HTMLInputElement).blur()
+                    }
+                  }}
+                />
+                <span className={styles.suffix}>{t('seconds')}</span>
+              </div>
+            </div>
+            <p className={styles.hint}>
+              {t('interceptorHint', { min: MIN_SECONDS, max: MAX_SECONDS, default: DEFAULT_SECONDS })}
+            </p>
+          </div>
+
+          <div className={styles.setting}>
+            <div className={styles.headerRow}>
+              <span className={styles.label}>
+                <PanelsLeftRight size={12} /> {t('dockPanelSide')}
+              </span>
+              <div className={styles.segmented}>
+                <button
+                  type="button"
+                  className={styles.segmentedBtn}
+                  data-active={spindleSettings.dockPanelDesktopSide === 'left'}
+                  onClick={() => updateDockSide('left')}
+                >
+                  {t('left')}
+                </button>
+                <button
+                  type="button"
+                  className={styles.segmentedBtn}
+                  data-active={spindleSettings.dockPanelDesktopSide === 'right'}
+                  onClick={() => updateDockSide('right')}
+                >
+                  {t('right')}
+                </button>
+              </div>
+            </div>
+            <p className={styles.hint}>
+              {t('dockHint')}
+            </p>
+          </div>
         </div>
-      </div>
-      <p className={styles.hint}>
-        {t('dockHint')}
-      </p>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/panels/spindle-extension-sort.test.ts
+++ b/frontend/src/components/panels/spindle-extension-sort.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'bun:test'
 import type { ExtensionInfo } from 'lumiverse-spindle-types'
-import { sortExtensions } from './spindle-extension-sort'
+import { filterExtensions, reconcileExtensionOrder, sortExtensions } from './spindle-extension-sort'
 
 function extension(overrides: Partial<ExtensionInfo>): ExtensionInfo {
   return {
@@ -26,9 +26,9 @@ function extension(overrides: Partial<ExtensionInfo>): ExtensionInfo {
 }
 
 const extensions = [
-  extension({ id: '1', name: 'zebra', installed_at: 10, updated_at: 30 }),
-  extension({ id: '2', name: 'Alpha 10', installed_at: 30, updated_at: 20 }),
-  extension({ id: '3', name: 'alpha 2', installed_at: 20, updated_at: 10 }),
+  extension({ id: '1', identifier: 'zebra', name: 'zebra', installed_at: 10, updated_at: 30 }),
+  extension({ id: '2', identifier: 'alpha-ten', name: 'Alpha 10', installed_at: 30, updated_at: 20, author: 'Kitty' }),
+  extension({ id: '3', identifier: 'alpha-two', name: 'alpha 2', installed_at: 20, updated_at: 10, permissions: ['image_gen'] as any }),
 ]
 
 test('sorts extensions by installation and update dates with the newest first', () => {
@@ -40,4 +40,16 @@ test('sorts extension names alphabetically in both directions without mutating t
   expect(sortExtensions(extensions, 'name-asc').map((item) => item.id)).toEqual(['3', '2', '1'])
   expect(sortExtensions(extensions, 'name-desc').map((item) => item.id)).toEqual(['1', '2', '3'])
   expect(extensions.map((item) => item.id)).toEqual(['1', '2', '3'])
+})
+
+test('reconciles persisted manual order and appends new extensions without stale ids', () => {
+  expect(reconcileExtensionOrder(extensions, ['3', 'missing', '1', '3'])).toEqual(['3', '1', '2'])
+  expect(sortExtensions(extensions, 'manual', ['3', '1', '2']).map((item) => item.id)).toEqual(['3', '1', '2'])
+})
+
+test('filters visible extension metadata and permissions case-insensitively', () => {
+  expect(filterExtensions(extensions, 'kitty').map((item) => item.id)).toEqual(['2'])
+  expect(filterExtensions(extensions, 'IMAGE GEN').map((item) => item.id)).toEqual(['3'])
+  expect(filterExtensions(extensions, 'alpha').map((item) => item.id)).toEqual(['2', '3'])
+  expect(filterExtensions(extensions, '   ')).toHaveLength(3)
 })

--- a/frontend/src/components/panels/spindle-extension-sort.ts
+++ b/frontend/src/components/panels/spindle-extension-sort.ts
@@ -1,8 +1,9 @@
 import type { ExtensionInfo } from 'lumiverse-spindle-types'
 
-export type ExtensionSortMode = 'installed' | 'updated' | 'name-asc' | 'name-desc'
+export type ExtensionSortMode = 'manual' | 'installed' | 'updated' | 'name-asc' | 'name-desc'
 
 export const EXTENSION_SORT_OPTIONS: ReadonlyArray<{ value: ExtensionSortMode; labelKey: string }> = [
+  { value: 'manual', labelKey: 'manual' },
   { value: 'installed', labelKey: 'dateInstalled' },
   { value: 'updated', labelKey: 'dateUpdated' },
   { value: 'name-asc', labelKey: 'alphabeticalAsc' },
@@ -15,8 +16,75 @@ function compareNames(left: ExtensionInfo, right: ExtensionInfo): number {
   return nameCollator.compare(left.name, right.name) || left.id.localeCompare(right.id)
 }
 
+function normalized(value: unknown): string {
+  return typeof value === 'string'
+    ? value.toLocaleLowerCase().replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim()
+    : ''
+}
+
+/**
+ * Keeps persisted IDs that still exist, drops stale IDs, and appends newly
+ * discovered extensions in the order supplied by the backend.
+ */
+export function reconcileExtensionOrder(extensions: readonly ExtensionInfo[], persistedOrder: readonly string[]): string[] {
+  const available = new Set(extensions.map((extension) => extension.id))
+  const seen = new Set<string>()
+  const reconciled: string[] = []
+
+  for (const id of persistedOrder) {
+    if (!available.has(id) || seen.has(id)) continue
+    seen.add(id)
+    reconciled.push(id)
+  }
+
+  for (const extension of extensions) {
+    if (seen.has(extension.id)) continue
+    seen.add(extension.id)
+    reconciled.push(extension.id)
+  }
+
+  return reconciled
+}
+
+/** Simple, predictable client-side search across the fields users can see or reason about. */
+export function filterExtensions(extensions: readonly ExtensionInfo[], query: string): ExtensionInfo[] {
+  const needle = normalized(query)
+  if (!needle) return [...extensions]
+
+  return extensions.filter((extension) => {
+    const metadata = (extension.metadata as Record<string, unknown> | null) ?? {}
+    const searchable = [
+      extension.name,
+      extension.author,
+      extension.description,
+      extension.identifier,
+      extension.version,
+      metadata.branch,
+      metadata.install_scope,
+      ...extension.permissions,
+      ...extension.granted_permissions,
+    ]
+
+    return searchable.some((value) => normalized(value).includes(needle))
+  })
+}
+
 /** Returns a sorted copy without mutating the extensions kept in the store. */
-export function sortExtensions(extensions: readonly ExtensionInfo[], mode: ExtensionSortMode): ExtensionInfo[] {
+export function sortExtensions(
+  extensions: readonly ExtensionInfo[],
+  mode: ExtensionSortMode,
+  manualOrder: readonly string[] = [],
+): ExtensionInfo[] {
+  if (mode === 'manual') {
+    const reconciled = reconcileExtensionOrder(extensions, manualOrder)
+    const rank = new Map(reconciled.map((id, index) => [id, index]))
+    return [...extensions].sort((left, right) => {
+      const leftRank = rank.get(left.id) ?? Number.MAX_SAFE_INTEGER
+      const rightRank = rank.get(right.id) ?? Number.MAX_SAFE_INTEGER
+      return leftRank - rightRank || compareNames(left, right)
+    })
+  }
+
   return [...extensions].sort((left, right) => {
     switch (mode) {
       case 'updated':

--- a/frontend/src/components/spindle/SpindleUIControlPanel.module.css
+++ b/frontend/src/components/spindle/SpindleUIControlPanel.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 10px 12px;
+  padding: 8px 10px;
   border-radius: var(--lumiverse-radius);
   background: var(--lumiverse-fill-subtle);
   border: 1px solid var(--lumiverse-border);
@@ -11,17 +11,38 @@
 .header {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   color: var(--lumiverse-text-muted);
+}
+
+.collapseBtn {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 0;
+  border: 0;
+  background: transparent;
+  color: var(--lumiverse-text-muted);
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+}
+
+.collapseBtn:hover .headerLabel {
+  color: var(--lumiverse-text);
 }
 
 .headerLabel {
   flex: 1;
+  min-width: 0;
   font-size: calc(11px * var(--lumiverse-font-scale, 1));
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--lumiverse-text-dim);
+  transition: color var(--lumiverse-transition-fast);
 }
 
 .headerActions {
@@ -41,13 +62,61 @@
   font-size: calc(10px * var(--lumiverse-font-scale, 1));
   font-weight: 500;
   cursor: pointer;
-  transition: all var(--lumiverse-transition-fast);
+  transition: background var(--lumiverse-transition-fast), color var(--lumiverse-transition-fast), border-color var(--lumiverse-transition-fast);
 }
 
 .smallBtn:hover {
   background: var(--lumiverse-fill-subtle);
   color: var(--lumiverse-text);
   border-color: var(--lumiverse-border-hover);
+}
+
+.tabs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.tabBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  min-height: 28px;
+  padding: 4px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--lumiverse-border);
+  background: var(--lumiverse-fill);
+  color: var(--lumiverse-text-muted);
+  font-family: inherit;
+  font-size: calc(11px * var(--lumiverse-font-scale, 1));
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background var(--lumiverse-transition-fast), color var(--lumiverse-transition-fast), border-color var(--lumiverse-transition-fast);
+}
+
+.tabBtn:hover {
+  color: var(--lumiverse-text);
+  border-color: var(--lumiverse-border-hover);
+}
+
+.tabBtnActive {
+  color: var(--lumiverse-primary);
+  background: var(--lumiverse-primary-010);
+  border-color: var(--lumiverse-primary-020);
+}
+
+.tabCount {
+  min-width: 16px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: var(--lumiverse-fill-hover);
+  color: inherit;
+  font-size: calc(9px * var(--lumiverse-font-scale, 1));
+  font-variant-numeric: tabular-nums;
 }
 
 .list {
@@ -63,7 +132,11 @@
   padding: 5px 8px;
   border-radius: 6px;
   background: var(--lumiverse-fill);
-  transition: opacity 0.15s ease;
+  transition: opacity var(--lumiverse-transition-fast), background var(--lumiverse-transition-fast);
+}
+
+.item:hover {
+  background: var(--lumiverse-fill-hover);
 }
 
 .itemHidden {
@@ -104,10 +177,33 @@
   cursor: pointer;
   border-radius: 4px;
   flex-shrink: 0;
-  transition: all 0.15s ease;
+  transition: background var(--lumiverse-transition-fast), color var(--lumiverse-transition-fast);
 }
 
 .toggleBtn:hover {
   background: var(--lumiverse-fill-subtle);
   color: var(--lumiverse-text);
+}
+
+.emptyTab {
+  padding: 10px 8px;
+  border-radius: var(--lumiverse-radius);
+  background: var(--lumiverse-fill);
+  color: var(--lumiverse-text-dim);
+  font-size: calc(11px * var(--lumiverse-font-scale, 1));
+  text-align: center;
+}
+
+@media (max-width: 520px) {
+  .panel {
+    padding: 8px;
+  }
+
+  .header {
+    align-items: flex-start;
+  }
+
+  .headerActions {
+    flex-shrink: 0;
+  }
 }

--- a/frontend/src/components/spindle/SpindleUIControlPanel.tsx
+++ b/frontend/src/components/spindle/SpindleUIControlPanel.tsx
@@ -1,5 +1,6 @@
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Eye, EyeOff } from 'lucide-react'
+import { ChevronDown, ChevronRight, Eye, EyeOff } from 'lucide-react'
 import { IconApps } from '@tabler/icons-react'
 import { useStore } from '@/store'
 import useIsMobile from '@/hooks/useIsMobile'
@@ -7,6 +8,23 @@ import { resolveDockPanelEdge } from '@/lib/spindle/dock-placement'
 import styles from './SpindleUIControlPanel.module.css'
 import clsx from 'clsx'
 import { filterEnabledFrontendContributions } from '@/lib/spindle/frontend-extension-availability'
+
+type SurfaceTab = 'all' | 'sidebar' | 'widget' | 'dock'
+type SurfaceKind = SurfaceTab | 'app'
+
+const COLLAPSE_STORAGE_KEY = 'lumiverse:spindle:extension-ui-collapsed'
+const TAB_STORAGE_KEY = 'lumiverse:spindle:extension-ui-tab'
+
+function readCollapsedPreference(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.localStorage.getItem(COLLAPSE_STORAGE_KEY) === 'true'
+}
+
+function readTabPreference(): SurfaceTab {
+  if (typeof window === 'undefined') return 'all'
+  const value = window.localStorage.getItem(TAB_STORAGE_KEY)
+  return value === 'sidebar' || value === 'widget' || value === 'dock' ? value : 'all'
+}
 
 export default function SpindleUIControlPanel() {
   const { t } = useTranslation('shared', { keyPrefix: 'spindle' })
@@ -21,62 +39,171 @@ export default function SpindleUIControlPanel() {
   const hideAllPlacements = useStore((s) => s.hideAllPlacements)
   const dockPanelDesktopSide = useStore((s) => s.spindleSettings.dockPanelDesktopSide)
   const isMobile = useIsMobile()
+  const [collapsed, setCollapsed] = useState(readCollapsedPreference)
+  const [activeTab, setActiveTab] = useState<SurfaceTab>(readTabPreference)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    window.localStorage.setItem(COLLAPSE_STORAGE_KEY, String(collapsed))
+  }, [collapsed])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    window.localStorage.setItem(TAB_STORAGE_KEY, activeTab)
+  }, [activeTab])
+
   const enabledDrawerTabs = filterEnabledFrontendContributions(drawerTabs, extensions)
   const enabledFloatWidgets = filterEnabledFrontendContributions(floatWidgets, extensions)
   const enabledDockPanels = filterEnabledFrontendContributions(dockPanels, extensions)
   const enabledAppMounts = filterEnabledFrontendContributions(appMounts, extensions)
 
-  const allItems = [
-    ...enabledDrawerTabs.map((tab) => ({ id: tab.id, label: tab.title, kind: t('drawerTab'), ext: tab.extensionId })),
-    ...enabledFloatWidgets.map((w) => ({ id: w.id, label: w.tooltip || t('floatWidget'), kind: t('floatWidget'), ext: w.extensionId })),
-    ...enabledDockPanels.map((p) => ({
-      id: p.id,
-      label: p.title,
-      kind: t('dockPanel', { edge: resolveDockPanelEdge(p.edge, dockPanelDesktopSide, isMobile) }),
-      ext: p.extensionId,
+  const allItems = useMemo(() => [
+    ...enabledDrawerTabs.map((tab) => ({
+      id: tab.id,
+      label: tab.title,
+      kind: t('drawerTab'),
+      surface: 'sidebar' as SurfaceKind,
     })),
-    ...enabledAppMounts.map((m) => ({ id: m.id, label: t('appMount'), kind: t('appMount'), ext: m.extensionId })),
-  ]
+    ...enabledFloatWidgets.map((widget) => ({
+      id: widget.id,
+      label: widget.tooltip || t('floatWidget'),
+      kind: t('floatWidget'),
+      surface: 'widget' as SurfaceKind,
+    })),
+    ...enabledDockPanels.map((panel) => ({
+      id: panel.id,
+      label: panel.title,
+      kind: t('dockPanel', { edge: resolveDockPanelEdge(panel.edge, dockPanelDesktopSide, isMobile) }),
+      surface: 'dock' as SurfaceKind,
+    })),
+    ...enabledAppMounts.map((mount) => ({
+      id: mount.id,
+      label: t('appMount'),
+      kind: t('appMount'),
+      surface: 'app' as SurfaceKind,
+    })),
+  ], [
+    dockPanelDesktopSide,
+    enabledAppMounts,
+    enabledDockPanels,
+    enabledDrawerTabs,
+    enabledFloatWidgets,
+    isMobile,
+    t,
+  ])
 
   if (allItems.length === 0) return null
 
-  const hiddenCount = allItems.filter((i) => hiddenPlacements.includes(i.id)).length
+  const visibleItems = activeTab === 'all'
+    ? allItems
+    : allItems.filter((item) => item.surface === activeTab)
+
+  const counts = {
+    all: allItems.length,
+    sidebar: allItems.filter((item) => item.surface === 'sidebar').length,
+    widget: allItems.filter((item) => item.surface === 'widget').length,
+    dock: allItems.filter((item) => item.surface === 'dock').length,
+  }
+
+  const handleShowVisible = () => {
+    if (activeTab === 'all') {
+      showAllPlacements()
+      return
+    }
+    visibleItems.forEach((item) => {
+      if (hiddenPlacements.includes(item.id)) togglePlacementVisibility(item.id)
+    })
+  }
+
+  const handleHideVisible = () => {
+    if (activeTab === 'all') {
+      hideAllPlacements()
+      return
+    }
+    visibleItems.forEach((item) => {
+      if (!hiddenPlacements.includes(item.id)) togglePlacementVisibility(item.id)
+    })
+  }
+
+  const tabs: Array<{ id: SurfaceTab; label: string; count: number }> = [
+    { id: 'all', label: t('surfaceAll', { defaultValue: 'All' }), count: counts.all },
+    { id: 'sidebar', label: t('surfaceSidebar', { defaultValue: 'Sidebar' }), count: counts.sidebar },
+    { id: 'widget', label: t('surfaceWidget', { defaultValue: 'Widget' }), count: counts.widget },
+    { id: 'dock', label: t('surfaceDock', { defaultValue: 'Dock' }), count: counts.dock },
+  ]
 
   return (
     <div className={styles.panel}>
       <div className={styles.header}>
-        <IconApps size={13} />
-        <span className={styles.headerLabel}>{t('extensionUi', { count: allItems.length })}</span>
-        <div className={styles.headerActions}>
-          <button className={styles.smallBtn} onClick={showAllPlacements} title={t('showAll')}>
-            <Eye size={12} /> {t('show')}
-          </button>
-          <button className={styles.smallBtn} onClick={hideAllPlacements} title={t('hideAll')}>
-            <EyeOff size={12} /> {t('hide')}
-          </button>
-        </div>
+        <button
+          type="button"
+          className={styles.collapseBtn}
+          onClick={() => setCollapsed((value) => !value)}
+          aria-expanded={!collapsed}
+        >
+          {collapsed ? <ChevronRight size={13} /> : <ChevronDown size={13} />}
+          <IconApps size={13} />
+          <span className={styles.headerLabel}>{t('extensionUi', { count: allItems.length })}</span>
+        </button>
+        {!collapsed && (
+          <div className={styles.headerActions}>
+            <button className={styles.smallBtn} onClick={handleShowVisible} title={t('showAll')}>
+              <Eye size={12} /> {t('show')}
+            </button>
+            <button className={styles.smallBtn} onClick={handleHideVisible} title={t('hideAll')}>
+              <EyeOff size={12} /> {t('hide')}
+            </button>
+          </div>
+        )}
       </div>
 
-      <div className={styles.list}>
-        {allItems.map((item) => {
-          const isHidden = hiddenPlacements.includes(item.id)
-          return (
-            <div key={item.id} className={clsx(styles.item, isHidden && styles.itemHidden)}>
-              <div className={styles.itemInfo}>
-                <span className={styles.itemLabel}>{item.label}</span>
-                <span className={styles.itemMeta}>{item.kind}</span>
-              </div>
+      {!collapsed && (
+        <>
+          <div className={styles.tabs} role="tablist" aria-label={t('extensionUi', { count: allItems.length })}>
+            {tabs.map((tab) => (
               <button
-                className={styles.toggleBtn}
-                onClick={() => togglePlacementVisibility(item.id)}
-                title={isHidden ? t('show') : t('hide')}
+                key={tab.id}
+                type="button"
+                role="tab"
+                aria-selected={activeTab === tab.id}
+                className={clsx(styles.tabBtn, activeTab === tab.id && styles.tabBtnActive)}
+                onClick={() => setActiveTab(tab.id)}
               >
-                {isHidden ? <EyeOff size={13} /> : <Eye size={13} />}
+                {tab.label}
+                <span className={styles.tabCount}>{tab.count}</span>
               </button>
+            ))}
+          </div>
+
+          {visibleItems.length === 0 ? (
+            <div className={styles.emptyTab}>
+              {t('noSurfaceItems', { defaultValue: 'No extension UI in this category.' })}
             </div>
-          )
-        })}
-      </div>
+          ) : (
+            <div className={styles.list}>
+              {visibleItems.map((item) => {
+                const isHidden = hiddenPlacements.includes(item.id)
+                return (
+                  <div key={item.id} className={clsx(styles.item, isHidden && styles.itemHidden)}>
+                    <div className={styles.itemInfo}>
+                      <span className={styles.itemLabel}>{item.label}</span>
+                      <span className={styles.itemMeta}>{item.kind}</span>
+                    </div>
+                    <button
+                      className={styles.toggleBtn}
+                      onClick={() => togglePlacementVisibility(item.id)}
+                      title={isHidden ? t('show') : t('hide')}
+                      aria-label={`${isHidden ? t('show') : t('hide')} ${item.label}`}
+                    >
+                      {isHidden ? <EyeOff size={13} /> : <Eye size={13} />}
+                    </button>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Reworks the Extensions panel to improve navigation and usability as the number of installed extensions grows.

### Changes

- adds extension search
- adds persistent Cards/List display modes
- makes sorting visible and easier to use
- adds a persistent manual extension ordering mode
- moves Update All into the Installed extensions header
- adds compact expandable extension rows in List mode
- summarizes permission state and surfaces the existing Enable All flow
- collapses global Extension settings by default
- makes the Extension UI registry collapsible
- adds All / Sidebar / Widget / Dock filters to Extension UI
- improves toolbar behavior across narrow drawer widths
- preserves existing extension card styling classes and theme variables for compatibility with themes and component styling

## Notes

This is primarily a frontend UX refactor. It does not change Spindle extension APIs or runtime behavior.

Existing card styling primitives and theme-aware CSS variables are retained wherever possible to minimize regressions for custom themes.

## Testing

- verified extension search and sorting
- verified Cards/List switching
- verified manual extension ordering
- verified permission controls
- verified collapsed settings/UI sections
- verified responsive toolbar behavior at multiple drawer widths
- `git diff --check` clean

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass.
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [x] Backend: `bun x tsc --noEmit`
  - [x] Frontend: `cd frontend && bun run typecheck`, `bun run lint`
  
bun run lint currently fails on a pre-existing unrelated error, with two unrelated warnings.

## UI changes (if applicable)

- [x] I validated this change in more than one browser.
- [x] I verified the integrated experience on a mobile interface or through
      the mobile PWA.
- Browsers, devices, and PWA coverage:
Chromium Desktop and Mobile
FF Desktop and Mobile
Chromium devtools mobile shim

## Performance changes (if applicable)
N/A

## Security-sensitive changes (if applicable)
N/A

## LLM-assisted work (if applicable)

- [x] I, as the human orchestrating this work, audited the submitted changes
      in a live environment.