### PR TITLE
Expose semantic material and chat shell theme tokens

### DIFF
--- a/frontend/scripts/extract-css-vars.ts
+++ b/frontend/scripts/extract-css-vars.ts
@@ -12,7 +12,7 @@ if (!rootMatch) {
 }
 
 const rootContent = rootMatch[1];
-const varRegex = /(--lumiverse-[a-zA-Z0-9-]+)\s*:\s*([^;]+);/g;
+const varRegex = /(--(?:lumiverse|lcs)-[a-zA-Z0-9-]+)\s*:\s*([^;]+);/g;
 let match;
 const result: Record<string, string> = {};
 

--- a/frontend/scripts/extract-props.ts
+++ b/frontend/scripts/extract-props.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import * as ts from "typescript";
 import path from "path";
 import { Glob } from "bun";
 import {

--- a/frontend/src/theme/engine.test.ts
+++ b/frontend/src/theme/engine.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, test } from 'bun:test'
 import { generateThemeVariables } from './engine'
 import { DEFAULT_THEME } from './presets'
+import GENERATED_VARS from '../lib/generatedCssVariables'
 
 describe('generateThemeVariables', () => {
   test('derives a dark accent control surface and a readable glyph in both modes', () => {
@@ -33,5 +34,36 @@ describe('generateThemeVariables', () => {
 
     expect(vars['--lumiverse-bg']).toBe('rgb(32 42 52)')
     expect(vars['--lumiverse-bg-deep']).toBe('rgb(9 12 15)')
+  })
+
+  test('keeps semantic material aliases synchronized after theme overrides resolve', () => {
+    const vars = generateThemeVariables({
+      ...DEFAULT_THEME,
+      baseColors: {
+        primary: '#4f46e5',
+        background: 'rgb(32 42 52)',
+        text: '#e8ecf4',
+      },
+    }, 'dark')
+
+    expect(vars['--lumiverse-surface']).toBe(vars['--lumiverse-bg'])
+    expect(vars['--lumiverse-surface-raised']).toBe(vars['--lumiverse-bg-elevated'])
+    expect(vars['--lumiverse-surface-hover']).toBe(vars['--lumiverse-bg-hover'])
+    expect(vars['--lumiverse-surface-muted']).toBe(vars['--lumiverse-fill-subtle'])
+    expect(vars['--lumiverse-input-bg']).toBe(vars['--lumiverse-fill'])
+    expect(vars['--lumiverse-border-subtle']).toBe(vars['--lumiverse-border-light'])
+    expect(vars['--lumiverse-primary-soft']).toBe(vars['--lumiverse-primary-015'])
+    expect(vars['--lumiverse-text-primary']).toBe(vars['--lumiverse-text'])
+    expect(vars['--lumiverse-text-secondary']).toBe(vars['--lumiverse-text-muted'])
+  })
+
+  test('ships semantic material and Chat Shell variables in the public variable reference', () => {
+    expect(GENERATED_VARS['--lumiverse-surface']).toBe('var(--lumiverse-bg)')
+    expect(GENERATED_VARS['--lumiverse-surface-raised']).toBe('var(--lumiverse-bg-elevated)')
+    expect(GENERATED_VARS['--lumiverse-input-bg']).toBe('var(--lumiverse-fill)')
+    expect(GENERATED_VARS['--lumiverse-border-subtle']).toBe('var(--lumiverse-border-light)')
+    expect(GENERATED_VARS['--lcs-glass-bg']).toBeDefined()
+    expect(GENERATED_VARS['--lcs-glass-bg-hover']).toBeDefined()
+    expect(GENERATED_VARS['--lcs-glass-border-hover']).toBeDefined()
   })
 })

--- a/frontend/src/theme/engine.ts
+++ b/frontend/src/theme/engine.ts
@@ -481,5 +481,20 @@ export function generateThemeVariables(
     }
   }
 
+  // ── Semantic material aliases ──
+  // Keep the newer component-facing material vocabulary tied to the canonical
+  // low-level ladder after all mode and base-color overrides have resolved.
+  // These are emitted as concrete runtime values so public theme consumers
+  // (including Spindle's variable catalog) can reason about them directly.
+  vars['--lumiverse-surface'] = vars['--lumiverse-bg']
+  vars['--lumiverse-surface-raised'] = vars['--lumiverse-bg-elevated']
+  vars['--lumiverse-surface-hover'] = vars['--lumiverse-bg-hover']
+  vars['--lumiverse-surface-muted'] = vars['--lumiverse-fill-subtle']
+  vars['--lumiverse-input-bg'] = vars['--lumiverse-fill']
+  vars['--lumiverse-border-subtle'] = vars['--lumiverse-border-light']
+  vars['--lumiverse-primary-soft'] = vars['--lumiverse-primary-015']
+  vars['--lumiverse-text-primary'] = vars['--lumiverse-text']
+  vars['--lumiverse-text-secondary'] = vars['--lumiverse-text-muted']
+
   return vars
 }

--- a/frontend/src/theme/variables.css
+++ b/frontend/src/theme/variables.css
@@ -9,6 +9,8 @@
   --lumiverse-primary-015: rgba(147, 112, 219, 0.15);
   --lumiverse-primary-020: rgba(147, 112, 219, 0.2);
   --lumiverse-primary-050: rgba(147, 112, 219, 0.5);
+  /* Semantic accent alias used by component surfaces. */
+  --lumiverse-primary-soft: var(--lumiverse-primary-015);
   --lumiverse-primary-deep: rgb(26 20 39);
   --lumiverse-primary-deep-hover: rgb(38 29 57);
   --lumiverse-primary-deep-contrast: hsl(273, 30%, 95%);
@@ -48,16 +50,26 @@
   --lumiverse-bg-deep-080: rgba(20, 17, 28, 0.8);
   --lumiverse-scene-text-scrim: rgba(7, 9, 16, 0.46);
 
+  /* Semantic material ladder. These are public aliases consumed by newer
+     component CSS and kept in lockstep with the canonical theme engine. */
+  --lumiverse-surface: var(--lumiverse-bg);
+  --lumiverse-surface-raised: var(--lumiverse-bg-elevated);
+  --lumiverse-surface-hover: var(--lumiverse-bg-hover);
+  --lumiverse-surface-muted: var(--lumiverse-fill-subtle);
+
   /* Subtle purple-tinted borders */
   --lumiverse-border: rgba(147, 112, 219, 0.12);
   --lumiverse-border-hover: rgba(147, 112, 219, 0.25);
   --lumiverse-border-light: rgba(128, 128, 128, 0.12);
+  --lumiverse-border-subtle: var(--lumiverse-border-light);
 
   /* Text colors */
   --lumiverse-text: rgba(255, 255, 255, 0.9);
   --lumiverse-text-muted: rgba(255, 255, 255, 0.65);
   --lumiverse-text-dim: rgba(255, 255, 255, 0.4);
   --lumiverse-text-hint: rgba(255, 255, 255, 0.3);
+  --lumiverse-text-primary: var(--lumiverse-text);
+  --lumiverse-text-secondary: var(--lumiverse-text-muted);
 
   /* Border radii */
   --lumiverse-radius-sm: 5px;
@@ -91,6 +103,7 @@
   /* Fill colors */
   --lumiverse-fill-subtle: rgba(0, 0, 0, 0.1);
   --lumiverse-fill: rgba(0, 0, 0, 0.15);
+  --lumiverse-input-bg: var(--lumiverse-fill);
   --lumiverse-fill-hover: rgba(0, 0, 0, 0.2);
   --lumiverse-fill-medium: rgba(0, 0, 0, 0.25);
   --lumiverse-fill-strong: rgba(0, 0, 0, 0.3);
@@ -127,7 +140,9 @@
 
   /* Chat — glassmorphic tokens */
   --lcs-glass-bg: rgba(18, 16, 28, 0.55);
+  --lcs-glass-bg-hover: rgba(24, 21, 36, 0.65);
   --lcs-glass-border: rgba(255, 255, 255, 0.06);
+  --lcs-glass-border-hover: rgba(255, 255, 255, 0.1);
   --lcs-glass-blur: 8px;
   --lcs-glass-soft-blur: 6px;
   --lcs-glass-strong-blur: 12px;


### PR DESCRIPTION
## Summary

Expose semantic material and Chat Shell theme variables through Lumiverse's existing theme variable catalog.

This change:

- Adds semantic material aliases for common host surfaces:
  - `--lumiverse-surface`
  - `--lumiverse-surface-raised`
  - `--lumiverse-surface-hover`
  - `--lumiverse-surface-muted`
  - `--lumiverse-input-bg`
  - `--lumiverse-border-subtle`
  - `--lumiverse-primary-soft`
  - `--lumiverse-text-primary`
  - `--lumiverse-text-secondary`
- Keeps those aliases synchronized with the resolved theme engine values after theme overrides are applied.
- Exposes the existing `--lcs-*` Chat Shell variables through the generated CSS variable catalog alongside `--lumiverse-*`.
- Updates the CSS variable extractor to recognize both public namespaces.
- Updates the TypeScript component extractor to use a namespace import for compatibility with Bun canary.
- Adds regression coverage for the semantic material aliases and public Chat Shell variable catalog.

The goal is to let extensions consume host material semantics such as surfaces, raised surfaces, controls, and glass without inferring those roles from lower-level color variables.

This uses the existing `theme-catalog-v1` contract. No Spindle API shape, capability, permission, or spindle-types change is required.

## Validation

Ran from `frontend/` unless otherwise noted:

```text
bun run generate
PASS
- Generated component metadata successfully.
- Wrote 373 components.
- Wrote CSS for 235 components.
- Wrote 117 CSS variables.

bun test src/theme/engine.test.ts
PASS
- 4 pass
- 0 fail
- 25 expect() calls

bun run typecheck
PASS
- Regenerated assets successfully.
- TypeScript project check completed with no type errors.

bun run lint
BLOCKED BY PRE-EXISTING STAGING LINT FAILURE
- src/components/modals/RegexPromptActivationEditor.test.tsx
  react-compiler/react-compiler error
- src/hooks/useDisplayRegex.ts
  react-hooks/exhaustive-deps warning
- src/hooks/useDisplayTask.ts
  react-hooks/exhaustive-deps warning

These files are unrelated to this pull request.

git diff --check
PASS
- No whitespace errors.

Live validation:
- Verified the new theme/material catalog in a live Lumiverse staging environment using a Spindle extension consuming the exposed variables.
- Confirmed semantic surface and Chat Shell variables can be consumed through the existing theme catalog.
```

## Required checklist

* [x] This pull request is based on the latest `staging` branch and targets
  `staging`, not `main`.
* [x] All applicable tests pass.
* [x] I ran the relevant type check(s) with no type errors or warnings:

  * [ ] Backend: `bun x tsc --noEmit` — not applicable; no backend files changed.
  * [x] Frontend: `cd frontend && bun run typecheck`, `bun run lint`
    - `bun run typecheck` passes.
    - `bun run lint` is blocked by the pre-existing unrelated staging lint failure documented above.

## UI changes (if applicable)

This does not directly change Lumiverse UI/UX presentation. It exposes and synchronizes theme material tokens for consumers of the existing theme catalog.

* [ ] I validated this change in more than one browser.
* [ ] I verified the integrated experience on a mobile interface or through
  the mobile PWA.
* Browsers, devices, and PWA coverage: Not applicable to the host-side catalog change. Live extension consumption was validated against Lumiverse staging.

## Performance changes (if applicable)

Not applicable. This change does not introduce a performance-oriented code path.

* [x] I added or updated tests.
* [ ] I included reproducible benchmarks and comparison results below.
* Benchmark commands and results: Not applicable.

## Security-sensitive changes (if applicable)

No security-sensitive backend behavior is changed.

The existing Spindle `theme-catalog-v1` contract is unchanged. This pull request only expands the variables available through the existing catalog and does not add capabilities, permissions, privileged APIs, or new Spindle contract surface.

No `lumiverse-spindle-types` change is required.

## LLM-assisted work (if applicable)

* [x] I, as the human orchestrating this work, audited the submitted changes
  in a live environment.
Verified against current Lumiverse staging with a Spindle extension consuming the exposed semantic material and Chat Shell variables through the existing theme-catalog-v1 API. Confirmed direct accent fidelity, semantic surface differentiation, Chat Shell/glass material consumption, and preserved material hierarchy under extreme theme transforms.

<img width="1612" height="944" alt="image" src="https://github.com/user-attachments/assets/91670523-7f06-4073-86e0-97f8533334d7" />
look at my monstruosity prolics