### PR TITLE
fix: forward macro invocation contract fields

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
         "hono": "^4.7.0",
         "js-tiktoken": "^1.0.16",
         "linkedom": "0.18.13",
-        "lumiverse-spindle-types": "0.6.29",
+        "lumiverse-spindle-types": "0.6.30",
         "mute-stream": "^3.0.0",
         "sharp": "^0.34.5",
         "ssh2-sftp-client": "^12.1.1",
@@ -709,7 +709,7 @@
 
     "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
-    "lumiverse-spindle-types": ["lumiverse-spindle-types@0.6.29", "", {}, "sha512-LLLn7F3OKTiBanZGGRCk3b8tDib5CyqiP/9XjCYHYSORMQwokzuvQRubEDwqh63mjdZrUVG7Xe8hDYT+Ky9qdA=="],
+    "lumiverse-spindle-types": ["lumiverse-spindle-types@0.6.30", "", {}, "sha512-RZBawz4KWx4VlNySS47+sIKkiwNgKstzcDNQsTjuZ6Zc4QgBoAPcPI/XSI/bdlBewobVw7rtNwjKL8ujM9KqXQ=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "hono": "^4.7.0",
     "js-tiktoken": "^1.0.16",
     "linkedom": "0.18.13",
-    "lumiverse-spindle-types": "0.6.29",
+    "lumiverse-spindle-types": "0.6.30",
     "mute-stream": "^3.0.0",
     "sharp": "^0.34.5",
     "ssh2-sftp-client": "^12.1.1"

--- a/src/services/generate.service.ts
+++ b/src/services/generate.service.ts
@@ -1677,6 +1677,7 @@ async function runPromptPipeline(opts: {
       personaId: opts.personaId,
       personaAddonStates: opts.personaAddonStates,
       generationType: opts.generationType as GenerationType,
+      macroCommit: opts.isDryRun !== true,
       impersonateMode: opts.impersonateMode,
       impersonateInput: opts.impersonateInput,
       userInput: opts.userInput,

--- a/src/spindle/worker-host.ts
+++ b/src/spindle/worker-host.ts
@@ -2682,6 +2682,7 @@ export class WorkerHost {
       category: definition.category || `extension:${this.manifest.identifier}`,
       description: definition.description || "",
       returnType: definition.returnType || "string",
+      volatile: definition.volatile === true,
       args: Array.isArray(definition.args)
         ? definition.args.map((arg: any) => ({
             name: String(arg.name || "arg"),
@@ -2775,6 +2776,7 @@ export class WorkerHost {
                   args: ctx.args,
                   flags: ctx.flags,
                   commit: ctx.commit !== false,
+                  chatId: typeof chatId === "string" && chatId ? chatId : undefined,
                   isScoped: ctx.isScoped,
                   body: ctx.body,
                   offset: ctx.offset,


### PR DESCRIPTION
## Summary

Updates lumiverse-spindle-types to 0.6.30 and forwards the existing volatile and chatId macro contract fields through the Spindle host.
Also marks dry-run prompt assembly as non-committing via the existing macroCommit context field.

Normal generation behavior is unchanged.

## Validation

List the commands you ran and their results. Include any relevant test output.

```text
bun x tsc --noEmit
cd frontend && bun run typecheck
bun run lint
```

## Required checklist

- [x] This pull request is based on the latest `staging` branch and targets
      `staging`, not `main`.
- [x] All applicable tests pass.
- [x] I ran the relevant type check(s) with no type errors or warnings:
  - [x] Backend: `bun x tsc --noEmit`
  - [x] Frontend: `cd frontend && bun run typecheck`, `bun run lint`

## UI changes (if applicable)
N/A

## Performance changes (if applicable)
N/A

## Security-sensitive changes (if applicable)
N/A

## LLM-assisted work (if applicable)

- [x] I, as the human orchestrating this work, audited the submitted changes
      in a live environment.