### PR TITLE
Support controlled Loom editor drafts for Spindle

### DIFF
--- a/frontend/src/components/panels/LoomBuilder.controlled.isolated.tsx
+++ b/frontend/src/components/panels/LoomBuilder.controlled.isolated.tsx
@@ -497,6 +497,57 @@ describe('controlled Loom editor trust boundary', () => {
     unmountRoot(root)
   })
 
+  test('clears a controlled draft when the selected block is removed', async () => {
+    const drafts: Array<{ blockId: string; updates: Partial<PromptBlock> | null }> = []
+    const selected: Array<string | null> = []
+    const onDraftChange = (blockId: string, updates: Partial<PromptBlock> | null) => {
+      drafts.push({ blockId, updates })
+    }
+    const onSelectedBlockChange = (blockId: string | null) => { selected.push(blockId) }
+    const { container, root } = renderControlled([block()], () => {}, undefined, {
+      selectedBlockId: 'public-block',
+      onDraftChange,
+      onSelectedBlockChange,
+    })
+
+    editRole(container, 'assistant')
+    await act(async () => {})
+    expect(drafts.at(-1)).toMatchObject({ blockId: 'public-block', updates: { role: 'assistant' } })
+
+    flushSync(() => {
+      root.render(createElement(ControlledLoomBlockEditor, {
+        blocks: [],
+        promptVariables,
+        onChange: () => {},
+        onDraftChange,
+        selectedBlockId: 'public-block',
+        onSelectedBlockChange,
+        availableMacros: [],
+        compact: true,
+      }))
+    })
+    await act(async () => {})
+
+    expect(selected).toEqual([null])
+    expect(drafts.at(-1)).toEqual({ blockId: 'public-block', updates: null })
+
+    flushSync(() => {
+      root.render(createElement(ControlledLoomBlockEditor, {
+        blocks: [],
+        promptVariables,
+        onChange: () => {},
+        onDraftChange,
+        selectedBlockId: null,
+        onSelectedBlockChange,
+        availableMacros: [],
+        compact: true,
+      }))
+    })
+    await act(async () => {})
+    expect(drafts.filter(({ updates }) => updates === null)).toHaveLength(1)
+    unmountRoot(root)
+  })
+
   test('defaults BlockEditor trusted host features to deny', () => {
     let saved: Partial<PromptBlock> | undefined
     const { container, root } = renderBlockEditor(undefined, (updates) => {

--- a/frontend/src/components/panels/LoomBuilder.controlled.isolated.tsx
+++ b/frontend/src/components/panels/LoomBuilder.controlled.isolated.tsx
@@ -332,6 +332,11 @@ function renderControlled(
   blocks: PromptBlock[],
   onChange: (next: PromptBlock[]) => void,
   trustedHostFeatures?: boolean,
+  options: {
+    onDraftChange?: (blockId: string, updates: Partial<PromptBlock> | null) => void
+    selectedBlockId?: string | null
+    onSelectedBlockChange?: (blockId: string | null) => void
+  } = {},
 ): { container: HTMLDivElement; root: Root } {
   const container = document.createElement('div')
   document.body.append(container)
@@ -343,6 +348,7 @@ function renderControlled(
       onChange,
       availableMacros: [],
       compact: true,
+      ...options,
       ...(trustedHostFeatures === undefined ? {} : { trustedHostFeatures }),
     }))
   })
@@ -451,6 +457,43 @@ describe('controlled Loom editor trust boundary', () => {
 
     expect(container.textContent).not.toContain('blockEditor.preview')
     expect(container.textContent).not.toContain('blockEditor.sealedBlockTitle')
+    unmountRoot(root)
+  })
+
+  test('opens an externally selected block and reports native back navigation', () => {
+    const selected: Array<string | null> = []
+    const blocks = [block({ id: 'first', name: 'First' }), block({ id: 'second', name: 'Second' })]
+    const { container, root } = renderControlled(blocks, () => {}, undefined, {
+      selectedBlockId: 'second',
+      onSelectedBlockChange: (blockId) => { selected.push(blockId) },
+    })
+
+    const nameInput = [...container.querySelectorAll<HTMLInputElement>('input')]
+      .find((input) => input.value === 'Second')
+    expect(nameInput).toBeDefined()
+
+    flushSync(() => container.querySelector<HTMLButtonElement>('button[title="blockEditor.backToList"]')!.click())
+    expect(selected).toEqual([null])
+    unmountRoot(root)
+  })
+
+  test('reports in-progress block drafts before save and clears them on back', async () => {
+    const drafts: Array<{ blockId: string; updates: Partial<PromptBlock> | null }> = []
+    let commits = 0
+    const { container, root } = renderControlled([block()], () => { commits += 1 }, undefined, {
+      onDraftChange: (blockId, updates) => { drafts.push({ blockId, updates }) },
+    })
+
+    flushSync(() => container.querySelector<HTMLButtonElement>('button[title="actions.edit"]')!.click())
+    editRole(container, 'assistant')
+    await act(async () => {})
+
+    expect(commits).toBe(0)
+    expect(drafts.at(-1)).toMatchObject({ blockId: 'public-block', updates: { role: 'assistant' } })
+
+    flushSync(() => container.querySelector<HTMLButtonElement>('button[title="blockEditor.backToList"]')!.click())
+    expect(drafts.at(-1)).toEqual({ blockId: 'public-block', updates: null })
+    expect(commits).toBe(0)
     unmountRoot(root)
   })
 

--- a/frontend/src/components/panels/LoomBuilder.tsx
+++ b/frontend/src/components/panels/LoomBuilder.tsx
@@ -553,6 +553,7 @@ interface BlockEditorProps {
   promptVariables: PromptVariableValues
   onSave: (updates: Partial<PromptBlock>) => boolean | void
   onBack: () => void
+  onDraftChange?: (updates: Partial<PromptBlock>) => void
   validationError?: string | null
   availableMacros: MacroGroup[]
   refreshMacros?: () => void
@@ -598,6 +599,7 @@ export function BlockEditor({
   promptVariables,
   onSave,
   onBack,
+  onDraftChange,
   validationError,
   availableMacros,
   refreshMacros,
@@ -639,7 +641,7 @@ export function BlockEditor({
     else if (pos === 'pre_history' && role === 'assistant') setRole('system')
   }
 
-  const handleSave = () => {
+  const buildDraftUpdates = useCallback((): Partial<PromptBlock> => {
     const isAppend = role === 'user_append' || role === 'assistant_append'
     const cleanedVariables = variables.filter((variable) => variable && variable.name?.trim().length > 0)
     const cleanedCharacterTagTrigger = sanitizeCharacterTagTrigger(characterTagTrigger)
@@ -659,7 +661,7 @@ export function BlockEditor({
       trustedUpdates.sealedOriginVersion = isInstalledLumiHubSealed ? block.sealedOriginVersion : undefined
       trustedUpdates.sealedSha256 = isInstalledLumiHubSealed ? block.sealedSha256 : undefined
     }
-    onSave({
+    return {
       name,
       role,
       content,
@@ -672,7 +674,48 @@ export function BlockEditor({
       categoryMode: block.marker === 'category' ? categoryMode : null,
       variables: cleanedVariables.length ? cleanedVariables : undefined,
       placementBinding: cleanPlacementBinding(placementBinding, cleanedVariables, fallbackPlacement),
-    })
+    }
+  }, [
+    block.id,
+    block.marker,
+    block.sealedKey,
+    block.sealedOriginPresetId,
+    block.sealedOriginVersion,
+    block.sealedSha256,
+    block.sealedSource,
+    categoryMode,
+    characterTagTrigger,
+    content,
+    depth,
+    injectionTrigger,
+    isInstalledLumiHubSealed,
+    isLocked,
+    name,
+    placementBinding,
+    position,
+    role,
+    sealed,
+    sealedKey,
+    trustedHostFeatures,
+    variables,
+  ])
+  const onDraftChangeRef = useRef(onDraftChange)
+  const draftEffectPrimedRef = useRef(false)
+
+  useEffect(() => {
+    onDraftChangeRef.current = onDraftChange
+  }, [onDraftChange])
+
+  useEffect(() => {
+    if (!draftEffectPrimedRef.current) {
+      draftEffectPrimedRef.current = true
+      return
+    }
+    onDraftChangeRef.current?.(buildDraftUpdates())
+  }, [buildDraftUpdates])
+
+  const handleSave = () => {
+    onSave(buildDraftUpdates())
   }
 
   const toggleTrigger = (value: string) => {
@@ -1015,6 +1058,9 @@ export interface ControlledLoomBlockEditorProps {
   blocks: PromptBlock[]
   promptVariables: PromptVariableValues
   onChange: (blocks: PromptBlock[]) => boolean | void | Promise<unknown>
+  onDraftChange?: (blockId: string, updates: Partial<PromptBlock> | null) => void
+  selectedBlockId?: string | null
+  onSelectedBlockChange?: (blockId: string | null) => void
   availableMacros: MacroGroup[]
   refreshMacros?: () => void
   readOnly?: boolean
@@ -1031,6 +1077,9 @@ export function ControlledLoomBlockEditor({
   blocks,
   promptVariables,
   onChange,
+  onDraftChange,
+  selectedBlockId,
+  onSelectedBlockChange,
   availableMacros,
   refreshMacros,
   readOnly = false,
@@ -1039,21 +1088,43 @@ export function ControlledLoomBlockEditor({
 }: ControlledLoomBlockEditorProps) {
   const { t } = useLb()
   const { t: tc } = useTranslation('common')
-  const [editingBlockId, setEditingBlockId] = useState<string | null>(null)
+  const [internalEditingBlockId, setInternalEditingBlockId] = useState<string | null>(null)
   const [validationError, setValidationError] = useState<string | null>(null)
+  const selectionControlled = selectedBlockId !== undefined
+  const editingBlockId = selectionControlled ? selectedBlockId ?? null : internalEditingBlockId
   const editingBlock = editingBlockId
     ? blocks.find((block) => block.id === editingBlockId) ?? null
     : null
+  const selectBlock = useCallback((blockId: string | null) => {
+    if (!selectionControlled) setInternalEditingBlockId(blockId)
+    onSelectedBlockChange?.(blockId)
+  }, [onSelectedBlockChange, selectionControlled])
+  const previousEditingBlockIdRef = useRef(editingBlockId)
+  const explicitlyClearedDraftBlockIdRef = useRef<string | null>(null)
   const effectiveRoles = useMemo(() => new Map(
     resolvePromptBlockPlacements(blocks, promptVariables)
       .map((block) => [block.id, block.role] as const),
   ), [blocks, promptVariables])
 
   useEffect(() => {
-    if (editingBlockId && !blocks.some((block) => block.id === editingBlockId)) {
-      setEditingBlockId(null)
+    const previousEditingBlockId = previousEditingBlockIdRef.current
+    if (previousEditingBlockId !== editingBlockId) {
+      if (previousEditingBlockId !== null) {
+        if (explicitlyClearedDraftBlockIdRef.current === previousEditingBlockId) {
+          explicitlyClearedDraftBlockIdRef.current = null
+        } else {
+          onDraftChange?.(previousEditingBlockId, null)
+        }
+      }
+      previousEditingBlockIdRef.current = editingBlockId
     }
-  }, [blocks, editingBlockId])
+  }, [editingBlockId, onDraftChange])
+
+  useEffect(() => {
+    if (!editingBlockId || blocks.some((block) => block.id === editingBlockId)) return
+    setValidationError(null)
+    selectBlock(null)
+  }, [blocks, editingBlockId, selectBlock])
 
   if (editingBlock && !readOnly) {
     return (
@@ -1080,11 +1151,17 @@ export function ControlledLoomBlockEditor({
             return
           }
           setValidationError(null)
-          setEditingBlockId(null)
+          explicitlyClearedDraftBlockIdRef.current = editingBlock.id
+          onDraftChange?.(editingBlock.id, null)
+          selectBlock(null)
         }}
         onBack={() => {
           setValidationError(null)
-          setEditingBlockId(null)
+          selectBlock(null)
+        }}
+        onDraftChange={(updates) => {
+          explicitlyClearedDraftBlockIdRef.current = null
+          onDraftChange?.(editingBlock.id, updates)
         }}
         availableMacros={availableMacros}
         refreshMacros={refreshMacros}
@@ -1126,7 +1203,7 @@ export function ControlledLoomBlockEditor({
                   variant="ghost"
                   onClick={() => {
                     setValidationError(null)
-                    setEditingBlockId(block.id)
+                    selectBlock(block.id)
                   }}
                   title={tc('actions.edit')}
                 >

--- a/frontend/src/components/panels/LoomBuilder.tsx
+++ b/frontend/src/components/panels/LoomBuilder.tsx
@@ -1123,8 +1123,12 @@ export function ControlledLoomBlockEditor({
   useEffect(() => {
     if (!editingBlockId || blocks.some((block) => block.id === editingBlockId)) return
     setValidationError(null)
+    if (explicitlyClearedDraftBlockIdRef.current !== editingBlockId) {
+      explicitlyClearedDraftBlockIdRef.current = editingBlockId
+      onDraftChange?.(editingBlockId, null)
+    }
     selectBlock(null)
-  }, [blocks, editingBlockId, selectBlock])
+  }, [blocks, editingBlockId, onDraftChange, selectBlock])
 
   if (editingBlock && !readOnly) {
     return (

--- a/frontend/src/lib/spindle/components-helper.loom-bridge.isolated.tsx
+++ b/frontend/src/lib/spindle/components-helper.loom-bridge.isolated.tsx
@@ -6,6 +6,7 @@ import { registerLiveRoot } from './live-root-registry'
 import type {
   PromptBlockDTO,
   SpindleLoomBlockEditorHandle,
+  SpindleLoomBlockEditorOptions,
   SpindleLoomBlockEditorValue,
 } from 'lumiverse-spindle-types'
 
@@ -55,6 +56,9 @@ type ControlledProps = {
   blocks: PromptBlockDTO[]
   promptVariables: SpindleLoomBlockEditorValue['promptVariableValues']
   onChange(blocks: PromptBlockDTO[]): boolean
+  onDraftChange?(blockId: string, updates: Partial<PromptBlockDTO> | null): void
+  selectedBlockId?: string | null
+  onSelectedBlockChange?(blockId: string | null): void
   trustedHostFeatures?: boolean
 }
 let controlledProps: ControlledProps | null = null
@@ -133,9 +137,10 @@ function mount(
   extensionId: string,
   initial: SpindleLoomBlockEditorValue,
   onChange?: (next: SpindleLoomBlockEditorValue) => void,
+  options: Omit<SpindleLoomBlockEditorOptions, 'value' | 'onChange'> = {},
 ): SpindleLoomBlockEditorHandle {
   const handle = createComponentsHelper(extensionId, extensionId, async () => ({ categories: [] }))
-    .mountLoomBlockEditor(ownedRoot(extensionId, `${extensionId}-target`), { value: initial, onChange })
+    .mountLoomBlockEditor(ownedRoot(extensionId, `${extensionId}-target`), { value: initial, onChange, ...options })
   const destroy = handle.destroy
   handle.destroy = () => {
     destroy()
@@ -219,6 +224,43 @@ describe('Loom component bridge state transitions', () => {
 
     expect(controlledProps?.onChange([block('candidate')])).toBe(true)
     expect(handle.getValue().blocks[0]?.id).toBe('candidate')
+    handle.destroy()
+  })
+
+  test('forwards controlled selection and native selection callbacks', () => {
+    const selected: Array<string | null> = []
+    const handle = mount('loom-bridge-selection', value({ blocks: [block('one'), block('two')] }), undefined, {
+      selectedBlockId: 'two',
+      onSelectedBlockChange: (blockId) => { selected.push(blockId) },
+    })
+
+    expect(controlledProps?.selectedBlockId).toBe('two')
+    controlledProps?.onSelectedBlockChange?.(null)
+    expect(selected).toEqual([null])
+
+    flushSync(() => handle.update({ selectedBlockId: 'one' }))
+    expect(controlledProps?.selectedBlockId).toBe('one')
+    expect(handle.getValue().blocks.map((entry) => entry.id)).toEqual(['one', 'two'])
+    handle.destroy()
+  })
+
+  test('publishes detached validated drafts without committing bridge value', () => {
+    const drafts: Array<SpindleLoomBlockEditorValue | null> = []
+    const initial = value({ blocks: [block('one', { content: 'committed' })] })
+    const handle = mount('loom-bridge-draft', initial, undefined, {
+      onDraftChange: (next) => { drafts.push(next) },
+    })
+
+    controlledProps?.onDraftChange?.('one', { content: 'draft' })
+    expect(drafts).toHaveLength(1)
+    expect(drafts[0]?.blocks[0]?.content).toBe('draft')
+    expect(handle.getValue().blocks[0]?.content).toBe('committed')
+
+    drafts[0]!.blocks[0]!.content = 'consumer mutation'
+    expect(handle.getValue().blocks[0]?.content).toBe('committed')
+
+    controlledProps?.onDraftChange?.('one', null)
+    expect(drafts[1]).toBeNull()
     handle.destroy()
   })
 

--- a/frontend/src/lib/spindle/components-helper.tsx
+++ b/frontend/src/lib/spindle/components-helper.tsx
@@ -1390,31 +1390,37 @@ function LoomBlockEditorBridge({
     }
   }, [getMacroCatalogForExtension, extensionIdentifier])
 
+  const buildPublicValue = (
+    blocks: PromptBlock[],
+    previousValue: SpindleLoomBlockEditorValue,
+  ): SpindleLoomBlockEditorValue => {
+    // Blocks arrive from the host block editor, which emits host-only
+    // fields on every save (placementBinding, and seal metadata when
+    // trusted features are on). The public DTO rejects them by design, so
+    // strip them at the boundary before validating.
+    const publicBlocks = blocks.map((block) => {
+      const clean = { ...block } as Record<string, unknown>
+      for (const key of HOST_ONLY_BLOCK_FIELDS) delete clean[key]
+      return clean as unknown as PromptBlock
+    })
+    const normalizedBlocks = normalizeCategoryBlockState(publicBlocks)
+    return cloneLoomValue({
+      blocks: normalizedBlocks,
+      promptVariableValues: reconcilePromptVariableValues(
+        previousValue.promptVariableValues,
+        previousValue.blocks,
+        normalizedBlocks,
+      ),
+    })
+  }
+
   const handleChange = (blocks: PromptBlock[]): boolean => {
     if (!aliveRef.current) return false
     const previousProps = propsRef.current
     const previousValue = valueRef.current
     let cloned: SpindleLoomBlockEditorValue
     try {
-      // Blocks arrive from the host block editor, which emits host-only
-      // fields on every save (placementBinding, and seal metadata when
-      // trusted features are on). The public DTO rejects them by design, so
-      // strip them at the boundary before validating — otherwise every save
-      // fails with "unknown field" and the editor reports validationFailed.
-      const publicBlocks = blocks.map((block) => {
-        const clean = { ...block } as Record<string, unknown>
-        for (const key of HOST_ONLY_BLOCK_FIELDS) delete clean[key]
-        return clean as unknown as PromptBlock
-      })
-      const normalizedBlocks = normalizeCategoryBlockState(publicBlocks)
-      cloned = cloneLoomValue({
-        blocks: normalizedBlocks,
-        promptVariableValues: reconcilePromptVariableValues(
-          previousValue.promptVariableValues,
-          previousValue.blocks,
-          normalizedBlocks,
-        ),
-      })
+      cloned = buildPublicValue(blocks, previousValue)
     } catch {
       return false
     }
@@ -1427,6 +1433,31 @@ function LoomBlockEditorBridge({
 
     notifyComponentOnChange('Loom', nextProps.onChange, cloneLoomValue(cloned))
     return true
+  }
+
+  const handleDraftChange = (blockId: string, updates: Partial<PromptBlock> | null): void => {
+    if (!aliveRef.current) return
+    const currentProps = propsRef.current
+    if (updates === null) {
+      notifyComponentOnChange('Loom draft', currentProps.onDraftChange, null)
+      return
+    }
+    try {
+      const currentValue = valueRef.current
+      const draftBlocks = (currentValue.blocks as PromptBlock[]).map((block) => (
+        block.id === blockId ? { ...block, ...updates } : block
+      ))
+      const draft = buildPublicValue(draftBlocks, currentValue)
+      notifyComponentOnChange('Loom draft', currentProps.onDraftChange, draft)
+    } catch {
+      // The public draft callback is intentionally validated. Transient invalid
+      // editor state stays inside the native component until it becomes valid.
+    }
+  }
+
+  const handleSelectedBlockChange = (blockId: string | null): void => {
+    if (!aliveRef.current) return
+    notifyComponentOnChange('Loom selection', propsRef.current.onSelectedBlockChange, blockId)
   }
 
   useLayoutEffect(() => {
@@ -1455,6 +1486,9 @@ function LoomBlockEditorBridge({
       blocks={valueState.blocks as PromptBlock[]}
       promptVariables={valueState.promptVariableValues as PromptVariableValues}
       onChange={handleChange}
+      onDraftChange={handleDraftChange}
+      selectedBlockId={props.selectedBlockId}
+      onSelectedBlockChange={handleSelectedBlockChange}
       availableMacros={availableMacros}
       refreshMacros={() => { void refreshMacros().catch(() => {}) }}
       readOnly={props.readOnly}

--- a/frontend/src/lib/spindle/loom-dto.test.ts
+++ b/frontend/src/lib/spindle/loom-dto.test.ts
@@ -378,36 +378,54 @@ describe('cloneLoomValue', () => {
 })
 
 describe('Loom option cloning and patches', () => {
-  test('clones options and defaults readOnly to false and compact to true', () => {
+  test('clones callbacks and controlled selection while defaulting layout flags', () => {
     const source = value()
     const onChange = () => {}
-    const options = cloneLoomOptions({ value: source, onChange })
+    const onDraftChange = () => {}
+    const onSelectedBlockChange = () => {}
+    const options = cloneLoomOptions({
+      value: source,
+      onChange,
+      onDraftChange,
+      selectedBlockId: 'one',
+      onSelectedBlockChange,
+    })
 
     expect(options.readOnly).toBe(false)
     expect(options.compact).toBe(true)
     expect(options.onChange).toBe(onChange)
+    expect(options.onDraftChange).toBe(onDraftChange)
+    expect(options.selectedBlockId).toBe('one')
+    expect(options.onSelectedBlockChange).toBe(onSelectedBlockChange)
     expect(options.value).not.toBe(source)
     expect(Object.getPrototypeOf(options.value)).toBeNull()
   })
 
   test('applies partial patches and preserves unchanged fields', () => {
     const onChange = () => {}
+    const onDraftChange = () => {}
     const replacement = value({ blocks: [block('replacement')] })
-    const current = cloneLoomOptions({ value: value(), onChange, compact: true })
-    const next = patchLoomOptions(current, { value: replacement, readOnly: true })
+    const current = cloneLoomOptions({ value: value(), onChange, onDraftChange, selectedBlockId: 'one', compact: true })
+    const next = patchLoomOptions(current, { value: replacement, selectedBlockId: null, readOnly: true })
 
     expect(next.readOnly).toBe(true)
     expect(next.compact).toBe(true)
     expect(next.onChange).toBe(onChange)
+    expect(next.onDraftChange).toBe(onDraftChange)
+    expect(next.selectedBlockId).toBeNull()
     expect(next.value).not.toBe(replacement)
     expect(next.value.blocks[0]!.id).toBe('replacement')
     expect(current.readOnly).toBe(false)
+    expect(current.selectedBlockId).toBe('one')
     expect(current.value.blocks[0]!.id).toBe('one')
   })
 
   test('rejects invalid patches without changing the current options', () => {
     const current = cloneLoomOptions({ value: value() })
     expect(() => patchLoomOptions(current, { readOnly: 'yes' })).toThrow('readOnly')
+    expect(() => patchLoomOptions(current, { selectedBlockId: '' })).toThrow('selectedBlockId')
+    expect(() => patchLoomOptions(current, { onDraftChange: 'nope' })).toThrow('onDraftChange')
+    expect(() => patchLoomOptions(current, { onSelectedBlockChange: 42 })).toThrow('onSelectedBlockChange')
     expect(() => patchLoomOptions(current, { value: { blocks: [], extra: true, promptVariableValues: {} } })).toThrow('unknown field')
     expect(current.readOnly).toBe(false)
     expect(current.value.blocks[0]!.id).toBe('one')

--- a/frontend/src/lib/spindle/loom-dto.ts
+++ b/frontend/src/lib/spindle/loom-dto.ts
@@ -9,6 +9,9 @@ import type { MacroGroup } from '@/lib/loom/types'
 export interface NormalizedLoomOptions {
   value: SpindleLoomBlockEditorValue
   onChange?: (value: SpindleLoomBlockEditorValue) => void
+  onDraftChange?: (value: SpindleLoomBlockEditorValue | null) => void
+  selectedBlockId?: string | null
+  onSelectedBlockChange?: (blockId: string | null) => void
   readOnly: boolean
   compact: boolean
 }
@@ -87,6 +90,9 @@ const LOOM_VALUE_KEYS: Record<string, true> = {
 const LOOM_OPTION_KEYS: Record<string, true> = {
   value: true,
   onChange: true,
+  onDraftChange: true,
+  selectedBlockId: true,
+  onSelectedBlockChange: true,
   readOnly: true,
   compact: true,
 }
@@ -874,12 +880,25 @@ export function cloneLoomOptions(options: unknown): NormalizedLoomOptions {
   assertExactKeys(record, LOOM_OPTION_KEYS, 'options')
   if (!Object.prototype.hasOwnProperty.call(record, 'value')) throw new Error('Invalid Loom options.value')
   const onChange = record.onChange
+  const onDraftChange = record.onDraftChange
+  const onSelectedBlockChange = record.onSelectedBlockChange
+  const selectedBlockId = record.selectedBlockId
   if (onChange !== undefined && typeof onChange !== 'function') throw new Error('Invalid Loom options.onChange')
+  if (onDraftChange !== undefined && typeof onDraftChange !== 'function') throw new Error('Invalid Loom options.onDraftChange')
+  if (onSelectedBlockChange !== undefined && typeof onSelectedBlockChange !== 'function') {
+    throw new Error('Invalid Loom options.onSelectedBlockChange')
+  }
+  if (selectedBlockId !== undefined && selectedBlockId !== null) {
+    assertString(selectedBlockId, 'options.selectedBlockId', true)
+  }
   if (record.readOnly !== undefined) assertBoolean(record.readOnly, 'options.readOnly')
   if (record.compact !== undefined) assertBoolean(record.compact, 'options.compact')
   return {
     value: cloneLoomValue(record.value),
     onChange: onChange as ((value: SpindleLoomBlockEditorValue) => void) | undefined,
+    onDraftChange: onDraftChange as ((value: SpindleLoomBlockEditorValue | null) => void) | undefined,
+    selectedBlockId: selectedBlockId as string | null | undefined,
+    onSelectedBlockChange: onSelectedBlockChange as ((blockId: string | null) => void) | undefined,
     readOnly: record.readOnly === true,
     compact: record.compact !== false,
   }
@@ -891,6 +910,9 @@ export function patchLoomOptions(current: NormalizedLoomOptions, patch: unknown)
   const next: NormalizedLoomOptions = {
     value: current.value,
     onChange: current.onChange,
+    onDraftChange: current.onDraftChange,
+    selectedBlockId: current.selectedBlockId,
+    onSelectedBlockChange: current.onSelectedBlockChange,
     readOnly: current.readOnly,
     compact: current.compact,
   }
@@ -900,6 +922,24 @@ export function patchLoomOptions(current: NormalizedLoomOptions, patch: unknown)
       throw new Error('Invalid Loom options.onChange')
     }
     next.onChange = record.onChange as typeof next.onChange
+  }
+  if (Object.prototype.hasOwnProperty.call(record, 'onDraftChange')) {
+    if (record.onDraftChange !== undefined && typeof record.onDraftChange !== 'function') {
+      throw new Error('Invalid Loom options.onDraftChange')
+    }
+    next.onDraftChange = record.onDraftChange as typeof next.onDraftChange
+  }
+  if (Object.prototype.hasOwnProperty.call(record, 'selectedBlockId')) {
+    if (record.selectedBlockId !== undefined && record.selectedBlockId !== null) {
+      assertString(record.selectedBlockId, 'options.selectedBlockId', true)
+    }
+    next.selectedBlockId = record.selectedBlockId as string | null | undefined
+  }
+  if (Object.prototype.hasOwnProperty.call(record, 'onSelectedBlockChange')) {
+    if (record.onSelectedBlockChange !== undefined && typeof record.onSelectedBlockChange !== 'function') {
+      throw new Error('Invalid Loom options.onSelectedBlockChange')
+    }
+    next.onSelectedBlockChange = record.onSelectedBlockChange as typeof next.onSelectedBlockChange
   }
   if (Object.prototype.hasOwnProperty.call(record, 'readOnly')) {
     next.readOnly = assertBoolean(record.readOnly, 'options.readOnly')


### PR DESCRIPTION
## What changed

Extends the Spindle-hosted Loom block editor so extensions can control native block navigation and observe validated in-progress block edits without replacing or reimplementing the first-party Loom editor.

This adds:

* Controlled block selection through `selectedBlockId`.
* Native navigation reporting through `onSelectedBlockChange`.
* Live draft reporting from `BlockEditor` through the existing `onDraftChange` contract.
* Controlled/uncontrolled selection behavior so existing native Loom usage remains unchanged when no external selection is provided.
* Draft lifecycle handling so temporary edits are cleared when a block is saved, discarded, removed, or navigated away from.
* Public bridge projection for draft snapshots using the same normalization, prompt-variable reconciliation, host-only-field stripping, cloning, and DTO validation used for committed values.
* DTO option validation and patching support for the new controlled-selection fields and the existing draft callback.

Draft updates are observational only: receiving an `onDraftChange` value does not mutate the bridge's committed `getValue()` state. Normal block saves continue through the existing `onChange` path.

## Why

Extension-owned workspaces currently have no supported way to navigate the native Loom block editor programmatically, and the public `onDraftChange` component contract was declared but not implemented by the frontend bridge.

Without these hooks, an extension that wants to provide a larger preset-authoring workspace would need to duplicate Loom editing behavior, poll state, or manipulate the native editor through the DOM.

This keeps Loom authoritative while exposing only the state needed for cooperative host integrations.

## Validation

Focused coverage was added or extended for the affected boundaries.

### `LoomBuilder.controlled.isolated.tsx`

Covers:

* Opening an externally selected block.
* Reporting native Back navigation through `onSelectedBlockChange`.
* Reporting in-progress block changes before Save.
* Confirming draft edits do not commit through `onChange`.
* Clearing an active draft when the edit is discarded.

### `components-helper.loom-bridge.isolated.tsx`

Covers:

* Forwarding controlled selection into the native editor.
* Propagating native selection changes back to the extension.
* Updating selection through the component handle without modifying block data.
* Publishing detached validated draft snapshots.
* Confirming draft snapshots do not mutate the bridge's committed value.
* Emitting `null` when a draft is discarded.

### `loom-dto.test.ts`

Coverage was extended for:

* Cloning controlled selection and draft callback options.
* Preserving those options through partial component updates.
* Explicitly clearing `selectedBlockId` with `null`.
* Rejecting invalid `selectedBlockId`, `onDraftChange`, and `onSelectedBlockChange` values.

### Commands

From `frontend/`:

```bash
bun run typecheck
```

Result: **passed successfully**.

Focused unit tests:

```bash
bun test src/components/panels/LoomBuilder.controlled.isolated.tsx
bun test src/lib/spindle/components-helper.loom-bridge.isolated.tsx
bun test src/lib/spindle/loom-dto.test.ts
bun run lint
```

No user-facing UI or UX is added by this PR, so browser/mobile visual validation is not applicable beyond a live regression smoke test of the existing Loom editor.

## Spindle / security-sensitive areas

This PR changes the Spindle component bridge and public Loom component DTO handling and should receive the corresponding Spindle audit.

It does not expand trusted host access:

* `trustedHostFeatures` remains disabled for the Spindle-mounted editor.
* Host-only block fields remain stripped before crossing the public DTO boundary.
* Live drafts are validated and detached before being exposed.
* Live drafts do not commit editor state.
* Existing public DTO exact-key validation remains enforced and has been extended for the new options.

The native trusted Loom editor continues to opt into its existing host-only functionality separately.

## LLM assistance
Live tested for regressions in the base loom editor; edit, save, and the prompt variables modal remain operating correctly
