### PR TITLE
fix(chats): remove prompt breakdowns with deleted messages

### DIFF
--- a/src/services/breakdown.service.ts
+++ b/src/services/breakdown.service.ts
@@ -26,3 +26,30 @@ export function deleteBreakdownsForChat(userId: string, chatId: string): void {
   const db = getDb();
   db.run("DELETE FROM message_breakdowns WHERE chat_id = ? AND user_id = ?", [chatId, userId]);
 }
+
+export function deleteBreakdownForMessage(userId: string, messageId: string): void {
+  const db = getDb();
+  db.run("DELETE FROM message_breakdowns WHERE message_id = ? AND user_id = ?", [messageId, userId]);
+}
+
+/**
+ * A breakdown stores the prompt history used to generate its message. Removing
+ * an earlier message therefore invalidates every later breakdown in the chat,
+ * even when those later messages remain visible.
+ */
+export function deleteBreakdownsAfterMessage(
+  userId: string,
+  chatId: string,
+  messageIndex: number,
+): void {
+  const db = getDb();
+  db.run(
+    `DELETE FROM message_breakdowns
+     WHERE user_id = ?
+       AND message_id IN (
+         SELECT id FROM messages
+         WHERE chat_id = ? AND index_in_chat > ?
+       )`,
+    [userId, chatId, messageIndex],
+  );
+}

--- a/src/services/chats.service.test.ts
+++ b/src/services/chats.service.test.ts
@@ -11,7 +11,10 @@ import {
   branchChat,
   convertSoloChatToGroup,
   createChat,
+  deleteChat,
   deleteChats,
+  deleteMessage,
+  bulkDeleteMessages,
   getChat,
   getChatTree,
   cycleSwipe,
@@ -104,6 +107,14 @@ function initChatsTestDb(): void {
     updated_at INTEGER NOT NULL,
     UNIQUE(chat_id, settings_key)
   )`);
+
+  db.run(`CREATE TABLE message_breakdowns (
+    message_id TEXT PRIMARY KEY,
+    chat_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    data TEXT NOT NULL,
+    created_at INTEGER NOT NULL DEFAULT 1
+  )`);
 }
 
 function seedCharacter(id: string, name: string): void {
@@ -156,6 +167,17 @@ function seedMessage(
       null,
       sendDate,
     );
+}
+
+function seedBreakdown(
+  messageId: string,
+  chatId: string,
+  data: unknown = { marker: messageId },
+  userId = "u1",
+): void {
+  getDb()
+    .query("INSERT INTO message_breakdowns (message_id, chat_id, user_id, data) VALUES (?, ?, ?, ?)")
+    .run(messageId, chatId, userId, JSON.stringify(data));
 }
 
 beforeEach(() => {
@@ -796,6 +818,71 @@ describe("bulk chat deletion", () => {
     expect(getChat("u1", "keep")?.name).toBe("Keep");
     const foreign = getDb().query("SELECT id FROM chats WHERE id = ?").get("foreign") as { id: string } | null;
     expect(foreign?.id).toBe("foreign");
+  });
+});
+
+describe("message breakdown deletion", () => {
+  test("deletes all breakdowns for a deleted chat and preserves other chats", () => {
+    seedChat("delete-chat", "c1", "Delete", "{}", 100);
+    seedMessage("delete-message-1", "delete-chat", "One", {}, { index: 0 });
+    seedMessage("delete-message-2", "delete-chat", "Two", {}, { index: 1 });
+    seedBreakdown("delete-message-1", "delete-chat");
+    seedBreakdown("delete-message-2", "delete-chat");
+
+    seedChat("keep-chat", "c1", "Keep", "{}", 200);
+    seedMessage("keep-message", "keep-chat", "Keep", {});
+    seedBreakdown("keep-message", "keep-chat");
+
+    expect(deleteChat("u1", "delete-chat")).toBe(true);
+
+    const deletedCount = getDb()
+      .query("SELECT COUNT(*) AS count FROM message_breakdowns WHERE chat_id = ?")
+      .get("delete-chat") as { count: number };
+    expect(deletedCount.count).toBe(0);
+    expect(getDb().query("SELECT message_id FROM message_breakdowns WHERE message_id = ?").get("keep-message")).not.toBeNull();
+  });
+
+  test("deletes the selected and later prompt breakdowns while preserving earlier ones", () => {
+    const deletedContentMarker = "deleted-sensitive-prompt-marker";
+    seedChat("message-chat", "c1", "Messages", "{}", 100);
+    seedMessage("keep-earlier", "message-chat", "Earlier", {}, { index: 0 });
+    seedMessage("delete-message", "message-chat", deletedContentMarker, {}, { index: 1 });
+    seedMessage("keep-later", "message-chat", "Later", {}, { index: 2 });
+    seedBreakdown("keep-earlier", "message-chat");
+    seedBreakdown("delete-message", "message-chat");
+    seedBreakdown("keep-later", "message-chat", {
+      messages: [
+        { role: "user", content: deletedContentMarker },
+        { role: "assistant", content: "Later" },
+      ],
+    });
+
+    expect(deleteMessage("u1", "delete-message")).toBe(true);
+
+    expect(getDb().query("SELECT message_id FROM message_breakdowns WHERE message_id = ?").get("delete-message")).toBeNull();
+    expect(getDb().query("SELECT message_id FROM message_breakdowns WHERE message_id = ?").get("keep-later")).toBeNull();
+    expect(getDb().query("SELECT message_id FROM message_breakdowns WHERE message_id = ?").get("keep-earlier")).not.toBeNull();
+    expect(getMessage("u1", "keep-later")).not.toBeNull();
+    const retainedMarkerCount = getDb()
+      .query("SELECT COUNT(*) AS count FROM message_breakdowns WHERE instr(data, ?) > 0")
+      .get(deletedContentMarker) as { count: number };
+    expect(retainedMarkerCount.count).toBe(0);
+  });
+
+  test("deletes breakdowns for bulk-deleted messages and preserves unselected messages", () => {
+    seedChat("bulk-message-chat", "c1", "Bulk", "{}", 100);
+    for (const [index, id] of ["delete-one", "keep", "delete-two"].entries()) {
+      seedMessage(id, "bulk-message-chat", id, {}, { index });
+      seedBreakdown(id, "bulk-message-chat");
+    }
+
+    expect(bulkDeleteMessages("u1", "bulk-message-chat", ["delete-one", "missing", "delete-two"])).toBe(2);
+
+    const remaining = getDb()
+      .query("SELECT message_id FROM message_breakdowns WHERE chat_id = ? ORDER BY message_id")
+      .all("bulk-message-chat") as Array<{ message_id: string }>;
+    expect(remaining).toEqual([]);
+    expect(getMessage("u1", "keep")).not.toBeNull();
   });
 });
 

--- a/src/services/chats.service.ts
+++ b/src/services/chats.service.ts
@@ -21,6 +21,7 @@ import * as embeddingsSvc from "./embeddings.service";
 import * as audioSvc from "./audio.service";
 import * as memoryCortex from "./memory-cortex";
 import * as regexScriptsSvc from "./regex-scripts.service";
+import * as breakdownSvc from "./breakdown.service";
 import { removePoolEntriesForChat } from "./generation-pool.service";
 import { invalidateChatMemoryCache, scheduleChatMemoryRefresh } from "./chat-memory-cache.service";
 import { enqueueChatPipelineTask } from "./chat-pipeline-coordinator.service";
@@ -1282,7 +1283,12 @@ export function deleteChat(userId: string, id: string): boolean {
     console.warn(`[chats] Failed to scan messages for audio cleanup in chat ${id}:`, err);
   }
 
-  const result = getDb().query("DELETE FROM chats WHERE id = ? AND user_id = ?").run(id, userId);
+  const db = getDb();
+  const result = db.transaction(() => {
+    const deleted = db.query("DELETE FROM chats WHERE id = ? AND user_id = ?").run(id, userId);
+    if (deleted.changes > 0) breakdownSvc.deleteBreakdownsForChat(userId, id);
+    return deleted;
+  })();
   if (result.changes > 0) {
     cleanupAudioAttachments(userId, audioAttachments);
     invalidateChatMemoryCache(id);
@@ -2965,12 +2971,13 @@ export function bulkDeleteMessages(userId: string, chatId: string, messageIds: s
   if (messageIds.length > 500) throw new Error("Maximum 500 messages per batch");
 
   const db = getDb();
-  const getStmt = db.query("SELECT id, extra FROM messages WHERE id = ? AND chat_id = ?");
+  const getStmt = db.query("SELECT id, extra, index_in_chat FROM messages WHERE id = ? AND chat_id = ?");
   const deleteStmt = db.query("DELETE FROM messages WHERE id = ? AND chat_id = ?");
 
   let deleted = 0;
   const deletedIds: string[] = [];
   const attachmentsToCleanup: any[] = [];
+  let earliestDeletedIndex: number | null = null;
 
   const transaction = db.transaction(() => {
     for (const msgId of messageIds) {
@@ -2978,9 +2985,18 @@ export function bulkDeleteMessages(userId: string, chatId: string, messageIds: s
       if (!row) continue;
 
       attachmentsToCleanup.push(...collectMessageAttachments(row));
-      deleteStmt.run(msgId, chatId);
-      deleted++;
-      deletedIds.push(msgId);
+      const result = deleteStmt.run(msgId, chatId);
+      if (result.changes > 0) {
+        breakdownSvc.deleteBreakdownForMessage(userId, msgId);
+        earliestDeletedIndex = earliestDeletedIndex == null
+          ? row.index_in_chat
+          : Math.min(earliestDeletedIndex, row.index_in_chat);
+        deleted++;
+        deletedIds.push(msgId);
+      }
+    }
+    if (earliestDeletedIndex != null) {
+      breakdownSvc.deleteBreakdownsAfterMessage(userId, chatId, earliestDeletedIndex);
     }
   });
 
@@ -3021,7 +3037,15 @@ export function deleteMessage(userId: string, id: string): boolean {
   const msg = getMessage(userId, id);
   if (!msg) return false;
   const attachmentsToCleanup = collectMessageAttachments(msg);
-  const result = getDb().query("DELETE FROM messages WHERE id = ? AND chat_id = ?").run(id, msg.chat_id);
+  const db = getDb();
+  const result = db.transaction(() => {
+    const deleted = db.query("DELETE FROM messages WHERE id = ? AND chat_id = ?").run(id, msg.chat_id);
+    if (deleted.changes > 0) {
+      breakdownSvc.deleteBreakdownForMessage(userId, id);
+      breakdownSvc.deleteBreakdownsAfterMessage(userId, msg.chat_id, msg.index_in_chat);
+    }
+    return deleted;
+  })();
   if (result.changes > 0) {
     const chat = getChat(userId, msg.chat_id);
     if (chat?.metadata?.context_history_anchor_message_id === id) {


### PR DESCRIPTION
## Summary

Deleting a chat or message removed its source row but could leave content-bearing `message_breakdowns` rows behind. A later message's breakdown can also contain the deleted message in its saved prompt history, so removing only a breakdown keyed to the deleted message is insufficient.

This change allows the deleted message or chat to be fully purged when a vacuum action is initiated.

## Result

- Whole-chat deletion removes all of the user's breakdowns for that chat.
- Single-message deletion removes the selected message's breakdown and later breakdowns that could contain its prompt history.
- Bulk-message deletion performs the same cleanup from the earliest deleted message.
- Source deletion and breakdown cleanup share a SQLite transaction.
- Earlier unaffected breakdowns, retained messages, other chats, and other users remain untouched.

## Security-sensitive areas

This changes deletion of content-bearing prompt breakdowns. Cleanup queries are ownership-scoped by `user_id`. Existing orphaned breakdowns created by older versions are outside this focused change and require separate reconciliation.

## Fresh validation record

Tested September 10, 2026.

- Branch: `privacy/message-breakdown-cleanup`
- Commit: `3ab7ff0ce89e151a4186e79586d24ddce4719df2`
- Base: `upstream/staging` at `7bc88fabe333618d015ddd17e2066eb955608c11`
- Bun: `1.4.2`

### Focused regression tests

```sh
bun test --isolate \
  src/services/chats.service.test.ts \
  tests/temporary-chats.test.ts
```

Result: **53 passed, 0 failed; 223 assertions across 2 files.**

Coverage includes whole-chat deletion, single-message deletion, bulk-message deletion, downstream prompt-history removal, preservation of earlier unaffected breakdowns, preservation of retained messages, and temporary-chat deletion. The suite's existing minimal-fixture warnings for omitted `settings` and `chat_chunks` tables did not fail any test.

### Backend type check

```sh
bun x tsc --noEmit
```

Result: **passed with no errors or warnings.**

### Patch validation

```sh
git diff --check
```

Result: **passed.**

## Manual verification
I created a new chat, added a comment with a breadcrumb and performed a grep to identify the marker.
I deleted the message and performed the vacuum command, then repeated the grep. Before fix marker present, after fix marker was deleted.
I created a new chat, added a comment with a breadcrumb and performed a grep to identify the marker.
I deleted the full chat and performed the vacuum command, then repeated the grep. Before fix marker present, after fix marker was deleted.